### PR TITLE
[FIX] Move getSupabaseBrowser() into queryFn to prevent SSG crash (#168)

### DIFF
--- a/apps/web/hooks/use-agents.ts
+++ b/apps/web/hooks/use-agents.ts
@@ -55,11 +55,11 @@ type AgentsParams = {
  */
 export function useAgents(params: AgentsParams = {}) {
   const { sort = 'karma', limit = PAGINATION.DEFAULT_LIMIT } = params;
-  const supabase = getSupabaseBrowser();
 
   return useQuery({
     queryKey: ['agents', { sort, limit }],
     queryFn: async () => {
+      const supabase = getSupabaseBrowser();
       let query = supabase.from('agents').select('*');
 
       // Sorting
@@ -89,13 +89,12 @@ export function useAgents(params: AgentsParams = {}) {
  * Fetch a single agent by ID
  */
 export function useAgent(agentId: string | undefined) {
-  const supabase = getSupabaseBrowser();
-
   return useQuery({
     queryKey: ['agents', agentId],
     queryFn: async () => {
       if (!agentId) throw new Error('Agent ID is required');
 
+      const supabase = getSupabaseBrowser();
       const { data, error } = await supabase
         .from('agents')
         .select('*')

--- a/apps/web/hooks/use-comments.ts
+++ b/apps/web/hooks/use-comments.ts
@@ -45,13 +45,12 @@ function transformComment(comment: CommentResponse): Comment {
  * Fetch comments for a post
  */
 export function useComments(postId: string | undefined) {
-  const supabase = getSupabaseBrowser();
-
   return useQuery({
     queryKey: ['comments', postId],
     queryFn: async () => {
       if (!postId) throw new Error('Post ID is required');
 
+      const supabase = getSupabaseBrowser();
       const { data, error } = await supabase
         .from('comments')
         .select(

--- a/apps/web/hooks/use-posts.ts
+++ b/apps/web/hooks/use-posts.ts
@@ -88,11 +88,11 @@ export function usePostsFeed(params: FeedParams = {}) {
     communityId,
     limit = PAGINATION.DEFAULT_LIMIT,
   } = params;
-  const supabase = getSupabaseBrowser();
 
   return useInfiniteQuery({
     queryKey: ['posts', 'feed', { sort, communityId }],
     queryFn: async ({ pageParam = 0 }) => {
+      const supabase = getSupabaseBrowser();
       let query = supabase.from('posts').select(
         `
           *,
@@ -138,13 +138,12 @@ export function usePostsFeed(params: FeedParams = {}) {
  * Fetch a single post by ID
  */
 export function usePost(postId: string | undefined) {
-  const supabase = getSupabaseBrowser();
-
   return useQuery({
     queryKey: ['posts', postId],
     queryFn: async () => {
       if (!postId) throw new Error('Post ID is required');
 
+      const supabase = getSupabaseBrowser();
       const { data, error } = await supabase
         .from('posts')
         .select(


### PR DESCRIPTION
## Description

`pnpm build` was crashing during static generation because `getSupabaseBrowser()` was called at hook function top-level (render-time), causing it to throw when Supabase env vars are unavailable during prerender. Moved all 5 call sites into `queryFn` callbacks so the client is only created when queries execute on the client.

## Type of Change

- [x] Bug fix

## Changes Made

- `hooks/use-agents.ts` — moved `getSupabaseBrowser()` inside `queryFn` for `useAgents` (L58) and `useAgent` (L92)
- `hooks/use-posts.ts` — moved `getSupabaseBrowser()` inside `queryFn` for `usePostsFeed` (L91) and `usePost` (L141)
- `hooks/use-comments.ts` — moved `getSupabaseBrowser()` inside `queryFn` for `useComments` (L48)

**Before:**
```typescript
export function useAgents() {
  const supabase = getSupabaseBrowser(); // executes during SSR prerender
  return useQuery({ queryFn: async () => { /* ... */ } });
}
```

**After:**
```typescript
export function useAgents() {
  return useQuery({
    queryFn: async () => {
      const supabase = getSupabaseBrowser(); // only executes client-side
      /* ... */
    }
  });
}
```

## Related Issues

Closes #168

## Testing

- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`) — 0 errors, 5 pre-existing warnings
- [x] Build succeeds (`pnpm build`) — all 38 pages statically generated, including `/agents`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Minimal fix — only moved call sites, no other changes