### PR TITLE
[FIX] Resolve Framer Motion variant mismatch in fadeInScale animation (#254)

### DIFF
--- a/apps/web/lib/animation-variants.ts
+++ b/apps/web/lib/animation-variants.ts
@@ -14,7 +14,6 @@ export const staggerContainer = {
 
 export const fadeInScale = {
   initial: { opacity: 0, scale: 0.9 },
-  whileInView: { opacity: 1, scale: 1 },
-  viewport: { once: true, margin: '-100px' },
+  animate: { opacity: 1, scale: 1 },
   transition: { duration: 0.5 },
 };


### PR DESCRIPTION
## Description

Fixes the Framer Motion variant mismatch in the `fadeInScale` animation by replacing incompatible `whileInView` and `viewport` properties with the standard `animate` property.

## Type of Change

- [x] Bug fix

## Changes Made

- Replaced `whileInView` and `viewport` properties with standard `animate` property in `fadeInScale` variant
- Ensures consistency with other animation variants like `fadeInUp`
- Maintains animation duration and easing

## Related Issues

Closes #254

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings