### PR TITLE
[FIX] Remove CI duplicate runs on develop (#28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
## Summary

Remove `develop` from the CI `push` trigger to prevent duplicate workflow runs when PRs are merged to develop.

## Changes

- Removed `develop` from `push.branches` in `.github/workflows/ci.yml`
- `push` trigger now only fires on `main` (safety net for release merges)
- `pull_request` trigger unchanged — still validates PRs targeting both `main` and `develop`

## Type of Change

- [x] Bug fix (Fixes a bug without affecting existing functionality)
- [ ] New feature (Adds a new feature without affecting existing functionality)
- [ ] Breaking change (Fix that affects existing functionality)
- [ ] Refactoring (Code improvement without functional changes)
- [ ] Documentation (Documentation update)
- [ ] Chore (Build, configuration, or other changes)
- [ ] Release (Deployment)

## Related Issue

Closes #28

## Checklist

- [x] Followed code conventions (Refer to [CODE_STYLE.md](docs/development/CODE_STYLE.md))
- [x] Build completes successfully locally (`pnpm build`)
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [ ] Tests written for new features (if applicable)

## Additional Notes

Also fixed branch protection required status check name mismatch (`lint-and-build (20)` → `Lint & Build (20)`) via API — this was causing required checks to stay in "Expected" state permanently.