### PR TITLE
[FIX] PostCard does not display images for media posts (#220)

### DIFF
--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Heart, MessageCircle, MoreHorizontal, Bot, Send } from 'lucide-react';
 import { Post } from '@agentgram/shared';
+import type { PostMedia } from '@agentgram/shared';
 import { useLike } from '@/hooks/use-posts';
 import { useToast } from '@/hooks/use-toast';
 import { TranslateButton } from '@/components/common';
@@ -40,6 +41,8 @@ export function PostCard({
   // Local toggle state — API doesn't return `is_liked` on posts yet.
   // Resets on page reload. Will be accurate once API adds `is_liked` field.
   const [isLiked, setIsLiked] = useState(false);
+
+  const mediaUrl = (post.metadata?.media as PostMedia[] | undefined)?.[0]?.url;
 
   const handleLike = async (e?: React.MouseEvent) => {
     e?.preventDefault();
@@ -108,9 +111,9 @@ export function PostCard({
           className
         )}
       >
-        {post.postType === 'media' && post.url ? (
+        {post.postType === 'media' && mediaUrl ? (
           <Image
-            src={post.url}
+            src={mediaUrl!}
             alt={post.title}
             fill
             className="object-cover transition-transform duration-300 group-hover:scale-105"
@@ -204,9 +207,9 @@ export function PostCard({
               : 'aspect-square'
           )}
         >
-          {post.postType === 'media' && post.url ? (
+          {post.postType === 'media' && mediaUrl ? (
             <Image
-              src={post.url}
+              src={mediaUrl!}
               alt={post.title}
               fill
               className="object-cover"


### PR DESCRIPTION
## Description

Fix PostCard component to correctly read image URLs from `metadata.media[0].url` instead of `post.url`. The upload API stores images in the metadata field, but the component was looking at the wrong property.

## Type of Change

- [x] Bug fix

## Changes Made

- Import `PostMedia` type from `@agentgram/shared`
- Derive `mediaUrl` from `post.metadata.media[0].url` with proper type casting
- Update both grid and feed variants to use `mediaUrl` instead of `post.url` for media display

## Related Issues

Closes #220

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)