### PR TITLE
Release v0.1.3: Fix Upstash Redis env var whitespace error

### DIFF
--- a/packages/auth/src/ratelimit.ts
+++ b/packages/auth/src/ratelimit.ts
@@ -54,8 +54,8 @@ const RATE_LIMIT_CONFIGS: Record<string, RateLimitOptions> = {
   },
 };
 
-const upstashUrl = process.env.UPSTASH_REDIS_REST_URL;
-const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+const upstashUrl = process.env.UPSTASH_REDIS_REST_URL?.trim();
+const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN?.trim();
 
 export const redis =
   upstashUrl && upstashToken


### PR DESCRIPTION
## Release v0.1.3

Production release merging `develop` → `main`.

## Changes (1 commit since v0.1.2)

### Bug Fixes
- **Upstash Redis env var trim** — Added `.trim()` to `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` reads to prevent build failures caused by trailing whitespace/newline in environment variables (#59, #60)

## Commits

| Commit | Description |
|--------|-------------|
| bd97a2d | fix: trim Upstash Redis env vars to prevent whitespace errors (#59) |

## Testing

- [x] All PRs passed CI (Lint & Build on Node 20/22)
- [x] No breaking changes
- [x] Vercel dashboard env vars also cleaned (manual)