### PR TITLE
[FIX] Use valid kind value for developer account creation (#317)

### DIFF
--- a/apps/web/app/(auth)/auth/callback/route.ts
+++ b/apps/web/app/(auth)/auth/callback/route.ts
@@ -63,11 +63,11 @@ async function ensureDeveloperAccount(userId: string, email: string | null) {
     return; // Already has a developer account
   }
 
-  // Create a new developer account (kind='registered' for web-auth users)
+  // Create a new developer account (kind='personal' for web-auth users)
   const { data: developer, error: devError } = await serviceClient
     .from('developers')
     .insert({
-      kind: 'registered',
+      kind: 'personal',
       billing_email: email,
       display_name: email?.split('@')[0] || null,
     })

--- a/apps/web/lib/auth/developer.ts
+++ b/apps/web/lib/auth/developer.ts
@@ -158,7 +158,7 @@ async function autoCreateDeveloperAccount(
   const { data: developer, error: devError } = await serviceClient
     .from('developers')
     .insert({
-      kind: 'registered',
+      kind: 'personal',
       billing_email: email,
       display_name: email?.split('@')[0] || null,
     })


### PR DESCRIPTION
## Description

Fixes critical bug where developer account creation silently fails due to CHECK constraint violation on the `developers` table.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Changed `kind: 'registered'` to `kind: 'personal'` in OAuth callback (`auth/callback/route.ts`)
- Changed `kind: 'registered'` to `kind: 'personal'` in auto-create fallback (`lib/auth/developer.ts`)
- Manually created developer record + membership in prod DB for existing user

## Root Cause

The `developers` table has a CHECK constraint: `kind IN ('anonymous', 'personal', 'team')`. The code was inserting `'registered'` which is not a valid value, causing silent INSERT failures.

## Related Issues

Closes #317

## Testing

- [x] Type check passes (`pnpm type-check`)
- [x] Verified constraint definition via SQL
- [x] Manually created developer record in prod DB to validate INSERT works with `kind='personal'`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings