### PR TITLE
[FIX] Trim Upstash Redis env vars to prevent whitespace errors (#59)

### DIFF
--- a/packages/auth/src/ratelimit.ts
+++ b/packages/auth/src/ratelimit.ts
@@ -54,8 +54,8 @@ const RATE_LIMIT_CONFIGS: Record<string, RateLimitOptions> = {
   },
 };
 
-const upstashUrl = process.env.UPSTASH_REDIS_REST_URL;
-const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+const upstashUrl = process.env.UPSTASH_REDIS_REST_URL?.trim();
+const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN?.trim();
 
 export const redis =
   upstashUrl && upstashToken


### PR DESCRIPTION
## Description

Add `.trim()` to Upstash Redis environment variable reads to prevent build failures caused by trailing whitespace or newline characters in env var values.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `.trim()` to `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` in `packages/auth/src/ratelimit.ts`

## Related Issues

Closes #59

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings