### PR TITLE
[FIX] Restrict RLS write policies to service_role on 5 tables (#171)

### DIFF
--- a/supabase/migrations/20260204100001_fix_permissive_rls_policies.sql
+++ b/supabase/migrations/20260204100001_fix_permissive_rls_policies.sql
@@ -1,0 +1,39 @@
+-- #171: Fix overly permissive RLS INSERT/UPDATE policies
+--
+-- Five tables have policies missing the `TO service_role` clause, causing
+-- PostgreSQL to default to `TO PUBLIC` (includes anon). This allows anyone
+-- with the anon key to INSERT/UPDATE these tables. Security fix: restrict
+-- all write policies to service_role only. Public SELECT is left intact.
+
+-- mentions
+DROP POLICY "Service insert" ON mentions;
+CREATE POLICY "Service role insert" ON mentions
+  FOR INSERT TO service_role WITH CHECK (true);
+
+-- notifications
+DROP POLICY "Service insert" ON notifications;
+CREATE POLICY "Service role insert" ON notifications
+  FOR INSERT TO service_role WITH CHECK (true);
+
+DROP POLICY "Service update" ON notifications;
+CREATE POLICY "Service role update" ON notifications
+  FOR UPDATE TO service_role USING (true);
+
+-- hashtags
+DROP POLICY "Service insert" ON hashtags;
+CREATE POLICY "Service role insert" ON hashtags
+  FOR INSERT TO service_role WITH CHECK (true);
+
+DROP POLICY "Service update" ON hashtags;
+CREATE POLICY "Service role update" ON hashtags
+  FOR UPDATE TO service_role USING (true);
+
+-- post_hashtags
+DROP POLICY "Service insert" ON post_hashtags;
+CREATE POLICY "Service role insert" ON post_hashtags
+  FOR INSERT TO service_role WITH CHECK (true);
+
+-- story_views
+DROP POLICY "Service insert" ON story_views;
+CREATE POLICY "Service role insert" ON story_views
+  FOR INSERT TO service_role WITH CHECK (true);


### PR DESCRIPTION
## Description

Five tables had RLS INSERT/UPDATE policies named "Service insert"/"Service update" that were missing the `TO service_role` clause. PostgreSQL defaults missing role grants to `PUBLIC`, which includes the `anon` role — meaning anyone with the Supabase anon key could insert arbitrary data into these tables.

Discovered during a security audit prompted by the [Moltbook hack incident](https://news.ycombinator.com/item?id=42893419).

### Affected Tables

| Table | Operations Fixed |
|-------|-----------------|
| `mentions` | INSERT |
| `notifications` | INSERT, UPDATE |
| `hashtags` | INSERT, UPDATE |
| `post_hashtags` | INSERT |
| `story_views` | INSERT |

Public SELECT policies are intentionally preserved — these tables should be publicly readable.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `supabase/migrations/20260204100001_fix_permissive_rls_policies.sql`:
  - Drops 7 misconfigured policies
  - Recreates each with explicit `TO service_role` restriction

## Related Issues

Closes #171

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`) — SQL-only change, no TS impact
- [x] Lint passes (`pnpm lint`) — SQL-only change
- [x] Build succeeds (`pnpm build`) — SQL-only change

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Verified anon SELECT policies remain intact
- [x] Verified no application code changes needed (all writes use service_role client)