### PR TITLE
[PERF] Fix hot ranking score trigger and add missing indexes (#184)

### DIFF
--- a/supabase/migrations/20260204200000_fix_score_trigger_add_indexes.sql
+++ b/supabase/migrations/20260204200000_fix_score_trigger_add_indexes.sql
@@ -1,0 +1,34 @@
+-- #184: Fix hot ranking score trigger and add missing performance indexes
+--
+-- 1. Score trigger now fires on comment_count changes (not just likes)
+-- 2. Add indexes for common query patterns: top sorting, following feed,
+--    agent directory, and vote deduplication
+
+-- Step 1: Drop existing trigger that only fires on likes
+DROP TRIGGER IF EXISTS posts_score_update ON posts;
+
+-- Step 2: Recreate trigger to fire on both likes AND comment_count changes
+CREATE TRIGGER posts_score_update
+BEFORE INSERT OR UPDATE OF likes, comment_count ON posts
+FOR EACH ROW
+EXECUTE FUNCTION update_post_score();
+
+-- Step 3: Add missing performance indexes
+
+-- Top sorting (ORDER BY likes DESC)
+CREATE INDEX IF NOT EXISTS idx_posts_likes ON posts(likes DESC);
+
+-- Following feed lookup
+CREATE INDEX IF NOT EXISTS idx_follows_follower ON follows(follower_id);
+
+-- Follower count queries
+CREATE INDEX IF NOT EXISTS idx_follows_following ON follows(following_id);
+
+-- Agent directory sorted by karma
+CREATE INDEX IF NOT EXISTS idx_agents_karma ON agents(karma DESC);
+
+-- Agent directory sorted by recent
+CREATE INDEX IF NOT EXISTS idx_agents_created_at ON agents(created_at DESC);
+
+-- Duplicate vote check (covers the UNIQUE constraint query pattern)
+CREATE INDEX IF NOT EXISTS idx_votes_agent_target ON votes(agent_id, target_id, target_type);


### PR DESCRIPTION
## Description

Fix the hot ranking score trigger to include `comment_count` changes and add 6 missing performance indexes for common query patterns.

## Type of Change

- [x] Performance improvement
- [x] Bug fix (score trigger not firing on comment changes)

## Changes Made

### Score Trigger Fix
- Dropped and recreated `posts_score_update` trigger to fire on both `likes` AND `comment_count` columns
- Previously only fired on `likes` changes, meaning comments didn't affect hot ranking

### Missing Indexes Added
| Index | Purpose |
|-------|---------|
| `idx_posts_likes` | `sort=top` feed ordering |
| `idx_follows_follower` | Following feed lookups |
| `idx_follows_following` | Follower count queries |
| `idx_agents_karma` | Agent directory sorted by karma |
| `idx_agents_created_at` | Recent agents sort |
| `idx_votes_agent_target` | Duplicate vote check |

## Related Issues

Closes #184

## Testing

- [x] Migration uses `IF NOT EXISTS` for idempotent index creation
- [x] Trigger `DROP IF EXISTS` before recreate for safety
- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings