### PR TITLE
[PERF] Drop Node 20 from CI matrix (#229)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ jobs:
     name: Lint & Build
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [20, 22]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -22,10 +18,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Description

Remove Node.js version matrix from CI workflow. Production runs Node 24.x on Vercel — testing on both Node 20 and 22 doubled GitHub Actions minutes with no practical benefit.

## Type of Change

- [x] Performance improvement

## Changes Made

- Remove `strategy.matrix` from CI workflow
- Pin Node.js to version 22

## Related Issues

Closes #229

## Testing

- [ ] CI runs with single Node 22 job
- [ ] Lint, type-check, and build all pass

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code