### PR TITLE
[FIX] Billing hardening: webhook ordering, duplicate subscriptions, role gating (#69)

### DIFF
--- a/packages/auth/src/plan-limits.ts
+++ b/packages/auth/src/plan-limits.ts
@@ -41,6 +41,10 @@ async function incrementDaily(
     }
   }
 
+  dailyCounters.forEach((v, k) => {
+    if (v.date !== today) dailyCounters.delete(k);
+  });
+
   const entry = dailyCounters.get(key);
   if (!entry || entry.date !== today) {
     dailyCounters.set(key, { count: 1, date: today });

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -4,727 +4,780 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[]
+  | Json[];
 
 export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "14.1"
-  }
+    PostgrestVersion: '14.1';
+  };
   graphql_public: {
     Tables: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       graphql: {
         Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
+          extensions?: Json;
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+        };
+        Returns: Json;
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       agent_claim_tokens: {
         Row: {
-          agent_id: string
-          created_at: string
-          expires_at: string
-          id: string
-          redeemed_at: string | null
-          redeemed_by_user_id: string | null
-          token_hash: string
-          token_prefix: string | null
-        }
+          agent_id: string;
+          created_at: string;
+          expires_at: string;
+          id: string;
+          redeemed_at: string | null;
+          redeemed_by_user_id: string | null;
+          token_hash: string;
+          token_prefix: string | null;
+        };
         Insert: {
-          agent_id: string
-          created_at?: string
-          expires_at: string
-          id?: string
-          redeemed_at?: string | null
-          redeemed_by_user_id?: string | null
-          token_hash: string
-          token_prefix?: string | null
-        }
+          agent_id: string;
+          created_at?: string;
+          expires_at: string;
+          id?: string;
+          redeemed_at?: string | null;
+          redeemed_by_user_id?: string | null;
+          token_hash: string;
+          token_prefix?: string | null;
+        };
         Update: {
-          agent_id?: string
-          created_at?: string
-          expires_at?: string
-          id?: string
-          redeemed_at?: string | null
-          redeemed_by_user_id?: string | null
-          token_hash?: string
-          token_prefix?: string | null
-        }
+          agent_id?: string;
+          created_at?: string;
+          expires_at?: string;
+          id?: string;
+          redeemed_at?: string | null;
+          redeemed_by_user_id?: string | null;
+          token_hash?: string;
+          token_prefix?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "agent_claim_tokens_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'agent_claim_tokens_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       agents: {
         Row: {
-          avatar_url: string | null
-          created_at: string | null
-          description: string | null
-          developer_id: string | null
-          display_name: string | null
-          email: string | null
-          email_verified: boolean | null
-          id: string
-          karma: number | null
-          last_active: string | null
-          metadata: Json | null
-          name: string
-          public_key: string | null
-          status: string | null
-          trust_score: number | null
-          updated_at: string | null
-        }
+          avatar_url: string | null;
+          created_at: string | null;
+          description: string | null;
+          developer_id: string | null;
+          display_name: string | null;
+          email: string | null;
+          email_verified: boolean | null;
+          id: string;
+          karma: number | null;
+          last_active: string | null;
+          metadata: Json | null;
+          name: string;
+          public_key: string | null;
+          status: string | null;
+          trust_score: number | null;
+          updated_at: string | null;
+        };
         Insert: {
-          avatar_url?: string | null
-          created_at?: string | null
-          description?: string | null
-          developer_id?: string | null
-          display_name?: string | null
-          email?: string | null
-          email_verified?: boolean | null
-          id?: string
-          karma?: number | null
-          last_active?: string | null
-          metadata?: Json | null
-          name: string
-          public_key?: string | null
-          status?: string | null
-          trust_score?: number | null
-          updated_at?: string | null
-        }
+          avatar_url?: string | null;
+          created_at?: string | null;
+          description?: string | null;
+          developer_id?: string | null;
+          display_name?: string | null;
+          email?: string | null;
+          email_verified?: boolean | null;
+          id?: string;
+          karma?: number | null;
+          last_active?: string | null;
+          metadata?: Json | null;
+          name: string;
+          public_key?: string | null;
+          status?: string | null;
+          trust_score?: number | null;
+          updated_at?: string | null;
+        };
         Update: {
-          avatar_url?: string | null
-          created_at?: string | null
-          description?: string | null
-          developer_id?: string | null
-          display_name?: string | null
-          email?: string | null
-          email_verified?: boolean | null
-          id?: string
-          karma?: number | null
-          last_active?: string | null
-          metadata?: Json | null
-          name?: string
-          public_key?: string | null
-          status?: string | null
-          trust_score?: number | null
-          updated_at?: string | null
-        }
+          avatar_url?: string | null;
+          created_at?: string | null;
+          description?: string | null;
+          developer_id?: string | null;
+          display_name?: string | null;
+          email?: string | null;
+          email_verified?: boolean | null;
+          id?: string;
+          karma?: number | null;
+          last_active?: string | null;
+          metadata?: Json | null;
+          name?: string;
+          public_key?: string | null;
+          status?: string | null;
+          trust_score?: number | null;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "agents_developer_id_fkey"
-            columns: ["developer_id"]
-            isOneToOne: false
-            referencedRelation: "developers"
-            referencedColumns: ["id"]
+            foreignKeyName: 'agents_developer_id_fkey';
+            columns: ['developer_id'];
+            isOneToOne: false;
+            referencedRelation: 'developers';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       api_keys: {
         Row: {
-          agent_id: string | null
-          created_at: string | null
-          expires_at: string | null
-          id: string
-          key_hash: string
-          key_prefix: string | null
-          last_used: string | null
-          name: string | null
-          permissions: Json | null
-        }
+          agent_id: string | null;
+          created_at: string | null;
+          expires_at: string | null;
+          id: string;
+          key_hash: string;
+          key_prefix: string | null;
+          last_used: string | null;
+          name: string | null;
+          permissions: Json | null;
+        };
         Insert: {
-          agent_id?: string | null
-          created_at?: string | null
-          expires_at?: string | null
-          id?: string
-          key_hash: string
-          key_prefix?: string | null
-          last_used?: string | null
-          name?: string | null
-          permissions?: Json | null
-        }
+          agent_id?: string | null;
+          created_at?: string | null;
+          expires_at?: string | null;
+          id?: string;
+          key_hash: string;
+          key_prefix?: string | null;
+          last_used?: string | null;
+          name?: string | null;
+          permissions?: Json | null;
+        };
         Update: {
-          agent_id?: string | null
-          created_at?: string | null
-          expires_at?: string | null
-          id?: string
-          key_hash?: string
-          key_prefix?: string | null
-          last_used?: string | null
-          name?: string | null
-          permissions?: Json | null
-        }
+          agent_id?: string | null;
+          created_at?: string | null;
+          expires_at?: string | null;
+          id?: string;
+          key_hash?: string;
+          key_prefix?: string | null;
+          last_used?: string | null;
+          name?: string | null;
+          permissions?: Json | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "api_keys_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'api_keys_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       comments: {
         Row: {
-          author_id: string | null
-          content: string
-          created_at: string | null
-          depth: number | null
-          downvotes: number | null
-          id: string
-          parent_id: string | null
-          post_id: string | null
-          updated_at: string | null
-          upvotes: number | null
-        }
+          author_id: string | null;
+          content: string;
+          created_at: string | null;
+          depth: number | null;
+          downvotes: number | null;
+          id: string;
+          parent_id: string | null;
+          post_id: string | null;
+          updated_at: string | null;
+          upvotes: number | null;
+        };
         Insert: {
-          author_id?: string | null
-          content: string
-          created_at?: string | null
-          depth?: number | null
-          downvotes?: number | null
-          id?: string
-          parent_id?: string | null
-          post_id?: string | null
-          updated_at?: string | null
-          upvotes?: number | null
-        }
+          author_id?: string | null;
+          content: string;
+          created_at?: string | null;
+          depth?: number | null;
+          downvotes?: number | null;
+          id?: string;
+          parent_id?: string | null;
+          post_id?: string | null;
+          updated_at?: string | null;
+          upvotes?: number | null;
+        };
         Update: {
-          author_id?: string | null
-          content?: string
-          created_at?: string | null
-          depth?: number | null
-          downvotes?: number | null
-          id?: string
-          parent_id?: string | null
-          post_id?: string | null
-          updated_at?: string | null
-          upvotes?: number | null
-        }
+          author_id?: string | null;
+          content?: string;
+          created_at?: string | null;
+          depth?: number | null;
+          downvotes?: number | null;
+          id?: string;
+          parent_id?: string | null;
+          post_id?: string | null;
+          updated_at?: string | null;
+          upvotes?: number | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "comments_author_id_fkey"
-            columns: ["author_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'comments_author_id_fkey';
+            columns: ['author_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "comments_parent_id_fkey"
-            columns: ["parent_id"]
-            isOneToOne: false
-            referencedRelation: "comments"
-            referencedColumns: ["id"]
+            foreignKeyName: 'comments_parent_id_fkey';
+            columns: ['parent_id'];
+            isOneToOne: false;
+            referencedRelation: 'comments';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "comments_post_id_fkey"
-            columns: ["post_id"]
-            isOneToOne: false
-            referencedRelation: "posts"
-            referencedColumns: ["id"]
+            foreignKeyName: 'comments_post_id_fkey';
+            columns: ['post_id'];
+            isOneToOne: false;
+            referencedRelation: 'posts';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       communities: {
         Row: {
-          created_at: string | null
-          creator_id: string | null
-          description: string | null
-          display_name: string
-          id: string
-          is_default: boolean | null
-          member_count: number | null
-          name: string
-          post_count: number | null
-          rules: string | null
-        }
+          created_at: string | null;
+          creator_id: string | null;
+          description: string | null;
+          display_name: string;
+          id: string;
+          is_default: boolean | null;
+          member_count: number | null;
+          name: string;
+          post_count: number | null;
+          rules: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          creator_id?: string | null
-          description?: string | null
-          display_name: string
-          id?: string
-          is_default?: boolean | null
-          member_count?: number | null
-          name: string
-          post_count?: number | null
-          rules?: string | null
-        }
+          created_at?: string | null;
+          creator_id?: string | null;
+          description?: string | null;
+          display_name: string;
+          id?: string;
+          is_default?: boolean | null;
+          member_count?: number | null;
+          name: string;
+          post_count?: number | null;
+          rules?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          creator_id?: string | null
-          description?: string | null
-          display_name?: string
-          id?: string
-          is_default?: boolean | null
-          member_count?: number | null
-          name?: string
-          post_count?: number | null
-          rules?: string | null
-        }
+          created_at?: string | null;
+          creator_id?: string | null;
+          description?: string | null;
+          display_name?: string;
+          id?: string;
+          is_default?: boolean | null;
+          member_count?: number | null;
+          name?: string;
+          post_count?: number | null;
+          rules?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "communities_creator_id_fkey"
-            columns: ["creator_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'communities_creator_id_fkey';
+            columns: ['creator_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       developer_members: {
         Row: {
-          created_at: string
-          developer_id: string
-          id: string
-          role: string
-          user_id: string
-        }
+          created_at: string;
+          developer_id: string;
+          id: string;
+          role: string;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string
-          developer_id: string
-          id?: string
-          role?: string
-          user_id: string
-        }
+          created_at?: string;
+          developer_id: string;
+          id?: string;
+          role?: string;
+          user_id: string;
+        };
         Update: {
-          created_at?: string
-          developer_id?: string
-          id?: string
-          role?: string
-          user_id?: string
-        }
+          created_at?: string;
+          developer_id?: string;
+          id?: string;
+          role?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "developer_members_developer_id_fkey"
-            columns: ["developer_id"]
-            isOneToOne: false
-            referencedRelation: "developers"
-            referencedColumns: ["id"]
+            foreignKeyName: 'developer_members_developer_id_fkey';
+            columns: ['developer_id'];
+            isOneToOne: false;
+            referencedRelation: 'developers';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       developers: {
         Row: {
-          billing_email: string | null
-          created_at: string
-          current_period_end: string | null
-          display_name: string | null
-          id: string
-          kind: string
-          last_payment_at: string | null
-          metadata: Json
-          payment_customer_id: string | null
-          payment_provider: string
-          payment_subscription_id: string | null
-          payment_variant_id: string | null
-          plan: string
-          status: string
-          subscription_status: string
-          updated_at: string
-        }
+          billing_email: string | null;
+          billing_last_event_at: string | null;
+          created_at: string;
+          current_period_end: string | null;
+          display_name: string | null;
+          id: string;
+          kind: string;
+          last_payment_at: string | null;
+          metadata: Json;
+          payment_customer_id: string | null;
+          payment_provider: string;
+          payment_subscription_id: string | null;
+          payment_variant_id: string | null;
+          plan: string;
+          status: string;
+          subscription_status: string;
+          updated_at: string;
+        };
         Insert: {
-          billing_email?: string | null
-          created_at?: string
-          current_period_end?: string | null
-          display_name?: string | null
-          id?: string
-          kind?: string
-          last_payment_at?: string | null
-          metadata?: Json
-          payment_customer_id?: string | null
-          payment_provider?: string
-          payment_subscription_id?: string | null
-          payment_variant_id?: string | null
-          plan?: string
-          status?: string
-          subscription_status?: string
-          updated_at?: string
-        }
+          billing_email?: string | null;
+          billing_last_event_at?: string | null;
+          created_at?: string;
+          current_period_end?: string | null;
+          display_name?: string | null;
+          id?: string;
+          kind?: string;
+          last_payment_at?: string | null;
+          metadata?: Json;
+          payment_customer_id?: string | null;
+          payment_provider?: string;
+          payment_subscription_id?: string | null;
+          payment_variant_id?: string | null;
+          plan?: string;
+          status?: string;
+          subscription_status?: string;
+          updated_at?: string;
+        };
         Update: {
-          billing_email?: string | null
-          created_at?: string
-          current_period_end?: string | null
-          display_name?: string | null
-          id?: string
-          kind?: string
-          last_payment_at?: string | null
-          metadata?: Json
-          payment_customer_id?: string | null
-          payment_provider?: string
-          payment_subscription_id?: string | null
-          payment_variant_id?: string | null
-          plan?: string
-          status?: string
-          subscription_status?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
+          billing_email?: string | null;
+          billing_last_event_at?: string | null;
+          created_at?: string;
+          current_period_end?: string | null;
+          display_name?: string | null;
+          id?: string;
+          kind?: string;
+          last_payment_at?: string | null;
+          metadata?: Json;
+          payment_customer_id?: string | null;
+          payment_provider?: string;
+          payment_subscription_id?: string | null;
+          payment_variant_id?: string | null;
+          plan?: string;
+          status?: string;
+          subscription_status?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       follows: {
         Row: {
-          created_at: string | null
-          follower_id: string
-          following_id: string
-        }
+          created_at: string | null;
+          follower_id: string;
+          following_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          follower_id: string
-          following_id: string
-        }
+          created_at?: string | null;
+          follower_id: string;
+          following_id: string;
+        };
         Update: {
-          created_at?: string | null
-          follower_id?: string
-          following_id?: string
-        }
+          created_at?: string | null;
+          follower_id?: string;
+          following_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "follows_follower_id_fkey"
-            columns: ["follower_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'follows_follower_id_fkey';
+            columns: ['follower_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "follows_following_id_fkey"
-            columns: ["following_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'follows_following_id_fkey';
+            columns: ['following_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       posts: {
         Row: {
-          author_id: string | null
-          comment_count: number | null
-          community_id: string | null
-          content: string | null
-          created_at: string | null
-          downvotes: number | null
-          embedding: string | null
-          id: string
-          metadata: Json | null
-          post_type: string | null
-          score: number | null
-          title: string
-          updated_at: string | null
-          upvotes: number | null
-          url: string | null
-        }
+          author_id: string | null;
+          comment_count: number | null;
+          community_id: string | null;
+          content: string | null;
+          created_at: string | null;
+          downvotes: number | null;
+          embedding: string | null;
+          id: string;
+          metadata: Json | null;
+          post_type: string | null;
+          score: number | null;
+          title: string;
+          updated_at: string | null;
+          upvotes: number | null;
+          url: string | null;
+        };
         Insert: {
-          author_id?: string | null
-          comment_count?: number | null
-          community_id?: string | null
-          content?: string | null
-          created_at?: string | null
-          downvotes?: number | null
-          embedding?: string | null
-          id?: string
-          metadata?: Json | null
-          post_type?: string | null
-          score?: number | null
-          title: string
-          updated_at?: string | null
-          upvotes?: number | null
-          url?: string | null
-        }
+          author_id?: string | null;
+          comment_count?: number | null;
+          community_id?: string | null;
+          content?: string | null;
+          created_at?: string | null;
+          downvotes?: number | null;
+          embedding?: string | null;
+          id?: string;
+          metadata?: Json | null;
+          post_type?: string | null;
+          score?: number | null;
+          title: string;
+          updated_at?: string | null;
+          upvotes?: number | null;
+          url?: string | null;
+        };
         Update: {
-          author_id?: string | null
-          comment_count?: number | null
-          community_id?: string | null
-          content?: string | null
-          created_at?: string | null
-          downvotes?: number | null
-          embedding?: string | null
-          id?: string
-          metadata?: Json | null
-          post_type?: string | null
-          score?: number | null
-          title?: string
-          updated_at?: string | null
-          upvotes?: number | null
-          url?: string | null
-        }
+          author_id?: string | null;
+          comment_count?: number | null;
+          community_id?: string | null;
+          content?: string | null;
+          created_at?: string | null;
+          downvotes?: number | null;
+          embedding?: string | null;
+          id?: string;
+          metadata?: Json | null;
+          post_type?: string | null;
+          score?: number | null;
+          title?: string;
+          updated_at?: string | null;
+          upvotes?: number | null;
+          url?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "posts_author_id_fkey"
-            columns: ["author_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'posts_author_id_fkey';
+            columns: ['author_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "posts_community_id_fkey"
-            columns: ["community_id"]
-            isOneToOne: false
-            referencedRelation: "communities"
-            referencedColumns: ["id"]
+            foreignKeyName: 'posts_community_id_fkey';
+            columns: ['community_id'];
+            isOneToOne: false;
+            referencedRelation: 'communities';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       rate_limits: {
         Row: {
-          action: string
-          agent_id: string | null
-          count: number | null
-          id: string
-          window_start: string | null
-        }
+          action: string;
+          agent_id: string | null;
+          count: number | null;
+          id: string;
+          window_start: string | null;
+        };
         Insert: {
-          action: string
-          agent_id?: string | null
-          count?: number | null
-          id?: string
-          window_start?: string | null
-        }
+          action: string;
+          agent_id?: string | null;
+          count?: number | null;
+          id?: string;
+          window_start?: string | null;
+        };
         Update: {
-          action?: string
-          agent_id?: string | null
-          count?: number | null
-          id?: string
-          window_start?: string | null
-        }
+          action?: string;
+          agent_id?: string | null;
+          count?: number | null;
+          id?: string;
+          window_start?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "rate_limits_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'rate_limits_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       subscriptions: {
         Row: {
-          agent_id: string
-          community_id: string
-          created_at: string | null
-        }
+          agent_id: string;
+          community_id: string;
+          created_at: string | null;
+        };
         Insert: {
-          agent_id: string
-          community_id: string
-          created_at?: string | null
-        }
+          agent_id: string;
+          community_id: string;
+          created_at?: string | null;
+        };
         Update: {
-          agent_id?: string
-          community_id?: string
-          created_at?: string | null
-        }
+          agent_id?: string;
+          community_id?: string;
+          created_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "subscriptions_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'subscriptions_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "subscriptions_community_id_fkey"
-            columns: ["community_id"]
-            isOneToOne: false
-            referencedRelation: "communities"
-            referencedColumns: ["id"]
+            foreignKeyName: 'subscriptions_community_id_fkey';
+            columns: ['community_id'];
+            isOneToOne: false;
+            referencedRelation: 'communities';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
+      webhook_events: {
+        Row: {
+          id: string;
+          event_name: string;
+          subscription_id: string | null;
+          developer_id: string | null;
+          payload: Json;
+          processed_at: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          event_name: string;
+          subscription_id?: string | null;
+          developer_id?: string | null;
+          payload?: Json;
+          processed_at?: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          event_name?: string;
+          subscription_id?: string | null;
+          developer_id?: string | null;
+          payload?: Json;
+          processed_at?: string;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'webhook_events_developer_id_fkey';
+            columns: ['developer_id'];
+            isOneToOne: false;
+            referencedRelation: 'developers';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       votes: {
         Row: {
-          agent_id: string | null
-          created_at: string | null
-          id: string
-          target_id: string
-          target_type: string
-          vote_type: number
-        }
+          agent_id: string | null;
+          created_at: string | null;
+          id: string;
+          target_id: string;
+          target_type: string;
+          vote_type: number;
+        };
         Insert: {
-          agent_id?: string | null
-          created_at?: string | null
-          id?: string
-          target_id: string
-          target_type: string
-          vote_type: number
-        }
+          agent_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          target_id: string;
+          target_type: string;
+          vote_type: number;
+        };
         Update: {
-          agent_id?: string | null
-          created_at?: string | null
-          id?: string
-          target_id?: string
-          target_type?: string
-          vote_type?: number
-        }
+          agent_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          target_id?: string;
+          target_type?: string;
+          vote_type?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "votes_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'votes_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
-      change_vote_to_downvote: { Args: { post_id: string }; Returns: undefined }
-      change_vote_to_upvote: { Args: { post_id: string }; Returns: undefined }
-      decrement_post_downvote: { Args: { post_id: string }; Returns: undefined }
-      decrement_post_upvote: { Args: { post_id: string }; Returns: undefined }
-      increment_post_downvote: { Args: { post_id: string }; Returns: undefined }
-      increment_post_upvote: { Args: { post_id: string }; Returns: undefined }
-    }
+      change_vote_to_downvote: {
+        Args: { post_id: string };
+        Returns: undefined;
+      };
+      change_vote_to_upvote: { Args: { post_id: string }; Returns: undefined };
+      decrement_post_downvote: {
+        Args: { post_id: string };
+        Returns: undefined;
+      };
+      decrement_post_upvote: { Args: { post_id: string }; Returns: undefined };
+      increment_post_downvote: {
+        Args: { post_id: string };
+        Returns: undefined;
+      };
+      increment_post_upvote: { Args: { post_id: string }; Returns: undefined };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<
+  keyof Database,
+  'public'
+>];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+      Row: infer R;
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])
+    ? (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Insert: infer I;
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Update: infer U;
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
+    | keyof DefaultSchema['Enums']
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
+    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+    : never;
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
+    | keyof DefaultSchema['CompositeTypes']
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
+    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+    : never;
 
 export const Constants = {
   graphql_public: {
@@ -733,4 +786,4 @@ export const Constants = {
   public: {
     Enums: {},
   },
-} as const
+} as const;

--- a/supabase/migrations/20260203010000_add_billing_last_event_at.sql
+++ b/supabase/migrations/20260203010000_add_billing_last_event_at.sql
@@ -1,0 +1,10 @@
+-- Add billing_last_event_at column to developers table.
+-- Used for monotonic webhook event ordering: only apply updates
+-- where the incoming event's updated_at is newer than the stored value.
+-- Prevents out-of-order or replayed events from regressing billing state.
+
+ALTER TABLE developers
+  ADD COLUMN billing_last_event_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN developers.billing_last_event_at
+  IS 'Timestamp of the last processed webhook event. Used to enforce monotonic ordering and reject stale/replayed events.';


### PR DESCRIPTION
## Description

Implements billing system hardening identified in Oracle code review. Adds monotonic webhook event ordering to prevent state regression from out-of-order events, blocks duplicate subscription creation, restricts billing operations to account owners/admins, and fixes in-memory counter memory leaks.

> **Depends on**: #74 (must merge first). This branch is based on `fix/billing-webhook-reliability-#68`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Changes Made

### Migration (`supabase/migrations/20260203010000_add_billing_last_event_at.sql`)
- Adds `billing_last_event_at TIMESTAMPTZ` column to `developers` table
- Used for monotonic webhook ordering — rejects stale/replayed events

### Webhook Handler (`apps/web/app/api/v1/billing/webhook/route.ts`)
- Added `monotonicFilter()` — PostgREST filter that only applies updates when `attrs.updated_at > billing_last_event_at`
- All 8 handlers now include `billing_last_event_at` in update payload and use the monotonic filter
- Prevents out-of-order events from regressing billing state (e.g., stale `subscription_updated` after `subscription_expired`)

### Checkout Route (`apps/web/app/api/v1/billing/checkout/route.ts`)
- **Duplicate subscription prevention**: blocks checkout when `payment_subscription_id` is non-null (was only checking `active` status — missed `past_due`/`paused`)
- **Role gating**: restricts to `owner`/`admin` via `x-developer-role` header (set by `withDeveloperAuth`)

### Portal Route (`apps/web/app/api/v1/billing/portal/route.ts`)
- **Role gating**: same `owner`/`admin` restriction as checkout

### Plan Limits (`packages/auth/src/plan-limits.ts`)
- **Memory leak fix**: `dailyCounters` Map now prunes entries from previous dates on each call to `incrementDaily()`

### DB Types (`packages/db/src/types.ts`)
- Added `billing_last_event_at` to `developers` type
- Added `webhook_events` table type (was missing since #67)

## Related Issues

Closes #69

## Testing

- [x] Type check passes (`pnpm type-check`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual: send out-of-order webhook events → only newer events should apply
- [ ] Manual: attempt checkout with `past_due` subscription → should be blocked
- [ ] Manual: non-owner member attempts checkout → should get 403

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings