### PR TITLE
[REFACTOR] Consolidate agent transform logic (#196)

### DIFF
--- a/apps/web/app/(public)/agents/[name]/page.tsx
+++ b/apps/web/app/(public)/agents/[name]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getSupabaseServiceClient } from '@agentgram/db';
 import { ProfileContent } from '@/components/agents/ProfileContent';
-import { Agent } from '@agentgram/shared';
+import { Agent, transformAgent } from '@agentgram/shared';
 
 interface PageProps {
   params: Promise<{ name: string }>;
@@ -18,25 +18,7 @@ async function getAgent(name: string): Promise<Agent | null> {
 
   if (error || !data) return null;
 
-  return {
-    id: data.id,
-    name: data.name,
-    displayName: data.display_name || undefined,
-    description: data.description || undefined,
-    publicKey: data.public_key || undefined,
-    email: data.email || undefined,
-    emailVerified: data.email_verified,
-    karma: data.karma,
-    status: data.status,
-    trustScore: data.trust_score,
-    metadata: data.metadata,
-    avatarUrl: data.avatar_url || undefined,
-    createdAt: data.created_at,
-    updatedAt: data.updated_at,
-    lastActive: data.last_active,
-    followerCount: data.follower_count || 0,
-    followingCount: data.following_count || 0,
-  };
+  return transformAgent(data);
 }
 
 export async function generateMetadata({

--- a/apps/web/hooks/transform.ts
+++ b/apps/web/hooks/transform.ts
@@ -1,29 +1,3 @@
-import type { Agent } from '@agentgram/shared';
-
-export type AuthorResponse = {
-  id: string;
-  name: string;
-  display_name: string | null;
-  avatar_url: string | null;
-  karma: number;
-};
-
-export function transformAuthor(author: AuthorResponse): Agent {
-  return {
-    id: author.id,
-    name: author.name,
-    displayName: author.display_name || undefined,
-    description: undefined,
-    publicKey: undefined,
-    email: undefined,
-    emailVerified: false,
-    karma: author.karma,
-    status: 'active',
-    trustScore: 0,
-    metadata: {},
-    avatarUrl: author.avatar_url || undefined,
-    createdAt: '',
-    updatedAt: '',
-    lastActive: '',
-  };
-}
+// Re-export from shared package for backward compatibility
+export { transformAuthor } from '@agentgram/shared';
+export type { AuthorResponse } from '@agentgram/shared';

--- a/apps/web/hooks/use-agents.ts
+++ b/apps/web/hooks/use-agents.ts
@@ -8,52 +8,8 @@ import {
 } from '@tanstack/react-query';
 import { getSupabaseBrowser } from '@/lib/supabase-browser';
 import type { Agent } from '@agentgram/shared';
-import { PAGINATION } from '@agentgram/shared';
+import { PAGINATION, transformAgent } from '@agentgram/shared';
 import { transformPost } from './use-posts';
-
-// Type for agent response from Supabase
-type AgentResponse = {
-  id: string;
-  name: string;
-  display_name: string | null;
-  description: string | null;
-  public_key: string | null;
-  email: string | null;
-  email_verified: boolean;
-  karma: number;
-  status: 'active' | 'suspended' | 'banned';
-  trust_score: number;
-  metadata: Record<string, unknown>;
-  avatar_url: string | null;
-  created_at: string;
-  updated_at: string;
-  last_active: string;
-  follower_count?: number;
-  following_count?: number;
-};
-
-// Transform Supabase response to match Agent type
-function transformAgent(agent: AgentResponse): Agent {
-  return {
-    id: agent.id,
-    name: agent.name,
-    displayName: agent.display_name || undefined,
-    description: agent.description || undefined,
-    publicKey: agent.public_key || undefined,
-    email: agent.email || undefined,
-    emailVerified: agent.email_verified,
-    karma: agent.karma,
-    status: agent.status,
-    trustScore: agent.trust_score,
-    metadata: agent.metadata,
-    avatarUrl: agent.avatar_url || undefined,
-    createdAt: agent.created_at,
-    updatedAt: agent.updated_at,
-    lastActive: agent.last_active,
-    followerCount: agent.follower_count || 0,
-    followingCount: agent.following_count || 0,
-  };
-}
 
 type AgentsParams = {
   sort?: 'karma' | 'recent' | 'active';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,3 +4,4 @@ export * from './sanitize';
 export * from './api-helpers';
 export * from './hashtags';
 export * from './mentions';
+export * from './transforms';

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -1,0 +1,72 @@
+import type { Agent } from '../types';
+
+// Type for agent response from Supabase
+export type AgentResponse = {
+  id: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  public_key: string | null;
+  email: string | null;
+  email_verified: boolean;
+  karma: number;
+  status: 'active' | 'suspended' | 'banned';
+  trust_score: number;
+  metadata: Record<string, unknown>;
+  avatar_url: string | null;
+  created_at: string;
+  updated_at: string;
+  last_active: string;
+  follower_count?: number;
+  following_count?: number;
+};
+
+export type AuthorResponse = {
+  id: string;
+  name: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  karma: number;
+};
+
+export function transformAgent(agent: AgentResponse): Agent {
+  return {
+    id: agent.id,
+    name: agent.name,
+    displayName: agent.display_name || undefined,
+    description: agent.description || undefined,
+    publicKey: agent.public_key || undefined,
+    email: agent.email || undefined,
+    emailVerified: agent.email_verified,
+    karma: agent.karma,
+    status: agent.status,
+    trustScore: agent.trust_score,
+    metadata: agent.metadata,
+    avatarUrl: agent.avatar_url || undefined,
+    createdAt: agent.created_at,
+    updatedAt: agent.updated_at,
+    lastActive: agent.last_active,
+    followerCount: agent.follower_count || 0,
+    followingCount: agent.following_count || 0,
+  };
+}
+
+export function transformAuthor(author: AuthorResponse): Agent {
+  return {
+    id: author.id,
+    name: author.name,
+    displayName: author.display_name || undefined,
+    description: undefined,
+    publicKey: undefined,
+    email: undefined,
+    emailVerified: false,
+    karma: author.karma,
+    status: 'active',
+    trustScore: 0,
+    metadata: {},
+    avatarUrl: author.avatar_url || undefined,
+    createdAt: '',
+    updatedAt: '',
+    lastActive: '',
+  };
+}

--- a/packages/shared/src/transforms/index.ts
+++ b/packages/shared/src/transforms/index.ts
@@ -1,0 +1,2 @@
+export { transformAgent, transformAuthor } from './agent';
+export type { AgentResponse, AuthorResponse } from './agent';


### PR DESCRIPTION
## Description

Consolidates 3 duplicate agent transform functions (`transformAgent` in `use-agents.ts`, inline transform in `agents/[name]/page.tsx`, and `transformAuthor` in `hooks/transform.ts`) into a single shared location in `packages/shared/src/transforms/`.

## Type of Change

- [x] Refactoring (no functional changes)

## Changes Made

- Created `packages/shared/src/transforms/agent.ts` with `transformAgent()` and `transformAuthor()`
- Created barrel export `packages/shared/src/transforms/index.ts`
- Updated `packages/shared/src/index.ts` to export transforms
- Removed local `AgentResponse` type and `transformAgent` function from `hooks/use-agents.ts` (-46 lines)
- Replaced `hooks/transform.ts` with re-exports from shared for backward compatibility
- Replaced 19-line inline transform in `agents/[name]/page.tsx` with `transformAgent(data)` call

## Related Issues

Closes #196

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings