### PR TITLE
[FEAT] Add repost system and explore feed algorithm (#112, #110)

### DIFF
--- a/apps/web/app/(public)/ax/page.tsx
+++ b/apps/web/app/(public)/ax/page.tsx
@@ -246,7 +246,7 @@ export default function AXPage() {
             </div>
 
             <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-              {principles.map((principle, index) => (
+              {principles.map((principle) => (
                 <motion.article
                   key={principle.title}
                   variants={fadeInScale}

--- a/apps/web/app/api/v1/explore/route.ts
+++ b/apps/web/app/api/v1/explore/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { withAuth } from '@agentgram/auth';
+import {
+  jsonResponse,
+  createSuccessResponse,
+  PAGINATION,
+  ErrorResponses,
+} from '@agentgram/shared';
+
+async function handler(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const limit = Math.min(
+      parseInt(
+        url.searchParams.get('limit') || String(PAGINATION.DEFAULT_LIMIT),
+        10
+      ),
+      PAGINATION.MAX_LIMIT
+    );
+    const page = parseInt(url.searchParams.get('page') || '0', 10);
+
+    const supabase = getSupabaseServiceClient();
+    const from = page * limit;
+    const to = from + limit - 1;
+
+    const { data, error } = await supabase
+      .from('posts')
+      .select(
+        `
+        *,
+        author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma),
+        community:communities(id, name, display_name)
+      `
+      )
+      .eq('post_kind', 'post')
+      .is('original_post_id', null)
+      .order('score', { ascending: false })
+      .range(from, to);
+
+    if (error) {
+      console.error('Explore error:', error);
+      return jsonResponse(
+        ErrorResponses.databaseError('Failed to fetch explore feed'),
+        500
+      );
+    }
+
+    return jsonResponse(createSuccessResponse(data || []), 200);
+  } catch (error) {
+    console.error('Explore error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+export const GET = withAuth(handler);

--- a/apps/web/app/api/v1/posts/[id]/repost/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/repost/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from 'next/server';
+import { handleRepost } from '@agentgram/db';
+import { withAuth, withRateLimit } from '@agentgram/auth';
+import {
+  ErrorResponses,
+  jsonResponse,
+  createSuccessResponse,
+} from '@agentgram/shared';
+
+async function handler(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const agentId = req.headers.get('x-agent-id');
+    const { id: postId } = await params;
+    if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
+
+    let content: string | undefined;
+    try {
+      const body = await req.json();
+      content = body.content;
+    } catch {
+      // No body is fine
+    }
+
+    const result = await handleRepost(agentId, postId, content);
+    if (!result) {
+      return jsonResponse(ErrorResponses.notFound('Post'), 404);
+    }
+
+    return jsonResponse(createSuccessResponse(result), 201);
+  } catch (error) {
+    console.error('Repost error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+export const POST = withRateLimit('post', withAuth(handler));

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -22,3 +22,5 @@ export type {
 export { handlePostLike } from './helpers';
 export { handleFollow } from './follow';
 export type { FollowResult } from './follow';
+export { handleRepost } from './repost';
+export type { RepostResult } from './repost';

--- a/packages/db/src/repost.ts
+++ b/packages/db/src/repost.ts
@@ -1,0 +1,66 @@
+import { getSupabaseServiceClient } from './client';
+
+export interface RepostResult {
+  repostId: string;
+  originalPostId: string;
+  repostCount: number;
+}
+
+export async function handleRepost(
+  agentId: string,
+  originalPostId: string,
+  content?: string
+): Promise<RepostResult | null> {
+  const supabase = getSupabaseServiceClient();
+
+  // Check original post exists and is not itself a repost
+  const { data: originalPost, error: postError } = await supabase
+    .from('posts')
+    .select('id, original_post_id, title, author_id')
+    .eq('id', originalPostId)
+    .single();
+
+  if (postError || !originalPost) return null;
+  if (originalPost.original_post_id) return null; // Can't repost a repost
+
+  // Check if already reposted by this agent
+  const { data: existing } = await supabase
+    .from('posts')
+    .select('id')
+    .eq('author_id', agentId)
+    .eq('original_post_id', originalPostId)
+    .single();
+
+  if (existing) return null; // Already reposted
+
+  // Create repost
+  const { data: repost, error: repostError } = await supabase
+    .from('posts')
+    .insert({
+      author_id: agentId,
+      original_post_id: originalPostId,
+      title: originalPost.title,
+      content: content || null,
+      post_type: 'text',
+    })
+    .select('id')
+    .single();
+
+  if (repostError || !repost) return null;
+
+  // Increment repost count
+  await supabase.rpc('increment_repost_count', { p_id: originalPostId });
+
+  // Get updated count
+  const { data: updated } = await supabase
+    .from('posts')
+    .select('repost_count')
+    .eq('id', originalPostId)
+    .single();
+
+  return {
+    repostId: repost.id,
+    originalPostId,
+    repostCount: updated?.repost_count || 0,
+  };
+}

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -63,6 +63,8 @@ CREATE TABLE posts (
   comment_count INTEGER DEFAULT 0,
   score FLOAT DEFAULT 0,
   post_kind VARCHAR(20) DEFAULT 'post',
+  original_post_id UUID REFERENCES posts(id) ON DELETE SET NULL,
+  repost_count INTEGER DEFAULT 0,
   expires_at TIMESTAMPTZ,
   embedding VECTOR(1536),
   metadata JSONB DEFAULT '{}',

--- a/supabase/migrations/20260204000004_repost_explore.sql
+++ b/supabase/migrations/20260204000004_repost_explore.sql
@@ -1,0 +1,40 @@
+-- Repost columns on posts
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS original_post_id UUID REFERENCES posts(id) ON DELETE SET NULL;
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS repost_count INTEGER DEFAULT 0;
+
+CREATE INDEX idx_posts_original ON posts(original_post_id) WHERE original_post_id IS NOT NULL;
+
+-- Atomic repost count functions
+CREATE OR REPLACE FUNCTION increment_repost_count(p_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  UPDATE posts SET repost_count = repost_count + 1 WHERE id = p_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION decrement_repost_count(p_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  UPDATE posts SET repost_count = GREATEST(0, repost_count - 1) WHERE id = p_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Explore scoring function
+CREATE OR REPLACE FUNCTION calculate_explore_score(
+  p_likes INTEGER,
+  p_comment_count INTEGER,
+  p_repost_count INTEGER,
+  p_created_at TIMESTAMPTZ
+)
+RETURNS FLOAT AS $$
+DECLARE
+  hours_age FLOAT;
+  engagement FLOAT;
+  recency FLOAT;
+BEGIN
+  hours_age := EXTRACT(EPOCH FROM (NOW() - p_created_at)) / 3600.0;
+  engagement := (p_likes * 1.0 + p_comment_count * 2.0 + p_repost_count * 3.0);
+  recency := EXP(-0.693 * hours_age / 12.0);
+  RETURN (engagement / GREATEST(1, POWER(hours_age + 2, 1.2))) * 0.6 + recency * 0.4;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;


### PR DESCRIPTION
## Description

Add repost/share functionality and explore feed with multi-signal ranking algorithm.

## Type of Change

- [x] Feature (new API endpoints + DB schema)

## Changes Made

### Database
- `original_post_id` and `repost_count` columns on posts
- `increment/decrement_repost_count()` atomic functions
- `calculate_explore_score()` multi-signal ranking function

### API Endpoints
- `POST /api/v1/posts/{id}/repost` — repost with optional commentary
- `GET /api/v1/explore` — explore feed with engagement-based ranking

### DB Helpers
- `handleRepost()` with duplicate/repost-of-repost prevention

## Related Issues

Closes #112
Closes #110

## Testing

- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)