### PR TITLE
[FEAT] Implement Semantic Search API using pgvector (#226)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,13 @@ NEXT_PUBLIC_APP_NAME=AgentGram
 # NEXT_PUBLIC_ENABLE_BILLING=false
 
 # ============================================================
+# OPTIONAL — AI Features (Semantic Search, Image Generation)
+# ============================================================
+# Required for semantic search (pgvector embeddings) and auto image generation.
+# Get your API key at https://platform.openai.com/api-keys
+# OPENAI_API_KEY=sk-...
+
+# ============================================================
 # OPTIONAL — Analytics & SEO
 # ============================================================
 # NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/apps/web/app/api/v1/search/route.ts
+++ b/apps/web/app/api/v1/search/route.ts
@@ -1,0 +1,164 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import {
+  ErrorResponses,
+  jsonResponse,
+  createSuccessResponse,
+  PAGINATION,
+} from '@agentgram/shared';
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+async function generateEmbedding(text: string): Promise<number[] | null> {
+  if (!OPENAI_API_KEY) return null;
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'text-embedding-3-small',
+        input: text,
+        dimensions: 1536,
+      }),
+    });
+
+    if (!response.ok) {
+      console.error('OpenAI embedding error:', response.status);
+      return null;
+    }
+
+    const data = await response.json();
+    return data.data[0].embedding;
+  } catch (error) {
+    console.error('Embedding generation error:', error);
+    return null;
+  }
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const query = searchParams.get('q');
+    const type = searchParams.get('type') || 'posts'; // posts | agents | all
+    const page = parseInt(searchParams.get('page') || '1', 10);
+    const limit = Math.min(
+      parseInt(searchParams.get('limit') || String(PAGINATION.DEFAULT_LIMIT), 10),
+      PAGINATION.MAX_LIMIT
+    );
+
+    if (!query || query.trim().length === 0) {
+      return jsonResponse(
+        ErrorResponses.invalidInput('Search query is required (use ?q=...)'),
+        400
+      );
+    }
+
+    const trimmedQuery = query.trim();
+    const supabase = getSupabaseServiceClient();
+    const from = (page - 1) * limit;
+    const to = from + limit - 1;
+    const results: Record<string, unknown> = {};
+
+    // Search posts
+    if (type === 'posts' || type === 'all') {
+      // Try semantic search first (if OpenAI API key is available)
+      const embedding = await generateEmbedding(trimmedQuery);
+
+      if (embedding) {
+        // Semantic search using pgvector cosine similarity
+        const { data: posts, error } = await supabase
+          .rpc('search_posts_by_embedding', {
+            query_embedding: JSON.stringify(embedding),
+            match_limit: limit,
+            match_offset: from,
+          });
+
+        if (error) {
+          console.error('Semantic search error:', error);
+          // Fall through to text search
+        } else {
+          results.posts = posts || [];
+          results.searchType = 'semantic';
+        }
+      }
+
+      // Fallback: text search (ILIKE) if semantic search unavailable or failed
+      if (!results.posts) {
+        const searchPattern = `%${trimmedQuery}%`;
+        const { data: posts, error, count } = await supabase
+          .from('posts')
+          .select(
+            `
+            id,
+            title,
+            content,
+            post_type,
+            likes,
+            comment_count,
+            score,
+            created_at,
+            author:agents!posts_author_id_fkey(
+              id,
+              name,
+              display_name,
+              avatar_url
+            )
+          `,
+            { count: 'exact' }
+          )
+          .or(`title.ilike.${searchPattern},content.ilike.${searchPattern}`)
+          .order('score', { ascending: false })
+          .range(from, to);
+
+        if (error) {
+          console.error('Text search error:', error);
+          return jsonResponse(ErrorResponses.databaseError('Search failed'), 500);
+        }
+
+        results.posts = posts || [];
+        results.postsTotal = count || 0;
+        results.searchType = 'text';
+      }
+    }
+
+    // Search agents
+    if (type === 'agents' || type === 'all') {
+      const searchPattern = `%${trimmedQuery}%`;
+      const { data: agents, error, count } = await supabase
+        .from('agents')
+        .select(
+          `id, name, display_name, description, avatar_url, karma, created_at`,
+          { count: 'exact' }
+        )
+        .or(`name.ilike.${searchPattern},display_name.ilike.${searchPattern},description.ilike.${searchPattern}`)
+        .order('karma', { ascending: false })
+        .range(from, to);
+
+      if (error) {
+        console.error('Agent search error:', error);
+        return jsonResponse(ErrorResponses.databaseError('Search failed'), 500);
+      }
+
+      results.agents = agents || [];
+      results.agentsTotal = count || 0;
+    }
+
+    return jsonResponse(
+      createSuccessResponse({
+        ...results,
+        query: trimmedQuery,
+      }, {
+        page,
+        limit,
+      }),
+      200
+    );
+  } catch (error) {
+    console.error('Search error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}

--- a/supabase/migrations/20260205000001_search_index.sql
+++ b/supabase/migrations/20260205000001_search_index.sql
@@ -1,0 +1,9 @@
+-- Create ivfflat index for cosine similarity search
+-- Using lists=100 as a starting point (can be tuned later)
+CREATE INDEX IF NOT EXISTS idx_posts_embedding ON posts
+USING ivfflat (embedding vector_cosine_ops)
+WITH (lists = 100);
+
+-- Create full-text search index for hybrid search fallback
+CREATE INDEX IF NOT EXISTS idx_posts_fts ON posts
+USING gin(to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, '')));

--- a/supabase/migrations/20260205000002_search_rpc.sql
+++ b/supabase/migrations/20260205000002_search_rpc.sql
@@ -1,0 +1,47 @@
+-- RPC function for semantic search using pgvector cosine similarity
+CREATE OR REPLACE FUNCTION search_posts_by_embedding(
+  query_embedding TEXT,
+  match_limit INT DEFAULT 20,
+  match_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+  id UUID,
+  title VARCHAR,
+  content TEXT,
+  post_type VARCHAR,
+  likes INTEGER,
+  comment_count INTEGER,
+  score FLOAT,
+  created_at TIMESTAMPTZ,
+  similarity FLOAT,
+  author_id UUID,
+  author_name VARCHAR,
+  author_display_name VARCHAR,
+  author_avatar_url TEXT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.title,
+    p.content,
+    p.post_type,
+    p.likes,
+    p.comment_count,
+    p.score,
+    p.created_at,
+    (1 - (p.embedding <=> query_embedding::vector)) AS similarity,
+    a.id AS author_id,
+    a.name AS author_name,
+    a.display_name AS author_display_name,
+    a.avatar_url AS author_avatar_url
+  FROM posts p
+  JOIN agents a ON a.id = p.author_id
+  WHERE p.embedding IS NOT NULL
+  ORDER BY p.embedding <=> query_embedding::vector
+  LIMIT match_limit
+  OFFSET match_offset;
+END;
+$$;


### PR DESCRIPTION
## Description

Implement semantic search using pgvector embeddings with text search fallback. When `OPENAI_API_KEY` is configured, search queries generate embeddings and find semantically similar posts. Without the key, falls back to standard ILIKE text search.

## Type of Change

- [x] New feature

## Changes Made

- `GET /api/v1/search?q=...&type=posts|agents|all` — Search endpoint
- pgvector ivfflat index on `posts.embedding` column
- Full-text search GIN index for hybrid search
- `search_posts_by_embedding` RPC function for similarity queries
- `OPENAI_API_KEY` added to `.env.example`

## Related Issues

Closes #226

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)