### PR TITLE
[REFACTOR] Upgrade workspace to TypeScript 6.0.2 (#354)

### DIFF
--- a/apps/web/global.d.ts
+++ b/apps/web/global.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,6 +50,6 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.2.1",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@agentgram/tsconfig/nextjs.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eslint": "^9.39.2",
     "prettier": "^3.8.1",
     "turbo": "^2.8.10",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   },
   "packageManager": "pnpm@10.28.2",
   "engines": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -25,6 +25,6 @@
     "@types/bcryptjs": "^3.0.0",
     "@types/node": "^25.3.0",
     "next": "^16.1.6",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@agentgram/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,6 +16,6 @@
     "@agentgram/eslint-config": "workspace:*",
     "@agentgram/tsconfig": "workspace:*",
     "@types/node": "^25.3.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@agentgram/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -15,7 +15,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "globals": "^17.3.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8.56.0"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,6 +13,6 @@
     "@agentgram/eslint-config": "workspace:*",
     "@agentgram/tsconfig": "workspace:*",
     "@types/node": "^25.3.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@agentgram/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       vercel:
         specifier: ^50.22.1
-        version: 50.22.1(typescript@5.9.3)
+        version: 50.22.1(typescript@6.0.2)
     devDependencies:
       '@turbo/gen':
         specifier: ^2.8.10
@@ -25,8 +25,8 @@ importers:
         specifier: ^2.8.10
         version: 2.8.10
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
   apps/web:
     dependencies:
@@ -146,8 +146,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
   packages/auth:
     dependencies:
@@ -183,8 +183,8 @@ importers:
         specifier: ^16.1.6
         version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
   packages/db:
     dependencies:
@@ -202,8 +202,8 @@ importers:
         specifier: ^25.3.0
         version: 25.3.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
   packages/eslint-config:
     devDependencies:
@@ -229,11 +229,11 @@ importers:
         specifier: ^17.3.0
         version: 17.3.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       typescript-eslint:
         specifier: ^8.56.0
-        version: 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
 
   packages/shared:
     devDependencies:
@@ -247,8 +247,8 @@ importers:
         specifier: ^25.3.0
         version: 25.3.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
   packages/tsconfig: {}
 
@@ -4152,6 +4152,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -5677,40 +5682,40 @@ snapshots:
     dependencies:
       '@types/node': 25.3.0
 
-  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 8.56.0
-      '@typescript-eslint/type-utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.56.0
       eslint: 9.39.2(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.56.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.56.0(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.56.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5719,47 +5724,47 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
 
-  '@typescript-eslint/tsconfig-utils@8.56.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.56.0(typescript@6.0.2)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
-  '@typescript-eslint/type-utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.56.0': {}
 
-  '@typescript-eslint/typescript-estree@8.56.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.56.0(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.56.0(typescript@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3
       minimatch: 9.0.6
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@6.0.2)
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5781,7 +5786,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/backends@0.0.36(typescript@5.9.3)':
+  '@vercel/backends@0.0.36(typescript@6.0.2)':
     dependencies:
       '@vercel/build-utils': 13.4.3
       '@vercel/nft': 1.3.0
@@ -5793,7 +5798,7 @@ snapshots:
       rolldown: 1.0.0-rc.1
       srvx: 0.8.9
       tsx: 4.21.0
-      typescript: 5.9.3
+      typescript: 6.0.2
       zod: 3.22.4
     transitivePeerDependencies:
       - encoding
@@ -5812,10 +5817,10 @@ snapshots:
     dependencies:
       '@vercel/python-analysis': 0.6.0
 
-  '@vercel/cervel@0.0.23(typescript@5.9.3)':
+  '@vercel/cervel@0.0.23(typescript@6.0.2)':
     dependencies:
-      '@vercel/backends': 0.0.36(typescript@5.9.3)
-      typescript: 5.9.3
+      '@vercel/backends': 0.0.36(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -5834,9 +5839,9 @@ snapshots:
 
   '@vercel/error-utils@2.0.3': {}
 
-  '@vercel/express@0.1.48(typescript@5.9.3)':
+  '@vercel/express@0.1.48(typescript@6.0.2)':
     dependencies:
-      '@vercel/cervel': 0.0.23(typescript@5.9.3)
+      '@vercel/cervel': 0.0.23(typescript@6.0.2)
       '@vercel/nft': 1.1.1
       '@vercel/node': 5.6.6
       '@vercel/static-config': 3.1.2
@@ -8297,9 +8302,9 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
+  ts-api-utils@2.4.0(typescript@6.0.2):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   ts-morph@12.0.0:
     dependencies:
@@ -8387,18 +8392,20 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.9.3: {}
+
+  typescript@6.0.2: {}
 
   uglify-js@3.19.3:
     optional: true
@@ -8463,14 +8470,14 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  vercel@50.22.1(typescript@5.9.3):
+  vercel@50.22.1(typescript@6.0.2):
     dependencies:
-      '@vercel/backends': 0.0.36(typescript@5.9.3)
+      '@vercel/backends': 0.0.36(typescript@6.0.2)
       '@vercel/blob': 2.3.0
       '@vercel/build-utils': 13.4.3
       '@vercel/detect-agent': 1.1.0
       '@vercel/elysia': 0.1.39
-      '@vercel/express': 0.1.48(typescript@5.9.3)
+      '@vercel/express': 0.1.48(typescript@6.0.2)
       '@vercel/fastify': 0.1.42
       '@vercel/fun': 1.3.0
       '@vercel/go': 3.4.1


### PR DESCRIPTION
## Summary
This PR upgrades the workspace TypeScript version from `^5.9.3` to `^6.0.2`.

Closes #354

## Changes
- Bumped `typescript` in:
  - root `package.json`
  - `apps/web/package.json`
  - `packages/auth/package.json`
  - `packages/db/package.json`
  - `packages/shared/package.json`
  - `packages/eslint-config/package.json`
- Updated `pnpm-lock.yaml`
- TS6 compatibility follow-ups:
  - `packages/auth/tsconfig.json`: add `types: ["node"]`
  - `packages/db/tsconfig.json`: add `types: ["node"]`
  - `packages/shared/tsconfig.json`: add DOM libs for web API globals
  - `apps/web/tsconfig.json`: remove deprecated `baseUrl`
  - `apps/web/global.d.ts`: declare CSS module side-effect imports (`*.css`)

## Validation
- ✅ `pnpm type-check`
- ✅ `pnpm lint`
- ✅ `pnpm build`

## Notes
- `pnpm up` reports peer warnings from `typescript-eslint` and some `vercel` internals that currently declare TS peer ranges up to `<6.0.0`.
- Despite peer warnings, lint/typecheck/build pass in this workspace.
