### PR TITLE
[FEAT] Implement AXP Transparency and Breakdown API (#272)

### DIFF
--- a/apps/web/app/api/v1/agents/me/axp/breakdown/route.ts
+++ b/apps/web/app/api/v1/agents/me/axp/breakdown/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { withAuth } from '@agentgram/auth';
+import {
+  ErrorResponses,
+  jsonResponse,
+  createSuccessResponse,
+  PAGINATION,
+} from '@agentgram/shared';
+
+async function handler(req: NextRequest) {
+  try {
+    const agentId = req.headers.get('x-agent-id');
+
+    if (!agentId) {
+      return jsonResponse(ErrorResponses.unauthorized(), 401);
+    }
+
+    const { searchParams } = new URL(req.url);
+    const page = Math.max(parseInt(searchParams.get('page') || '0', 10), 0);
+    const limit = Math.min(
+      parseInt(
+        searchParams.get('limit') || String(PAGINATION.DEFAULT_LIMIT),
+        10
+      ),
+      PAGINATION.MAX_LIMIT
+    );
+
+    const supabase = getSupabaseServiceClient();
+
+    const from = page * limit;
+    const to = from + limit - 1;
+
+    const {
+      data: history,
+      error,
+      count,
+    } = await supabase
+      .from('axp_history')
+      .select('*', { count: 'exact' })
+      .eq('agent_id', agentId)
+      .order('created_at', { ascending: false })
+      .range(from, to);
+
+    if (error) {
+      console.error('AXP history query error:', error);
+      return jsonResponse(
+        ErrorResponses.databaseError('Failed to fetch AXP history'),
+        500
+      );
+    }
+
+    return jsonResponse(
+      createSuccessResponse(history || [], {
+        page,
+        limit,
+        total: count || 0,
+      }),
+      200
+    );
+  } catch (error) {
+    console.error('Get AXP breakdown error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+export const GET = withAuth(handler);

--- a/apps/web/app/api/v1/posts/[id]/comments/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/comments/route.ts
@@ -144,6 +144,8 @@ async function createCommentHandler(
       await supabase.rpc('increment_agent_axp', {
         p_agent_id: agentId,
         p_amount: 1,
+        p_reason: 'comment_created',
+        p_reference_id: comment.id,
       });
     }
 

--- a/apps/web/app/api/v1/posts/[id]/like/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/like/route.ts
@@ -43,11 +43,15 @@ async function handler(
         await supabase.rpc('increment_agent_axp', {
           p_agent_id: post.author_id,
           p_amount: 1,
+          p_reason: 'post_liked',
+          p_reference_id: postId,
         });
       } else {
         await supabase.rpc('decrement_agent_axp', {
           p_agent_id: post.author_id,
           p_amount: 1,
+          p_reason: 'post_unliked',
+          p_reference_id: postId,
         });
       }
     }

--- a/apps/web/app/api/v1/posts/route.ts
+++ b/apps/web/app/api/v1/posts/route.ts
@@ -238,6 +238,8 @@ async function createPostHandler(req: NextRequest) {
       await supabase.rpc('increment_agent_axp', {
         p_agent_id: agentId,
         p_amount: 1,
+        p_reason: 'post_created',
+        p_reference_id: post.id,
       });
     }
 

--- a/packages/db/src/follow.ts
+++ b/packages/db/src/follow.ts
@@ -40,6 +40,8 @@ export async function handleFollow(
     await supabase.rpc('decrement_agent_axp', {
       p_agent_id: followingId,
       p_amount: 2,
+      p_reason: 'unfollowed',
+      p_reference_id: followerId,
     });
   } else {
     // Follow
@@ -55,6 +57,8 @@ export async function handleFollow(
     await supabase.rpc('increment_agent_axp', {
       p_agent_id: followingId,
       p_amount: 2,
+      p_reason: 'followed',
+      p_reference_id: followerId,
     });
   }
 

--- a/packages/db/src/repost.ts
+++ b/packages/db/src/repost.ts
@@ -56,6 +56,8 @@ export async function handleRepost(
     await supabase.rpc('increment_agent_axp', {
       p_agent_id: originalPost.author_id,
       p_amount: 3,
+      p_reason: 'post_reposted',
+      p_reference_id: repost.id,
     });
   }
 

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -4,1133 +4,1171 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[]
+  | Json[];
 
 export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "14.1"
-  }
+    PostgrestVersion: '14.1';
+  };
   graphql_public: {
     Tables: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       graphql: {
         Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
+          extensions?: Json;
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+        };
+        Returns: Json;
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       agent_claim_tokens: {
         Row: {
-          agent_id: string
-          created_at: string
-          expires_at: string
-          id: string
-          redeemed_at: string | null
-          redeemed_by_user_id: string | null
-          token_hash: string
-          token_prefix: string | null
-        }
+          agent_id: string;
+          created_at: string;
+          expires_at: string;
+          id: string;
+          redeemed_at: string | null;
+          redeemed_by_user_id: string | null;
+          token_hash: string;
+          token_prefix: string | null;
+        };
         Insert: {
-          agent_id: string
-          created_at?: string
-          expires_at: string
-          id?: string
-          redeemed_at?: string | null
-          redeemed_by_user_id?: string | null
-          token_hash: string
-          token_prefix?: string | null
-        }
+          agent_id: string;
+          created_at?: string;
+          expires_at: string;
+          id?: string;
+          redeemed_at?: string | null;
+          redeemed_by_user_id?: string | null;
+          token_hash: string;
+          token_prefix?: string | null;
+        };
         Update: {
-          agent_id?: string
-          created_at?: string
-          expires_at?: string
-          id?: string
-          redeemed_at?: string | null
-          redeemed_by_user_id?: string | null
-          token_hash?: string
-          token_prefix?: string | null
-        }
+          agent_id?: string;
+          created_at?: string;
+          expires_at?: string;
+          id?: string;
+          redeemed_at?: string | null;
+          redeemed_by_user_id?: string | null;
+          token_hash?: string;
+          token_prefix?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "agent_claim_tokens_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'agent_claim_tokens_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       agent_personas: {
         Row: {
-          agent_id: string
-          backstory: string | null
-          catchphrase: string | null
-          communication_style: string | null
-          created_at: string | null
-          id: string
-          is_active: boolean | null
-          name: string
-          personality: string | null
-          role: string | null
-          soul_url: string | null
-          updated_at: string | null
-        }
+          agent_id: string;
+          backstory: string | null;
+          catchphrase: string | null;
+          communication_style: string | null;
+          created_at: string | null;
+          id: string;
+          is_active: boolean | null;
+          name: string;
+          personality: string | null;
+          role: string | null;
+          soul_url: string | null;
+          updated_at: string | null;
+        };
         Insert: {
-          agent_id: string
-          backstory?: string | null
-          catchphrase?: string | null
-          communication_style?: string | null
-          created_at?: string | null
-          id?: string
-          is_active?: boolean | null
-          name: string
-          personality?: string | null
-          role?: string | null
-          soul_url?: string | null
-          updated_at?: string | null
-        }
+          agent_id: string;
+          backstory?: string | null;
+          catchphrase?: string | null;
+          communication_style?: string | null;
+          created_at?: string | null;
+          id?: string;
+          is_active?: boolean | null;
+          name: string;
+          personality?: string | null;
+          role?: string | null;
+          soul_url?: string | null;
+          updated_at?: string | null;
+        };
         Update: {
-          agent_id?: string
-          backstory?: string | null
-          catchphrase?: string | null
-          communication_style?: string | null
-          created_at?: string | null
-          id?: string
-          is_active?: boolean | null
-          name?: string
-          personality?: string | null
-          role?: string | null
-          soul_url?: string | null
-          updated_at?: string | null
-        }
+          agent_id?: string;
+          backstory?: string | null;
+          catchphrase?: string | null;
+          communication_style?: string | null;
+          created_at?: string | null;
+          id?: string;
+          is_active?: boolean | null;
+          name?: string;
+          personality?: string | null;
+          role?: string | null;
+          soul_url?: string | null;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "agent_personas_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'agent_personas_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       agents: {
         Row: {
-          avatar_url: string | null
-          created_at: string | null
-          description: string | null
-          developer_id: string | null
-          display_name: string | null
-          email: string | null
-          email_verified: boolean | null
-          follower_count: number | null
-          following_count: number | null
-          id: string
-          axp: number | null
-          last_active: string | null
-          metadata: Json | null
-          name: string
-          public_key: string | null
-          status: string | null
-          trust_score: number | null
-          updated_at: string | null
-          webhook_url: string | null
-        }
+          avatar_url: string | null;
+          axp: number | null;
+          created_at: string | null;
+          description: string | null;
+          developer_id: string | null;
+          display_name: string | null;
+          email: string | null;
+          email_verified: boolean | null;
+          follower_count: number | null;
+          following_count: number | null;
+          id: string;
+          last_active: string | null;
+          metadata: Json | null;
+          name: string;
+          public_key: string | null;
+          status: string | null;
+          trust_score: number | null;
+          updated_at: string | null;
+          webhook_url: string | null;
+        };
         Insert: {
-          avatar_url?: string | null
-          created_at?: string | null
-          description?: string | null
-          developer_id?: string | null
-          display_name?: string | null
-          email?: string | null
-          email_verified?: boolean | null
-          follower_count?: number | null
-          following_count?: number | null
-          id?: string
-          axp?: number | null
-          last_active?: string | null
-          metadata?: Json | null
-          name: string
-          public_key?: string | null
-          status?: string | null
-          trust_score?: number | null
-          updated_at?: string | null
-          webhook_url?: string | null
-        }
+          avatar_url?: string | null;
+          axp?: number | null;
+          created_at?: string | null;
+          description?: string | null;
+          developer_id?: string | null;
+          display_name?: string | null;
+          email?: string | null;
+          email_verified?: boolean | null;
+          follower_count?: number | null;
+          following_count?: number | null;
+          id?: string;
+          last_active?: string | null;
+          metadata?: Json | null;
+          name: string;
+          public_key?: string | null;
+          status?: string | null;
+          trust_score?: number | null;
+          updated_at?: string | null;
+          webhook_url?: string | null;
+        };
         Update: {
-          avatar_url?: string | null
-          created_at?: string | null
-          description?: string | null
-          developer_id?: string | null
-          display_name?: string | null
-          email?: string | null
-          email_verified?: boolean | null
-          follower_count?: number | null
-          following_count?: number | null
-          id?: string
-          axp?: number | null
-          last_active?: string | null
-          metadata?: Json | null
-          name?: string
-          public_key?: string | null
-          status?: string | null
-          trust_score?: number | null
-          updated_at?: string | null
-          webhook_url?: string | null
-        }
+          avatar_url?: string | null;
+          axp?: number | null;
+          created_at?: string | null;
+          description?: string | null;
+          developer_id?: string | null;
+          display_name?: string | null;
+          email?: string | null;
+          email_verified?: boolean | null;
+          follower_count?: number | null;
+          following_count?: number | null;
+          id?: string;
+          last_active?: string | null;
+          metadata?: Json | null;
+          name?: string;
+          public_key?: string | null;
+          status?: string | null;
+          trust_score?: number | null;
+          updated_at?: string | null;
+          webhook_url?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "agents_developer_id_fkey"
-            columns: ["developer_id"]
-            isOneToOne: false
-            referencedRelation: "developers"
-            referencedColumns: ["id"]
+            foreignKeyName: 'agents_developer_id_fkey';
+            columns: ['developer_id'];
+            isOneToOne: false;
+            referencedRelation: 'developers';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
+      axp_history: {
+        Row: {
+          agent_id: string;
+          amount: number;
+          created_at: string;
+          id: string;
+          reason: string;
+          reference_id: string | null;
+        };
+        Insert: {
+          agent_id: string;
+          amount: number;
+          created_at?: string;
+          id?: string;
+          reason: string;
+          reference_id?: string | null;
+        };
+        Update: {
+          agent_id?: string;
+          amount?: number;
+          created_at?: string;
+          id?: string;
+          reason?: string;
+          reference_id?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'axp_history_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       api_keys: {
         Row: {
-          agent_id: string | null
-          created_at: string | null
-          expires_at: string | null
-          id: string
-          key_hash: string
-          key_prefix: string | null
-          last_used: string | null
-          name: string | null
-          permissions: Json | null
-        }
+          agent_id: string | null;
+          created_at: string | null;
+          expires_at: string | null;
+          id: string;
+          key_hash: string;
+          key_prefix: string | null;
+          last_used: string | null;
+          name: string | null;
+          permissions: Json | null;
+        };
         Insert: {
-          agent_id?: string | null
-          created_at?: string | null
-          expires_at?: string | null
-          id?: string
-          key_hash: string
-          key_prefix?: string | null
-          last_used?: string | null
-          name?: string | null
-          permissions?: Json | null
-        }
+          agent_id?: string | null;
+          created_at?: string | null;
+          expires_at?: string | null;
+          id?: string;
+          key_hash: string;
+          key_prefix?: string | null;
+          last_used?: string | null;
+          name?: string | null;
+          permissions?: Json | null;
+        };
         Update: {
-          agent_id?: string | null
-          created_at?: string | null
-          expires_at?: string | null
-          id?: string
-          key_hash?: string
-          key_prefix?: string | null
-          last_used?: string | null
-          name?: string | null
-          permissions?: Json | null
-        }
+          agent_id?: string | null;
+          created_at?: string | null;
+          expires_at?: string | null;
+          id?: string;
+          key_hash?: string;
+          key_prefix?: string | null;
+          last_used?: string | null;
+          name?: string | null;
+          permissions?: Json | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "api_keys_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'api_keys_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       comments: {
         Row: {
-          author_id: string | null
-          content: string
-          created_at: string | null
-          depth: number | null
-          id: string
-          parent_id: string | null
-          post_id: string | null
-          updated_at: string | null
-        }
+          author_id: string | null;
+          content: string;
+          created_at: string | null;
+          depth: number | null;
+          id: string;
+          parent_id: string | null;
+          post_id: string | null;
+          updated_at: string | null;
+        };
         Insert: {
-          author_id?: string | null
-          content: string
-          created_at?: string | null
-          depth?: number | null
-          id?: string
-          parent_id?: string | null
-          post_id?: string | null
-          updated_at?: string | null
-        }
+          author_id?: string | null;
+          content: string;
+          created_at?: string | null;
+          depth?: number | null;
+          id?: string;
+          parent_id?: string | null;
+          post_id?: string | null;
+          updated_at?: string | null;
+        };
         Update: {
-          author_id?: string | null
-          content?: string
-          created_at?: string | null
-          depth?: number | null
-          id?: string
-          parent_id?: string | null
-          post_id?: string | null
-          updated_at?: string | null
-        }
+          author_id?: string | null;
+          content?: string;
+          created_at?: string | null;
+          depth?: number | null;
+          id?: string;
+          parent_id?: string | null;
+          post_id?: string | null;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "comments_author_id_fkey"
-            columns: ["author_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'comments_author_id_fkey';
+            columns: ['author_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "comments_parent_id_fkey"
-            columns: ["parent_id"]
-            isOneToOne: false
-            referencedRelation: "comments"
-            referencedColumns: ["id"]
+            foreignKeyName: 'comments_parent_id_fkey';
+            columns: ['parent_id'];
+            isOneToOne: false;
+            referencedRelation: 'comments';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "comments_post_id_fkey"
-            columns: ["post_id"]
-            isOneToOne: false
-            referencedRelation: "posts"
-            referencedColumns: ["id"]
+            foreignKeyName: 'comments_post_id_fkey';
+            columns: ['post_id'];
+            isOneToOne: false;
+            referencedRelation: 'posts';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       communities: {
         Row: {
-          created_at: string | null
-          creator_id: string | null
-          description: string | null
-          display_name: string
-          id: string
-          is_default: boolean | null
-          member_count: number | null
-          name: string
-          post_count: number | null
-          rules: string | null
-        }
+          created_at: string | null;
+          creator_id: string | null;
+          description: string | null;
+          display_name: string;
+          id: string;
+          is_default: boolean | null;
+          member_count: number | null;
+          name: string;
+          post_count: number | null;
+          rules: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          creator_id?: string | null
-          description?: string | null
-          display_name: string
-          id?: string
-          is_default?: boolean | null
-          member_count?: number | null
-          name: string
-          post_count?: number | null
-          rules?: string | null
-        }
+          created_at?: string | null;
+          creator_id?: string | null;
+          description?: string | null;
+          display_name: string;
+          id?: string;
+          is_default?: boolean | null;
+          member_count?: number | null;
+          name: string;
+          post_count?: number | null;
+          rules?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          creator_id?: string | null
-          description?: string | null
-          display_name?: string
-          id?: string
-          is_default?: boolean | null
-          member_count?: number | null
-          name?: string
-          post_count?: number | null
-          rules?: string | null
-        }
+          created_at?: string | null;
+          creator_id?: string | null;
+          description?: string | null;
+          display_name?: string;
+          id?: string;
+          is_default?: boolean | null;
+          member_count?: number | null;
+          name?: string;
+          post_count?: number | null;
+          rules?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "communities_creator_id_fkey"
-            columns: ["creator_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'communities_creator_id_fkey';
+            columns: ['creator_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       developer_members: {
         Row: {
-          created_at: string
-          developer_id: string
-          id: string
-          role: string
-          user_id: string
-        }
+          created_at: string;
+          developer_id: string;
+          id: string;
+          role: string;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string
-          developer_id: string
-          id?: string
-          role?: string
-          user_id: string
-        }
+          created_at?: string;
+          developer_id: string;
+          id?: string;
+          role?: string;
+          user_id: string;
+        };
         Update: {
-          created_at?: string
-          developer_id?: string
-          id?: string
-          role?: string
-          user_id?: string
-        }
+          created_at?: string;
+          developer_id?: string;
+          id?: string;
+          role?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "developer_members_developer_id_fkey"
-            columns: ["developer_id"]
-            isOneToOne: false
-            referencedRelation: "developers"
-            referencedColumns: ["id"]
+            foreignKeyName: 'developer_members_developer_id_fkey';
+            columns: ['developer_id'];
+            isOneToOne: false;
+            referencedRelation: 'developers';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       developers: {
         Row: {
-          billing_email: string | null
-          billing_last_event_at: string | null
-          created_at: string
-          current_period_end: string | null
-          display_name: string | null
-          id: string
-          kind: string
-          last_payment_at: string | null
-          metadata: Json
-          payment_customer_id: string | null
-          payment_provider: string
-          payment_subscription_id: string | null
-          payment_variant_id: string | null
-          plan: string
-          status: string
-          subscription_status: string
-          updated_at: string
-        }
+          billing_email: string | null;
+          billing_last_event_at: string | null;
+          created_at: string;
+          current_period_end: string | null;
+          display_name: string | null;
+          id: string;
+          kind: string;
+          last_payment_at: string | null;
+          metadata: Json;
+          payment_customer_id: string | null;
+          payment_provider: string;
+          payment_subscription_id: string | null;
+          payment_variant_id: string | null;
+          plan: string;
+          status: string;
+          subscription_status: string;
+          updated_at: string;
+        };
         Insert: {
-          billing_email?: string | null
-          billing_last_event_at?: string | null
-          created_at?: string
-          current_period_end?: string | null
-          display_name?: string | null
-          id?: string
-          kind?: string
-          last_payment_at?: string | null
-          metadata?: Json
-          payment_customer_id?: string | null
-          payment_provider?: string
-          payment_subscription_id?: string | null
-          payment_variant_id?: string | null
-          plan?: string
-          status?: string
-          subscription_status?: string
-          updated_at?: string
-        }
+          billing_email?: string | null;
+          billing_last_event_at?: string | null;
+          created_at?: string;
+          current_period_end?: string | null;
+          display_name?: string | null;
+          id?: string;
+          kind?: string;
+          last_payment_at?: string | null;
+          metadata?: Json;
+          payment_customer_id?: string | null;
+          payment_provider?: string;
+          payment_subscription_id?: string | null;
+          payment_variant_id?: string | null;
+          plan?: string;
+          status?: string;
+          subscription_status?: string;
+          updated_at?: string;
+        };
         Update: {
-          billing_email?: string | null
-          billing_last_event_at?: string | null
-          created_at?: string
-          current_period_end?: string | null
-          display_name?: string | null
-          id?: string
-          kind?: string
-          last_payment_at?: string | null
-          metadata?: Json
-          payment_customer_id?: string | null
-          payment_provider?: string
-          payment_subscription_id?: string | null
-          payment_variant_id?: string | null
-          plan?: string
-          status?: string
-          subscription_status?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
+          billing_email?: string | null;
+          billing_last_event_at?: string | null;
+          created_at?: string;
+          current_period_end?: string | null;
+          display_name?: string | null;
+          id?: string;
+          kind?: string;
+          last_payment_at?: string | null;
+          metadata?: Json;
+          payment_customer_id?: string | null;
+          payment_provider?: string;
+          payment_subscription_id?: string | null;
+          payment_variant_id?: string | null;
+          plan?: string;
+          status?: string;
+          subscription_status?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       follows: {
         Row: {
-          created_at: string | null
-          follower_id: string
-          following_id: string
-        }
+          created_at: string | null;
+          follower_id: string;
+          following_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          follower_id: string
-          following_id: string
-        }
+          created_at?: string | null;
+          follower_id: string;
+          following_id: string;
+        };
         Update: {
-          created_at?: string | null
-          follower_id?: string
-          following_id?: string
-        }
+          created_at?: string | null;
+          follower_id?: string;
+          following_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "follows_follower_id_fkey"
-            columns: ["follower_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'follows_follower_id_fkey';
+            columns: ['follower_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "follows_following_id_fkey"
-            columns: ["following_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'follows_following_id_fkey';
+            columns: ['following_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       hashtags: {
         Row: {
-          created_at: string | null
-          id: string
-          last_used_at: string | null
-          name: string
-          post_count: number | null
-        }
+          created_at: string | null;
+          id: string;
+          last_used_at: string | null;
+          name: string;
+          post_count: number | null;
+        };
         Insert: {
-          created_at?: string | null
-          id?: string
-          last_used_at?: string | null
-          name: string
-          post_count?: number | null
-        }
+          created_at?: string | null;
+          id?: string;
+          last_used_at?: string | null;
+          name: string;
+          post_count?: number | null;
+        };
         Update: {
-          created_at?: string | null
-          id?: string
-          last_used_at?: string | null
-          name?: string
-          post_count?: number | null
-        }
-        Relationships: []
-      }
+          created_at?: string | null;
+          id?: string;
+          last_used_at?: string | null;
+          name?: string;
+          post_count?: number | null;
+        };
+        Relationships: [];
+      };
       mentions: {
         Row: {
-          created_at: string | null
-          id: string
-          mentioned_id: string
-          mentioner_id: string
-          source_id: string
-          source_type: string
-        }
+          created_at: string | null;
+          id: string;
+          mentioned_id: string;
+          mentioner_id: string;
+          source_id: string;
+          source_type: string;
+        };
         Insert: {
-          created_at?: string | null
-          id?: string
-          mentioned_id: string
-          mentioner_id: string
-          source_id: string
-          source_type: string
-        }
+          created_at?: string | null;
+          id?: string;
+          mentioned_id: string;
+          mentioner_id: string;
+          source_id: string;
+          source_type: string;
+        };
         Update: {
-          created_at?: string | null
-          id?: string
-          mentioned_id?: string
-          mentioner_id?: string
-          source_id?: string
-          source_type?: string
-        }
+          created_at?: string | null;
+          id?: string;
+          mentioned_id?: string;
+          mentioner_id?: string;
+          source_id?: string;
+          source_type?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "mentions_mentioned_id_fkey"
-            columns: ["mentioned_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'mentions_mentioned_id_fkey';
+            columns: ['mentioned_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "mentions_mentioner_id_fkey"
-            columns: ["mentioner_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'mentions_mentioner_id_fkey';
+            columns: ['mentioner_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       notifications: {
         Row: {
-          actor_id: string
-          created_at: string | null
-          id: string
-          message: string | null
-          read: boolean | null
-          recipient_id: string
-          target_id: string | null
-          target_type: string | null
-          type: string
-        }
+          actor_id: string;
+          created_at: string | null;
+          id: string;
+          message: string | null;
+          read: boolean | null;
+          recipient_id: string;
+          target_id: string | null;
+          target_type: string | null;
+          type: string;
+        };
         Insert: {
-          actor_id: string
-          created_at?: string | null
-          id?: string
-          message?: string | null
-          read?: boolean | null
-          recipient_id: string
-          target_id?: string | null
-          target_type?: string | null
-          type: string
-        }
+          actor_id: string;
+          created_at?: string | null;
+          id?: string;
+          message?: string | null;
+          read?: boolean | null;
+          recipient_id: string;
+          target_id?: string | null;
+          target_type?: string | null;
+          type: string;
+        };
         Update: {
-          actor_id?: string
-          created_at?: string | null
-          id?: string
-          message?: string | null
-          read?: boolean | null
-          recipient_id?: string
-          target_id?: string | null
-          target_type?: string | null
-          type?: string
-        }
+          actor_id?: string;
+          created_at?: string | null;
+          id?: string;
+          message?: string | null;
+          read?: boolean | null;
+          recipient_id?: string;
+          target_id?: string | null;
+          target_type?: string | null;
+          type?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "notifications_actor_id_fkey"
-            columns: ["actor_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'notifications_actor_id_fkey';
+            columns: ['actor_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "notifications_recipient_id_fkey"
-            columns: ["recipient_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'notifications_recipient_id_fkey';
+            columns: ['recipient_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       post_hashtags: {
         Row: {
-          created_at: string | null
-          hashtag_id: string
-          post_id: string
-        }
+          created_at: string | null;
+          hashtag_id: string;
+          post_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          hashtag_id: string
-          post_id: string
-        }
+          created_at?: string | null;
+          hashtag_id: string;
+          post_id: string;
+        };
         Update: {
-          created_at?: string | null
-          hashtag_id?: string
-          post_id?: string
-        }
+          created_at?: string | null;
+          hashtag_id?: string;
+          post_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "post_hashtags_hashtag_id_fkey"
-            columns: ["hashtag_id"]
-            isOneToOne: false
-            referencedRelation: "hashtags"
-            referencedColumns: ["id"]
+            foreignKeyName: 'post_hashtags_hashtag_id_fkey';
+            columns: ['hashtag_id'];
+            isOneToOne: false;
+            referencedRelation: 'hashtags';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "post_hashtags_post_id_fkey"
-            columns: ["post_id"]
-            isOneToOne: false
-            referencedRelation: "posts"
-            referencedColumns: ["id"]
+            foreignKeyName: 'post_hashtags_post_id_fkey';
+            columns: ['post_id'];
+            isOneToOne: false;
+            referencedRelation: 'posts';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       posts: {
         Row: {
-          author_id: string | null
-          comment_count: number | null
-          community_id: string | null
-          content: string | null
-          created_at: string | null
-          embedding: string | null
-          expires_at: string | null
-          id: string
-          likes: number | null
-          metadata: Json | null
-          original_post_id: string | null
-          post_kind: string | null
-          post_type: string | null
-          repost_count: number | null
-          score: number | null
-          title: string
-          updated_at: string | null
-          url: string | null
-          view_count: number | null
-        }
+          author_id: string | null;
+          comment_count: number | null;
+          community_id: string | null;
+          content: string | null;
+          created_at: string | null;
+          embedding: string | null;
+          expires_at: string | null;
+          id: string;
+          likes: number | null;
+          metadata: Json | null;
+          original_post_id: string | null;
+          post_kind: string | null;
+          post_type: string | null;
+          repost_count: number | null;
+          score: number | null;
+          title: string;
+          updated_at: string | null;
+          url: string | null;
+          view_count: number | null;
+        };
         Insert: {
-          author_id?: string | null
-          comment_count?: number | null
-          community_id?: string | null
-          content?: string | null
-          created_at?: string | null
-          embedding?: string | null
-          expires_at?: string | null
-          id?: string
-          likes?: number | null
-          metadata?: Json | null
-          original_post_id?: string | null
-          post_kind?: string | null
-          post_type?: string | null
-          repost_count?: number | null
-          score?: number | null
-          title: string
-          updated_at?: string | null
-          url?: string | null
-          view_count?: number | null
-        }
+          author_id?: string | null;
+          comment_count?: number | null;
+          community_id?: string | null;
+          content?: string | null;
+          created_at?: string | null;
+          embedding?: string | null;
+          expires_at?: string | null;
+          id?: string;
+          likes?: number | null;
+          metadata?: Json | null;
+          original_post_id?: string | null;
+          post_kind?: string | null;
+          post_type?: string | null;
+          repost_count?: number | null;
+          score?: number | null;
+          title: string;
+          updated_at?: string | null;
+          url?: string | null;
+          view_count?: number | null;
+        };
         Update: {
-          author_id?: string | null
-          comment_count?: number | null
-          community_id?: string | null
-          content?: string | null
-          created_at?: string | null
-          embedding?: string | null
-          expires_at?: string | null
-          id?: string
-          likes?: number | null
-          metadata?: Json | null
-          original_post_id?: string | null
-          post_kind?: string | null
-          post_type?: string | null
-          repost_count?: number | null
-          score?: number | null
-          title?: string
-          updated_at?: string | null
-          url?: string | null
-          view_count?: number | null
-        }
+          author_id?: string | null;
+          comment_count?: number | null;
+          community_id?: string | null;
+          content?: string | null;
+          created_at?: string | null;
+          embedding?: string | null;
+          expires_at?: string | null;
+          id?: string;
+          likes?: number | null;
+          metadata?: Json | null;
+          original_post_id?: string | null;
+          post_kind?: string | null;
+          post_type?: string | null;
+          repost_count?: number | null;
+          score?: number | null;
+          title?: string;
+          updated_at?: string | null;
+          url?: string | null;
+          view_count?: number | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "posts_author_id_fkey"
-            columns: ["author_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'posts_author_id_fkey';
+            columns: ['author_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "posts_community_id_fkey"
-            columns: ["community_id"]
-            isOneToOne: false
-            referencedRelation: "communities"
-            referencedColumns: ["id"]
+            foreignKeyName: 'posts_community_id_fkey';
+            columns: ['community_id'];
+            isOneToOne: false;
+            referencedRelation: 'communities';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "posts_original_post_id_fkey"
-            columns: ["original_post_id"]
-            isOneToOne: false
-            referencedRelation: "posts"
-            referencedColumns: ["id"]
+            foreignKeyName: 'posts_original_post_id_fkey';
+            columns: ['original_post_id'];
+            isOneToOne: false;
+            referencedRelation: 'posts';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       rate_limits: {
         Row: {
-          action: string
-          agent_id: string | null
-          count: number | null
-          id: string
-          window_start: string | null
-        }
+          action: string;
+          agent_id: string | null;
+          count: number | null;
+          id: string;
+          window_start: string | null;
+        };
         Insert: {
-          action: string
-          agent_id?: string | null
-          count?: number | null
-          id?: string
-          window_start?: string | null
-        }
+          action: string;
+          agent_id?: string | null;
+          count?: number | null;
+          id?: string;
+          window_start?: string | null;
+        };
         Update: {
-          action?: string
-          agent_id?: string | null
-          count?: number | null
-          id?: string
-          window_start?: string | null
-        }
+          action?: string;
+          agent_id?: string | null;
+          count?: number | null;
+          id?: string;
+          window_start?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "rate_limits_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'rate_limits_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       story_views: {
         Row: {
-          story_id: string
-          viewed_at: string | null
-          viewer_id: string
-        }
+          story_id: string;
+          viewed_at: string | null;
+          viewer_id: string;
+        };
         Insert: {
-          story_id: string
-          viewed_at?: string | null
-          viewer_id: string
-        }
+          story_id: string;
+          viewed_at?: string | null;
+          viewer_id: string;
+        };
         Update: {
-          story_id?: string
-          viewed_at?: string | null
-          viewer_id?: string
-        }
+          story_id?: string;
+          viewed_at?: string | null;
+          viewer_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "story_views_story_id_fkey"
-            columns: ["story_id"]
-            isOneToOne: false
-            referencedRelation: "posts"
-            referencedColumns: ["id"]
+            foreignKeyName: 'story_views_story_id_fkey';
+            columns: ['story_id'];
+            isOneToOne: false;
+            referencedRelation: 'posts';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "story_views_viewer_id_fkey"
-            columns: ["viewer_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'story_views_viewer_id_fkey';
+            columns: ['viewer_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       subscriptions: {
         Row: {
-          agent_id: string
-          community_id: string
-          created_at: string | null
-        }
+          agent_id: string;
+          community_id: string;
+          created_at: string | null;
+        };
         Insert: {
-          agent_id: string
-          community_id: string
-          created_at?: string | null
-        }
+          agent_id: string;
+          community_id: string;
+          created_at?: string | null;
+        };
         Update: {
-          agent_id?: string
-          community_id?: string
-          created_at?: string | null
-        }
+          agent_id?: string;
+          community_id?: string;
+          created_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "subscriptions_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'subscriptions_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
           {
-            foreignKeyName: "subscriptions_community_id_fkey"
-            columns: ["community_id"]
-            isOneToOne: false
-            referencedRelation: "communities"
-            referencedColumns: ["id"]
+            foreignKeyName: 'subscriptions_community_id_fkey';
+            columns: ['community_id'];
+            isOneToOne: false;
+            referencedRelation: 'communities';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       votes: {
         Row: {
-          agent_id: string | null
-          created_at: string | null
-          id: string
-          target_id: string
-          target_type: string
-          vote_type: number
-        }
+          agent_id: string | null;
+          created_at: string | null;
+          id: string;
+          target_id: string;
+          target_type: string;
+          vote_type: number;
+        };
         Insert: {
-          agent_id?: string | null
-          created_at?: string | null
-          id?: string
-          target_id: string
-          target_type: string
-          vote_type: number
-        }
+          agent_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          target_id: string;
+          target_type: string;
+          vote_type: number;
+        };
         Update: {
-          agent_id?: string | null
-          created_at?: string | null
-          id?: string
-          target_id?: string
-          target_type?: string
-          vote_type?: number
-        }
+          agent_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          target_id?: string;
+          target_type?: string;
+          vote_type?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "votes_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'votes_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
+        ];
+      };
       webhook_events: {
         Row: {
-          created_at: string
-          developer_id: string | null
-          event_name: string
-          id: string
-          payload: Json
-          processed_at: string
-          subscription_id: string | null
-        }
+          created_at: string;
+          developer_id: string | null;
+          event_name: string;
+          id: string;
+          payload: Json;
+          processed_at: string;
+          subscription_id: string | null;
+        };
         Insert: {
-          created_at?: string
-          developer_id?: string | null
-          event_name: string
-          id?: string
-          payload?: Json
-          processed_at?: string
-          subscription_id?: string | null
-        }
+          created_at?: string;
+          developer_id?: string | null;
+          event_name: string;
+          id?: string;
+          payload?: Json;
+          processed_at?: string;
+          subscription_id?: string | null;
+        };
         Update: {
-          created_at?: string
-          developer_id?: string | null
-          event_name?: string
-          id?: string
-          payload?: Json
-          processed_at?: string
-          subscription_id?: string | null
-        }
+          created_at?: string;
+          developer_id?: string | null;
+          event_name?: string;
+          id?: string;
+          payload?: Json;
+          processed_at?: string;
+          subscription_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "webhook_events_developer_id_fkey"
-            columns: ["developer_id"]
-            isOneToOne: false
-            referencedRelation: "developers"
-            referencedColumns: ["id"]
+            foreignKeyName: 'webhook_events_developer_id_fkey';
+            columns: ['developer_id'];
+            isOneToOne: false;
+            referencedRelation: 'developers';
+            referencedColumns: ['id'];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Views: {
       post_likes: {
         Row: {
-          agent_id: string | null
-          created_at: string | null
-          post_id: string | null
-        }
+          agent_id: string | null;
+          created_at: string | null;
+          post_id: string | null;
+        };
         Insert: {
-          agent_id?: string | null
-          created_at?: string | null
-          post_id?: string | null
-        }
+          agent_id?: string | null;
+          created_at?: string | null;
+          post_id?: string | null;
+        };
         Update: {
-          agent_id?: string | null
-          created_at?: string | null
-          post_id?: string | null
-        }
+          agent_id?: string | null;
+          created_at?: string | null;
+          post_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "votes_agent_id_fkey"
-            columns: ["agent_id"]
-            isOneToOne: false
-            referencedRelation: "agents"
-            referencedColumns: ["id"]
+            foreignKeyName: 'votes_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Functions: {
       batch_upsert_hashtags: {
-        Args: { p_hashtag_names: string[]; p_post_id: string }
-        Returns: undefined
-      }
+        Args: { p_hashtag_names: string[]; p_post_id: string };
+        Returns: undefined;
+      };
       calculate_explore_score: {
         Args: {
-          p_comment_count: number
-          p_created_at: string
-          p_likes: number
-          p_repost_count: number
-        }
-        Returns: number
-      }
-      cleanup_expired_stories: { Args: never; Returns: number }
+          p_comment_count: number;
+          p_created_at: string;
+          p_likes: number;
+          p_repost_count: number;
+        };
+        Returns: number;
+      };
+      cleanup_expired_stories: { Args: never; Returns: number };
       decrement_agent_axp: {
-        Args: { p_agent_id: string; p_amount?: number }
-        Returns: undefined
-      }
+        Args: { p_agent_id: string; p_amount?: number };
+        Returns: undefined;
+      };
       decrement_follow_counts: {
-        Args: { p_follower: string; p_following: string }
-        Returns: undefined
-      }
-      decrement_hashtag_count: { Args: { h_id: string }; Returns: undefined }
-      decrement_post_like: { Args: { p_id: string }; Returns: undefined }
-      decrement_repost_count: { Args: { p_id: string }; Returns: undefined }
+        Args: { p_follower: string; p_following: string };
+        Returns: undefined;
+      };
+      decrement_hashtag_count: { Args: { h_id: string }; Returns: undefined };
+      decrement_post_like: { Args: { p_id: string }; Returns: undefined };
+      decrement_repost_count: { Args: { p_id: string }; Returns: undefined };
       get_following_feed: {
-        Args: { p_follower_id: string; p_limit?: number; p_offset?: number }
+        Args: { p_follower_id: string; p_limit?: number; p_offset?: number };
         Returns: {
-          author_avatar_url: string
-          author_display_name: string
-          author_id: string
-          author_axp: number
-          author_name: string
-          comment_count: number
-          community_display_name: string
-          community_id: string
-          community_name: string
-          content: string
-          created_at: string
-          expires_at: string
-          id: string
-          likes: number
-          metadata: Json
-          original_post_id: string
-          post_kind: string
-          post_type: string
-          repost_count: number
-          score: number
-          title: string
-          updated_at: string
-          url: string
-          view_count: number
-        }[]
-      }
+          author_avatar_url: string;
+          author_axp: number;
+          author_display_name: string;
+          author_id: string;
+          author_name: string;
+          comment_count: number;
+          community_display_name: string;
+          community_id: string;
+          community_name: string;
+          content: string;
+          created_at: string;
+          expires_at: string;
+          id: string;
+          likes: number;
+          metadata: Json;
+          original_post_id: string;
+          post_kind: string;
+          post_type: string;
+          repost_count: number;
+          score: number;
+          title: string;
+          updated_at: string;
+          url: string;
+          view_count: number;
+        }[];
+      };
       increment_agent_axp: {
-        Args: { p_agent_id: string; p_amount?: number }
-        Returns: undefined
-      }
+        Args: { p_agent_id: string; p_amount?: number };
+        Returns: undefined;
+      };
       increment_follow_counts: {
-        Args: { p_follower: string; p_following: string }
-        Returns: undefined
-      }
-      increment_hashtag_count: { Args: { h_id: string }; Returns: undefined }
-      increment_post_like: { Args: { p_id: string }; Returns: undefined }
-      increment_repost_count: { Args: { p_id: string }; Returns: undefined }
-      increment_view_count: { Args: { p_id: string }; Returns: undefined }
+        Args: { p_follower: string; p_following: string };
+        Returns: undefined;
+      };
+      increment_hashtag_count: { Args: { h_id: string }; Returns: undefined };
+      increment_post_like: { Args: { p_id: string }; Returns: undefined };
+      increment_repost_count: { Args: { p_id: string }; Returns: undefined };
+      increment_view_count: { Args: { p_id: string }; Returns: undefined };
       search_posts_by_embedding: {
         Args: {
-          match_limit?: number
-          match_offset?: number
-          query_embedding: string
-        }
+          match_limit?: number;
+          match_offset?: number;
+          query_embedding: string;
+        };
         Returns: {
-          author_avatar_url: string
-          author_display_name: string
-          author_id: string
-          author_name: string
-          comment_count: number
-          content: string
-          created_at: string
-          id: string
-          likes: number
-          post_type: string
-          score: number
-          similarity: number
-          title: string
-        }[]
-      }
-    }
+          author_avatar_url: string;
+          author_display_name: string;
+          author_id: string;
+          author_name: string;
+          comment_count: number;
+          content: string;
+          created_at: string;
+          id: string;
+          likes: number;
+          post_type: string;
+          score: number;
+          similarity: number;
+          title: string;
+        }[];
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<
+  keyof Database,
+  'public'
+>];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+      Row: infer R;
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])
+    ? (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Insert: infer I;
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Update: infer U;
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
+    | keyof DefaultSchema['Enums']
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
+    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+    : never;
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
+    | keyof DefaultSchema['CompositeTypes']
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
+    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+    : never;
 
 export const Constants = {
   graphql_public: {
@@ -1139,4 +1177,4 @@ export const Constants = {
   public: {
     Enums: {},
   },
-} as const
+} as const;

--- a/supabase/migrations/20260207000001_axp_history.sql
+++ b/supabase/migrations/20260207000001_axp_history.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS axp_history (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id    UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  amount      INTEGER NOT NULL,
+  reason      VARCHAR(100) NOT NULL,
+  reference_id UUID,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_axp_history_agent_id ON axp_history(agent_id);
+CREATE INDEX idx_axp_history_created_at ON axp_history(created_at DESC);
+
+ALTER TABLE axp_history ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Agents can view their own AXP history" ON axp_history
+  FOR SELECT USING (auth.uid() = agent_id);
+
+CREATE OR REPLACE FUNCTION increment_agent_axp(
+  p_agent_id UUID,
+  p_amount INTEGER DEFAULT 1,
+  p_reason VARCHAR(100) DEFAULT 'unknown',
+  p_reference_id UUID DEFAULT NULL
+)
+RETURNS void AS $$
+BEGIN
+  UPDATE agents
+  SET axp = COALESCE(axp, 0) + p_amount
+  WHERE id = p_agent_id;
+
+  INSERT INTO axp_history (agent_id, amount, reason, reference_id)
+  VALUES (p_agent_id, p_amount, p_reason, p_reference_id);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION decrement_agent_axp(
+  p_agent_id UUID,
+  p_amount INTEGER DEFAULT 1,
+  p_reason VARCHAR(100) DEFAULT 'unknown',
+  p_reference_id UUID DEFAULT NULL
+)
+RETURNS void AS $$
+BEGIN
+  UPDATE agents
+  SET axp = GREATEST(0, COALESCE(axp, 0) - p_amount)
+  WHERE id = p_agent_id;
+
+  INSERT INTO axp_history (agent_id, amount, reason, reference_id)
+  VALUES (p_agent_id, -p_amount, p_reason, p_reference_id);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON TABLE axp_history IS 'Ledger for AXP changes to provide transparency and breakdown';


### PR DESCRIPTION
## Description
This PR adds AXP transparency by introducing an AXP history ledger and a breakdown API.

## Changes Made
- Created `axp_history` table via migration
- Updated AXP increment/decrement RPCs to record history with reasons
- Implemented `GET /api/v1/agents/me/axp/breakdown` endpoint
- Updated existing code to provide reasons for AXP changes