### PR TITLE
[REFACTOR] Centralize API key format validation constants (#162)

### DIFF
--- a/apps/web/app/api/v1/auth/refresh/route.ts
+++ b/apps/web/app/api/v1/auth/refresh/route.ts
@@ -4,6 +4,9 @@ import { createToken, withRateLimit } from '@agentgram/auth';
 import { getSupabaseServiceClient } from '@agentgram/db';
 import {
   API_KEY_PREFIX,
+  API_KEY_REGEX,
+  API_KEY_MAX_LENGTH,
+  API_KEY_PREFIX_LENGTH,
   JWT_EXPIRY,
   ErrorResponses,
   jsonResponse,
@@ -15,9 +18,6 @@ const REFRESH_RATE_LIMIT = {
   windowMs: 60 * 1000,
 };
 
-const API_KEY_REGEX = /^ag_[a-f0-9]{32,64}$/;
-const API_KEY_MAX_LENGTH = 67;
-const KEY_PREFIX_LENGTH = 8;
 const MAX_PREFIX_MATCHES = 5;
 const GENERIC_UNAUTHORIZED_MESSAGE = 'Invalid or expired API key';
 
@@ -83,12 +83,12 @@ async function refreshHandler(req: NextRequest) {
       return unauthorizedResponse();
     }
 
-    if (apiKey.length < KEY_PREFIX_LENGTH) {
+    if (apiKey.length < API_KEY_PREFIX_LENGTH) {
       return unauthorizedResponse();
     }
 
     const supabase = getSupabaseServiceClient();
-    const keyPrefix = apiKey.substring(0, KEY_PREFIX_LENGTH);
+    const keyPrefix = apiKey.substring(0, API_KEY_PREFIX_LENGTH);
     const { data: apiKeys, error: keyError } = await supabase
       .from('api_keys')
       .select('agent_id, key_hash, expires_at, permissions')

--- a/packages/auth/src/ratelimit.ts
+++ b/packages/auth/src/ratelimit.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { ApiResponse } from '@agentgram/shared';
-import { RATE_LIMITS } from '@agentgram/shared';
+import {
+  RATE_LIMITS,
+  API_KEY_REGEX,
+  API_KEY_MAX_LENGTH,
+  API_KEY_PREFIX_LENGTH,
+} from '@agentgram/shared';
 import { Ratelimit, type Duration } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 
@@ -12,10 +17,6 @@ import { Redis } from '@upstash/redis';
  */
 
 const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
-
-const API_KEY_REGEX = /^ag_[a-f0-9]{32,64}$/;
-const API_KEY_MAX_LENGTH = 67;
-const API_KEY_PREFIX_LENGTH = 8;
 
 // Cleanup old entries every 5 minutes to prevent memory leak
 setInterval(

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -70,6 +70,9 @@ export const DEFAULT_COMMUNITY = {
 export const API_VERSION = 'v1' as const;
 export const API_BASE_PATH = '/api/v1' as const;
 export const API_KEY_PREFIX = 'ag_' as const;
+export const API_KEY_REGEX = /^ag_[a-f0-9]{32,64}$/;
+export const API_KEY_MAX_LENGTH = 67 as const;
+export const API_KEY_PREFIX_LENGTH = 8 as const;
 
 // Auth Configuration
 export const JWT_EXPIRY = '7d' as const;


### PR DESCRIPTION
## Description

Moves duplicated API key validation constants (`API_KEY_REGEX`, `API_KEY_MAX_LENGTH`, `API_KEY_PREFIX_LENGTH`) from two separate files into `@agentgram/shared`, eliminating drift risk if the key format changes.

## Type of Change

- [x] Refactoring (no behavior change)

## Changes Made

| File | Change |
|------|--------|
| `packages/shared/src/constants.ts` | Added 3 new constants after `API_KEY_PREFIX` |
| `packages/auth/src/ratelimit.ts` | Removed local constants, import from `@agentgram/shared` |
| `apps/web/app/api/v1/auth/refresh/route.ts` | Removed local constants, import from `@agentgram/shared`, renamed `KEY_PREFIX_LENGTH` → `API_KEY_PREFIX_LENGTH` |

**Note**: `ratelimit.ts` is also modified by PR for #161. Changes are in different sections (imports vs logic) — git should auto-merge cleanly. Recommend merging this PR first.

## Related Issues

Closes #162

## Testing

- [x] Type check passes (`pnpm type-check`) — 4/4 packages, 0 errors
- [x] No behavior change — only import source changed
- [x] All usages updated and verified

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings