### PR TITLE
[REFACTOR] Remove unnecessary getBaseUrl() from client-side hooks (#88)

### DIFF
--- a/apps/web/hooks/use-comments.ts
+++ b/apps/web/hooks/use-comments.ts
@@ -2,7 +2,6 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getSupabaseBrowser } from '@/lib/supabase-browser';
-import { getBaseUrl } from '@/lib/env';
 import type { Comment, CreateComment } from '@agentgram/shared';
 import { transformAuthor } from './transform';
 
@@ -82,8 +81,7 @@ export function useCreateComment(postId: string) {
 
   return useMutation({
     mutationFn: async (commentData: CreateComment) => {
-      const baseUrl = getBaseUrl();
-      const res = await fetch(`${baseUrl}/api/v1/posts/${postId}/comments`, {
+      const res = await fetch(`/api/v1/posts/${postId}/comments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(commentData),

--- a/apps/web/hooks/use-posts.ts
+++ b/apps/web/hooks/use-posts.ts
@@ -7,7 +7,6 @@ import {
   useInfiniteQuery,
 } from '@tanstack/react-query';
 import { getSupabaseBrowser } from '@/lib/supabase-browser';
-import { getBaseUrl } from '@/lib/env';
 import type {
   Post,
   CreatePost,
@@ -177,8 +176,7 @@ export function useCreatePost() {
 
   return useMutation({
     mutationFn: async (postData: CreatePost) => {
-      const baseUrl = getBaseUrl();
-      const res = await fetch(`${baseUrl}/api/v1/posts`, {
+      const res = await fetch(`/api/v1/posts`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(postData),
@@ -210,8 +208,7 @@ export function useVote(postId: string) {
 
   return useMutation({
     mutationFn: async ({ voteType }: { voteType: 'upvote' | 'downvote' }) => {
-      const baseUrl = getBaseUrl();
-      const res = await fetch(`${baseUrl}/api/v1/posts/${postId}/${voteType}`, {
+      const res = await fetch(`/api/v1/posts/${postId}/${voteType}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
       });


### PR DESCRIPTION
## Description

Remove `getBaseUrl()` usage from client-side React hooks (`use-posts.ts`, `use-comments.ts`). Browser `fetch()` calls resolve relative paths against the current origin automatically, making `getBaseUrl()` unnecessary in client-side mutation hooks.

## Type of Change

- [ ] 🐛 Bug fix (`type: bug`)
- [ ] ✨ New feature (`type: feature`)
- [ ] 🔧 Enhancement (`type: enhancement`)
- [ ] 📚 Documentation (`type: documentation`)
- [x] ♻️ Refactor (`type: refactor`)
- [ ] ⚡ Performance (`type: performance`)
- [ ] 🔒 Security (`type: security`)

## Area

- [ ] 🔧 Backend (`area: backend`)
- [x] 🎨 Frontend (`area: frontend`)
- [ ] 🤖 Agent SDK (`area: agent-sdk`)
- [ ] 💾 Database (`area: database`)
- [ ] 🔐 Authentication (`area: auth`)
- [ ] 🔍 Search (`area: search`)
- [ ] 🏗️ Infrastructure (`area: infrastructure`)
- [ ] 🧪 Testing (`area: testing`)

## Changes Made

- Remove `getBaseUrl()` import and usage from `useCreatePost` and `useVote` mutations in `use-posts.ts`
- Remove `getBaseUrl()` import and usage from `useCreateComment` mutation in `use-comments.ts`
- Replace absolute URLs (`${baseUrl}/api/v1/...`) with relative paths (`/api/v1/...`)

## Related Issues

Closes #88

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] E2E tests added/updated

### Test Steps

1. Create a post → verify fetch goes to `/api/v1/posts`
2. Vote on a post → verify fetch goes to `/api/v1/posts/:id/:voteType`
3. Create a comment → verify fetch goes to `/api/v1/posts/:id/comments`

## Breaking Changes

- [x] ✅ No breaking changes

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] `pnpm type-check` passes