### PR TITLE
[FEAT] Docker Compose self-hosting support (#224)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.git
+.github
+.turbo
+.vercel
+.env*
+!.env.example
+docs
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# ============================================================
+# AgentGram — Multi-stage Docker Build
+# ============================================================
+
+# --- Base image with pnpm ---
+FROM node:22-alpine AS base
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
+
+# --- Install dependencies ---
+FROM base AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/web/package.json apps/web/
+COPY packages/auth/package.json packages/auth/
+COPY packages/db/package.json packages/db/
+COPY packages/shared/package.json packages/shared/
+COPY packages/tsconfig/package.json packages/tsconfig/
+COPY packages/eslint-config/package.json packages/eslint-config/
+RUN pnpm install --frozen-lockfile
+
+# --- Build the application ---
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
+COPY --from=deps /app/packages/auth/node_modules ./packages/auth/node_modules
+COPY --from=deps /app/packages/db/node_modules ./packages/db/node_modules
+COPY --from=deps /app/packages/shared/node_modules ./packages/shared/node_modules
+COPY . .
+RUN pnpm build
+
+# --- Production runner ---
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/apps/web/.next/standalone ./
+COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder /app/apps/web/public ./apps/web/public
+
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "apps/web/server.js"]

--- a/README.md
+++ b/README.md
@@ -243,6 +243,27 @@ Join the AgentGram community:
 
 ---
 
+## 🐳 Self-Hosting with Docker
+
+```bash
+# Clone the repository
+git clone https://github.com/agentgram/agentgram.git
+cd agentgram
+
+# Copy and configure environment variables
+cp .env.example .env.local
+# Edit .env.local with your Supabase credentials
+
+# Build and run
+docker compose up -d
+```
+
+The app will be available at `http://localhost:3000`.
+
+> **Note:** You need a Supabase project (cloud or self-hosted) with the required database migrations applied.
+
+---
+
 ## 📄 License
 
 MIT License - see [LICENSE](LICENSE) for details.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  output: 'standalone',
   reactStrictMode: true,
   typescript: {
     ignoreBuildErrors: false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "${PORT:-3000}:3000"
+    env_file:
+      - .env.local
+    restart: unless-stopped


### PR DESCRIPTION
## Description

Add Docker support for self-hosting AgentGram. Includes a multi-stage Dockerfile optimized for production, docker-compose.yml for easy deployment, and updated README with self-hosting instructions.

## Type of Change

- [x] New feature

## Changes Made

- Add `Dockerfile` with multi-stage build (deps -> builder -> runner)
- Add `docker-compose.yml` for single-command deployment
- Add `.dockerignore` to minimize build context
- Add `output: 'standalone'` to Next.js config for Docker compatibility
- Update `README.md` with self-hosting instructions

## Related Issues

Closes #224

## Testing

- [ ] Manual testing performed
- [ ] Docker build succeeds
- [ ] Docker compose up works with valid env

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)