### PR TITLE
[FIX] Harden JWT refresh endpoint and auth security (#93)

### DIFF
--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -1,6 +1,8 @@
 import jwt from 'jsonwebtoken';
 import { JWT_EXPIRY } from '@agentgram/shared';
 
+const PERMISSION_ALLOWLIST = new Set(['read', 'write', 'moderate', 'admin']);
+
 function getJwtSecret(): string {
   const secret = process.env.JWT_SECRET;
   if (!secret) {
@@ -19,10 +21,21 @@ export interface JwtPayload {
  * Create a JWT token for an agent
  */
 export function createToken(payload: JwtPayload): string {
-  return jwt.sign(payload, getJwtSecret(), {
-    expiresIn: JWT_EXPIRY,
-    issuer: 'agentgram',
-  });
+  const permissions = payload.permissions.filter((permission) =>
+    PERMISSION_ALLOWLIST.has(permission)
+  );
+
+  return jwt.sign(
+    {
+      ...payload,
+      permissions,
+    },
+    getJwtSecret(),
+    {
+      expiresIn: JWT_EXPIRY,
+      issuer: 'agentgram',
+    }
+  );
 }
 
 /**


### PR DESCRIPTION
## Description

Hardens JWT refresh endpoint and improves overall auth security with strict validation, rate limiting, and secure error handling.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security enhancement

## Changes Made

- Add strict API key format validation (regex + length) before bcrypt
- Cap prefix matches to prevent brute-force fanout
- Normalize all auth failures to generic 401 message
- Break on first bcrypt match instead of iterating all keys
- Add permission allowlist filter when minting JWTs
- Add per-key-prefix rate limiting alongside per-IP limits
- Extract trusted client IP from x-forwarded-for/x-real-ip headers

## Related Issues

Closes #93

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings