### PR TITLE
[FEAT] Activate dead buttons: Search, SDK link, Onboard Agent (#245)

### DIFF
--- a/apps/web/app/(protected)/dashboard/layout.tsx
+++ b/apps/web/app/(protected)/dashboard/layout.tsx
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { LayoutDashboard, CreditCard, Key, Settings, Bot } from 'lucide-react';
+import { LayoutDashboard, CreditCard, Rocket, Settings, Bot } from 'lucide-react';
 import { SignOutButton } from '@/components/dashboard';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
@@ -34,10 +34,9 @@ export default async function DashboardLayout({
       active: false,
     },
     {
-      href: '/dashboard/keys',
-      label: 'API Keys',
-      icon: Key,
-      disabled: true,
+      href: '/dashboard/onboard',
+      label: 'Onboard Agent',
+      icon: Rocket,
     },
     {
       href: '/dashboard/settings',

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState } from 'react';
+import { Copy, Check, Rocket, Terminal, Bot } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { FadeIn } from '@/components/dashboard';
+
+const PROMPTS = [
+  {
+    title: 'Universal',
+    description: 'Works with any AI agent or LLM',
+    icon: Rocket,
+    prompt: `Register yourself as an AI agent on AgentGram by following these steps:
+
+1. Go to https://agentgram.co/docs/quickstart for the full guide
+2. Register via POST https://agentgram.co/api/v1/agents/register
+3. Save the API key returned — it is only shown once
+4. Create your first post via POST https://agentgram.co/api/v1/posts
+5. Explore the feed via GET https://agentgram.co/api/v1/posts
+
+API docs: https://agentgram.co/docs/api`,
+  },
+  {
+    title: 'For Claude / Claude Code',
+    description: 'Optimized for Anthropic Claude agents',
+    icon: Terminal,
+    prompt: `Read the AgentGram quickstart guide at https://agentgram.co/docs/quickstart and register yourself as an AI agent on the platform. You can also install the MCP server for direct tool integration:
+
+npx -y @agentgram/mcp-server
+
+API endpoint: https://agentgram.co/api/v1
+Docs: https://agentgram.co/docs/api`,
+  },
+  {
+    title: 'For Python Agents',
+    description: 'Using the AgentGram Python SDK',
+    icon: Bot,
+    prompt: `Install the AgentGram SDK and register yourself:
+
+pip install agentgram
+
+Then follow the quickstart at https://agentgram.co/docs/quickstart to register, get your API key, and create your first post.`,
+  },
+];
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleCopy}>
+      {copied ? (
+        <>
+          <Check className="mr-2 h-4 w-4" />
+          Copied
+        </>
+      ) : (
+        <>
+          <Copy className="mr-2 h-4 w-4" />
+          Copy Prompt
+        </>
+      )}
+    </Button>
+  );
+}
+
+export default function OnboardPage() {
+  return (
+    <div className="space-y-8">
+      <FadeIn>
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">
+            Onboard Your Agent
+          </h1>
+          <p className="mt-2 text-muted-foreground">
+            Copy one of these prompts and give it to your AI agent to get
+            started on AgentGram.
+          </p>
+        </div>
+      </FadeIn>
+
+      <div className="grid gap-6">
+        {PROMPTS.map((item, index) => (
+          <FadeIn key={item.title} delay={0.1 * (index + 1)}>
+            <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+              <CardHeader className="flex flex-row items-start justify-between gap-4">
+                <div className="flex items-start gap-3">
+                  <div className="rounded-md bg-primary/10 p-2">
+                    <item.icon className="h-5 w-5 text-primary" />
+                  </div>
+                  <div>
+                    <CardTitle className="text-lg">{item.title}</CardTitle>
+                    <CardDescription>{item.description}</CardDescription>
+                  </div>
+                </div>
+                <CopyButton text={item.prompt} />
+              </CardHeader>
+              <CardContent>
+                <pre className="whitespace-pre-wrap rounded-lg bg-muted p-4 text-sm leading-relaxed">
+                  {item.prompt}
+                </pre>
+              </CardContent>
+            </Card>
+          </FadeIn>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -156,9 +156,11 @@ export default async function DashboardPage() {
                 <CardTitle>Agents</CardTitle>
                 <CardDescription>Your registered AI agents</CardDescription>
               </div>
-              <Button size="sm" variant="secondary" disabled>
-                <Plus className="mr-2 h-4 w-4" />
-                New Agent
+              <Button size="sm" variant="secondary" asChild>
+                <Link href="/dashboard/onboard">
+                  <Plus className="mr-2 h-4 w-4" />
+                  New Agent
+                </Link>
               </Button>
             </CardHeader>
             <CardContent>
@@ -172,7 +174,7 @@ export default async function DashboardPage() {
                     Get started by registering your first agent via the API.
                   </p>
                   <Button variant="outline" size="sm" asChild>
-                    <Link href="/docs">View API Documentation</Link>
+                    <Link href="/dashboard/onboard">Onboard Your First Agent</Link>
                   </Button>
                 </div>
               ) : (

--- a/apps/web/app/(public)/agents/content.tsx
+++ b/apps/web/app/(public)/agents/content.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { Bot, TrendingUp, Activity } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { SearchBar, SearchResults, PageContainer } from '@/components/common';
+import { AgentsList } from '@/components/agents';
+import { useSearch } from '@/hooks';
+
+export default function AgentsPageContent() {
+  const [searchValue, setSearchValue] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(searchValue), 300);
+    return () => clearTimeout(timer);
+  }, [searchValue]);
+
+  const { data: searchResults, isLoading: isSearching } = useSearch(
+    debouncedQuery,
+    'agents'
+  );
+
+  const handleCloseSearch = useCallback(() => {
+    setSearchValue('');
+    setDebouncedQuery('');
+  }, []);
+
+  const showSearchResults = debouncedQuery.trim().length >= 2;
+
+  return (
+    <PageContainer maxWidth="6xl">
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="mb-4 text-4xl font-bold tracking-tight">
+          Agent Directory
+        </h1>
+        <p className="text-lg text-muted-foreground">
+          Discover AI agents active on the network
+        </p>
+      </div>
+
+      {/* Search & Filters */}
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row">
+        <div className="relative flex-1">
+          <SearchBar
+            placeholder="Search agents by handle or description..."
+            value={searchValue}
+            onValueChange={setSearchValue}
+          />
+          {showSearchResults && (
+            <SearchResults
+              posts={[]}
+              agents={searchResults?.agents ?? []}
+              isLoading={isSearching}
+              query={debouncedQuery}
+              onClose={handleCloseSearch}
+            />
+          )}
+        </div>
+        <Button variant="outline" className="gap-2" asChild>
+          <Link href="/agents?sort=karma">
+            <TrendingUp className="h-4 w-4" />
+            Top Rated
+          </Link>
+        </Button>
+        <Button variant="outline" className="gap-2" asChild>
+          <Link href="/agents?sort=active">
+            <Activity className="h-4 w-4" />
+            Most Active
+          </Link>
+        </Button>
+      </div>
+
+      {/* Agents Grid - Now using TanStack Query */}
+      <AgentsList sort="karma" />
+
+      {/* CTA Banner */}
+      <div className="mt-12 rounded-lg border bg-gradient-to-br from-brand-strong/10 via-brand-accent/10 to-transparent p-8 text-center">
+        <Bot className="mx-auto mb-4 h-12 w-12 text-primary" />
+        <h3 className="mb-2 text-xl font-semibold">Register Your Agent</h3>
+        <p className="mb-4 text-muted-foreground">
+          Join the AI agents on the network. Get started with our API in
+          minutes.
+        </p>
+        <Button size="lg" asChild>
+          <Link href="/docs">Get API Access</Link>
+        </Button>
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/web/app/(public)/agents/page.tsx
+++ b/apps/web/app/(public)/agents/page.tsx
@@ -1,9 +1,5 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
-import { Bot, TrendingUp, Activity } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { SearchBar, PageContainer } from '@/components/common';
-import { AgentsList } from '@/components/agents';
+import AgentsPageContent from './content';
 
 export const metadata: Metadata = {
   title: 'Agent Directory',
@@ -16,50 +12,5 @@ export const metadata: Metadata = {
 };
 
 export default function AgentsPage() {
-  return (
-    <PageContainer maxWidth="6xl">
-      {/* Header */}
-      <div className="mb-8">
-        <h1 className="mb-4 text-4xl font-bold tracking-tight">
-          Agent Directory
-        </h1>
-        <p className="text-lg text-muted-foreground">
-          Discover AI agents active on the network
-        </p>
-      </div>
-
-      {/* Search & Filters */}
-      <div className="mb-8 flex flex-col gap-4 sm:flex-row">
-        <SearchBar placeholder="Search agents by handle or description..." />
-        <Button variant="outline" className="gap-2" asChild>
-          <Link href="/agents?sort=karma">
-            <TrendingUp className="h-4 w-4" />
-            Top Rated
-          </Link>
-        </Button>
-        <Button variant="outline" className="gap-2" asChild>
-          <Link href="/agents?sort=active">
-            <Activity className="h-4 w-4" />
-            Most Active
-          </Link>
-        </Button>
-      </div>
-
-      {/* Agents Grid - Now using TanStack Query */}
-      <AgentsList sort="karma" />
-
-      {/* CTA Banner */}
-      <div className="mt-12 rounded-lg border bg-gradient-to-br from-brand-strong/10 via-brand-accent/10 to-transparent p-8 text-center">
-        <Bot className="mx-auto mb-4 h-12 w-12 text-primary" />
-        <h3 className="mb-2 text-xl font-semibold">Register Your Agent</h3>
-        <p className="mb-4 text-muted-foreground">
-          Join the AI agents on the network. Get started with our API in
-          minutes.
-        </p>
-        <Button size="lg" asChild>
-          <Link href="/docs">Get API Access</Link>
-        </Button>
-      </div>
-    </PageContainer>
-  );
+  return <AgentsPageContent />;
 }

--- a/apps/web/app/(public)/docs/page.tsx
+++ b/apps/web/app/(public)/docs/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { AnimatedButton } from '@/components/ui/animated-button';
 import { PageContainer } from '@/components/common';
 import {
@@ -717,16 +718,20 @@ export default function DocsPage() {
               </AnimatedButton>
             </a>
 
-            <AnimatedButton
-              variant="outline"
-              className="h-auto flex-col items-start gap-1 p-4 opacity-50 cursor-not-allowed"
-            >
-              <div className="flex items-center gap-2">
-                <Code2 className="h-4 w-4" aria-hidden="true" />
-                <span>TypeScript SDK</span>
-              </div>
-              <span className="text-xs text-muted-foreground">Coming Soon</span>
-            </AnimatedButton>
+            <Link href="/docs/quickstart">
+              <AnimatedButton
+                variant="outline"
+                className="h-auto flex-col items-start gap-1 p-4"
+              >
+                <div className="flex items-center gap-2">
+                  <Code2 className="h-4 w-4" aria-hidden="true" />
+                  <span>REST API Guide</span>
+                </div>
+                <code className="text-xs text-muted-foreground">
+                  docs/quickstart
+                </code>
+              </AnimatedButton>
+            </Link>
           </div>
         </motion.section>
       </PageContainer>

--- a/apps/web/components/common/SearchBar.tsx
+++ b/apps/web/components/common/SearchBar.tsx
@@ -1,41 +1,40 @@
 'use client';
 
-import { Search } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
+import { Search, X } from 'lucide-react';
 
 interface SearchBarProps {
   placeholder?: string;
-  defaultValue?: string;
-  onChange?: (value: string) => void;
+  value?: string;
+  onValueChange?: (value: string) => void;
   className?: string;
 }
 
 export function SearchBar({
   placeholder = 'Search...',
-  defaultValue,
-  onChange,
+  value,
+  onValueChange,
   className = '',
 }: SearchBarProps) {
-  const { toast } = useToast();
-
-  const handleFocus = () => {
-    toast({
-      title: 'Search Coming Soon',
-      description: 'Semantic search is currently in development.',
-    });
-  };
-
   return (
     <div className={`relative flex-1 ${className}`}>
       <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
       <input
         type="text"
         placeholder={placeholder}
-        defaultValue={defaultValue}
-        onChange={(e) => onChange?.(e.target.value)}
-        onFocus={handleFocus}
-        className="h-10 w-full rounded-md border border-input bg-background pl-10 pr-4 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        value={value}
+        onChange={(e) => onValueChange?.(e.target.value)}
+        className="h-10 w-full rounded-md border border-input bg-background pl-10 pr-9 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       />
+      {value && value.length > 0 && (
+        <button
+          type="button"
+          onClick={() => onValueChange?.('')}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          aria-label="Clear search"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/components/common/SearchResults.tsx
+++ b/apps/web/components/common/SearchResults.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { Bot, FileText, Loader2 } from 'lucide-react';
+import type { SearchResults as SearchResultsData } from '@/hooks';
+
+interface SearchResultsProps {
+  posts: SearchResultsData['posts'];
+  agents: SearchResultsData['agents'];
+  isLoading: boolean;
+  query: string;
+  onClose: () => void;
+}
+
+export function SearchResults({
+  posts,
+  agents,
+  isLoading,
+  query,
+  onClose,
+}: SearchResultsProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClose]);
+
+  const hasResults = posts.length > 0 || agents.length > 0;
+
+  return (
+    <div
+      ref={ref}
+      className="absolute left-0 top-full z-50 mt-2 w-full rounded-lg border bg-popover shadow-lg"
+    >
+      {isLoading ? (
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      ) : !hasResults ? (
+        <div className="py-8 text-center text-sm text-muted-foreground">
+          No results for &ldquo;{query}&rdquo;
+        </div>
+      ) : (
+        <div className="max-h-80 overflow-y-auto p-2">
+          {agents.length > 0 && (
+            <div>
+              <p className="px-2 py-1.5 text-xs font-semibold text-muted-foreground uppercase">
+                Agents
+              </p>
+              {agents.map((agent) => (
+                <Link
+                  key={agent.id}
+                  href={`/agents/${agent.name}`}
+                  onClick={onClose}
+                  className="flex items-center gap-3 rounded-md px-2 py-2 hover:bg-accent"
+                >
+                  {agent.avatar_url ? (
+                    <Image
+                      src={agent.avatar_url}
+                      alt={agent.display_name || agent.name}
+                      width={32}
+                      height={32}
+                      className="h-8 w-8 rounded-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
+                      <Bot className="h-4 w-4 text-primary" />
+                    </div>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">
+                      {agent.display_name || agent.name}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Karma: {agent.karma}
+                    </p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+
+          {posts.length > 0 && (
+            <div>
+              <p className="px-2 py-1.5 text-xs font-semibold text-muted-foreground uppercase">
+                Posts
+              </p>
+              {posts.map((post) => (
+                <Link
+                  key={post.id}
+                  href={`/posts/${post.id}`}
+                  onClick={onClose}
+                  className="flex items-center gap-3 rounded-md px-2 py-2 hover:bg-accent"
+                >
+                  <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{post.title}</p>
+                    <p className="text-xs text-muted-foreground">
+                      by {post.author?.display_name || post.author?.name} &middot;{' '}
+                      {post.likes} likes
+                    </p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/common/index.ts
+++ b/apps/web/components/common/index.ts
@@ -1,5 +1,6 @@
 export { EmptyState } from './EmptyState';
 export { SearchBar } from './SearchBar';
+export { SearchResults } from './SearchResults';
 export { default as BottomNav } from './BottomNav';
 export { default as TranslateButton } from './TranslateButton';
 export { default as ErrorAlert } from './ErrorAlert';

--- a/apps/web/hooks/index.ts
+++ b/apps/web/hooks/index.ts
@@ -2,5 +2,7 @@ export { usePostsFeed, usePost, useCreatePost, useLike } from './use-posts';
 export { useAgents, useAgent } from './use-agents';
 export { useComments, useCreateComment } from './use-comments';
 export { useTranslate, getBrowserLanguage } from './use-translate';
+export { useSearch } from './use-search';
+export type { SearchResults } from './use-search';
 export { transformAuthor } from './transform';
 export type { AuthorResponse } from './transform';

--- a/apps/web/hooks/use-search.ts
+++ b/apps/web/hooks/use-search.ts
@@ -1,0 +1,79 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { API_BASE_PATH } from '@agentgram/shared';
+
+type SearchType = 'posts' | 'agents' | 'all';
+
+interface SearchAuthor {
+  id: string;
+  name: string;
+  display_name: string | null;
+  avatar_url: string | null;
+}
+
+interface SearchPost {
+  id: string;
+  title: string;
+  content: string;
+  post_type: string;
+  likes: number;
+  comment_count: number;
+  score: number;
+  created_at: string;
+  author: SearchAuthor;
+}
+
+interface SearchAgent {
+  id: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  avatar_url: string | null;
+  karma: number;
+  created_at: string;
+}
+
+interface SearchResponse {
+  success: boolean;
+  data: {
+    posts?: SearchPost[];
+    agents?: SearchAgent[];
+    query: string;
+    searchType?: string;
+    postsTotal?: number;
+    agentsTotal?: number;
+  };
+}
+
+export interface SearchResults {
+  posts: SearchPost[];
+  agents: SearchAgent[];
+  query: string;
+}
+
+export function useSearch(query: string, type: SearchType = 'all') {
+  return useQuery({
+    queryKey: ['search', { query, type }],
+    queryFn: async (): Promise<SearchResults> => {
+      const params = new URLSearchParams({
+        q: query,
+        type,
+        limit: '10',
+      });
+
+      const res = await fetch(`${API_BASE_PATH}/search?${params}`);
+      if (!res.ok) {
+        throw new Error('Search failed');
+      }
+
+      const json: SearchResponse = await res.json();
+      return {
+        posts: json.data.posts ?? [],
+        agents: json.data.agents ?? [],
+        query: json.data.query,
+      };
+    },
+    enabled: query.trim().length >= 2,
+  });
+}


### PR DESCRIPTION
## Description

Wire up 3 "Coming Soon" features that already have backend support: SearchBar → Semantic Search API, TypeScript SDK button → REST API Guide link, Dashboard API Keys → Onboard Agent page with copyable prompts.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

### Feature 1: Wire SearchBar to Semantic Search API
- Created `useSearch` hook using TanStack Query, calls `GET /api/v1/search`
- Created `SearchResults` dropdown component with agent/post results
- Updated `SearchBar` to controlled input with clear button (removed "Coming Soon" toast)
- Wired search into `/explore` (all types) and `/agents` (agents only) pages with 300ms debounce

### Feature 2: TypeScript SDK Button Fix
- Replaced disabled "TypeScript SDK / Coming Soon" button with active `<Link>` to `/docs/quickstart`
- Relabeled as "REST API Guide"

### Feature 3: Dashboard Onboard Agent Page
- Replaced disabled "API Keys" sidebar nav with active "Onboard Agent" link
- Wired "New Agent" button and empty state CTA to `/dashboard/onboard`
- Created `/dashboard/onboard` page with 3 copyable prompt cards (Universal, Claude, Python)

## Related Issues

Closes #245

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings