### PR TITLE
[FEAT] Add feed tabs with following/explore and grid/list toggle (#101)

### DIFF
--- a/apps/web/app/(public)/explore/page.tsx
+++ b/apps/web/app/(public)/explore/page.tsx
@@ -1,56 +1,189 @@
 'use client';
 
+import { useEffect, useState, Suspense } from 'react';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import { TrendingUp, Filter } from 'lucide-react';
+import { TrendingUp, Filter, ChevronDown } from 'lucide-react';
 import { SearchBar } from '@/components/common';
-import { PostsFeed } from '@/components/posts';
-import { useToast } from '@/hooks/use-toast';
+import { PostsFeed, FeedTabs, ViewToggle } from '@/components/posts';
+import { getSupabaseBrowser } from '@/lib/supabase-browser';
+import { cn } from '@/lib/utils';
 
-export default function ExplorePage() {
-  const { toast } = useToast();
+function ExploreContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoadingAuth, setIsLoadingAuth] = useState(true);
+  const [isSortOpen, setIsSortOpen] = useState(false);
 
-  const handleComingSoon = () => {
-    toast({
-      title: 'Coming Soon',
-      description: 'This feature is currently in development.',
+  // State from URL or defaults
+  const tab = (searchParams.get('tab') as 'following' | 'explore') || 'explore';
+  const viewParam = searchParams.get('view') as 'list' | 'grid' | null;
+  const sortParam = searchParams.get('sort') as 'hot' | 'new' | 'top' | null;
+
+  // Initialize view from localStorage if not in URL
+  const [localView, setLocalView] = useState<'list' | 'grid'>('list');
+
+  useEffect(() => {
+    const savedView = localStorage.getItem('agentgram:feed-view') as
+      | 'list'
+      | 'grid';
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (savedView) setLocalView(savedView);
+  }, []);
+
+  const view = viewParam || localView;
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const supabase = getSupabaseBrowser();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      setIsAuthenticated(!!session);
+      setIsLoadingAuth(false);
+    };
+    checkAuth();
+  }, []);
+
+  const updateParams = (updates: Record<string, string | null>) => {
+    const params = new URLSearchParams(searchParams.toString());
+    Object.entries(updates).forEach(([key, value]) => {
+      if (value === null) {
+        params.delete(key);
+      } else {
+        params.set(key, value);
+      }
     });
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
+  const handleTabChange = (newTab: 'following' | 'explore') => {
+    updateParams({ tab: newTab });
+  };
+
+  const handleViewChange = (newView: 'list' | 'grid') => {
+    setLocalView(newView);
+    updateParams({ view: newView });
+    localStorage.setItem('agentgram:feed-view', newView);
+  };
+
+  const handleSortChange = (newSort: 'hot' | 'new' | 'top') => {
+    updateParams({ sort: newSort });
+  };
+
+  // Determine effective sort
+  const sort = tab === 'following' ? 'new' : sortParam || 'hot';
+
   return (
-    <div className="container py-12">
-      <div className="mx-auto max-w-4xl">
-        {/* Header */}
-        <div className="mb-8">
-          <h1 className="mb-4 text-4xl font-bold tracking-tight">Explore</h1>
-          <p className="text-lg text-muted-foreground">
-            Discover what AI agents are sharing across the network
-          </p>
-        </div>
+    <div className="min-h-screen bg-background">
+      <FeedTabs activeTab={tab} onTabChange={handleTabChange} />
 
-        {/* Filters & Search */}
-        <div className="mb-8 flex flex-col gap-4 sm:flex-row">
-          <SearchBar placeholder="Search posts, agents, communities..." />
-          <Button
-            variant="outline"
-            className="gap-2"
-            onClick={handleComingSoon}
-          >
-            <Filter className="h-4 w-4" />
-            Filter
-          </Button>
-          <Button
-            variant="outline"
-            className="gap-2"
-            onClick={handleComingSoon}
-          >
-            <TrendingUp className="h-4 w-4" />
-            Trending
-          </Button>
-        </div>
+      <div className="container py-8">
+        <div className="mx-auto max-w-4xl space-y-8">
+          <div className="space-y-2">
+            <h1 className="text-4xl font-bold tracking-tight">
+              {tab === 'following' ? 'Following' : 'Explore'}
+            </h1>
+            <p className="text-lg text-muted-foreground">
+              {tab === 'following'
+                ? 'Latest updates from agents you follow'
+                : 'Discover what AI agents are sharing across the network'}
+            </p>
+          </div>
 
-        {/* Feed - Now using TanStack Query */}
-        <PostsFeed sort="hot" />
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="w-full sm:max-w-sm">
+              <SearchBar placeholder="Search posts, agents, communities..." />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <ViewToggle view={view} onViewChange={handleViewChange} />
+
+              {tab === 'explore' && (
+                <div className="relative">
+                  <Button
+                    variant="outline"
+                    className="gap-2"
+                    onClick={() => setIsSortOpen(!isSortOpen)}
+                  >
+                    {sort === 'hot' && <TrendingUp className="h-4 w-4" />}
+                    {sort === 'new' && <Filter className="h-4 w-4" />}
+                    {sort === 'top' && <TrendingUp className="h-4 w-4" />}
+                    <span className="capitalize">{sort}</span>
+                    <ChevronDown className="h-4 w-4 opacity-50" />
+                  </Button>
+
+                  {isSortOpen && (
+                    <>
+                      <button
+                        type="button"
+                        className="fixed inset-0 z-10 cursor-default"
+                        onClick={() => setIsSortOpen(false)}
+                        aria-label="Close menu"
+                      />
+                      <div className="absolute right-0 top-full z-20 mt-2 w-32 rounded-md border bg-popover p-1 shadow-md">
+                        {['hot', 'new', 'top'].map((s) => (
+                          <button
+                            key={s}
+                            type="button"
+                            className={cn(
+                              'flex w-full items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
+                              sort === s && 'bg-accent text-accent-foreground'
+                            )}
+                            onClick={() => {
+                              handleSortChange(s as 'hot' | 'new' | 'top');
+                              setIsSortOpen(false);
+                            }}
+                          >
+                            {s.charAt(0).toUpperCase() + s.slice(1)}
+                          </button>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {tab === 'following' && !isLoadingAuth && !isAuthenticated && (
+            <div className="rounded-lg border border-yellow-500/50 bg-yellow-500/10 p-4 text-yellow-600 dark:text-yellow-400">
+              <p className="font-medium">
+                Sign in to see posts from agents you follow.
+              </p>
+              <Button
+                variant="link"
+                className="h-auto p-0 text-yellow-600 underline dark:text-yellow-400"
+                onClick={() => router.push('/login')}
+              >
+                Sign in
+              </Button>
+            </div>
+          )}
+
+          <PostsFeed
+            sort={sort}
+            view={view}
+            scope={tab === 'following' ? 'following' : 'global'}
+          />
+        </div>
       </div>
     </div>
+  );
+}
+
+export default function ExplorePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="container py-12 text-center">
+          <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      }
+    >
+      <ExploreContent />
+    </Suspense>
   );
 }

--- a/apps/web/components/posts/FeedTabs.tsx
+++ b/apps/web/components/posts/FeedTabs.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface FeedTabsProps {
+  activeTab: 'following' | 'explore';
+  onTabChange: (tab: 'following' | 'explore') => void;
+}
+
+export function FeedTabs({ activeTab, onTabChange }: FeedTabsProps) {
+  return (
+    <div className="sticky top-[64px] z-40 flex w-full border-b bg-background/80 backdrop-blur-xl">
+      <div className="flex w-full">
+        <Button
+          variant="ghost"
+          onClick={() => onTabChange('following')}
+          className={cn(
+            'flex-1 rounded-none border-b-2 bg-transparent px-4 py-6 text-base hover:bg-transparent',
+            activeTab === 'following'
+              ? 'border-primary font-semibold text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          )}
+        >
+          Following
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={() => onTabChange('explore')}
+          className={cn(
+            'flex-1 rounded-none border-b-2 bg-transparent px-4 py-6 text-base hover:bg-transparent',
+            activeTab === 'explore'
+              ? 'border-primary font-semibold text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          )}
+        >
+          Explore
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -22,9 +22,14 @@ interface PostCardProps {
     };
   };
   className?: string;
+  variant?: 'feed' | 'grid';
 }
 
-export function PostCard({ post, className = '' }: PostCardProps) {
+export function PostCard({
+  post,
+  className = '',
+  variant = 'feed',
+}: PostCardProps) {
   const likeMutation = useLike(post.id);
   const { toast } = useToast();
   const [showHeartOverlay, setShowHeartOverlay] = useState(false);
@@ -34,7 +39,9 @@ export function PostCard({ post, className = '' }: PostCardProps) {
   // Resets on page reload. Will be accurate once API adds `is_liked` field.
   const [isLiked, setIsLiked] = useState(false);
 
-  const handleLike = async () => {
+  const handleLike = async (e?: React.MouseEvent) => {
+    e?.preventDefault();
+    e?.stopPropagation();
     setIsLiked(!isLiked); // Optimistic toggle
     try {
       await likeMutation.mutateAsync();
@@ -47,7 +54,9 @@ export function PostCard({ post, className = '' }: PostCardProps) {
     }
   };
 
-  const handleDoubleTap = () => {
+  const handleDoubleTap = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
     const now = Date.now();
     const DOUBLE_TAP_DELAY = 300;
 
@@ -63,7 +72,9 @@ export function PostCard({ post, className = '' }: PostCardProps) {
   };
 
   // Also support double click for desktop
-  const handleDoubleClick = () => {
+  const handleDoubleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
     if (!isLiked) {
       handleLike();
     }
@@ -109,6 +120,46 @@ export function PostCard({ post, className = '' }: PostCardProps) {
   const authorName =
     post.author?.display_name || post.author?.name || 'AgentGram Team';
 
+  if (variant === 'grid') {
+    return (
+      <Link
+        href={`/posts/${post.id}`}
+        className={cn(
+          'group relative block aspect-square w-full overflow-hidden bg-muted/20',
+          className
+        )}
+      >
+        {post.postType === 'media' && post.url ? (
+          <Image
+            src={post.url}
+            alt={post.title}
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        ) : (
+          <div className="flex h-full w-full flex-col items-center justify-center bg-gradient-to-br from-background to-muted p-4 text-center">
+            <h3 className="line-clamp-3 text-sm font-bold">{post.title}</h3>
+          </div>
+        )}
+
+        <div className="absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+          <div className="p-3 text-white">
+            <div className="flex items-center gap-4 text-sm font-semibold">
+              <div className="flex items-center gap-1">
+                <Heart className="h-4 w-4 fill-white" />
+                <span>{post.likes}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <MessageCircle className="h-4 w-4 fill-white" />
+                <span>{post.commentCount}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Link>
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -147,7 +198,10 @@ export function PostCard({ post, className = '' }: PostCardProps) {
             )}
           </div>
         </div>
-        <button className="text-foreground hover:text-muted-foreground">
+        <button
+          type="button"
+          className="text-foreground hover:text-muted-foreground"
+        >
           <MoreHorizontal className="h-5 w-5" />
         </button>
       </div>
@@ -156,7 +210,7 @@ export function PostCard({ post, className = '' }: PostCardProps) {
       <div
         className="relative w-full overflow-hidden bg-muted/20"
         onDoubleClick={handleDoubleClick}
-        onClick={handleDoubleTap} // Simple tap handler that checks timing
+        onClick={handleDoubleTap}
       >
         {/* Aspect Ratio Container - Min height for text posts, or auto for images */}
         <div
@@ -237,7 +291,7 @@ export function PostCard({ post, className = '' }: PostCardProps) {
             <Link href={`/posts/${post.id}`}>
               <MessageCircle className="h-6 w-6 text-foreground hover:text-muted-foreground -rotate-90" />
             </Link>
-            <button onClick={handleShare}>
+            <button type="button" onClick={handleShare}>
               <Send className="h-6 w-6 text-foreground hover:text-muted-foreground -rotate-45 mb-1" />
             </button>
           </div>

--- a/apps/web/components/posts/PostsFeed.tsx
+++ b/apps/web/components/posts/PostsFeed.tsx
@@ -6,13 +6,23 @@ import { PostSkeleton } from './PostSkeleton';
 import { Button } from '@/components/ui/button';
 import { Bot, Loader2 } from 'lucide-react';
 import { EmptyState } from '@/components/common';
+import { cn } from '@/lib/utils';
 
 interface PostsFeedProps {
   sort?: 'hot' | 'new' | 'top';
   communityId?: string;
+  view?: 'list' | 'grid';
+  agentId?: string;
+  scope?: 'global' | 'following';
 }
 
-export function PostsFeed({ sort = 'hot', communityId }: PostsFeedProps) {
+export function PostsFeed({
+  sort = 'hot',
+  communityId,
+  view = 'list',
+  agentId,
+  scope = 'global',
+}: PostsFeedProps) {
   const {
     data,
     isLoading,
@@ -21,12 +31,18 @@ export function PostsFeed({ sort = 'hot', communityId }: PostsFeedProps) {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = usePostsFeed({ sort, communityId });
+  } = usePostsFeed({ sort, communityId, agentId, scope });
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
-        {Array.from({ length: 3 }).map((_, i) => (
+      <div
+        className={cn(
+          'space-y-4',
+          view === 'grid' &&
+            'grid grid-cols-1 gap-1 space-y-0 sm:grid-cols-2 lg:grid-cols-3'
+        )}
+      >
+        {Array.from({ length: 6 }).map((_, i) => (
           <PostSkeleton key={i} />
         ))}
       </div>
@@ -37,7 +53,8 @@ export function PostsFeed({ sort = 'hot', communityId }: PostsFeedProps) {
     return (
       <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
         <p className="text-destructive">
-          Failed to load posts: {error instanceof Error ? error.message : 'Unknown error'}
+          Failed to load posts:{' '}
+          {error instanceof Error ? error.message : 'Unknown error'}
         </p>
       </div>
     );
@@ -50,20 +67,36 @@ export function PostsFeed({ sort = 'hot', communityId }: PostsFeedProps) {
       <EmptyState
         icon={Bot}
         title="No posts yet"
-        description="Be the first to share something! Register your agent and start posting."
-        action={{ label: 'Get API Access' }}
+        description={
+          scope === 'following'
+            ? "You aren't following anyone yet, or they haven't posted anything."
+            : 'Be the first to share something! Register your agent and start posting.'
+        }
+        action={scope === 'following' ? undefined : { label: 'Get API Access' }}
       />
     );
   }
 
   return (
-    <div className="space-y-4">
-      {allPosts.map((post) => (
-        <PostCard key={post.id} post={post} />
-      ))}
+    <div className="space-y-8">
+      <div
+        className={cn(
+          'space-y-4',
+          view === 'grid' &&
+            'grid grid-cols-1 gap-1 space-y-0 sm:grid-cols-2 lg:grid-cols-3'
+        )}
+      >
+        {allPosts.map((post) => (
+          <PostCard
+            key={post.id}
+            post={post}
+            variant={view === 'grid' ? 'grid' : 'feed'}
+          />
+        ))}
+      </div>
 
       {hasNextPage && (
-        <div className="mt-8 text-center">
+        <div className="text-center">
           <Button
             variant="outline"
             size="lg"

--- a/apps/web/components/posts/ViewToggle.tsx
+++ b/apps/web/components/posts/ViewToggle.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+import { LayoutList, Grid3x3 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface ViewToggleProps {
+  view: 'list' | 'grid';
+  onViewChange: (view: 'list' | 'grid') => void;
+}
+
+export function ViewToggle({ view, onViewChange }: ViewToggleProps) {
+  // Persist to localStorage
+  useEffect(() => {
+    localStorage.setItem('agentgram:feed-view', view);
+  }, [view]);
+
+  return (
+    <div className="flex items-center gap-1 rounded-lg border bg-background p-1">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => onViewChange('list')}
+        className={cn(
+          'h-8 w-8 rounded-md',
+          view === 'list'
+            ? 'bg-muted text-foreground'
+            : 'text-muted-foreground hover:text-foreground'
+        )}
+        aria-label="List view"
+      >
+        <LayoutList className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => onViewChange('grid')}
+        className={cn(
+          'h-8 w-8 rounded-md',
+          view === 'grid'
+            ? 'bg-muted text-foreground'
+            : 'text-muted-foreground hover:text-foreground'
+        )}
+        aria-label="Grid view"
+      >
+        <Grid3x3 className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/components/posts/index.ts
+++ b/apps/web/components/posts/index.ts
@@ -1,2 +1,4 @@
 export { PostCard } from './PostCard';
 export { PostsFeed } from './PostsFeed';
+export { FeedTabs } from './FeedTabs';
+export { ViewToggle } from './ViewToggle';


### PR DESCRIPTION
## Description

Redesign the Explore page with two-tab feed (Following + Explore), grid/list view toggle with localStorage persistence, and URL-driven state management. Following tab filters posts from followed agents using client-side Supabase queries.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **New**: `FeedTabs.tsx` — Sticky tab bar switching between Following and Explore feeds
- **New**: `ViewToggle.tsx` — Grid/List toggle with `localStorage` persistence
- **Modified**: `PostCard.tsx` — Added `variant="grid"` prop for compact square card layout with title overlay
- **Modified**: `PostsFeed.tsx` — Grid layout support (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`), accepts `view`, `agentId`, `scope` props
- **Modified**: `use-posts.ts` — Added `agentId` filtering and `scope="following"` mode (fetches followed agent IDs, filters via `.in()`)
- **Rewritten**: `explore/page.tsx` — Two tabs, view toggle, sort dropdown, URL search params state, auth check for Following tab

## Related Issues

Closes #101

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] No `as any` or `@ts-ignore` used