### PR TITLE
[REFACTOR] Monorepo housekeeping: dependency alignment, build config, code cleanup (#135)

### DIFF
--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -1,6 +1,6 @@
-import { Agent } from '@agentgram/shared';
-import { Bot, Award } from 'lucide-react';
 import Image from 'next/image';
+import { Bot, Award } from 'lucide-react';
+import { Agent } from '@agentgram/shared';
 import { Button } from '@/components/ui/button';
 
 interface AgentCardProps {

--- a/apps/web/components/agents/AgentsList.tsx
+++ b/apps/web/components/agents/AgentsList.tsx
@@ -1,11 +1,11 @@
 'use client';
 
+import { Bot } from 'lucide-react';
+import { PAGINATION } from '@agentgram/shared';
 import { useAgents } from '@/hooks';
 import { AgentCard } from './AgentCard';
 import { AgentSkeleton } from './AgentSkeleton';
-import { Bot } from 'lucide-react';
 import { EmptyState } from '@/components/common';
-import { PAGINATION } from '@agentgram/shared';
 
 interface AgentsListProps {
   sort?: 'karma' | 'recent' | 'active';

--- a/apps/web/components/auth/AuthButton.tsx
+++ b/apps/web/components/auth/AuthButton.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { LogIn, LayoutDashboard } from 'lucide-react';
 import { createClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
-import { LogIn, LayoutDashboard } from 'lucide-react';
 import type { User } from '@supabase/supabase-js';
 
 /**

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Post } from '@agentgram/shared';
-import { Bot } from 'lucide-react';
 import Image from 'next/image';
+import { Bot } from 'lucide-react';
+import { Post } from '@agentgram/shared';
 import { useLike } from '@/hooks/use-posts';
 import { useToast } from '@/hooks/use-toast';
 

--- a/apps/web/hooks/use-comments.ts
+++ b/apps/web/hooks/use-comments.ts
@@ -125,10 +125,7 @@ export function useCreateComment(postId: string) {
 
       return { previousComments };
     },
-    onError: (err, variables, context) => {
-      Boolean(err);
-      Boolean(variables);
-      // Rollback on error
+    onError: (_err, _variables, context) => {
       if (context?.previousComments) {
         queryClient.setQueryData(
           ['comments', postId],

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,14 +3,14 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   transpilePackages: ['@agentgram/auth', '@agentgram/db', '@agentgram/shared'],
   serverExternalPackages: ['@noble/ed25519'],
-  
+
   // Turbopack configuration (stable in Next.js 16)
   // Note: Turbopack is now the default bundler, no additional config needed
-  
+
   // Enable experimental features for Next.js 16
   experimental: {
     // Consider enabling Cache Components for PPR

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -15,7 +15,7 @@
     "@noble/ed25519": "^2.0.0",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.1",
-    "bcryptjs": "^2.4.3",
+    "bcryptjs": "^3.0.3",
     "jsonwebtoken": "^9.0.2"
   },
   "peerDependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,12 +11,12 @@
   },
   "dependencies": {
     "@agentgram/shared": "workspace:*",
-    "@supabase/supabase-js": "^2.39.3"
+    "@supabase/supabase-js": "^2.93.3"
   },
   "devDependencies": {
     "@agentgram/eslint-config": "workspace:*",
     "@agentgram/tsconfig": "workspace:*",
     "@types/node": "^22.15.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,6 +13,6 @@
     "@agentgram/eslint-config": "workspace:*",
     "@agentgram/tsconfig": "workspace:*",
     "@types/node": "^22.15.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,4 @@
 export * from './types';
-export * from './types/index';
 export * from './constants';
 export * from './sanitize';
 export * from './api-helpers';

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -13,7 +13,7 @@
     "module": "esnext",
     "noEmit": true,
     "resolveJsonModule": true,
-    "target": "es5"
+    "target": "ES2022"
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,8 +170,8 @@ importers:
         specifier: ^1.36.1
         version: 1.36.1
       bcryptjs:
-        specifier: ^2.4.3
-        version: 2.4.3
+        specifier: ^3.0.3
+        version: 3.0.3
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
@@ -201,7 +201,7 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@supabase/supabase-js':
-        specifier: ^2.39.3
+        specifier: ^2.93.3
         version: 2.93.3
     devDependencies:
       '@agentgram/eslint-config':
@@ -214,7 +214,7 @@ importers:
         specifier: ^22.15.0
         version: 22.19.7
       typescript:
-        specifier: ^5.3.3
+        specifier: ^5.9.3
         version: 5.9.3
 
   packages/eslint-config:
@@ -259,7 +259,7 @@ importers:
         specifier: ^22.15.0
         version: 22.19.7
       typescript:
-        specifier: ^5.3.3
+        specifier: ^5.9.3
         version: 5.9.3
 
   packages/tsconfig: {}
@@ -2092,9 +2092,6 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
-
-  bcryptjs@2.4.3:
-    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
   bcryptjs@3.0.3:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
@@ -6223,8 +6220,6 @@ snapshots:
   baseline-browser-mapping@2.9.19: {}
 
   basic-ftp@5.1.0: {}
-
-  bcryptjs@2.4.3: {}
 
   bcryptjs@3.0.3: {}
 


### PR DESCRIPTION
## Description

Audit revealed dependency version drift, outdated build config, and minor code quality issues across the monorepo. This PR aligns everything.

## Type of Change

- [x] Code refactoring (no behavior change)

## Changes Made

### Dependency Version Alignment
- `packages/db`: `typescript` ^5.3.3 → ^5.9.3 (match rest of monorepo)
- `packages/shared`: `typescript` ^5.3.3 → ^5.9.3 (match rest of monorepo)
- `packages/auth`: `bcryptjs` ^2.4.3 → ^3.0.3 (match apps/web, major version sync)
- `packages/db`: `@supabase/supabase-js` ^2.39.3 → ^2.93.3 (match apps/web)
- Updated `pnpm-lock.yaml`

### Build Config
- `packages/tsconfig/nextjs.json`: `target` es5 → ES2022 (es5 unnecessary for Next.js 16)
- `apps/web/next.config.ts`: `ignoreBuildErrors` true → false (enforce TS checks in CI)

### Code Cleanup
- `packages/shared/src/index.ts`: Remove duplicate `export * from './types/index'` (already covered by `export * from './types'`)
- `apps/web/hooks/use-comments.ts`: Replace `Boolean(err)` / `Boolean(variables)` no-ops with `_err` / `_variables` underscore prefix convention
- Fix import order in 4 files (React/Next.js → External → Internal packages → Project internal):
  - `AgentCard.tsx`
  - `PostCard.tsx`
  - `AuthButton.tsx`
  - `AgentsList.tsx`

## Related Issues

Closes #135

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build fails on develop too (pre-existing: missing Supabase env vars for SSG prerender — unrelated to this PR)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings