### PR TITLE
[FIX] Harden JWT token verification (#160)

### DIFF
--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -17,9 +17,6 @@ export interface JwtPayload {
   permissions: string[];
 }
 
-/**
- * Create a JWT token for an agent
- */
 export function createToken(payload: JwtPayload): string {
   const permissions = payload.permissions.filter((permission) =>
     PERMISSION_ALLOWLIST.has(permission)
@@ -27,7 +24,8 @@ export function createToken(payload: JwtPayload): string {
 
   return jwt.sign(
     {
-      ...payload,
+      agentId: payload.agentId,
+      name: payload.name,
       permissions,
     },
     getJwtSecret(),
@@ -38,29 +36,40 @@ export function createToken(payload: JwtPayload): string {
   );
 }
 
-/**
- * Verify and decode a JWT token
- */
 export function verifyToken(token: string): JwtPayload | null {
   try {
     const decoded = jwt.verify(token, getJwtSecret(), {
       issuer: 'agentgram',
+      algorithms: ['HS256'],
     }) as JwtPayload;
 
-    return decoded;
+    if (
+      typeof decoded.agentId !== 'string' ||
+      typeof decoded.name !== 'string' ||
+      !Array.isArray(decoded.permissions)
+    ) {
+      return null;
+    }
+
+    const filteredPermissions = decoded.permissions.filter((permission) =>
+      PERMISSION_ALLOWLIST.has(permission)
+    );
+
+    return {
+      agentId: decoded.agentId,
+      name: decoded.name,
+      permissions: filteredPermissions,
+    };
   } catch (error) {
     console.error('JWT verification error:', error);
     return null;
   }
 }
 
-/**
- * Extract JWT token from Bearer authorization header
- */
 export function extractBearerToken(authHeader?: string): string | null {
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return null;
   }
 
-  return authHeader.substring(7);
+  return authHeader.substring(7).trim();
 }


### PR DESCRIPTION
## Description

Hardens JWT handling in `packages/auth/src/jwt.ts` based on Oracle security review findings. Addresses algorithm confusion attack vector, payload tampering, and input hygiene.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

| Severity | Fix | Detail |
|----------|-----|--------|
| HIGH | Algorithm pinning | `jwt.verify()` now enforces `algorithms: ['HS256']` to prevent algorithm confusion |
| HIGH | Payload validation on verify | `verifyToken()` validates `agentId`/`name`/`permissions` types and re-filters through `PERMISSION_ALLOWLIST` |
| MEDIUM | Explicit payload in sign | `createToken()` uses explicit field assignment instead of spread, preventing reserved JWT claim injection |
| LOW | Trim Bearer token | `extractBearerToken()` now trims whitespace from extracted token |

## Related Issues

Closes #160

## Testing

- [x] Type check passes (`pnpm type-check`) — 4/4 packages, 0 errors
- [x] No new dependencies added
- [x] Function signatures unchanged (backwards compatible)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings