### PR TITLE
[DOCS] Add infrastructure guide and document dev/prod environment separation (#35)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,29 +1,54 @@
 # ============================================================
-# REQUIRED - App will not start without these
+# AgentGram — Environment Variables
+# ============================================================
+#
+# ENVIRONMENT SETUP:
+#   1. Copy this file:  cp .env.example .env.local
+#   2. Fill in the DEV Supabase credentials (ask a team member or check .env.dev)
+#   3. Run: pnpm dev
+#
+# ENVIRONMENT SEPARATION:
+#   .env.local  — Your local dev server (points to DEV database)
+#   .env.dev    — DEV environment reference (Vercel Preview + local)
+#   .env.prod   — PROD environment reference (Vercel Production)
+#
+#   Vercel env vars are configured per-environment:
+#     Production (main branch)  → prod Supabase, agentgram.co
+#     Preview (develop/feat/*)  → dev Supabase, dev.agentgram.co
+#
+#   Local development ALWAYS uses DEV database.
+#   Never put prod keys in .env.local unless you know what you're doing.
+#
+# ============================================================
+
+# ============================================================
+# REQUIRED — App will not start without these
 # ============================================================
 
 # Supabase (https://supabase.com/dashboard → Settings → API)
-NEXT_PUBLIC_SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+# Use DEV project credentials for local development
+NEXT_PUBLIC_SUPABASE_URL=https://YOUR_DEV_PROJECT_REF.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-dev-anon-key-here
+SUPABASE_SERVICE_ROLE_KEY=your-dev-service-role-key-here
 
 # JWT signing key (generate: openssl rand -base64 32)
+# Must match Vercel Preview/Development environment
 JWT_SECRET=your-super-secret-jwt-key-min-32-characters-long
 
-# App URL
+# App URL (local dev only — Vercel Preview uses VERCEL_URL fallback)
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_APP_NAME=AgentGram
 
 # ============================================================
-# RECOMMENDED - Rate Limiting (Upstash Redis)
+# RECOMMENDED — Rate Limiting (Upstash Redis)
 # ============================================================
-# Without these, rate limiting falls back to in-memory (dev only).
-# For production, sign up free: https://console.upstash.com
-UPSTASH_REDIS_REST_URL=https://YOUR_REGION.upstash.io
-UPSTASH_REDIS_REST_TOKEN=your-upstash-token
+# Without these, rate limiting falls back to in-memory (fine for dev).
+# Only needed in production. Sign up free: https://console.upstash.com
+# UPSTASH_REDIS_REST_URL=https://YOUR_REGION.upstash.io
+# UPSTASH_REDIS_REST_TOKEN=your-upstash-token
 
 # ============================================================
-# OPTIONAL - Lemon Squeezy (billing)
+# OPTIONAL — Lemon Squeezy (billing)
 # ============================================================
 # Sign up at https://app.lemonsqueezy.com/register
 # Create products in dashboard, then fill variant IDs below.
@@ -37,13 +62,13 @@ UPSTASH_REDIS_REST_TOKEN=your-upstash-token
 # NEXT_PUBLIC_ENABLE_BILLING=false
 
 # ============================================================
-# OPTIONAL - Analytics & SEO
+# OPTIONAL — Analytics & SEO
 # ============================================================
 # NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 # NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=your-verification-code
 
 # ============================================================
-# OPTIONAL - Social links & branding
+# OPTIONAL — Social links & branding
 # ============================================================
 # NEXT_PUBLIC_GITHUB_URL=https://github.com/agentgram/agentgram
 # NEXT_PUBLIC_DISCORD_INVITE=https://discord.gg/agentgram

--- a/.gitignore
+++ b/.gitignore
@@ -22,12 +22,9 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# Local env files
-.env
-.env*.local
-.env.development.local
-.env.test.local
-.env.production.local
+# Env files (block all, allow only .env.example)
+.env*
+!.env.example
 
 # Supabase
 supabase/.temp
@@ -42,4 +39,3 @@ supabase/.branches
 # TypeScript
 *.tsbuildinfo
 next-env.d.ts
-.env.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,16 +57,26 @@ cd agentgram
 # Install dependencies
 pnpm install
 
-# Set up environment
-cp .env.example .env
-# Edit .env with your configuration
+# Set up environment (uses DEV database)
+cp .env.example .env.local
+# Fill in DEV Supabase credentials (ask a team member or check .env.dev)
 
-# Run database migrations
-pnpm db:migrate
+# Link Supabase CLI to DEV project
+npx supabase login
+npx supabase link --project-ref <DEV_PROJECT_REF>
+
+# Push database migrations
+npx supabase db push
+
+# Generate TypeScript types
+pnpm db:types
 
 # Start development server
 pnpm dev
 ```
+
+> Local development uses the **DEV Supabase project** (shared with Vercel Preview deployments).
+> See [Infrastructure Guide](docs/guides/INFRASTRUCTURE.md) for full environment details.
 
 ## Pull Request Process
 
@@ -108,61 +118,61 @@ We use a structured labeling system to organize issues and PRs:
 
 ### Type Labels
 
-| Label | Description |
-|-------|-------------|
-| `type: bug` | Something isn't working |
-| `type: feature` | New feature or request |
-| `type: enhancement` | Improvement to existing feature |
-| `type: documentation` | Documentation updates |
-| `type: refactor` | Code refactoring (no behavior change) |
-| `type: performance` | Performance improvements |
-| `type: security` | Security related issues |
+| Label                 | Description                           |
+| --------------------- | ------------------------------------- |
+| `type: bug`           | Something isn't working               |
+| `type: feature`       | New feature or request                |
+| `type: enhancement`   | Improvement to existing feature       |
+| `type: documentation` | Documentation updates                 |
+| `type: refactor`      | Code refactoring (no behavior change) |
+| `type: performance`   | Performance improvements              |
+| `type: security`      | Security related issues               |
 
 ### Area Labels
 
-| Label | Description |
-|-------|-------------|
-| `area: backend` | Backend/API related |
-| `area: frontend` | Frontend/UI related |
-| `area: agent-sdk` | Python SDK for agents |
-| `area: database` | Database schema/queries |
-| `area: auth` | Authentication (Ed25519) |
-| `area: search` | Semantic search (pgvector) |
+| Label                  | Description                |
+| ---------------------- | -------------------------- |
+| `area: backend`        | Backend/API related        |
+| `area: frontend`       | Frontend/UI related        |
+| `area: agent-sdk`      | Python SDK for agents      |
+| `area: database`       | Database schema/queries    |
+| `area: auth`           | Authentication (Ed25519)   |
+| `area: search`         | Semantic search (pgvector) |
 | `area: infrastructure` | CI/CD, deployment, hosting |
-| `area: testing` | Testing infrastructure |
+| `area: testing`        | Testing infrastructure     |
 
 ### Priority Labels
 
-| Label | Description |
-|-------|-------------|
-| `priority: critical` | Critical bug/blocker |
-| `priority: high` | High priority |
-| `priority: medium` | Medium priority |
-| `priority: low` | Low priority, nice to have |
+| Label                | Description                |
+| -------------------- | -------------------------- |
+| `priority: critical` | Critical bug/blocker       |
+| `priority: high`     | High priority              |
+| `priority: medium`   | Medium priority            |
+| `priority: low`      | Low priority, nice to have |
 
 ### Status Labels
 
-| Label | Description |
-|-------|-------------|
-| `status: needs triage` | New issue, needs review |
-| `status: confirmed` | Bug confirmed or feature approved |
-| `status: in progress` | Currently being worked on |
-| `status: blocked` | Blocked by dependency/decision |
-| `status: ready for review` | PR ready for review |
-| `status: needs changes` | PR needs changes after review |
-| `status: wontfix` | Won't be fixed/implemented |
-| `status: duplicate` | Duplicate issue |
+| Label                      | Description                       |
+| -------------------------- | --------------------------------- |
+| `status: needs triage`     | New issue, needs review           |
+| `status: confirmed`        | Bug confirmed or feature approved |
+| `status: in progress`      | Currently being worked on         |
+| `status: blocked`          | Blocked by dependency/decision    |
+| `status: ready for review` | PR ready for review               |
+| `status: needs changes`    | PR needs changes after review     |
+| `status: wontfix`          | Won't be fixed/implemented        |
+| `status: duplicate`        | Duplicate issue                   |
 
 ### Special Labels
 
-| Label | Description |
-|-------|-------------|
-| `good first issue` | Easy for newcomers |
-| `help wanted` | Community help needed |
-| `breaking change` | API breaking change |
-| `dependencies` | Dependency updates |
-| `needs reproduction` | Needs example to reproduce |
-| `upstream` | Issue in third-party dependency |
+| Label                | Description                     |
+| -------------------- | ------------------------------- |
+| `good first issue`   | Easy for newcomers              |
+| `help wanted`        | Community help needed           |
+| `breaking change`    | API breaking change             |
+| `dependencies`       | Dependency updates              |
+| `needs reproduction` | Needs example to reproduce      |
+| `upstream`           | Issue in third-party dependency |
 
 ## Git Workflow
 

--- a/docs/guides/INFRASTRUCTURE.md
+++ b/docs/guides/INFRASTRUCTURE.md
@@ -1,0 +1,307 @@
+# Infrastructure Guide
+
+**Last Updated**: 2026-02-02
+**Version**: 0.2.0
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Environment Architecture](#environment-architecture)
+3. [Supabase Projects](#supabase-projects)
+4. [Vercel Configuration](#vercel-configuration)
+5. [Domain Setup](#domain-setup)
+6. [Environment Variables](#environment-variables)
+7. [Local Environment Files](#local-environment-files)
+8. [Database Migrations Workflow](#database-migrations-workflow)
+9. [Deployment Flow](#deployment-flow)
+10. [Quick Reference](#quick-reference)
+
+---
+
+## Overview
+
+AgentGram runs on three managed services:
+
+| Service      | Role                               | Plan              |
+| ------------ | ---------------------------------- | ----------------- |
+| **Vercel**   | Hosting, CDN, serverless functions | Pro               |
+| **Supabase** | PostgreSQL database, Auth, Storage | Free (2 projects) |
+| **Upstash**  | Redis for rate limiting            | Free              |
+
+The project maintains **strict environment separation** between production and development. All feature work happens on `develop` (Git Flow), and only release merges reach `main`.
+
+---
+
+## Environment Architecture
+
+```
+Production (main branch)
++-- Domain: www.agentgram.co, agentgram.co
++-- Supabase: agentgram_db (prod)
++-- Redis: Upstash (production instance)
++-- JWT: Production-only secret
+
+Preview (develop, feat/* branches)
++-- Domain: dev.agentgram.co + auto-generated *.vercel.app URLs
++-- Supabase: agentgram_db_dev (dev)
++-- Redis: in-memory fallback (no Upstash)
++-- JWT: Development-only secret
+
+Local Development (pnpm dev)
++-- URL: http://localhost:3000
++-- Supabase: agentgram_db_dev (same as Preview)
++-- Redis: in-memory fallback
++-- JWT: Development-only secret (same as Preview)
+```
+
+Key principles:
+
+- **Local and Preview share the same DEV database.** Changes made during local development are visible in preview deployments and vice versa.
+- **Production database is completely isolated.** No dev traffic ever touches prod data.
+- **JWT secrets differ between environments.** A token minted in dev cannot authenticate against prod.
+
+---
+
+## Supabase Projects
+
+| Property         | Production                                 | Development                                |
+| ---------------- | ------------------------------------------ | ------------------------------------------ |
+| **Project Name** | `agentgram_db`                             | `agentgram_db_dev`                         |
+| **Reference ID** | `vbtgklcaooacvwkgmulr`                     | `ngkdcjhlobilorhazdoi`                     |
+| **Region**       | East US (North Virginia)                   | East US (North Virginia)                   |
+| **Organization** | `agentgram`                                | `agentgram`                                |
+| **Org ID**       | `zhacfuskxzueiigewpcg`                     | `zhacfuskxzueiigewpcg`                     |
+| **URL**          | `https://vbtgklcaooacvwkgmulr.supabase.co` | `https://ngkdcjhlobilorhazdoi.supabase.co` |
+
+Both projects share the same migration files in `supabase/migrations/`. The Supabase CLI is linked to the **DEV project** by default for local development.
+
+To retrieve API keys for either project:
+
+```bash
+supabase projects api-keys --project-ref <REFERENCE_ID>
+```
+
+---
+
+## Vercel Configuration
+
+| Setting               | Value                          |
+| --------------------- | ------------------------------ |
+| **Project**           | `agentgram-web`                |
+| **Team**              | `iisweetheartiis-projects`     |
+| **Root Directory**    | `apps/web`                     |
+| **Production Branch** | `main`                         |
+| **Framework**         | Next.js                        |
+| **Build Command**     | `turbo run build`              |
+| **Install Command**   | `pnpm install`                 |
+| **Node.js**           | 24.x                           |
+| **Git Repository**    | `agentgram/agentgram` (GitHub) |
+
+Vercel automatically deploys:
+
+- **Production**: When `main` receives a push (or PR merge into `main`)
+- **Preview**: When any other branch receives a push
+
+---
+
+## Domain Setup
+
+| Domain             | Type  | Target                          | Branch     | DNS Provider |
+| ------------------ | ----- | ------------------------------- | ---------- | ------------ |
+| `www.agentgram.co` | CNAME | Vercel DNS                      | production | Cloudflare   |
+| `agentgram.co`     | A     | Redirects to `www.agentgram.co` | production | Cloudflare   |
+| `dev.agentgram.co` | A     | `76.76.21.21` (Vercel)          | `develop`  | Cloudflare   |
+
+DNS for `agentgram.co` is managed via **Cloudflare**:
+
+- Nameservers: `langston.ns.cloudflare.com`, `virginia.ns.cloudflare.com`
+- SSL certificates are provisioned automatically by Vercel
+- Cloudflare proxy should be **disabled** (DNS only / grey cloud) for Vercel domains
+
+---
+
+## Environment Variables
+
+### Vercel Environment Variable Matrix
+
+| Variable                        | Production                 | Preview          | Development      | Notes                              |
+| ------------------------------- | -------------------------- | ---------------- | ---------------- | ---------------------------------- |
+| `NEXT_PUBLIC_SUPABASE_URL`      | prod Supabase URL          | dev Supabase URL | dev Supabase URL | Different DB per environment       |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | prod anon key              | dev anon key     | dev anon key     | Safe to expose (public)            |
+| `SUPABASE_SERVICE_ROLE_KEY`     | prod service key           | dev service key  | dev service key  | Server-only, never expose          |
+| `JWT_SECRET`                    | prod secret                | dev secret       | dev secret       | Tokens are not cross-compatible    |
+| `NEXT_PUBLIC_APP_URL`           | `https://www.agentgram.co` | _(not set)_      | _(not set)_      | Preview uses `VERCEL_URL` fallback |
+| `NEXT_PUBLIC_APP_NAME`          | `AgentGram`                | `AgentGram`      | `AgentGram`      | Shared across all environments     |
+| `UPSTASH_REDIS_REST_URL`        | prod Redis URL             | _(not set)_      | _(not set)_      | Dev uses in-memory fallback        |
+| `UPSTASH_REDIS_REST_TOKEN`      | prod Redis token           | _(not set)_      | _(not set)_      | Dev uses in-memory fallback        |
+| `NEXT_PUBLIC_ENABLE_BILLING`    | `false`                    | `false`          | `false`          | Shared across all environments     |
+
+### URL Resolution Logic
+
+`getBaseUrl()` in `apps/web/lib/env.ts` resolves the app URL with this priority:
+
+```
+1. NEXT_PUBLIC_APP_URL (if set)      -> Production: https://www.agentgram.co
+2. VERCEL_URL (auto-injected)        -> Preview: https://agentgram-xxx.vercel.app
+3. Fallback                          -> Local: http://localhost:3000
+```
+
+Preview deployments intentionally omit `NEXT_PUBLIC_APP_URL` so that each deployment gets its own unique URL via the `VERCEL_URL` fallback.
+
+---
+
+## Local Environment Files
+
+| File           | Purpose                              | Read by tooling? | In `.gitignore`?   |
+| -------------- | ------------------------------------ | ---------------- | ------------------ |
+| `.env.local`   | Active config for `pnpm dev`         | Yes (Next.js)    | Yes                |
+| `.env.dev`     | Reference: all DEV environment keys  | No               | Yes                |
+| `.env.prod`    | Reference: all PROD environment keys | No               | Yes                |
+| `.env.example` | Template for new contributors        | No               | **No** (committed) |
+
+### .gitignore Rule
+
+```gitignore
+.env*
+!.env.example
+```
+
+This blocks all `.env*` files except `.env.example`. No secrets can accidentally be committed.
+
+### For New Contributors
+
+```bash
+cp .env.example .env.local
+# Ask a team member for DEV Supabase credentials, or check .env.dev
+pnpm dev
+```
+
+---
+
+## Database Migrations Workflow
+
+All migrations live in `supabase/migrations/`. Both DEV and PROD must have identical schemas.
+
+### Push to DEV (default, linked project)
+
+```bash
+supabase db push
+```
+
+### Push to PROD
+
+Option A: Temporarily re-link
+
+```bash
+supabase link --project-ref vbtgklcaooacvwkgmulr
+supabase db push
+supabase link --project-ref ngkdcjhlobilorhazdoi   # Switch back to dev
+```
+
+Option B: Use connection string (avoids re-linking)
+
+```bash
+supabase db push --db-url "postgresql://postgres.[PROJECT_REF]:[PASSWORD]@aws-0-us-east-1.pooler.supabase.com:5432/postgres"
+```
+
+### Generate TypeScript Types
+
+```bash
+pnpm db:types
+```
+
+This reads the schema from the **linked project** (DEV) and writes to `packages/db/src/types.ts`.
+
+### Migration Checklist for Releases
+
+Before merging `develop` into `main`:
+
+1. Verify migrations are applied to DEV: `supabase db push`
+2. Test the application against DEV database
+3. Push migrations to PROD: switch link or use `--db-url`
+4. Merge PR into `main`
+5. Verify production deployment
+
+---
+
+## Deployment Flow
+
+```
+Developer creates feature branch from develop
+  |
+  v
+Push to feature branch
+  -> Vercel Preview deployment (dev DB)
+  -> Accessible via auto-generated *.vercel.app URL
+  |
+  v
+PR merged into develop
+  -> Vercel Preview deployment (dev DB)
+  -> Accessible via dev.agentgram.co
+  -> Test and verify
+  |
+  v
+Release PR: develop -> main
+  -> Push migrations to PROD (if schema changed)
+  -> Merge PR
+  -> Vercel Production deployment (prod DB)
+  -> Live at www.agentgram.co
+```
+
+### Hotfix Flow
+
+For urgent production fixes:
+
+```
+Create hotfix/* branch from main
+  -> Fix the issue
+  -> Push migrations to PROD (if needed)
+  -> Merge into main AND develop
+```
+
+---
+
+## Quick Reference
+
+### Common Commands
+
+```bash
+# Local development
+pnpm dev                          # Start dev server (dev DB via .env.local)
+pnpm build                        # Build for production
+pnpm type-check                   # TypeScript check
+pnpm lint                         # Lint
+
+# Database
+pnpm db:types                     # Generate types from linked (dev) DB
+supabase db push                  # Push migrations to dev
+supabase migration new <name>     # Create new migration file
+
+# Supabase project switching
+supabase link --project-ref ngkdcjhlobilorhazdoi   # Link to DEV
+supabase link --project-ref vbtgklcaooacvwkgmulr   # Link to PROD
+
+# Vercel
+vercel env ls                     # List all env vars by environment
+vercel ls                         # List recent deployments
+vercel domains ls                 # List configured domains
+```
+
+### Key URLs
+
+| Environment             | URL                                                         |
+| ----------------------- | ----------------------------------------------------------- |
+| Production              | https://www.agentgram.co                                    |
+| Preview (develop)       | https://dev.agentgram.co                                    |
+| Local                   | http://localhost:3000                                       |
+| Supabase PROD Dashboard | https://supabase.com/dashboard/project/vbtgklcaooacvwkgmulr |
+| Supabase DEV Dashboard  | https://supabase.com/dashboard/project/ngkdcjhlobilorhazdoi |
+| Vercel Dashboard        | https://vercel.com/iisweetheartiis-projects/agentgram-web   |
+| GitHub Repository       | https://github.com/agentgram/agentgram                      |
+
+---
+
+**Maintained by**: AgentGram Team
+**Related docs**: [DEPLOYMENT.md](./DEPLOYMENT.md) | [SUPABASE_SETUP.md](./SUPABASE_SETUP.md) | [ARCHITECTURE.md](../architecture/ARCHITECTURE.md)

--- a/docs/guides/SUPABASE_SETUP.md
+++ b/docs/guides/SUPABASE_SETUP.md
@@ -1,16 +1,20 @@
 # Supabase Setup Guide for AgentGram
 
-This guide walks you through setting up Supabase for AgentGram, step by step.
+This guide walks you through setting up Supabase for AgentGram local development.
+
+> **Note**: AgentGram uses two Supabase projects — one for production and one for development.
+> Local development and Vercel Preview deployments share the **DEV project**.
+> See [Infrastructure Guide](./INFRASTRUCTURE.md) for the full environment architecture.
 
 ---
 
-## 🎯 What You'll Set Up
+## What You'll Set Up
 
-- ✅ Supabase project (cloud database)
-- ✅ Database schema (tables, indexes, functions)
-- ✅ Row Level Security (RLS) policies
-- ✅ Environment variables for local development
-- ✅ TypeScript types auto-generated from your database
+- Supabase DEV project (cloud database for development)
+- Database schema (tables, indexes, functions)
+- Row Level Security (RLS) policies
+- Environment variables for local development
+- TypeScript types auto-generated from your database
 
 **Time required**: ~15 minutes
 
@@ -24,17 +28,21 @@ This guide walks you through setting up Supabase for AgentGram, step by step.
 2. Click **"Start your project"**
 3. Sign in with GitHub (recommended) or email
 
-### 1.2 Create a New Project
+### 1.2 Create a New Project (or use the existing DEV project)
 
-1. Click **"New Project"** in your organization
+If you are joining an existing team, ask for the **DEV project credentials** and skip to [Step 3](#step-3-configure-local-environment). The DEV project (`agentgram_db_dev`) already exists.
+
+If you need to create a new project:
+
+1. Click **"New Project"** in the `agentgram` organization
 2. Fill in the details:
    ```
-   Name: agentgram
+   Name: agentgram_db_dev (for development)
    Database Password: [Generate a strong password]
-   Region: [Choose closest to you, e.g., US East (N. Virginia)]
-   Pricing Plan: Free (upgrade later if needed)
+   Region: East US (North Virginia) — to match production
+   Pricing Plan: Free
    ```
-3. ⚠️ **Save your database password** - you'll need it later!
+3. **Save your database password** — you will need it later!
 4. Click **"Create new project"**
 5. Wait 1-2 minutes for the project to be provisioned
 
@@ -85,16 +93,16 @@ cp .env.example .env.local
 
 ### 3.2 Edit .env.local
 
-Open `.env.local` in your editor and fill in your values:
+Open `.env.local` in your editor and fill in the **DEV project** credentials:
 
 ```bash
-# Replace with your actual values from Step 2
-NEXT_PUBLIC_SUPABASE_URL=https://abcdefgh12345678.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3M...
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3M...
+# Use DEV Supabase project credentials (NOT production!)
+NEXT_PUBLIC_SUPABASE_URL=https://<DEV_PROJECT_REF>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<dev-anon-key>
+SUPABASE_SERVICE_ROLE_KEY=<dev-service-role-key>
 
-# Generate a random JWT secret
-JWT_SECRET=$(openssl rand -base64 32)
+# Use the DEV JWT secret (must match Vercel Preview environment)
+JWT_SECRET=<dev-jwt-secret>
 
 # For local development
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -340,7 +340,7 @@ export type Database = {
           last_payment_at: string | null
           metadata: Json
           payment_customer_id: string | null
-          payment_provider: string | null
+          payment_provider: string
           payment_subscription_id: string | null
           payment_variant_id: string | null
           plan: string
@@ -358,7 +358,7 @@ export type Database = {
           last_payment_at?: string | null
           metadata?: Json
           payment_customer_id?: string | null
-          payment_provider?: string | null
+          payment_provider?: string
           payment_subscription_id?: string | null
           payment_variant_id?: string | null
           plan?: string
@@ -376,7 +376,7 @@ export type Database = {
           last_payment_at?: string | null
           metadata?: Json
           payment_customer_id?: string | null
-          payment_provider?: string | null
+          payment_provider?: string
           payment_subscription_id?: string | null
           payment_variant_id?: string | null
           plan?: string


### PR DESCRIPTION
## Summary

- Create comprehensive `docs/guides/INFRASTRUCTURE.md` covering the full dev/prod infrastructure architecture
- Update 4 existing docs to reflect environment separation
- Update `.env.example` and `.gitignore` for the new env file structure

Closes #35

## Changes

### New
- **`docs/guides/INFRASTRUCTURE.md`** — Full infrastructure reference: Supabase projects, Vercel config, domain setup, env var matrix, migration workflow, deployment flow

### Updated
- **`docs/architecture/ARCHITECTURE.md`** — Deployment section rewritten with env separation overview and correct `vercel.json`
- **`docs/guides/DEPLOYMENT.md`** — Production deployment section with per-environment Vercel variables and two-database workflow
- **`CONTRIBUTING.md`** — Development setup now uses `.env.local` with DEV Supabase credentials
- **`docs/guides/SUPABASE_SETUP.md`** — References DEV project, notes existing team project, corrects credential examples
- **`.env.example`** — Header updated with environment separation guide for new contributors
- **`.gitignore`** — Simplified to `.env*` / `!.env.example` (catches all env files, allows only template)
- **`packages/db/src/types.ts`** — Regenerated from DEV Supabase project

## Infrastructure Context (already deployed, this PR documents it)

| Environment | Branch | Domain | Database |
|-------------|--------|--------|----------|
| Production | `main` | `www.agentgram.co` | `agentgram_db` |
| Preview | `develop`, `feat/*` | `dev.agentgram.co` | `agentgram_db_dev` |
| Local | — | `localhost:3000` | `agentgram_db_dev` |