### PR TITLE
[FIX] Fetch real developer plan for Pro feature gates (#320)

### DIFF
--- a/apps/web/app/(protected)/dashboard/ax-score/page.tsx
+++ b/apps/web/app/(protected)/dashboard/ax-score/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Search, Loader2, BarChart3, Globe, Clock, FileText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -42,20 +42,22 @@ import type {
   CompetitorComparisonResponse,
 } from '@agentgram/shared';
 
-// Plan hook — fetches from reports endpoint which indicates plan access via error codes
+// Plan hook — fetches current developer plan from /api/v1/developers/me
 function useDeveloperPlan() {
-  // This is a simple approach: if alerts endpoint returns AX_PRO_REQUIRED, plan is free/starter
-  // For now we'll default to checking if features load correctly
-  // The ProFeatureGate handles the actual gating on the server side
   const [plan, setPlan] = useState<string>('free');
 
-  // We check plan by trying the alerts endpoint - if it 403s, we know it's not Pro
-  const alertsCheck = useAxReports({ page: 1, limit: 1 });
-  // Reports always succeed, so we can use a simpler check
-  // Plan will be determined by whether Pro features load or error
-  void alertsCheck;
+  useEffect(() => {
+    fetch('/api/v1/developers/me')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.success && data.data?.plan) {
+          setPlan(data.data.plan);
+        }
+      })
+      .catch(() => {});
+  }, []);
 
-  return { plan, setPlan };
+  return { plan };
 }
 
 export default function DashboardAxScorePage() {

--- a/apps/web/app/api/v1/developers/me/route.ts
+++ b/apps/web/app/api/v1/developers/me/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { withDeveloperAuth } from '@/lib/auth/developer';
+
+export const GET = withDeveloperAuth(async function GET(req: NextRequest) {
+  const developerId = req.headers.get('x-developer-id');
+
+  if (!developerId) {
+    return NextResponse.json(
+      { success: false, error: { code: 'UNAUTHORIZED', message: 'Not authenticated' } },
+      { status: 401 }
+    );
+  }
+
+  const { data: developer, error } = await getSupabaseServiceClient()
+    .from('developers')
+    .select('id, plan, subscription_status, display_name, billing_email')
+    .eq('id', developerId)
+    .single();
+
+  if (error || !developer) {
+    return NextResponse.json(
+      { success: false, error: { code: 'NOT_FOUND', message: 'Developer not found' } },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ success: true, data: developer });
+});


### PR DESCRIPTION
## Description

Fixes Pro feature gates on AX Score page always showing "Upgrade to Pro" even for Pro subscribers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `GET /api/v1/developers/me` endpoint (returns plan, subscription_status, etc.)
- Updated `useDeveloperPlan()` hook to fetch real plan from API instead of hardcoding 'free'

## Related Issues

Closes #320

## Testing

- [x] Type check passes (`pnpm type-check`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings