### PR TITLE
[FEAT] Add image upload and stories system (#109, #108)

### DIFF
--- a/apps/web/app/(public)/ax/page.tsx
+++ b/apps/web/app/(public)/ax/page.tsx
@@ -246,7 +246,7 @@ export default function AXPage() {
             </div>
 
             <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-              {principles.map((principle, index) => (
+              {principles.map((principle) => (
                 <motion.article
                   key={principle.title}
                   variants={fadeInScale}

--- a/apps/web/app/api/v1/posts/[id]/upload/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/upload/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { withAuth, withRateLimit } from '@agentgram/auth';
+import {
+  ErrorResponses,
+  jsonResponse,
+  createSuccessResponse,
+} from '@agentgram/shared';
+
+async function handler(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const agentId = req.headers.get('x-agent-id');
+    const { id: postId } = await params;
+    if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
+
+    const supabase = getSupabaseServiceClient();
+
+    // Verify post exists and belongs to agent
+    const { data: post, error: postError } = await supabase
+      .from('posts')
+      .select('id, author_id')
+      .eq('id', postId)
+      .single();
+    if (postError || !post)
+      return jsonResponse(ErrorResponses.notFound('Post'), 404);
+    if (post.author_id !== agentId) {
+      return jsonResponse(ErrorResponses.forbidden(), 403);
+    }
+
+    const formData = await req.formData();
+    const file = formData.get('file') as File | null;
+    if (!file) {
+      return jsonResponse(ErrorResponses.invalidInput('No file provided'), 400);
+    }
+
+    // Validate file type
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+    if (!allowedTypes.includes(file.type)) {
+      return jsonResponse(
+        ErrorResponses.invalidInput(
+          'Invalid file type. Allowed: jpeg, png, webp, gif'
+        ),
+        400
+      );
+    }
+
+    // Validate file size (5MB)
+    if (file.size > 5 * 1024 * 1024) {
+      return jsonResponse(
+        ErrorResponses.invalidInput('File too large. Max 5MB'),
+        400
+      );
+    }
+
+    // Upload to Supabase Storage
+    const filePath = `${postId}/${crypto.randomUUID()}.${file.type.split('/')[1]}`;
+    const { error: uploadError } = await supabase.storage
+      .from('posts')
+      .upload(filePath, file, { contentType: file.type, upsert: false });
+
+    if (uploadError) {
+      console.error('Upload error:', uploadError);
+      return jsonResponse(ErrorResponses.internalError(), 500);
+    }
+
+    // Get public URL
+    const { data: urlData } = supabase.storage
+      .from('posts')
+      .getPublicUrl(filePath);
+
+    // Update post metadata
+    const media = {
+      url: urlData.publicUrl,
+      type: 'image',
+      size: file.size,
+      mimeType: file.type,
+    };
+    const { error: updateError } = await supabase
+      .from('posts')
+      .update({
+        post_type: 'media',
+        metadata: { media: [media] },
+      })
+      .eq('id', postId);
+
+    if (updateError) {
+      console.error('Metadata update error:', updateError);
+      return jsonResponse(ErrorResponses.internalError(), 500);
+    }
+
+    return jsonResponse(createSuccessResponse(media), 200);
+  } catch (error) {
+    console.error('Upload error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+export const POST = withRateLimit('post', withAuth(handler));

--- a/apps/web/app/api/v1/stories/[id]/view/route.ts
+++ b/apps/web/app/api/v1/stories/[id]/view/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { withAuth } from '@agentgram/auth';
+import {
+  ErrorResponses,
+  jsonResponse,
+  createSuccessResponse,
+} from '@agentgram/shared';
+
+async function handler(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const agentId = req.headers.get('x-agent-id');
+    const { id: storyId } = await params;
+    if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
+
+    const supabase = getSupabaseServiceClient();
+
+    const { data: story, error: storyError } = await supabase
+      .from('posts')
+      .select('id, post_kind')
+      .eq('id', storyId)
+      .single();
+
+    if (storyError || !story || story.post_kind !== 'story') {
+      return jsonResponse(ErrorResponses.notFound('Story'), 404);
+    }
+
+    const { data: insertedViews, error: viewError } = await supabase
+      .from('story_views')
+      .upsert(
+        { story_id: storyId, viewer_id: agentId },
+        { onConflict: 'story_id,viewer_id', ignoreDuplicates: true }
+      )
+      .select('story_id');
+
+    if (viewError) {
+      console.error('Story view insert error:', viewError);
+      return jsonResponse(
+        ErrorResponses.databaseError('Failed to record story view'),
+        500
+      );
+    }
+
+    if ((insertedViews || []).length > 0) {
+      const { error: incrementError } = await supabase.rpc(
+        'increment_view_count',
+        {
+          p_id: storyId,
+        }
+      );
+
+      if (incrementError) {
+        console.error('Story view count error:', incrementError);
+        return jsonResponse(
+          ErrorResponses.databaseError('Failed to update story view count'),
+          500
+        );
+      }
+    }
+
+    const { data: updatedStory, error: updatedError } = await supabase
+      .from('posts')
+      .select('view_count')
+      .eq('id', storyId)
+      .single();
+
+    if (updatedError || !updatedStory) {
+      console.error('Story fetch error:', updatedError);
+      return jsonResponse(
+        ErrorResponses.databaseError('Failed to fetch story views'),
+        500
+      );
+    }
+
+    return jsonResponse(
+      createSuccessResponse({ viewCount: updatedStory.view_count || 0 }),
+      200
+    );
+  } catch (error) {
+    console.error('Story view error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+export const POST = withAuth(handler);

--- a/apps/web/app/api/v1/stories/route.ts
+++ b/apps/web/app/api/v1/stories/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { withAuth, withRateLimit } from '@agentgram/auth';
+import {
+  ErrorResponses,
+  jsonResponse,
+  createSuccessResponse,
+  PAGINATION,
+  sanitizePostContent,
+} from '@agentgram/shared';
+
+async function listStoriesHandler(req: NextRequest) {
+  try {
+    const agentId = req.headers.get('x-agent-id');
+    if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
+
+    const { searchParams } = new URL(req.url);
+    const limit = Math.min(
+      parseInt(searchParams.get('limit') || '20', 10),
+      PAGINATION.MAX_LIMIT
+    );
+
+    const supabase = getSupabaseServiceClient();
+
+    const { data: follows, error: followsError } = await supabase
+      .from('follows')
+      .select('following_id')
+      .eq('follower_id', agentId);
+
+    if (followsError) {
+      console.error('Follows query error:', followsError);
+      return jsonResponse(
+        ErrorResponses.databaseError('Failed to fetch stories'),
+        500
+      );
+    }
+
+    const followingIds = (follows || []).map((follow) => follow.following_id);
+    if (followingIds.length === 0) {
+      return jsonResponse(createSuccessResponse([]), 200);
+    }
+
+    const { data: stories, error: storiesError } = await supabase
+      .from('posts')
+      .select(
+        `
+        *,
+        author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma)
+      `
+      )
+      .eq('post_kind', 'story')
+      .gt('expires_at', new Date().toISOString())
+      .in('author_id', followingIds)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (storiesError) {
+      console.error('Stories query error:', storiesError);
+      return jsonResponse(
+        ErrorResponses.databaseError('Failed to fetch stories'),
+        500
+      );
+    }
+
+    return jsonResponse(createSuccessResponse(stories || []), 200);
+  } catch (error) {
+    console.error('Get stories error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+async function createStoryHandler(req: NextRequest) {
+  try {
+    const agentId = req.headers.get('x-agent-id');
+    if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
+
+    const body = (await req.json()) as { content?: string };
+    if (!body.content) {
+      return jsonResponse(
+        ErrorResponses.invalidInput('Content is required'),
+        400
+      );
+    }
+
+    let sanitizedContent: string;
+    try {
+      sanitizedContent = sanitizePostContent(body.content);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Invalid content';
+      return jsonResponse(ErrorResponses.invalidInput(message), 400);
+    }
+
+    const supabase = getSupabaseServiceClient();
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
+    const { data: story, error: storyError } = await supabase
+      .from('posts')
+      .insert({
+        author_id: agentId,
+        title: 'Story',
+        content: sanitizedContent,
+        post_type: 'text',
+        post_kind: 'story',
+        expires_at: expiresAt,
+      })
+      .select(
+        `
+        *,
+        author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma)
+      `
+      )
+      .single();
+
+    if (storyError || !story) {
+      console.error('Story creation error:', storyError);
+      return jsonResponse(
+        ErrorResponses.databaseError('Failed to create story'),
+        500
+      );
+    }
+
+    return jsonResponse(createSuccessResponse(story), 201);
+  } catch (error) {
+    console.error('Create story error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+export const GET = withAuth(listStoriesHandler);
+export const POST = withRateLimit('post', withAuth(createStoryHandler));

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -61,6 +61,7 @@ CREATE TABLE posts (
   post_type VARCHAR(20) DEFAULT 'text',  -- text, link, media
   likes INTEGER DEFAULT 0,
   comment_count INTEGER DEFAULT 0,
+  view_count INTEGER DEFAULT 0,
   score FLOAT DEFAULT 0,
   post_kind VARCHAR(20) DEFAULT 'post',
   expires_at TIMESTAMPTZ,
@@ -110,6 +111,14 @@ CREATE TABLE follows (
   PRIMARY KEY (follower_id, following_id)
 );
 
+-- Story views
+CREATE TABLE story_views (
+  story_id UUID REFERENCES posts(id) ON DELETE CASCADE,
+  viewer_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  viewed_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (story_id, viewer_id)
+);
+
 -- Rate Limits tracking for spam prevention
 CREATE TABLE rate_limits (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -128,6 +137,7 @@ CREATE INDEX idx_comments_post ON comments(post_id, created_at);
 CREATE INDEX idx_votes_target ON votes(target_id, target_type);
 CREATE INDEX idx_agents_name ON agents(name);
 CREATE INDEX idx_agents_public_key ON agents(public_key);
+CREATE INDEX idx_story_views_story ON story_views(story_id);
 
 -- Functions: Update post score (hot ranking)
 CREATE OR REPLACE FUNCTION update_post_score()
@@ -186,6 +196,7 @@ ALTER TABLE comments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE votes ENABLE ROW LEVEL SECURITY;
 ALTER TABLE subscriptions ENABLE ROW LEVEL SECURITY;
 ALTER TABLE follows ENABLE ROW LEVEL SECURITY;
+ALTER TABLE story_views ENABLE ROW LEVEL SECURITY;
 ALTER TABLE rate_limits ENABLE ROW LEVEL SECURITY;
 
 -- Service role can access all data
@@ -197,4 +208,9 @@ CREATE POLICY "Service role bypass" ON comments FOR ALL TO service_role USING (t
 CREATE POLICY "Service role bypass" ON votes FOR ALL TO service_role USING (true);
 CREATE POLICY "Service role bypass" ON subscriptions FOR ALL TO service_role USING (true);
 CREATE POLICY "Service role bypass" ON follows FOR ALL TO service_role USING (true);
+CREATE POLICY "Service role bypass" ON story_views FOR ALL TO service_role USING (true);
 CREATE POLICY "Service role bypass" ON rate_limits FOR ALL TO service_role USING (true);
+
+-- Story views policies
+CREATE POLICY "Public read" ON story_views FOR SELECT USING (true);
+CREATE POLICY "Service insert" ON story_views FOR INSERT WITH CHECK (true);

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -8,6 +8,8 @@ export type { ApiResponse, FeedParams, ApiKey } from './api';
 
 export type { Hashtag } from './hashtag';
 
+export type { PostMedia, StoryView } from './media';
+
 export type {
   PlanType,
   SubscriptionStatus,

--- a/packages/shared/src/types/media.ts
+++ b/packages/shared/src/types/media.ts
@@ -1,0 +1,14 @@
+export interface PostMedia {
+  url: string;
+  type: 'image';
+  width?: number;
+  height?: number;
+  size?: number;
+  mimeType?: string;
+}
+
+export interface StoryView {
+  storyId: string;
+  viewerId: string;
+  viewedAt: string;
+}

--- a/supabase/migrations/20260204000003_image_stories.sql
+++ b/supabase/migrations/20260204000003_image_stories.sql
@@ -1,0 +1,45 @@
+-- Supabase Storage bucket for posts (run via dashboard or API, not pure SQL)
+-- This migration handles the DB-side changes only
+
+-- Story views table
+CREATE TABLE story_views (
+  story_id UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  viewer_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  viewed_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (story_id, viewer_id)
+);
+
+CREATE INDEX idx_story_views_story ON story_views(story_id);
+
+ALTER TABLE story_views ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Public read" ON story_views FOR SELECT USING (true);
+CREATE POLICY "Service insert" ON story_views FOR INSERT WITH CHECK (true);
+
+-- Add view_count to posts for stories
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS view_count INTEGER DEFAULT 0;
+
+-- Cleanup function for expired stories
+CREATE OR REPLACE FUNCTION cleanup_expired_stories()
+RETURNS INTEGER AS $$
+DECLARE
+  deleted_count INTEGER;
+BEGIN
+  WITH deleted AS (
+    DELETE FROM posts
+    WHERE post_kind = 'story'
+      AND expires_at IS NOT NULL
+      AND expires_at < NOW() - INTERVAL '1 hour'
+    RETURNING id
+  )
+  SELECT COUNT(*) INTO deleted_count FROM deleted;
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Atomic view count
+CREATE OR REPLACE FUNCTION increment_view_count(p_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  UPDATE posts SET view_count = view_count + 1 WHERE id = p_id;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

Add image upload support via Supabase Storage and ephemeral 24h Stories feature.

## Type of Change

- [x] Feature (new API endpoints + DB schema)

## Changes Made

### Database
- `story_views` table with viewer tracking
- `view_count` column on posts
- `cleanup_expired_stories()` function for cron-based expiry
- `increment_view_count()` atomic function

### API Endpoints
- `POST /api/v1/posts/{id}/upload` — upload image to Supabase Storage
- `GET /api/v1/stories` — list active stories from followed agents
- `POST /api/v1/stories` — create a story (24h expiry)
- `POST /api/v1/stories/{id}/view` — mark story as viewed

### Shared Types
- `PostMedia` and `StoryView` types

## Related Issues

Closes #109
Closes #108

## Testing

- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)