### PR TITLE
[PERF] Add pagination to comments loading (#202)

### DIFF
--- a/apps/web/app/(public)/posts/[id]/page.tsx
+++ b/apps/web/app/(public)/posts/[id]/page.tsx
@@ -79,7 +79,15 @@ export default function PostDetailPage() {
     error: postErrorData,
   } = usePost(postId);
 
-  const { data: comments, isLoading: commentsLoading } = useComments(postId);
+  const {
+    data: commentsData,
+    isLoading: commentsLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useComments(postId);
+
+  const comments = commentsData?.pages.flatMap((page) => page.comments) ?? [];
 
   if (postLoading) {
     return (
@@ -140,11 +148,30 @@ export default function PostDetailPage() {
               <Loader2 className="h-4 w-4 animate-spin" />
               <span className="text-sm">Loading comments...</span>
             </div>
-          ) : comments && comments.length > 0 ? (
+          ) : comments.length > 0 ? (
             <div className="space-y-4">
               {comments.map((comment) => (
                 <CommentItem key={comment.id} comment={comment} />
               ))}
+              {hasNextPage && (
+                <div className="text-center pt-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => fetchNextPage()}
+                    disabled={isFetchingNextPage}
+                  >
+                    {isFetchingNextPage ? (
+                      <>
+                        <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                        Loading...
+                      </>
+                    ) : (
+                      'Load More Comments'
+                    )}
+                  </Button>
+                </div>
+              )}
             </div>
           ) : (
             <p className="text-sm text-muted-foreground py-4">


### PR DESCRIPTION
## Description

Adds pagination to comments loading which previously fetched ALL comments without a LIMIT. Converts `useComments` from `useQuery` to `useInfiniteQuery` with a page size of 20, and adds a "Load More Comments" button to the post detail page.

## Type of Change

- [x] Performance improvement

## Changes Made

- Converted `useComments()` from `useQuery` to `useInfiniteQuery` with `COMMENTS_LIMIT = 20`
- Added `.range(from, to)` pagination to Supabase query
- Updated `useCreateComment()` optimistic update to handle infinite query page structure
- Updated `posts/[id]/page.tsx` to consume paginated data with `flatMap` and show "Load More Comments" button

## Related Issues

Closes #202

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings