### PR TITLE
[FIX] Add developer account auto-creation and activate billing (#314)

### DIFF
--- a/apps/web/app/(protected)/dashboard/layout.tsx
+++ b/apps/web/app/(protected)/dashboard/layout.tsx
@@ -5,6 +5,7 @@ import { LayoutDashboard, CreditCard, Rocket, Settings, Bot, BarChart3 } from 'l
 import { SignOutButton } from '@/components/dashboard';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
+import { ensureDeveloperAccount } from '@/lib/auth/developer';
 
 export default async function DashboardLayout({
   children,
@@ -19,6 +20,9 @@ export default async function DashboardLayout({
   if (!user) {
     redirect('/auth/login');
   }
+
+  // Ensure developer account exists (fallback if OAuth callback failed)
+  await ensureDeveloperAccount(user.id, user.email || null);
 
   const navItems = [
     {

--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -142,8 +142,8 @@ export default async function DashboardPage() {
               </div>
             </CardContent>
             <CardFooter>
-              <Button variant="outline" className="w-full" disabled>
-                Billing (Coming Soon)
+              <Button variant="outline" className="w-full" asChild>
+                <Link href="/dashboard/billing">Manage Billing</Link>
               </Button>
             </CardFooter>
           </Card>

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -130,7 +130,7 @@ export default function PricingPage() {
       } else if (res.status === 401) {
         router.push('/auth/login?redirect=/pricing');
       } else {
-        console.error('Checkout error:', data.error?.message);
+        alert(data.error?.message || 'Failed to create checkout. Please try again.');
       }
     } catch {
       console.error('Failed to create checkout session');

--- a/apps/web/lib/auth/developer.ts
+++ b/apps/web/lib/auth/developer.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createClient as createServiceClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import type { ApiResponse } from '@agentgram/shared';
 
 /**
@@ -63,17 +64,61 @@ export function withDeveloperAuth<T extends unknown[]>(
       .single();
 
     if (memberError || !membership) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: {
-            code: 'NO_DEVELOPER_ACCOUNT',
-            message:
-              'No developer account found. Register as a developer first.',
-          },
-        } satisfies ApiResponse,
-        { status: 403 }
+      // Auto-create developer account for authenticated users
+      const created = await autoCreateDeveloperAccount(
+        serviceClient,
+        user.id,
+        user.email || null
       );
+      if (!created) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: {
+              code: 'NO_DEVELOPER_ACCOUNT',
+              message:
+                'No developer account found. Please try again.',
+            },
+          } satisfies ApiResponse,
+          { status: 403 }
+        );
+      }
+
+      // Re-fetch membership after creation
+      const { data: newMembership } = await serviceClient
+        .from('developer_members')
+        .select('developer_id, role')
+        .eq('user_id', user.id)
+        .single();
+
+      if (!newMembership) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: {
+              code: 'NO_DEVELOPER_ACCOUNT',
+              message:
+                'Failed to create developer account. Please try again.',
+            },
+          } satisfies ApiResponse,
+          { status: 403 }
+        );
+      }
+
+      Object.assign(membership ?? {}, newMembership);
+      // Use newMembership below
+      const headers = new Headers(req.headers);
+      headers.set('x-developer-id', newMembership.developer_id);
+      headers.set('x-developer-role', newMembership.role);
+      headers.set('x-user-id', user.id);
+
+      const authedReq = new NextRequest(req.url, {
+        method: req.method,
+        headers,
+        body: req.body,
+      });
+
+      return handler(authedReq, ...args);
     }
 
     // Create a new request with developer context headers
@@ -90,4 +135,66 @@ export function withDeveloperAuth<T extends unknown[]>(
 
     return handler(authedReq, ...args);
   };
+}
+
+/**
+ * Auto-create a developer account for an authenticated user.
+ * Returns true if the account was created (or already existed).
+ */
+async function autoCreateDeveloperAccount(
+  serviceClient: SupabaseClient,
+  userId: string,
+  email: string | null
+): Promise<boolean> {
+  // Double-check: maybe it was just created
+  const { data: existing } = await serviceClient
+    .from('developer_members')
+    .select('developer_id')
+    .eq('user_id', userId)
+    .single();
+
+  if (existing) return true;
+
+  const { data: developer, error: devError } = await serviceClient
+    .from('developers')
+    .insert({
+      kind: 'registered',
+      billing_email: email,
+      display_name: email?.split('@')[0] || null,
+    })
+    .select('id')
+    .single();
+
+  if (devError || !developer) {
+    console.error('[autoCreateDeveloperAccount] Failed to create developer:', devError);
+    return false;
+  }
+
+  const { error: memberError } = await serviceClient
+    .from('developer_members')
+    .insert({
+      developer_id: developer.id,
+      user_id: userId,
+      role: 'owner',
+    });
+
+  if (memberError) {
+    console.error('[autoCreateDeveloperAccount] Failed to create membership:', memberError);
+    await serviceClient.from('developers').delete().eq('id', developer.id);
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Ensure a developer account exists for the given user.
+ * Exported for use in server components (e.g., dashboard layout).
+ */
+export async function ensureDeveloperAccount(
+  userId: string,
+  email: string | null
+): Promise<boolean> {
+  const serviceClient = getServiceClient();
+  return autoCreateDeveloperAccount(serviceClient, userId, email);
 }


### PR DESCRIPTION
## Description

Fixes critical production bug where developer accounts are not created during OAuth callback, causing cascading failures across dashboard, billing, and pricing pages.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **`lib/auth/developer.ts`**: Added `ensureDeveloperAccount` export and `autoCreateDeveloperAccount` fallback in `withDeveloperAuth` middleware — if an authenticated user has no developer record, one is created on-the-fly
- **`dashboard/layout.tsx`**: Calls `ensureDeveloperAccount` on every dashboard visit as a server-side fallback
- **`dashboard/page.tsx`**: Changed hardcoded disabled "Billing (Coming Soon)" button to active link to `/dashboard/billing`
- **`pricing/page.tsx`**: Shows error message instead of silently redirecting to login on checkout failure

## Related Issues

Closes #314

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings