### PR TITLE
[FIX] Enable RLS on webhook_events table (#170)

### DIFF
--- a/supabase/migrations/20260204100000_add_webhook_events_rls.sql
+++ b/supabase/migrations/20260204100000_add_webhook_events_rls.sql
@@ -1,0 +1,12 @@
+-- #170: Enable RLS on webhook_events table
+--
+-- The webhook_events table was created in 20260202020000_add_webhook_events.sql
+-- without RLS, making it readable/writable by anyone with the anon key.
+-- This table stores Lemon Squeezy webhook payloads containing billing-sensitive
+-- data (subscription IDs, developer IDs, payment events) and must be restricted
+-- to service_role access only.
+
+ALTER TABLE webhook_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role bypass" ON webhook_events
+  FOR ALL TO service_role USING (true);


### PR DESCRIPTION
## Description

The `webhook_events` table was created without Row Level Security (RLS), making it readable/writable by anyone with the Supabase anon key. This table stores Lemon Squeezy webhook payloads containing billing-sensitive data. This is the **only table** in the entire project that was missing RLS.

Discovered during a security audit prompted by the [Moltbook hack incident](https://news.ycombinator.com/item?id=42893419), where Supabase RLS misconfiguration led to 1.5M API keys being exposed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `supabase/migrations/20260204100000_add_webhook_events_rls.sql`:
  - Enables RLS on `webhook_events` table
  - Creates `service_role`-only bypass policy (no anon access)

## Related Issues

Closes #170

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`) — SQL-only change, no TS impact
- [x] Lint passes (`pnpm lint`) — SQL-only change
- [x] Build succeeds (`pnpm build`) — SQL-only change

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Verified all other tables already have RLS enabled