### PR TITLE
[FIX] Correct dead links routing to 404 pages (#193)

### DIFF
--- a/apps/web/app/(public)/explore/page.tsx
+++ b/apps/web/app/(public)/explore/page.tsx
@@ -156,7 +156,7 @@ function ExploreContent() {
               <Button
                 variant="link"
                 className="h-auto p-0 text-yellow-600 underline dark:text-yellow-400"
-                onClick={() => router.push('/login')}
+                onClick={() => router.push('/auth/login')}
               >
                 Sign in
               </Button>

--- a/apps/web/app/(public)/pricing/success/page.tsx
+++ b/apps/web/app/(public)/pricing/success/page.tsx
@@ -26,7 +26,7 @@ export default function SuccessPage() {
         </div>
 
         <Button size="lg" className="gap-2" asChild>
-          <Link href="/agents/me">
+          <Link href="/dashboard">
             Go to Dashboard
             <ArrowRight className="w-4 h-4" />
           </Link>

--- a/apps/web/components/common/BottomNav.tsx
+++ b/apps/web/components/common/BottomNav.tsx
@@ -3,7 +3,7 @@
 import { Suspense } from 'react';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { Home, Search, PlusCircle, Heart, User } from 'lucide-react';
+import { Home, Search, BookOpen, Heart, User } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 function BottomNavContent() {
@@ -41,25 +41,24 @@ function BottomNavContent() {
         </Link>
 
         <Link
-          href="/create"
-          className="flex flex-col items-center justify-center -mt-6"
+          href="/docs"
+          className="flex flex-col items-center justify-center space-y-1 p-2 transition-colors"
         >
-          <div className="rounded-full bg-gradient-to-r from-primary to-primary/80 p-3 shadow-lg transition-transform hover:scale-105 active:scale-95">
-            <PlusCircle className="h-6 w-6 text-primary-foreground" />
-          </div>
+          <BookOpen className="h-6 w-6" />
+          <span className="text-[10px] font-medium">Docs</span>
         </Link>
 
         <Link
-          href="/activity"
+          href="/explore?tab=following"
           className={cn(
             'flex flex-col items-center justify-center space-y-1 p-2 transition-colors',
-            pathname === '/activity'
+            pathname === '/explore' && tab === 'following'
               ? 'text-foreground'
               : 'text-muted-foreground hover:text-foreground'
           )}
         >
           <Heart className="h-6 w-6" />
-          <span className="text-[10px] font-medium">Activity</span>
+          <span className="text-[10px] font-medium">Following</span>
         </Link>
 
         <Link


### PR DESCRIPTION
## Description

Fixes 4 dead links that routed to non-existent pages (404):

1. BottomNav `/create` → `/docs` (no create page; docs explain API usage)
2. BottomNav `/activity` → `/explore?tab=following` (no activity page; following tab is the closest equivalent)
3. Pricing success `/agents/me` → `/dashboard` (the actual authenticated dashboard route)
4. Explore page `/login` → `/auth/login` (the actual auth login route)

## Type of Change

- [x] Bug fix

## Changes Made

- `BottomNav.tsx`: Updated Create link to Docs (with BookOpen icon), Activity link to Following tab
- `pricing/success/page.tsx`: Fixed dashboard link from `/agents/me` to `/dashboard`
- `explore/page.tsx`: Fixed login redirect from `/login` to `/auth/login`

## Related Issues

Closes #193

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings