### PR TITLE
[FEAT] Migrate from upvote/downvote to like system (#94)

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,6 +17,11 @@ export type {
   VoteInsert,
   Subscription,
   Follow,
+  LikeResult,
   VoteResult,
 } from './helpers';
-export { handlePostUpvote, handlePostDownvote } from './helpers';
+export {
+  handlePostLike,
+  handlePostUpvote,
+  handlePostDownvote,
+} from './helpers';

--- a/supabase/migrations/20260203000001_like_system_migration.sql
+++ b/supabase/migrations/20260203000001_like_system_migration.sql
@@ -1,0 +1,34 @@
+-- Step 1: Add new columns to posts
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS likes INTEGER DEFAULT 0;
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS post_kind VARCHAR(20) DEFAULT 'post';
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+
+-- Step 2: Backfill likes from upvotes
+UPDATE posts SET likes = upvotes WHERE likes = 0 AND upvotes > 0;
+
+-- Step 3: Create new atomic functions for likes
+CREATE OR REPLACE FUNCTION increment_post_like(p_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  UPDATE posts SET likes = likes + 1 WHERE id = p_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION decrement_post_like(p_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  UPDATE posts SET likes = GREATEST(0, likes - 1) WHERE id = p_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Step 4: Update ranking trigger to engagement-based
+CREATE OR REPLACE FUNCTION update_post_score()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.score := (
+    (NEW.likes + COALESCE(NEW.comment_count, 0) * 2) /
+    POWER((EXTRACT(EPOCH FROM (NOW() - NEW.created_at)) / 3600) + 2, 1.5)
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

Transitions the database and helpers from Reddit-style upvote/downvote to Instagram-style single like toggle, as part of the Instagram pivot Phase 1.

## Type of Change

- [x] New feature (additive migration — old columns preserved for backward compat)

## Changes Made

- **SQL migration**: adds `likes`, `post_kind`, `expires_at` columns to posts; backfills likes from upvotes; creates `increment_post_like`/`decrement_post_like` atomic functions; updates ranking trigger to engagement-based `(likes + comments*2) / time^1.5`
- **`packages/db/src/helpers.ts`**: new `handlePostLike` toggle function with `LikeResult` interface; old `handlePostUpvote`/`handlePostDownvote` deprecated as wrappers
- **`packages/db/src/index.ts`**: exports `handlePostLike` and `LikeResult`

## Related Issues

Closes #94

## Testing

- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [ ] Build has pre-existing SSG error on /agents page (unrelated to this PR)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] Old columns (upvotes/downvotes) preserved — dropped in #99
- [x] Old functions preserved — dropped in #99
- [x] My changes generate no new warnings