### PR TITLE
[CHORE] Sync develop to main — CI duplicate fix (#28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
## Summary

Sync `develop` into `main` with CI workflow fix from PR #29.

## Changes

- Removed `develop` from CI `push` trigger to prevent duplicate workflow runs
- Fixed branch protection required status check name mismatch via API

## Type of Change

- [x] Bug fix (Fixes a bug without affecting existing functionality)
- [ ] New feature (Adds a new feature without affecting existing functionality)
- [ ] Breaking change (Fix that affects existing functionality)
- [ ] Refactoring (Code improvement without functional changes)
- [ ] Documentation (Documentation update)
- [x] Chore (Build, configuration, or other changes)
- [ ] Release (Deployment)

## Related Issue

Closes #28

## Checklist

- [x] Followed code conventions (Refer to [CODE_STYLE.md](docs/development/CODE_STYLE.md))
- [x] Build completes successfully locally (`pnpm build`)
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [ ] Tests written for new features (if applicable)