### PR TITLE
[FIX] Billing webhook reliability and plan bypass security (#68)

### DIFF
--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket } from 'lucide-react';
 import { PricingCard } from '@/components/pricing';
@@ -76,13 +77,14 @@ const plans = [
 ];
 
 export default function PricingPage() {
+  const router = useRouter();
   const [billingPeriod, setBillingPeriod] = useState<'monthly' | 'annual'>(
     'monthly'
   );
 
   const handleSubscribe = async (planName: string) => {
     if (planName === 'Free') {
-      window.location.assign('/docs/quickstart');
+      router.push('/docs/quickstart');
       return;
     }
 
@@ -94,7 +96,7 @@ export default function PricingPage() {
     }
 
     if (!BILLING_ENABLED) {
-      window.location.assign('/docs/quickstart');
+      router.push('/docs/quickstart');
       return;
     }
 
@@ -112,7 +114,7 @@ export default function PricingPage() {
       if (data.success && data.data?.url) {
         window.location.assign(data.data.url);
       } else if (res.status === 401) {
-        window.location.assign('/auth/login?redirect=/pricing');
+        router.push('/auth/login?redirect=/pricing');
       } else {
         console.error('Checkout error:', data.error?.message);
       }

--- a/packages/auth/src/plan-limits.ts
+++ b/packages/auth/src/plan-limits.ts
@@ -65,7 +65,7 @@ export function withDailyPostLimit<T extends unknown[]>(
     if (!agentId) return handler(req, ...args);
 
     const plan = await resolveAgentPlan(agentId);
-    const limit = DAILY_POST_LIMITS[plan];
+    const limit = DAILY_POST_LIMITS[plan] ?? DAILY_POST_LIMITS.free;
 
     if (limit === -1) return handler(req, ...args);
 
@@ -98,7 +98,7 @@ export async function checkCommunityLimit(
   currentCount: number
 ): Promise<{ allowed: boolean; limit: number; plan: PlanName }> {
   const plan = await resolveAgentPlan(agentId);
-  const limit = COMMUNITY_LIMITS[plan];
+  const limit = COMMUNITY_LIMITS[plan] ?? COMMUNITY_LIMITS.free;
   if (limit === -1) return { allowed: true, limit, plan };
   return { allowed: currentCount < limit, limit, plan };
 }


### PR DESCRIPTION
## Description

Fixes critical billing reliability and security issues identified during Oracle code review. The webhook handler was silently swallowing DB errors (returning 200 to Lemon Squeezy, preventing retries), plan limits could be bypassed with invalid plan values, and the paywall middleware failed open when env vars were missing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

### Webhook Handler (`apps/web/app/api/v1/billing/webhook/route.ts`)
- Added `assertUpdate()` helper — throws on Supabase write failure → returns 500 so LS retries
- All 8 event handlers now use `assertUpdate()` instead of silent `console.error`
- Wrapped `JSON.parse(rawBody)` in try/catch → returns 400 on malformed payload
- Added `validateStoreId()` — rejects events from unexpected LS stores
- Added signature header length pre-validation

### Plan Limits (`packages/auth/src/plan-limits.ts`)
- `DAILY_POST_LIMITS[plan]` → `DAILY_POST_LIMITS[plan] ?? DAILY_POST_LIMITS.free` (prevents undefined bypass)
- Same fix for `COMMUNITY_LIMITS[plan]`

### Plan Gate (`packages/auth/src/plan-gate.ts`)
- `withPlan` returns 503 (fail-closed) when env vars missing, instead of calling handler directly
- DB plan value validated against `PLAN_HIERARCHY` before use
- Expired cache entries deleted on read

### Pricing Page (`apps/web/app/(public)/pricing/page.tsx`)
- Internal routes now use `router.push()` instead of `window.location.assign()`
- External URLs (LS checkout, mailto) still use `window.location.assign()`

## Related Issues

Closes #68

## Testing

- [x] Type check passes (`pnpm type-check`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual: send malformed JSON with valid sig → should return 400
- [ ] Manual: simulate DB failure → webhook should return 500
- [ ] Manual: set invalid plan in DB → post limit should default to free tier

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings