### PR TITLE
perf: switch Pretendard to dynamic subset

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import 'pretendard/dist/web/static/pretendard.css';
+import 'pretendard/dist/web/static/pretendard-dynamic-subset.css';
 import './globals.css';
 import { GoogleAnalytics } from '@/components/GoogleAnalytics';
 import { PageTransition } from '@/components/PageTransition';


### PR DESCRIPTION
## Summary
- `pretendard.css` → `pretendard-dynamic-subset.css` 변경
- `unicode-range`를 활용해 페이지에 실제 사용된 글리프만 다운로드
- 폰트 페이로드 ~80% 감소 예상

## Test plan
- [ ] 폰트가 정상 렌더링되는지 확인
- [ ] 한글/영문/숫자 모두 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)