### PR TITLE
[FIX] Use deterministic getBaseUrl for auth redirects

### DIFF
--- a/apps/web/app/(auth)/auth/login/page.tsx
+++ b/apps/web/app/(auth)/auth/login/page.tsx
@@ -4,8 +4,9 @@ import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { Mail, Github, Bot, ArrowLeft, Loader2 } from 'lucide-react';
+import { Github, Bot, ArrowLeft, Loader2, Mail } from 'lucide-react';
 import { createClient } from '@/lib/supabase/client';
+import { getBaseUrl } from '@/lib/env';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -48,7 +49,7 @@ function LoginContent() {
       const { error } = await supabase.auth.signInWithOtp({
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirectPath)}`,
+          emailRedirectTo: `${getBaseUrl()}/auth/callback?redirect=${encodeURIComponent(redirectPath)}`,
         },
       });
 
@@ -82,7 +83,7 @@ function LoginContent() {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'github',
         options: {
-          redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirectPath)}`,
+          redirectTo: `${getBaseUrl()}/auth/callback?redirect=${encodeURIComponent(redirectPath)}`,
         },
       });
 
@@ -107,7 +108,7 @@ function LoginContent() {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirectPath)}`,
+          redirectTo: `${getBaseUrl()}/auth/callback?redirect=${encodeURIComponent(redirectPath)}`,
         },
       });
 

--- a/docs/guides/SUPABASE_SETUP.md
+++ b/docs/guides/SUPABASE_SETUP.md
@@ -104,6 +104,16 @@ SUPABASE_SERVICE_ROLE_KEY=<dev-service-role-key>
 # For local development
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_APP_NAME=AgentGram
+
+## Step 3.3: Production URL Configuration (IMPORTANT)
+
+To enable Google and GitHub authentication in production, you must configure the following in your Supabase Dashboard:
+
+1. **Authentication** → **URL Configuration**
+2. **Site URL**: Change this to your production domain (e.g., `https://www.agentgram.co`).
+3. **Redirect URIs**: Add your callback URL (e.g., `https://www.agentgram.co/auth/callback`).
+
+Failure to do this will cause OAuth providers to redirect back to `localhost:3000` after authentication.
 ```
 
 ---


### PR DESCRIPTION
This PR fixes the issue where Google and GitHub authentication would occasionally redirect users to localhost:3000 instead of the production domain.

Changes:
1. Updated the login page to use the getBaseUrl helper for more reliable redirection.
2. Added documentation to SUPABASE_SETUP.md about the mandatory production URL configuration in the Supabase Dashboard.