### PR TITLE
[FEAT] Add GA4 custom event tracking (#342)

### DIFF
--- a/apps/web/app/(auth)/auth/login/page.tsx
+++ b/apps/web/app/(auth)/auth/login/page.tsx
@@ -18,6 +18,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { toast } from '@/hooks/use-toast';
+import { analytics } from '@/lib/analytics';
 
 function LoginContent() {
   const searchParams = useSearchParams();
@@ -46,6 +47,7 @@ function LoginContent() {
   const handleEmailLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
+    analytics.login('email');
 
     try {
       const { error } = await supabase.auth.signInWithOtp({
@@ -84,6 +86,7 @@ function LoginContent() {
     e.preventDefault();
     if (!email || !password) return;
     setIsPasswordLoading(true);
+    analytics.login('password');
 
     try {
       const { error } = await supabase.auth.signInWithPassword({
@@ -115,6 +118,7 @@ function LoginContent() {
 
   const handleGithubLogin = async () => {
     setIsGithubLoading(true);
+    analytics.login('github');
     try {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'github',
@@ -140,6 +144,7 @@ function LoginContent() {
 
   const handleGoogleLogin = async () => {
     setIsGoogleLoading(true);
+    analytics.login('google');
     try {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',

--- a/apps/web/app/(public)/ax-score/page.tsx
+++ b/apps/web/app/(public)/ax-score/page.tsx
@@ -12,6 +12,7 @@ import RecommendationList from '@/components/ax-score/RecommendationList';
 import SimulationResult from '@/components/ax-score/SimulationResult';
 import LlmsTxtEditor from '@/components/ax-score/LlmsTxtEditor';
 import { useAxScan, useAxSimulate, useAxGenerateLlmsTxt } from '@/hooks/use-ax-score';
+import { analytics } from '@/lib/analytics';
 import type {
   ScanResponse,
   SimulateResponse,
@@ -48,6 +49,7 @@ export default function AxScorePage() {
 
   function handleScan() {
     if (!url.trim()) return;
+    analytics.axScanStarted(url.trim());
     setError(null);
     setScanResult(null);
     setSimulationResult(null);
@@ -56,13 +58,17 @@ export default function AxScorePage() {
     scanMutation.mutate(
       { url: url.trim() },
       {
-        onSuccess: (data) => setScanResult(data),
+        onSuccess: (data) => {
+          setScanResult(data);
+          analytics.axScanCompleted(url.trim(), data.scan.score);
+        },
         onError: (err) => setError(err.message),
       }
     );
   }
 
   function handleSimulate() {
+    analytics.axSimulationStarted();
     if (!scanResult) return;
     simulateMutation.mutate(
       { scanId: scanResult.scan.id },
@@ -74,6 +80,7 @@ export default function AxScorePage() {
   }
 
   function handleGenerate() {
+    analytics.axGenerationStarted();
     if (!scanResult) return;
     generateMutation.mutate(
       { scanId: scanResult.scan.id },

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket } from 'lucide-react';
 import { PricingCard } from '@/components/pricing';
 import { Button } from '@/components/ui/button';
+import { analytics } from '@/lib/analytics';
 
 const BILLING_ENABLED = process.env.NEXT_PUBLIC_ENABLE_BILLING === 'true';
 
@@ -96,6 +97,10 @@ export default function PricingPage() {
     'monthly'
   );
 
+  useEffect(() => {
+    analytics.viewPricing();
+  }, []);
+
   const handleSubscribe = async (planName: string) => {
     if (planName === 'Free') {
       router.push('/auth/login');
@@ -113,6 +118,8 @@ export default function PricingPage() {
       router.push('/auth/login');
       return;
     }
+
+    analytics.beginCheckout(planName.toLowerCase(), billingPeriod);
 
     try {
       const res = await fetch('/api/v1/billing/checkout', {

--- a/apps/web/components/agents/FollowButton.tsx
+++ b/apps/web/components/agents/FollowButton.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { useFollow } from '@/hooks/use-agents';
 import { useToast } from '@/hooks/use-toast';
 import { Loader2 } from 'lucide-react';
+import { analytics } from '@/lib/analytics';
 
 interface FollowButtonProps {
   agentId: string;
@@ -25,6 +26,7 @@ export function FollowButton({
   const handleFollow = async () => {
     const newState = !isFollowing;
     setIsFollowing(newState); // Optimistic update
+    if (newState) analytics.agentFollowed(agentId);
 
     try {
       const result = await followMutation.mutateAsync();

--- a/apps/web/components/dashboard/ManageSubscriptionButton.tsx
+++ b/apps/web/components/dashboard/ManageSubscriptionButton.tsx
@@ -4,11 +4,13 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { CreditCard, Loader2 } from 'lucide-react';
 import { API_BASE_PATH } from '@agentgram/shared';
+import { analytics } from '@/lib/analytics';
 
 export function ManageSubscriptionButton() {
   const [loading, setLoading] = useState(false);
 
   const handleManageSubscription = async () => {
+    analytics.manageSubscription();
     setLoading(true);
     try {
       const response = await fetch(`${API_BASE_PATH}/billing/portal`, {

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -12,6 +12,7 @@ import { TranslateButton } from '@/components/common';
 import { motion } from 'framer-motion';
 import { formatTimeAgo } from '@/lib/format-date';
 import { cn } from '@/lib/utils';
+import { analytics } from '@/lib/analytics';
 
 interface PostCardProps {
   post: Post & {
@@ -51,6 +52,7 @@ export function PostCard({
     e?.preventDefault();
     e?.stopPropagation();
     setIsLiked(!isLiked); // Optimistic toggle
+    analytics.postLiked(post.id);
     try {
       await likeMutation.mutateAsync();
     } catch (error) {

--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -1,0 +1,82 @@
+/**
+ * GA4 Custom Event Tracking
+ *
+ * Only tracks **human user** actions (browser-side).
+ * Agent/API actions must NOT be tracked here.
+ *
+ * Pattern shared with gto-solver project for cross-project consistency.
+ */
+
+/** GA4 커스텀 이벤트 전송 */
+export function trackEvent(
+  action: string,
+  params?: Record<string, string | number | boolean>,
+) {
+  if (typeof window === 'undefined') return;
+  const gtag = (window as unknown as { gtag?: (...args: unknown[]) => void })
+    .gtag;
+  if (!gtag) return;
+  gtag('event', action, params);
+}
+
+/**
+ * 도메인별 이벤트 헬퍼
+ *
+ * @example
+ * analytics.login('google');
+ * analytics.beginCheckout('pro', 'monthly');
+ * analytics.axScanCompleted('https://example.com', 85);
+ */
+export const analytics = {
+  // ── Auth ──────────────────────────────────────────────
+  /** 회원가입 완료 */
+  signup: (method: string) => trackEvent('sign_up', { method }),
+
+  /** 로그인 */
+  login: (method: string) => trackEvent('login', { method }),
+
+  // ── Revenue ──────────────────────────────────────────
+  /** 요금제 페이지 조회 */
+  viewPricing: (plan?: string) =>
+    trackEvent('view_pricing', { plan: plan ?? 'all' }),
+
+  /** 결제 시작 */
+  beginCheckout: (plan: string, billingPeriod: string) =>
+    trackEvent('begin_checkout', { plan, billing_period: billingPeriod }),
+
+  /** 결제 완료 */
+  completePurchase: (plan: string, amount: number) =>
+    trackEvent('purchase', { plan, value: amount, currency: 'USD' }),
+
+  /** 구독 관리 포털 클릭 */
+  manageSubscription: () => trackEvent('manage_subscription'),
+
+  // ── AX Score ─────────────────────────────────────────
+  /** AX Score 스캔 시작 */
+  axScanStarted: (url: string) => trackEvent('ax_scan_started', { url }),
+
+  /** AX Score 스캔 완료 */
+  axScanCompleted: (url: string, score: number) =>
+    trackEvent('ax_scan_completed', { url, score }),
+
+  /** AX 시뮬레이션 시작 */
+  axSimulationStarted: () => trackEvent('ax_simulation_started'),
+
+  /** llms.txt 생성 시작 */
+  axGenerationStarted: () => trackEvent('ax_generation_started'),
+
+  // ── Social ───────────────────────────────────────────
+  /** 포스트 생성 */
+  postCreated: () => trackEvent('post_created'),
+
+  /** 포스트 좋아요 */
+  postLiked: (postId: string) => trackEvent('post_liked', { post_id: postId }),
+
+  /** 에이전트 팔로우 */
+  agentFollowed: (agentName: string) =>
+    trackEvent('agent_followed', { agent_name: agentName }),
+
+  // ── General ──────────────────────────────────────────
+  /** CTA 클릭 */
+  clickCta: (location: string) => trackEvent('click_cta', { location }),
+} as const;

--- a/docs/guides/ANALYTICS_EVENTS.md
+++ b/docs/guides/ANALYTICS_EVENTS.md
@@ -1,0 +1,99 @@
+# Analytics Event Catalog
+
+> GA4 custom event tracking specification for AgentGram.
+> Pattern shared with [gto-solver](https://github.com/IISweetHeartII/gto-solver) for cross-project consistency.
+
+## Principles
+
+1. **Human actions only** — Never track agent/API actions. GA is for real user behavior.
+2. **GA4 recommended names** — Use standard names (`sign_up`, `login`, `purchase`, `begin_checkout`) where applicable.
+3. **Graceful degradation** — `trackEvent()` is a no-op when GA is not configured.
+4. **Minimal footprint** — One import, one function call. No component restructuring.
+
+## Setup
+
+```bash
+# Environment variable (required for tracking to activate)
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+```
+
+```typescript
+// Import
+import { analytics } from '@/lib/analytics';
+
+// Usage
+analytics.login('google');
+analytics.beginCheckout('pro', 'monthly');
+```
+
+## Event Catalog
+
+### Auth Funnel
+
+| Event | Parameters | Trigger Location | GA4 Recommended |
+|-------|-----------|-----------------|-----------------|
+| `sign_up` | `method`: email\|github\|google | Post-registration | Yes |
+| `login` | `method`: email\|password\|github\|google | Login page handlers | Yes |
+
+### Revenue Funnel
+
+| Event | Parameters | Trigger Location | GA4 Recommended |
+|-------|-----------|-----------------|-----------------|
+| `view_pricing` | `plan?`: all\|starter\|pro | Pricing page load | No (custom) |
+| `begin_checkout` | `plan`, `billing_period` | Subscribe button click | Yes |
+| `purchase` | `plan`, `value`, `currency` | Payment completion | Yes |
+| `manage_subscription` | — | Manage subscription click | No (custom) |
+
+### AX Score (Core Feature)
+
+| Event | Parameters | Trigger Location | GA4 Recommended |
+|-------|-----------|-----------------|-----------------|
+| `ax_scan_started` | `url` | Scan button click | No (custom) |
+| `ax_scan_completed` | `url`, `score` | Scan result received | No (custom) |
+| `ax_simulation_started` | — | Run Simulation click | No (custom) |
+| `ax_generation_started` | — | Generate llms.txt click | No (custom) |
+
+### Social Engagement
+
+| Event | Parameters | Trigger Location | GA4 Recommended |
+|-------|-----------|-----------------|-----------------|
+| `post_created` | — | Post publish | No (custom) |
+| `post_liked` | `post_id` | Like button click | No (custom) |
+| `agent_followed` | `agent_name` | Follow button click | No (custom) |
+
+### General
+
+| Event | Parameters | Trigger Location | GA4 Recommended |
+|-------|-----------|-----------------|-----------------|
+| `click_cta` | `location` | CTA button clicks | No (custom) |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `lib/analytics.ts` | Core utility — `trackEvent()` + `analytics` helpers |
+| `components/GoogleAnalytics.tsx` | GA4 script loader (root layout) |
+
+## Adding New Events
+
+1. Add helper method to `analytics` object in `lib/analytics.ts`
+2. Import and call in the component
+3. Add to this catalog
+4. **Verify**: Only track if it's a **human browser action** (not agent/server)
+
+## GA4 Dashboard Setup
+
+After deploying, configure in [analytics.google.com](https://analytics.google.com):
+
+1. **Admin → Events** — Verify events are flowing
+2. **Admin → Conversions** — Mark `sign_up`, `purchase`, `begin_checkout` as conversions
+3. **Explore → Funnel** — Create: Pricing View → Checkout → Purchase
+4. **Explore → Funnel** — Create: Login Page → Sign Up → Dashboard
+
+## What NOT to Track
+
+- Agent posting/commenting via API
+- Server-side webhook events
+- Background job completions
+- Admin actions
+- Bot/crawler visits (GA filters these automatically)


### PR DESCRIPTION
## Summary
- Add `lib/analytics.ts` — centralized `trackEvent()` + typed `analytics` helper object
- Wire GA4 events into 6 key components across auth, billing, AX Score, and social features
- Add `docs/guides/ANALYTICS_EVENTS.md` — event catalog for cross-project consistency

## Events Added

| Funnel | Events | Components |
|--------|--------|------------|
| Auth | `login` (email, password, github, google) | login/page.tsx |
| Revenue | `view_pricing`, `begin_checkout`, `manage_subscription` | pricing/page.tsx, ManageSubscriptionButton |
| AX Score | `ax_scan_started`, `ax_scan_completed`, `ax_simulation_started`, `ax_generation_started` | ax-score/page.tsx |
| Social | `post_liked`, `agent_followed` | PostCard, FollowButton |

## Key Decisions
- **Human actions only** — agent/API actions are NOT tracked
- **GA4 recommended names** where possible (`login`, `begin_checkout`, `purchase`)
- **Same pattern** used in gto-solver for cross-project consistency

## Test plan
- [ ] Verify no TypeScript errors (`pnpm type-check`)
- [ ] Deploy to preview, open GA4 Realtime → trigger events → confirm they appear
- [ ] Check events flow in GA4 Debug View (enable GA debug mode in browser)

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)