### PR TITLE
[FIX] Harden rate limit infrastructure and centralize API key constants (#161, #162)

### DIFF
--- a/apps/web/app/api/v1/auth/refresh/route.ts
+++ b/apps/web/app/api/v1/auth/refresh/route.ts
@@ -4,6 +4,9 @@ import { createToken, withRateLimit } from '@agentgram/auth';
 import { getSupabaseServiceClient } from '@agentgram/db';
 import {
   API_KEY_PREFIX,
+  API_KEY_REGEX,
+  API_KEY_MAX_LENGTH,
+  API_KEY_PREFIX_LENGTH,
   JWT_EXPIRY,
   ErrorResponses,
   jsonResponse,
@@ -15,9 +18,6 @@ const REFRESH_RATE_LIMIT = {
   windowMs: 60 * 1000,
 };
 
-const API_KEY_REGEX = /^ag_[a-f0-9]{32,64}$/;
-const API_KEY_MAX_LENGTH = 67;
-const KEY_PREFIX_LENGTH = 8;
 const MAX_PREFIX_MATCHES = 5;
 const GENERIC_UNAUTHORIZED_MESSAGE = 'Invalid or expired API key';
 
@@ -83,12 +83,12 @@ async function refreshHandler(req: NextRequest) {
       return unauthorizedResponse();
     }
 
-    if (apiKey.length < KEY_PREFIX_LENGTH) {
+    if (apiKey.length < API_KEY_PREFIX_LENGTH) {
       return unauthorizedResponse();
     }
 
     const supabase = getSupabaseServiceClient();
-    const keyPrefix = apiKey.substring(0, KEY_PREFIX_LENGTH);
+    const keyPrefix = apiKey.substring(0, API_KEY_PREFIX_LENGTH);
     const { data: apiKeys, error: keyError } = await supabase
       .from('api_keys')
       .select('agent_id, key_hash, expires_at, permissions')

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -70,6 +70,17 @@ export const DEFAULT_COMMUNITY = {
 export const API_VERSION = 'v1' as const;
 export const API_BASE_PATH = '/api/v1' as const;
 export const API_KEY_PREFIX = 'ag_' as const;
+/**
+ * API key format validation constants
+ *
+ * Format: ag_[32-64 hex chars]
+ * Example: ag_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+ * Max length: 67 chars (3 prefix + 64 hex)
+ * Prefix length for DB lookup: 8 chars (ag_ + first 5 hex)
+ */
+export const API_KEY_REGEX = /^ag_[a-f0-9]{32,64}$/;
+export const API_KEY_MAX_LENGTH = 67;
+export const API_KEY_PREFIX_LENGTH = 8;
 
 // Auth Configuration
 export const JWT_EXPIRY = '7d' as const;


### PR DESCRIPTION
## Description

Harden rate limit infrastructure for production serverless environments and centralize duplicated API key validation constants, addressing Oracle security review items from #161 and refactoring from #162.

## Type of Change

- [x] Bug fix / Security hardening
- [x] Code refactoring (no behavior change)

## Changes Made

### #162 — Centralize API key constants
- Moved `API_KEY_REGEX`, `API_KEY_MAX_LENGTH`, `API_KEY_PREFIX_LENGTH` to `@agentgram/shared`
- Removed duplicated constants from `ratelimit.ts` and `auth/refresh/route.ts`
- Updated imports to use shared package (single source of truth)

### #161 — Rate limit infrastructure hardening
- **CRITICAL**: Added production warning when Upstash Redis is not configured (in-memory fallback is ineffective in serverless)
- **HIGH**: Gated `setInterval` cleanup to only run when in-memory fallback is active + `.unref()` to prevent keeping serverless processes alive
- **MEDIUM**: Added `normalizePathname()` to replace dynamic route segments (UUIDs, numeric IDs) with `:id` placeholders, preventing cardinality explosion in rate limit keys
- **HIGH**: Documented IP header trust boundary — Vercel sets `x-forwarded-for` at the edge (non-spoofable)

## Related Issues

Closes #161
Closes #162

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [x] Production warning correctly emits during build (expected — no Redis in CI)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error`