### PR TITLE
[REFACTOR] Migrate analytics to GA4-only (#333)

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,8 +2,6 @@ import type { Metadata } from 'next';
 import 'pretendard/dist/web/static/pretendard.css';
 import './globals.css';
 import { GoogleAnalytics } from '@/components/GoogleAnalytics';
-import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from '@vercel/speed-insights/next';
 import { PageTransition } from '@/components/PageTransition';
 import { Toaster } from '@/components/ui/toaster';
 import { BottomNav, Header, Footer } from '@/components/common';
@@ -99,8 +97,6 @@ export default function RootLayout({
       </head>
       <body>
         <GoogleAnalytics />
-        <Analytics />
-        <SpeedInsights />
         <Providers>
           <div className="relative flex min-h-screen flex-col">
             <Header githubUrl={githubUrl} />

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,8 +27,6 @@
     "@supabase/supabase-js": "^2.97.0",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
-    "@vercel/analytics": "^1.6.1",
-    "@vercel/speed-insights": "^1.3.1",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -110,7 +110,7 @@ AgentGram is a **social network platform designed exclusively for AI agents**. I
 - **Database**: Supabase Cloud
 - **CDN**: Vercel Edge Network
 - **Bundler**: Turbopack (stable, default in Next.js 16)
-- **Analytics**: Vercel Analytics (recommended)
+- **Analytics**: Google Analytics 4 (GA4)
 
 ### Development
 
@@ -1265,8 +1265,8 @@ CREATE INDEX idx_posts_community ON posts(community_id, created_at DESC);
 
 ### Metrics
 
-- **Performance**: Vercel Analytics
-- **User behavior**: Google Analytics (optional)
+- **Performance**: GA4 Web Vitals events and PageSpeed Insights
+- **User behavior**: Google Analytics 4
 - **Database**: Supabase Dashboard
 
 ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,12 +81,6 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.91.3
         version: 5.91.3(@tanstack/react-query@5.90.21(react@19.2.4))(react@19.2.4)
-      '@vercel/analytics':
-        specifier: ^1.6.1
-        version: 1.6.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
-      '@vercel/speed-insights':
-        specifier: ^1.3.1
-        version: 1.3.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1927,32 +1921,6 @@ packages:
   '@upstash/redis@1.36.2':
     resolution: {integrity: sha512-C0Yt8hc12vLaQYRG1fMci8iPrLtnTdbJG0HR5T8vKnvEP/1RdMMblsOJs5/jp0JXZJ1oSzMnQz4J9EVezNpI6A==}
 
-  '@vercel/analytics@1.6.1':
-    resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
-    peerDependencies:
-      '@remix-run/react': ^2
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
-
   '@vercel/backends@0.0.36':
     resolution: {integrity: sha512-V1//TxZMo3RTfkFE+yUa5lEl8jsxUDXh4/ljZSCDpSOqgam4ObLr5iENhMdZYoOon+FopEsP1LT3+9LkLZnuxg==}
     peerDependencies:
@@ -2048,29 +2016,6 @@ packages:
 
   '@vercel/rust@1.0.5':
     resolution: {integrity: sha512-Y03g59nv1uT6Da+PvB/50WqJSHlaFZ9MSkG00R82dUcTySslMbQdOeaXymZtabrmU8zQYhWDb1/CwBki8sWnaQ==}
-
-  '@vercel/speed-insights@1.3.1':
-    resolution: {integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==}
-    peerDependencies:
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
 
   '@vercel/static-build@2.8.40':
     resolution: {integrity: sha512-h4/Z2orXHPGU0fw+K+x9D9JwVkhYZeJvKjYcTDwfvUGR4gTEEtcVB3+OKQBE2XJz6qR7i8KIP9SCK1VqbM+apg==}
@@ -2223,6 +2168,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   bcryptjs@3.0.3:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
@@ -5835,11 +5781,6 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@1.6.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
-    optionalDependencies:
-      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
-
   '@vercel/backends@0.0.36(typescript@5.9.3)':
     dependencies:
       '@vercel/build-utils': 13.4.3
@@ -6122,11 +6063,6 @@ snapshots:
     dependencies:
       '@iarna/toml': 2.2.5
       execa: 5.1.1
-
-  '@vercel/speed-insights@1.3.1(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
-    optionalDependencies:
-      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
 
   '@vercel/static-build@2.8.40':
     dependencies:


### PR DESCRIPTION
## Description

Migrate AgentGram's analytics stack to GA4-only by removing Vercel Analytics and Speed Insights runtime/dependency integration and updating architecture guidance.

## Type of Change

- [x] Refactor

## Changes Made

- Removed `<Analytics />` and `<SpeedInsights />` from the root layout runtime path
- Removed `@vercel/analytics` and `@vercel/speed-insights` from `apps/web/package.json` and refreshed `pnpm-lock.yaml`
- Updated architecture documentation to describe GA4-first monitoring
- Removed an unrelated unused type import in AX scanner to keep lint clean

## Related Issues

Closes #333

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm --filter web type-check`)
- [x] Lint passes (`pnpm --filter web lint`)
- [x] Build succeeds (`pnpm --filter web build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings