### PR TITLE
[CHORE] Release develop to main (2026-02-20 hotfix #2)

### DIFF
--- a/apps/web/app/(auth)/auth/callback/route.ts
+++ b/apps/web/app/(auth)/auth/callback/route.ts
@@ -63,11 +63,11 @@ async function ensureDeveloperAccount(userId: string, email: string | null) {
     return; // Already has a developer account
   }
 
-  // Create a new developer account (kind='registered' for web-auth users)
+  // Create a new developer account (kind='personal' for web-auth users)
   const { data: developer, error: devError } = await serviceClient
     .from('developers')
     .insert({
-      kind: 'registered',
+      kind: 'personal',
       billing_email: email,
       display_name: email?.split('@')[0] || null,
     })

--- a/apps/web/lib/auth/developer.ts
+++ b/apps/web/lib/auth/developer.ts
@@ -158,7 +158,7 @@ async function autoCreateDeveloperAccount(
   const { data: developer, error: devError } = await serviceClient
     .from('developers')
     .insert({
-      kind: 'registered',
+      kind: 'personal',
       billing_email: email,
       display_name: email?.split('@')[0] || null,
     })


### PR DESCRIPTION
## Summary

- Fix developers kind CHECK constraint mismatch (#317, #318)
- `kind: 'registered'` → `kind: 'personal'` for web-auth developer creation

## Changes since last release

- **#318**: [FIX] Use valid kind value for developer account creation