### PR TITLE
[REFACTOR] Extract shared ErrorAlert and LoadingSpinner components (#198)

### DIFF
--- a/apps/web/components/agents/AgentsList.tsx
+++ b/apps/web/components/agents/AgentsList.tsx
@@ -5,7 +5,7 @@ import { PAGINATION } from '@agentgram/shared';
 import { useAgents } from '@/hooks';
 import { AgentCard } from './AgentCard';
 import { AgentSkeleton } from './AgentSkeleton';
-import { EmptyState } from '@/components/common';
+import { EmptyState, ErrorAlert } from '@/components/common';
 
 interface AgentsListProps {
   sort?: 'karma' | 'recent' | 'active';
@@ -29,14 +29,7 @@ export function AgentsList({
   }
 
   if (isError) {
-    return (
-      <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
-        <p className="text-destructive">
-          Failed to load agents:{' '}
-          {error instanceof Error ? error.message : 'Unknown error'}
-        </p>
-      </div>
-    );
+    return <ErrorAlert message="Failed to load agents" error={error} />;
   }
 
   const agents = data?.agents || [];

--- a/apps/web/components/common/ErrorAlert.tsx
+++ b/apps/web/components/common/ErrorAlert.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface ErrorAlertProps {
+  message: string;
+  error?: unknown;
+}
+
+export default function ErrorAlert({ message, error }: ErrorAlertProps) {
+  const errorDetail = error instanceof Error ? error.message : 'Unknown error';
+
+  return (
+    <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
+      <p className="text-destructive">
+        {message}: {errorDetail}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/common/LoadingSpinner.tsx
+++ b/apps/web/components/common/LoadingSpinner.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface LoadingSpinnerProps {
+  className?: string;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeMap = {
+  sm: 'h-4 w-4',
+  md: 'h-6 w-6',
+  lg: 'h-8 w-8',
+} as const;
+
+export default function LoadingSpinner({
+  className,
+  size = 'md',
+}: LoadingSpinnerProps) {
+  return (
+    <div className={cn('flex items-center justify-center', className)}>
+      <Loader2
+        className={cn('animate-spin text-muted-foreground', sizeMap[size])}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/common/index.ts
+++ b/apps/web/components/common/index.ts
@@ -3,3 +3,5 @@ export { SearchBar } from './SearchBar';
 export { StatCard } from './StatCard';
 export { default as BottomNav } from './BottomNav';
 export { default as TranslateButton } from './TranslateButton';
+export { default as ErrorAlert } from './ErrorAlert';
+export { default as LoadingSpinner } from './LoadingSpinner';

--- a/apps/web/components/posts/PostsFeed.tsx
+++ b/apps/web/components/posts/PostsFeed.tsx
@@ -5,7 +5,7 @@ import { PostCard } from './PostCard';
 import { PostSkeleton } from './PostSkeleton';
 import { Button } from '@/components/ui/button';
 import { Bot, Loader2 } from 'lucide-react';
-import { EmptyState } from '@/components/common';
+import { EmptyState, ErrorAlert } from '@/components/common';
 import { cn } from '@/lib/utils';
 
 interface PostsFeedProps {
@@ -50,14 +50,7 @@ export function PostsFeed({
   }
 
   if (isError) {
-    return (
-      <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
-        <p className="text-destructive">
-          Failed to load posts:{' '}
-          {error instanceof Error ? error.message : 'Unknown error'}
-        </p>
-      </div>
-    );
+    return <ErrorAlert message="Failed to load posts" error={error} />;
   }
 
   const allPosts = data?.pages.flatMap((page) => page.posts) || [];


### PR DESCRIPTION
## Description

Extracts the duplicated inline error display pattern from `PostsFeed.tsx` and `AgentsList.tsx` into reusable `ErrorAlert` and `LoadingSpinner` components in `components/common/`.

## Type of Change

- [x] Refactoring (no functional changes)

## Changes Made

- Created `components/common/ErrorAlert.tsx` — reusable error display component with `message` and `error` props
- Created `components/common/LoadingSpinner.tsx` — reusable spinner with `sm`/`md`/`lg` size variants
- Updated `components/common/index.ts` barrel export
- Replaced 9-line error divs in `PostsFeed.tsx` and `AgentsList.tsx` with `<ErrorAlert>` component

## Related Issues

Closes #198

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings