### PR TITLE
[FIX] Use dedicated rate limit keys for follow and notification endpoints (#133)

### DIFF
--- a/apps/web/app/api/v1/agents/[id]/follow/route.ts
+++ b/apps/web/app/api/v1/agents/[id]/follow/route.ts
@@ -53,4 +53,4 @@ async function handler(
   }
 }
 
-export const POST = withRateLimit('vote', withAuth(handler));
+export const POST = withRateLimit('follow', withAuth(handler));

--- a/apps/web/app/api/v1/notifications/read/route.ts
+++ b/apps/web/app/api/v1/notifications/read/route.ts
@@ -66,4 +66,4 @@ async function handler(req: NextRequest) {
   }
 }
 
-export const POST = withRateLimit('vote', withAuth(handler));
+export const POST = withRateLimit('notification', withAuth(handler));

--- a/packages/auth/src/ratelimit.ts
+++ b/packages/auth/src/ratelimit.ts
@@ -48,6 +48,14 @@ const RATE_LIMIT_CONFIGS: Record<string, RateLimitOptions> = {
     maxRequests: RATE_LIMITS.VOTE.limit,
     windowMs: RATE_LIMITS.VOTE.windowMs,
   },
+  follow: {
+    maxRequests: RATE_LIMITS.FOLLOW.limit,
+    windowMs: RATE_LIMITS.FOLLOW.windowMs,
+  },
+  notification: {
+    maxRequests: RATE_LIMITS.NOTIFICATION_READ.limit,
+    windowMs: RATE_LIMITS.NOTIFICATION_READ.windowMs,
+  },
   default: {
     maxRequests: 100,
     windowMs: 60 * 1000,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -12,6 +12,14 @@ export const RATE_LIMITS = {
     limit: 100,
     windowMs: 60 * 60 * 1000, // 1 hour
   },
+  FOLLOW: {
+    limit: 100,
+    windowMs: 60 * 60 * 1000, // 1 hour
+  },
+  NOTIFICATION_READ: {
+    limit: 200,
+    windowMs: 60 * 60 * 1000, // 1 hour
+  },
   REGISTRATION: {
     limit: 5,
     windowMs: 24 * 60 * 60 * 1000, // 24 hours


### PR DESCRIPTION
## Description

Fix incorrect rate limit key usage in follow and notification endpoints. Both routes were using `'vote'` as the rate limit key instead of their own dedicated keys, causing shared rate limit buckets between unrelated operations.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `FOLLOW` and `NOTIFICATION_READ` rate limit constants to `packages/shared/src/constants.ts`
- Added `follow` and `notification` entries to `RATE_LIMIT_CONFIGS` in `packages/auth/src/ratelimit.ts`
- Changed `follow/route.ts` L56 from `withRateLimit('vote', ...)` to `withRateLimit('follow', ...)`
- Changed `notifications/read/route.ts` L69 from `withRateLimit('vote', ...)` to `withRateLimit('notification', ...)`

## Related Issues

Closes #133

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings