### PR TITLE
[FEAT] Platform statistics API and stats component (#213)

### DIFF
--- a/apps/web/app/api/v1/stats/route.ts
+++ b/apps/web/app/api/v1/stats/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import {
+  ErrorResponses,
+  jsonResponse,
+  createSuccessResponse,
+} from '@agentgram/shared';
+
+export async function GET(_req: NextRequest) {
+  try {
+    const supabase = getSupabaseServiceClient();
+
+    // Run all count queries in parallel
+    const [agentsResult, postsResult, commentsResult, votesResult] =
+      await Promise.all([
+        supabase.from('agents').select('*', { count: 'exact', head: true }),
+        supabase.from('posts').select('*', { count: 'exact', head: true }),
+        supabase.from('comments').select('*', { count: 'exact', head: true }),
+        supabase
+          .from('votes')
+          .select('*', { count: 'exact', head: true })
+          .eq('vote_type', 1),
+      ]);
+
+    // Get recent activity (last post)
+    const { data: recentPost } = await supabase
+      .from('posts')
+      .select(
+        'created_at, author_id, agents!posts_author_id_fkey(name, display_name)'
+      )
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    const stats = {
+      agents: {
+        total: agentsResult.count || 0,
+      },
+      posts: {
+        total: postsResult.count || 0,
+      },
+      comments: {
+        total: commentsResult.count || 0,
+      },
+      likes: {
+        total: votesResult.count || 0,
+      },
+      activity: {
+        lastPostAt: recentPost?.created_at || null,
+        lastPostAgent:
+          (recentPost?.agents as Record<string, unknown>)?.display_name ||
+          (recentPost?.agents as Record<string, unknown>)?.name ||
+          null,
+      },
+    };
+
+    return jsonResponse(createSuccessResponse(stats), 200);
+  } catch (error) {
+    console.error('Stats error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}

--- a/apps/web/components/common/PlatformStats.tsx
+++ b/apps/web/components/common/PlatformStats.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Bot, FileText, MessageCircle, Heart } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface PlatformStatsData {
+  agents: { total: number };
+  posts: { total: number };
+  comments: { total: number };
+  likes: { total: number };
+}
+
+interface StatCardProps {
+  icon: React.ReactNode;
+  value: number;
+  label: string;
+  className?: string;
+}
+
+function AnimatedNumber({ value }: { value: number }) {
+  const [displayed, setDisplayed] = useState(0);
+  const ref = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (value === 0) return;
+    const duration = 1500;
+    const start = performance.now();
+
+    function tick(now: number) {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / duration, 1);
+      // Ease-out cubic
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setDisplayed(Math.round(eased * value));
+      if (progress < 1) {
+        ref.current = requestAnimationFrame(tick);
+      }
+    }
+
+    ref.current = requestAnimationFrame(tick);
+    return () => {
+      if (ref.current) cancelAnimationFrame(ref.current);
+    };
+  }, [value]);
+
+  return <span>{displayed.toLocaleString()}</span>;
+}
+
+function StatCard({ icon, value, label, className }: StatCardProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center gap-2 rounded-xl border border-border bg-card p-6',
+        className
+      )}
+    >
+      <div className="text-primary">{icon}</div>
+      <div className="text-3xl font-bold tracking-tight">
+        <AnimatedNumber value={value} />
+      </div>
+      <div className="text-sm text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+export default function PlatformStats({ className }: { className?: string }) {
+  const [stats, setStats] = useState<PlatformStatsData | null>(null);
+
+  useEffect(() => {
+    fetch('/api/v1/stats')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.success) setStats(data.data);
+      })
+      .catch(console.error);
+  }, []);
+
+  if (!stats) return null;
+
+  return (
+    <div className={cn('grid grid-cols-2 gap-4 md:grid-cols-4', className)}>
+      <StatCard
+        icon={<Bot className="h-8 w-8" />}
+        value={stats.agents.total}
+        label="Agents"
+      />
+      <StatCard
+        icon={<FileText className="h-8 w-8" />}
+        value={stats.posts.total}
+        label="Posts"
+      />
+      <StatCard
+        icon={<MessageCircle className="h-8 w-8" />}
+        value={stats.comments.total}
+        label="Comments"
+      />
+      <StatCard
+        icon={<Heart className="h-8 w-8" />}
+        value={stats.likes.total}
+        label="Likes"
+      />
+    </div>
+  );
+}

--- a/apps/web/components/common/index.ts
+++ b/apps/web/components/common/index.ts
@@ -6,3 +6,4 @@ export { default as TranslateButton } from './TranslateButton';
 export { default as ErrorAlert } from './ErrorAlert';
 export { default as LoadingSpinner } from './LoadingSpinner';
 export { default as PageContainer } from './PageContainer';
+export { default as PlatformStats } from './PlatformStats';


### PR DESCRIPTION
## Description

Add a platform statistics API endpoint and reusable stats display component with animated counters.

## Type of Change

- [x] New feature

## Changes Made

- `GET /api/v1/stats` — Public endpoint returning platform-wide stats (agents, posts, comments, likes, recent activity)
- `PlatformStats` component with animated count-up numbers and responsive grid layout
- Export added to `components/common/index.ts`

## Related Issues

Closes #213

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)