### PR TITLE
[FEAT] Add mobile bottom tab navigation (#102)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -170,3 +170,9 @@ body {
     transparent
   );
 }
+
+@supports (padding-bottom: env(safe-area-inset-bottom)) {
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,6 +11,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import { PageTransition } from '@/components/PageTransition';
 import { Toaster } from '@/components/ui/toaster';
 import { AuthButton } from '@/components/auth/AuthButton';
+import { BottomNav } from '@/components/common';
 import { Providers } from './providers';
 import { getBaseUrl } from '@/lib/env';
 
@@ -132,7 +133,7 @@ export default function RootLayout({
                 </div>
 
                 <nav
-                  className="flex flex-1 items-center space-x-6 text-sm font-medium"
+                  className="hidden md:flex flex-1 items-center space-x-6 text-sm font-medium"
                   aria-label="Main navigation"
                 >
                   <Link
@@ -166,7 +167,7 @@ export default function RootLayout({
                     href={githubUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center space-x-2 text-sm"
+                    className="hidden md:flex items-center space-x-2 text-sm"
                     aria-label="Star on GitHub"
                   >
                     <Button variant="outline" size="sm" className="gap-2">
@@ -180,12 +181,12 @@ export default function RootLayout({
             </header>
 
             {/* Main Content with Page Transition */}
-            <main className="flex-1">
+            <main className="flex-1 pb-16 md:pb-0">
               <PageTransition>{children}</PageTransition>
             </main>
 
             {/* Footer */}
-            <footer className="border-t border-border/40 py-12">
+            <footer className="hidden md:block border-t border-border/40 py-12">
               <div className="container">
                 <div className="grid grid-cols-1 gap-8 md:grid-cols-4">
                   <div className="space-y-3">
@@ -325,6 +326,7 @@ export default function RootLayout({
                 </div>
               </div>
             </footer>
+            <BottomNav />
           </div>
           <Toaster />
         </Providers>

--- a/apps/web/components/common/BottomNav.tsx
+++ b/apps/web/components/common/BottomNav.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { Suspense } from 'react';
+import Link from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { Home, Search, PlusCircle, Heart, User } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+function BottomNavContent() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const tab = searchParams.get('tab');
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-border/40 bg-background/95 backdrop-blur-xl pb-safe md:hidden">
+      <div className="flex h-16 items-center justify-around px-2">
+        <Link
+          href="/explore"
+          className={cn(
+            'flex flex-col items-center justify-center space-y-1 p-2 transition-colors',
+            pathname === '/explore' && !tab
+              ? 'text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <Home className="h-6 w-6" />
+          <span className="text-[10px] font-medium">Home</span>
+        </Link>
+
+        <Link
+          href="/explore?tab=explore"
+          className={cn(
+            'flex flex-col items-center justify-center space-y-1 p-2 transition-colors',
+            pathname === '/explore' && tab === 'explore'
+              ? 'text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <Search className="h-6 w-6" />
+          <span className="text-[10px] font-medium">Search</span>
+        </Link>
+
+        <Link
+          href="/create"
+          className="flex flex-col items-center justify-center -mt-6"
+        >
+          <div className="rounded-full bg-gradient-to-r from-primary to-primary/80 p-3 shadow-lg transition-transform hover:scale-105 active:scale-95">
+            <PlusCircle className="h-6 w-6 text-primary-foreground" />
+          </div>
+        </Link>
+
+        <Link
+          href="/activity"
+          className={cn(
+            'flex flex-col items-center justify-center space-y-1 p-2 transition-colors',
+            pathname === '/activity'
+              ? 'text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <Heart className="h-6 w-6" />
+          <span className="text-[10px] font-medium">Activity</span>
+        </Link>
+
+        <Link
+          href="/dashboard"
+          className={cn(
+            'flex flex-col items-center justify-center space-y-1 p-2 transition-colors',
+            pathname === '/dashboard'
+              ? 'text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <User className="h-6 w-6" />
+          <span className="text-[10px] font-medium">Me</span>
+        </Link>
+      </div>
+    </nav>
+  );
+}
+
+export default function BottomNav() {
+  return (
+    <Suspense fallback={null}>
+      <BottomNavContent />
+    </Suspense>
+  );
+}

--- a/apps/web/components/common/index.ts
+++ b/apps/web/components/common/index.ts
@@ -1,3 +1,4 @@
 export { EmptyState } from './EmptyState';
 export { SearchBar } from './SearchBar';
 export { StatCard } from './StatCard';
+export { default as BottomNav } from './BottomNav';


### PR DESCRIPTION
## Description

Add Instagram-style mobile bottom tab navigation bar with 5 tabs (Home, Search, Post, Activity, Me). Desktop layout unchanged; mobile header simplified to logo + auth button.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **New**: `BottomNav.tsx` — Fixed bottom nav with 5 tabs, elevated center Post button with gradient, active state via `usePathname`/`useSearchParams`, wrapped in Suspense for static page compatibility
- **Modified**: `layout.tsx` — Added BottomNav, mobile bottom padding (`pb-16 md:pb-0`), hidden footer on mobile, hidden nav links + GitHub button on mobile
- **Modified**: `globals.css` — Added iOS safe area inset support (`.pb-safe`)
- **Modified**: `common/index.ts` — Export BottomNav

## Related Issues

Closes #102

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] No `as any` or `@ts-ignore` used