### PR TITLE
[FEAT] Add agent profile page with Instagram-style header and post grid (#103)

### DIFF
--- a/apps/web/app/(public)/agents/[name]/page.tsx
+++ b/apps/web/app/(public)/agents/[name]/page.tsx
@@ -1,0 +1,72 @@
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { ProfileContent } from '@/components/agents/ProfileContent';
+import { Agent } from '@agentgram/shared';
+
+interface PageProps {
+  params: Promise<{ name: string }>;
+}
+
+async function getAgent(name: string): Promise<Agent | null> {
+  const supabase = getSupabaseServiceClient();
+  const { data, error } = await supabase
+    .from('agents')
+    .select('*')
+    .eq('name', name)
+    .single();
+
+  if (error || !data) return null;
+
+  return {
+    id: data.id,
+    name: data.name,
+    displayName: data.display_name || undefined,
+    description: data.description || undefined,
+    publicKey: data.public_key || undefined,
+    email: data.email || undefined,
+    emailVerified: data.email_verified,
+    karma: data.karma,
+    status: data.status,
+    trustScore: data.trust_score,
+    metadata: data.metadata,
+    avatarUrl: data.avatar_url || undefined,
+    createdAt: data.created_at,
+    updatedAt: data.updated_at,
+    lastActive: data.last_active,
+    followerCount: data.follower_count || 0,
+    followingCount: data.following_count || 0,
+  };
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { name } = await params;
+  const agent = await getAgent(name);
+
+  if (!agent) {
+    return {
+      title: 'Agent Not Found',
+    };
+  }
+
+  const displayName = agent.displayName || agent.name;
+
+  return {
+    title: `${displayName} (@${agent.name}) — AgentGram`,
+    description:
+      agent.description || `Check out ${displayName}'s profile on AgentGram.`,
+  };
+}
+
+export default async function AgentProfilePage({ params }: PageProps) {
+  const { name } = await params;
+  const agent = await getAgent(name);
+
+  if (!agent) {
+    notFound();
+  }
+
+  return <ProfileContent agent={agent} />;
+}

--- a/apps/web/app/(public)/pricing/success/page.tsx
+++ b/apps/web/app/(public)/pricing/success/page.tsx
@@ -4,6 +4,8 @@ import { motion } from 'framer-motion';
 import { CheckCircle2, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
+import Link from 'next/link';
+
 export default function SuccessPage() {
   return (
     <div className="min-h-screen flex items-center justify-center p-4">
@@ -24,10 +26,10 @@ export default function SuccessPage() {
         </div>
 
         <Button size="lg" className="gap-2" asChild>
-          <a href="/agents/me">
+          <Link href="/agents/me">
             Go to Dashboard
             <ArrowRight className="w-4 h-4" />
-          </a>
+          </Link>
         </Button>
       </motion.div>
     </div>

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -1,7 +1,9 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import { Bot, Award } from 'lucide-react';
 import { Agent } from '@agentgram/shared';
-import { Button } from '@/components/ui/button';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 interface AgentCardProps {
   agent: Agent & {
@@ -29,8 +31,12 @@ export function AgentCard({
     })();
 
   return (
-    <div
-      className={`group rounded-lg border bg-card p-6 transition-all hover:border-primary/50 hover:shadow-lg ${className}`}
+    <Link
+      href={`/agents/${agent.name}`}
+      className={cn(
+        'group block rounded-lg border bg-card p-6 transition-all hover:border-primary/50 hover:shadow-lg',
+        className
+      )}
     >
       <div className="mb-4 flex items-start justify-between">
         <div className="flex items-center gap-3">
@@ -80,10 +86,16 @@ export function AgentCard({
       </div>
 
       <div className="mt-4 pt-4 border-t">
-        <Button variant="outline" size="sm" className="w-full">
+        <div
+          className={buttonVariants({
+            variant: 'outline',
+            size: 'sm',
+            className: 'w-full',
+          })}
+        >
           View Profile
-        </Button>
+        </div>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/apps/web/components/agents/FollowButton.tsx
+++ b/apps/web/components/agents/FollowButton.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useFollow } from '@/hooks/use-agents';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2 } from 'lucide-react';
+
+interface FollowButtonProps {
+  agentId: string;
+  initialIsFollowing?: boolean;
+  onFollowChange?: (isFollowing: boolean) => void;
+}
+
+export function FollowButton({
+  agentId,
+  initialIsFollowing = false,
+  onFollowChange,
+}: FollowButtonProps) {
+  const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
+  const [isHovering, setIsHovering] = useState(false);
+  const { toast } = useToast();
+  const followMutation = useFollow(agentId);
+
+  const handleFollow = async () => {
+    const newState = !isFollowing;
+    setIsFollowing(newState); // Optimistic update
+
+    try {
+      const result = await followMutation.mutateAsync();
+      // result.data.following should match newState
+      if (result.data.following !== newState) {
+        setIsFollowing(result.data.following);
+      }
+      if (onFollowChange) {
+        onFollowChange(result.data.following);
+      }
+    } catch (error) {
+      setIsFollowing(!newState); // Revert
+      toast({
+        title: 'Error',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Failed to update follow status',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <Button
+      variant={
+        isFollowing ? (isHovering ? 'destructive' : 'outline') : 'default'
+      }
+      className={
+        isFollowing
+          ? 'w-28'
+          : 'w-28 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white border-0'
+      }
+      onClick={handleFollow}
+      onMouseEnter={() => isFollowing && setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+      disabled={followMutation.isPending}
+    >
+      {followMutation.isPending ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : isFollowing ? (
+        isHovering ? (
+          'Unfollow'
+        ) : (
+          'Following'
+        )
+      ) : (
+        'Follow'
+      )}
+    </Button>
+  );
+}

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useState } from 'react';
+import { Agent } from '@agentgram/shared';
+import { ProfileHeader } from './ProfileHeader';
+import { ProfileTabs } from './ProfileTabs';
+import { ProfilePostGrid } from './ProfilePostGrid';
+
+interface ProfileContentProps {
+  agent: Agent;
+}
+
+export function ProfileContent({ agent }: ProfileContentProps) {
+  const [activeTab, setActiveTab] = useState<'posts' | 'likes'>('posts');
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <ProfileHeader agent={agent} />
+      <ProfileTabs activeTab={activeTab} onTabChange={setActiveTab} />
+      <ProfilePostGrid
+        agentId={agent.id}
+        type={activeTab === 'posts' ? 'authored' : 'liked'}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import Image from 'next/image';
+import { Bot } from 'lucide-react';
+import { Agent } from '@agentgram/shared';
+import { FollowButton } from './FollowButton';
+
+interface ProfileHeaderProps {
+  agent: Agent;
+}
+
+export function ProfileHeader({ agent }: ProfileHeaderProps) {
+  return (
+    <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-10 px-4 py-8">
+      <div className="flex-shrink-0 mx-auto md:mx-0">
+        <div className="relative h-24 w-24 md:h-32 md:w-32 rounded-full overflow-hidden border-2 border-background ring-2 ring-border">
+          {agent.avatarUrl ? (
+            <Image
+              src={agent.avatarUrl}
+              alt={agent.displayName || agent.name}
+              fill
+              className="object-cover"
+              priority
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center bg-muted">
+              <Bot className="h-12 w-12 text-muted-foreground" />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1 flex flex-col items-center md:items-start gap-4">
+        <div className="flex flex-col md:flex-row items-center gap-4 w-full">
+          <h1 className="text-xl md:text-2xl font-bold truncate">
+            {agent.displayName || agent.name}
+          </h1>
+          <div className="flex gap-2">
+            <FollowButton agentId={agent.id} />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-6 text-sm md:text-base">
+          <div className="flex flex-col items-center md:flex-row md:gap-1">
+            <span className="font-bold">{0}</span>
+            <span className="text-muted-foreground">posts</span>
+          </div>
+          <div className="flex flex-col items-center md:flex-row md:gap-1">
+            <span className="font-bold">{agent.followerCount || 0}</span>
+            <span className="text-muted-foreground">followers</span>
+          </div>
+          <div className="flex flex-col items-center md:flex-row md:gap-1">
+            <span className="font-bold">{agent.followingCount || 0}</span>
+            <span className="text-muted-foreground">following</span>
+          </div>
+        </div>
+
+        <div className="text-center md:text-left max-w-md">
+          <p className="font-medium text-sm text-muted-foreground">
+            @{agent.name}
+          </p>
+          {agent.description && (
+            <p className="mt-2 text-sm whitespace-pre-wrap line-clamp-3">
+              {agent.description}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/agents/ProfilePostGrid.tsx
+++ b/apps/web/components/agents/ProfilePostGrid.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useAgentPosts } from '@/hooks/use-agents';
+import Image from 'next/image';
+import Link from 'next/link';
+import { Heart, MessageCircle, Copy } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface ProfilePostGridProps {
+  agentId: string;
+  type: 'authored' | 'liked';
+}
+
+export function ProfilePostGrid({ agentId, type }: ProfilePostGridProps) {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+    useAgentPosts(agentId, type);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const posts = data?.pages.flatMap((page) => page.posts) || [];
+
+  if (posts.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <div className="rounded-full bg-muted p-4 mb-4">
+          {type === 'authored' ? (
+            <Copy className="h-8 w-8 text-muted-foreground" />
+          ) : (
+            <Heart className="h-8 w-8 text-muted-foreground" />
+          )}
+        </div>
+        <h3 className="text-lg font-semibold">
+          {type === 'authored' ? 'No posts yet' : 'No liked posts'}
+        </h3>
+        <p className="text-muted-foreground max-w-xs mt-2">
+          {type === 'authored'
+            ? "When this agent creates posts, they'll appear here."
+            : 'Posts this agent likes will appear here.'}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pb-8">
+      <div className="grid grid-cols-3 gap-1 md:gap-4 mb-8">
+        {posts.map((post) => (
+          <Link
+            key={post.id}
+            href={`/posts/${post.id}`}
+            className="group relative aspect-square bg-muted overflow-hidden"
+          >
+            {post.postType === 'media' && post.url ? (
+              <Image
+                src={post.url}
+                alt={post.title}
+                fill
+                className="object-cover transition-transform group-hover:scale-105"
+              />
+            ) : (
+              <div className="flex h-full w-full flex-col items-center justify-center p-4 text-center bg-gradient-to-br from-background to-muted">
+                <p className="text-xs font-medium line-clamp-3">{post.title}</p>
+              </div>
+            )}
+
+            <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-4 text-white font-bold">
+              <div className="flex items-center gap-1">
+                <Heart className="h-5 w-5 fill-white" />
+                <span>{post.likes}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <MessageCircle className="h-5 w-5 fill-white" />
+                <span>{post.commentCount}</span>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      {hasNextPage && (
+        <div className="flex justify-center">
+          <Button
+            variant="outline"
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+          >
+            {isFetchingNextPage ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Loading...
+              </>
+            ) : (
+              'Load More'
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/agents/ProfileTabs.tsx
+++ b/apps/web/components/agents/ProfileTabs.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Grid3x3, Heart } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ProfileTabsProps {
+  activeTab: 'posts' | 'likes';
+  onTabChange: (tab: 'posts' | 'likes') => void;
+}
+
+export function ProfileTabs({ activeTab, onTabChange }: ProfileTabsProps) {
+  return (
+    <div className="flex items-center justify-center border-t border-border">
+      <button
+        type="button"
+        onClick={() => onTabChange('posts')}
+        className={cn(
+          'flex items-center gap-2 px-8 py-4 text-xs font-semibold uppercase tracking-widest transition-colors',
+          activeTab === 'posts'
+            ? 'border-t-2 border-foreground text-foreground -mt-[1px]'
+            : 'text-muted-foreground hover:text-foreground'
+        )}
+      >
+        <Grid3x3 className="h-4 w-4" />
+        <span className="hidden sm:inline">Posts</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => onTabChange('likes')}
+        className={cn(
+          'flex items-center gap-2 px-8 py-4 text-xs font-semibold uppercase tracking-widest transition-colors',
+          activeTab === 'likes'
+            ? 'border-t-2 border-foreground text-foreground -mt-[1px]'
+            : 'text-muted-foreground hover:text-foreground'
+        )}
+      >
+        <Heart className="h-4 w-4" />
+        <span className="hidden sm:inline">Likes</span>
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/agents/index.ts
+++ b/apps/web/components/agents/index.ts
@@ -1,2 +1,7 @@
 export { AgentCard } from './AgentCard';
 export { AgentsList } from './AgentsList';
+export { ProfileHeader } from './ProfileHeader';
+export { ProfileContent } from './ProfileContent';
+export { ProfileTabs } from './ProfileTabs';
+export { ProfilePostGrid } from './ProfilePostGrid';
+export { FollowButton } from './FollowButton';

--- a/apps/web/hooks/use-agents.ts
+++ b/apps/web/hooks/use-agents.ts
@@ -1,9 +1,15 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  useInfiniteQuery,
+} from '@tanstack/react-query';
 import { getSupabaseBrowser } from '@/lib/supabase-browser';
 import type { Agent } from '@agentgram/shared';
 import { PAGINATION } from '@agentgram/shared';
+import { transformPost } from './use-posts';
 
 // Type for agent response from Supabase
 type AgentResponse = {
@@ -22,6 +28,8 @@ type AgentResponse = {
   created_at: string;
   updated_at: string;
   last_active: string;
+  follower_count?: number;
+  following_count?: number;
 };
 
 // Transform Supabase response to match Agent type
@@ -42,6 +50,8 @@ function transformAgent(agent: AgentResponse): Agent {
     createdAt: agent.created_at,
     updatedAt: agent.updated_at,
     lastActive: agent.last_active,
+    followerCount: agent.follower_count || 0,
+    followingCount: agent.following_count || 0,
   };
 }
 
@@ -106,6 +116,120 @@ export function useAgent(agentId: string | undefined) {
 
       return transformAgent(data);
     },
+    enabled: !!agentId,
+  });
+}
+
+/**
+ * Fetch a single agent by Name
+ */
+export function useAgentByName(name: string) {
+  return useQuery({
+    queryKey: ['agents', 'name', name],
+    queryFn: async () => {
+      const supabase = getSupabaseBrowser();
+      const { data, error } = await supabase
+        .from('agents')
+        .select('*')
+        .eq('name', name)
+        .single();
+
+      if (error) throw error;
+      if (!data) throw new Error('Agent not found');
+
+      return transformAgent(data);
+    },
+    enabled: !!name,
+  });
+}
+
+/**
+ * Follow/Unfollow an agent
+ */
+export function useFollow(targetAgentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const res = await fetch(`/api/v1/agents/${targetAgentId}/follow`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.error?.message || 'Failed to follow');
+      }
+      return res.json();
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['agents'] });
+    },
+  });
+}
+
+/**
+ * Fetch posts by agent (authored or liked)
+ */
+export function useAgentPosts(
+  agentId: string,
+  type: 'authored' | 'liked' = 'authored',
+  limit = 12
+) {
+  return useInfiniteQuery({
+    queryKey: ['agents', agentId, 'posts', type],
+    queryFn: async ({ pageParam = 0 }) => {
+      const supabase = getSupabaseBrowser();
+      const from = pageParam * limit;
+      const to = from + limit - 1;
+
+      if (type === 'authored') {
+        const { data, error } = await supabase
+          .from('posts')
+          .select(
+            `
+            *,
+            author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma),
+            community:communities(id, name, display_name)
+          `
+          )
+          .eq('author_id', agentId)
+          .order('created_at', { ascending: false })
+          .range(from, to);
+
+        if (error) throw error;
+        return {
+          posts: (data || []).map(transformPost),
+          nextPage: data && data.length === limit ? pageParam + 1 : undefined,
+        };
+      } else {
+        // Liked posts
+        const { data, error } = await supabase
+          .from('post_likes')
+          .select(
+            `
+            post:posts!inner(
+              *,
+              author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma),
+              community:communities(id, name, display_name)
+            )
+          `
+          )
+          .eq('agent_id', agentId)
+          .order('created_at', { ascending: false })
+          .range(from, to);
+
+        if (error) throw error;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const posts = (data || []).map((item: any) => transformPost(item.post));
+
+        return {
+          posts,
+          nextPage: data && data.length === limit ? pageParam + 1 : undefined,
+        };
+      }
+    },
+    getNextPageParam: (lastPage) => lastPage.nextPage,
+    initialPageParam: 0,
     enabled: !!agentId,
   });
 }

--- a/apps/web/hooks/use-posts.ts
+++ b/apps/web/hooks/use-posts.ts
@@ -16,7 +16,7 @@ import { PAGINATION } from '@agentgram/shared';
 import { transformAuthor } from './transform';
 
 // Type for the post response from Supabase
-type PostResponse = {
+export type PostResponse = {
   id: string;
   author_id: string;
   community_id: string | null;
@@ -45,7 +45,7 @@ type PostResponse = {
 };
 
 // Transform Supabase response to match Post type
-function transformPost(post: PostResponse): Post {
+export function transformPost(post: PostResponse): Post {
   return {
     id: post.id,
     authorId: post.author_id,


### PR DESCRIPTION
## Description

Add Instagram-style agent profile page at `/agents/[name]` with profile header (avatar, stats, bio), follow button, and tabbed post grid (authored + liked posts). Server-side rendering with SEO metadata.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **New**: `agents/[name]/page.tsx` — Server component with `generateMetadata`, fetches agent by name, 404 handling
- **New**: `ProfileHeader.tsx` — Avatar (96px/128px), display name, @username, follower/following stats, bio
- **New**: `FollowButton.tsx` — Toggle follow/unfollow with optimistic UI, hover "Unfollow" state
- **New**: `ProfileTabs.tsx` — Posts/Likes tab bar with icons
- **New**: `ProfilePostGrid.tsx` — 3-column grid with hover overlay (likes/comments), infinite scroll
- **New**: `ProfileContent.tsx` — Tab state orchestrator
- **Modified**: `use-agents.ts` — Added `useAgentByName`, `useFollow`, `useAgentPosts` hooks
- **Modified**: `use-posts.ts` — Exported `transformPost` for reuse
- **Modified**: `AgentCard.tsx` — Wrapped with Link to profile page
- **Modified**: `agents/index.ts` — Export new components

## Related Issues

Closes #103

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] No `as any` or `@ts-ignore` used