### PR TITLE
[REFACTOR] Consolidate posts SELECT query into shared constant (#200)

### DIFF
--- a/apps/web/app/api/v1/explore/route.ts
+++ b/apps/web/app/api/v1/explore/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest } from 'next/server';
-import { getSupabaseServiceClient } from '@agentgram/db';
+import {
+  getSupabaseServiceClient,
+  POSTS_SELECT_WITH_RELATIONS,
+} from '@agentgram/db';
 import { withAuth } from '@agentgram/auth';
 import {
   jsonResponse,
@@ -26,13 +29,7 @@ async function handler(req: NextRequest) {
 
     const { data, error } = await supabase
       .from('posts')
-      .select(
-        `
-        *,
-        author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma),
-        community:communities(id, name, display_name)
-      `
-      )
+      .select(POSTS_SELECT_WITH_RELATIONS)
       .eq('post_kind', 'post')
       .is('original_post_id', null)
       .order('score', { ascending: false })

--- a/apps/web/app/api/v1/posts/route.ts
+++ b/apps/web/app/api/v1/posts/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest } from 'next/server';
-import { createNotification, getSupabaseServiceClient } from '@agentgram/db';
+import {
+  createNotification,
+  getSupabaseServiceClient,
+  POSTS_SELECT_WITH_RELATIONS,
+} from '@agentgram/db';
 import { withAuth, withRateLimit, withDailyPostLimit } from '@agentgram/auth';
 import type { CreatePost, FeedParams } from '@agentgram/shared';
 import {
@@ -31,14 +35,9 @@ export async function GET(req: NextRequest) {
 
     const supabase = getSupabaseServiceClient();
 
-    let query = supabase.from('posts').select(
-      `
-        *,
-        author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma),
-        community:communities(id, name, display_name)
-      `,
-      { count: 'exact' }
-    );
+    let query = supabase
+      .from('posts')
+      .select(POSTS_SELECT_WITH_RELATIONS, { count: 'exact' });
 
     // Filter by community
     if (communityId) {
@@ -147,13 +146,7 @@ async function createPostHandler(req: NextRequest) {
         url: url || null,
         post_type: postType || 'text',
       })
-      .select(
-        `
-        *,
-        author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma),
-        community:communities(id, name, display_name)
-      `
-      )
+      .select(POSTS_SELECT_WITH_RELATIONS)
       .single();
 
     if (postError || !post) {

--- a/apps/web/hooks/use-agents.ts
+++ b/apps/web/hooks/use-agents.ts
@@ -7,6 +7,7 @@ import {
   useInfiniteQuery,
 } from '@tanstack/react-query';
 import { getSupabaseBrowser } from '@/lib/supabase-browser';
+import { POSTS_SELECT_WITH_RELATIONS } from '@agentgram/db';
 import type { Agent } from '@agentgram/shared';
 import { PAGINATION } from '@agentgram/shared';
 import { transformPost } from './use-posts';
@@ -184,13 +185,7 @@ export function useAgentPosts(
       if (type === 'authored') {
         const { data, error } = await supabase
           .from('posts')
-          .select(
-            `
-            *,
-            author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma),
-            community:communities(id, name, display_name)
-          `
-          )
+          .select(POSTS_SELECT_WITH_RELATIONS)
           .eq('author_id', agentId)
           .order('created_at', { ascending: false })
           .range(from, to);

--- a/apps/web/hooks/use-posts.ts
+++ b/apps/web/hooks/use-posts.ts
@@ -7,6 +7,7 @@ import {
   useInfiniteQuery,
 } from '@tanstack/react-query';
 import { getSupabaseBrowser } from '@/lib/supabase-browser';
+import { POSTS_SELECT_WITH_RELATIONS } from '@agentgram/db';
 import type {
   Post,
   CreatePost,
@@ -98,13 +99,7 @@ export function usePostsFeed(params: FeedParams = {}) {
     queryKey: ['posts', 'feed', { sort, communityId, agentId, scope }],
     queryFn: async ({ pageParam = 0 }) => {
       const supabase = getSupabaseBrowser();
-      let query = supabase.from('posts').select(
-        `
-          *,
-          author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma),
-          community:communities(id, name, display_name)
-        `
-      );
+      let query = supabase.from('posts').select(POSTS_SELECT_WITH_RELATIONS);
 
       if (communityId) {
         query = query.eq('community_id', communityId);
@@ -238,13 +233,7 @@ export function usePost(postId: string | undefined) {
       const supabase = getSupabaseBrowser();
       const { data, error } = await supabase
         .from('posts')
-        .select(
-          `
-          *,
-          author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma),
-          community:communities(id, name, display_name)
-        `
-        )
+        .select(POSTS_SELECT_WITH_RELATIONS)
         .eq('id', postId)
         .single();
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -25,3 +25,4 @@ export type { FollowResult } from './follow';
 export { createNotification } from './notifications';
 export { handleRepost } from './repost';
 export type { RepostResult } from './repost';
+export * from './queries';

--- a/packages/db/src/queries/index.ts
+++ b/packages/db/src/queries/index.ts
@@ -1,0 +1,1 @@
+export { POSTS_SELECT_WITH_RELATIONS } from './posts';

--- a/packages/db/src/queries/posts.ts
+++ b/packages/db/src/queries/posts.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared Supabase SELECT query for posts with author and community joins.
+ * Used by API routes and client-side hooks for consistent field selection.
+ */
+export const POSTS_SELECT_WITH_RELATIONS = `
+  *,
+  author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, karma),
+  community:communities(id, name, display_name)
+` as const;


### PR DESCRIPTION
## Description

Extracts the duplicated Supabase posts SELECT query string (with author and community joins) into a shared constant `POSTS_SELECT_WITH_RELATIONS` in `packages/db`, eliminating duplication across 4 consumer files.

## Type of Change

- [x] Refactoring (no functional changes)

## Changes Made

- Created `packages/db/src/queries/posts.ts` with `POSTS_SELECT_WITH_RELATIONS` constant
- Created `packages/db/src/queries/index.ts` barrel export
- Updated `packages/db/src/index.ts` to export queries
- Replaced inline SELECT strings in:
  - `hooks/use-posts.ts` (2 occurrences: `usePostsFeed` + `usePost`)
  - `hooks/use-agents.ts` (1 occurrence: authored posts branch)
  - `api/v1/posts/route.ts` (2 occurrences: GET + POST handlers)
  - `api/v1/explore/route.ts` (1 occurrence)

## Related Issues

Closes #200

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings