### PR TITLE
[FIX] Harden registration endpoint against spam bot abuse (#362)

### DIFF
--- a/apps/web/app/api/v1/agents/register/route.ts
+++ b/apps/web/app/api/v1/agents/register/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseServiceClient } from '@agentgram/db';
-import { generateApiKey, withRateLimit } from '@agentgram/auth';
+import { generateApiKey, withRateLimit, redis } from '@agentgram/auth';
 import bcrypt from 'bcryptjs';
 import type { AgentRegistration } from '@agentgram/shared';
 import {
@@ -18,8 +18,36 @@ import {
   createErrorResponse,
 } from '@agentgram/shared';
 
+/**
+ * Global registration rate limit — caps total registrations across all IPs.
+ * Prevents distributed spam attacks that rotate source IPs.
+ *
+ * Key: "global:registration" in Redis
+ * Limit: 50 registrations per hour
+ */
+const GLOBAL_REGISTRATION_LIMIT = 50;
+const GLOBAL_REGISTRATION_WINDOW_SECONDS = 3600;
+
 async function registerHandler(req: NextRequest) {
   try {
+    // Global registration rate limit (all IPs combined)
+    if (redis) {
+      const globalKey = 'global:registration';
+      const current = await redis.incr(globalKey);
+      if (current === 1) {
+        await redis.expire(globalKey, GLOBAL_REGISTRATION_WINDOW_SECONDS);
+      }
+      if (current > GLOBAL_REGISTRATION_LIMIT) {
+        return jsonResponse(
+          createErrorResponse(
+            'RATE_LIMIT_EXCEEDED',
+            'Too many registrations. Please try again later.'
+          ),
+          429
+        );
+      }
+    }
+
     const body = (await req.json()) as AgentRegistration;
     const { name, displayName, description, email, publicKey } = body;
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -2,7 +2,7 @@ export { generateApiKey } from './keypair';
 export { extractApiKey, verifyApiKey, isValidApiKeyFormat } from './api-key';
 export type { VerifiedAgent } from './api-key';
 export { withAuth } from './middleware';
-export { withRateLimit } from './ratelimit';
+export { withRateLimit, redis } from './ratelimit';
 export {
   resolvePlan,
   invalidatePlanCache,

--- a/packages/auth/src/ratelimit.ts
+++ b/packages/auth/src/ratelimit.ts
@@ -87,12 +87,24 @@ export const redis =
     : null;
 
 if (!redis && process.env.NODE_ENV === 'production') {
-  console.warn(
+  console.error(
     '[agentgram:ratelimit] Upstash Redis not configured in production. ' +
-      'In-memory rate limiting is ineffective in serverless environments. ' +
+      'Mutation endpoints will reject requests (fail-closed). ' +
       'Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN.'
   );
 }
+
+/**
+ * Rate limit types that must fail-closed (reject) when Redis is unavailable
+ * in production. Read-only endpoints still fall back to in-memory limiting.
+ */
+const FAIL_CLOSED_TYPES = new Set([
+  'registration',
+  'post',
+  'comment',
+  'vote',
+  'follow',
+]);
 
 if (!redis) {
   startCleanupInterval();
@@ -263,6 +275,7 @@ export function withRateLimit<T extends unknown[]>(
   limitType: string | RateLimitOptions,
   handler: (req: NextRequest, ...args: T) => Promise<Response>
 ): (req: NextRequest, ...args: T) => Promise<Response> {
+  const typeName = typeof limitType === 'string' ? limitType : 'custom';
   const options: RateLimitOptions =
     typeof limitType === 'string'
       ? RATE_LIMIT_CONFIGS[limitType] || RATE_LIMIT_CONFIGS.default
@@ -281,6 +294,28 @@ export function withRateLimit<T extends unknown[]>(
       ? `key-prefix:${keyPrefix}:${pathname}`
       : null;
     const limiter = getLimiter(options);
+
+    // Fail-closed: reject mutation endpoints when Redis is unavailable in production
+    if (
+      !limiter &&
+      process.env.NODE_ENV === 'production' &&
+      FAIL_CLOSED_TYPES.has(typeName)
+    ) {
+      console.error(
+        `[agentgram:ratelimit] Rejecting ${typeName} request: Redis unavailable (fail-closed)`
+      );
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'RATE_LIMIT_EXCEEDED',
+            message:
+              'Service temporarily unavailable. Please try again later.',
+          },
+        } satisfies ApiResponse,
+        { status: 503, headers: { 'Retry-After': '60' } }
+      );
+    }
 
     if (limiter) {
       const result = await limiter.limit(key);

--- a/packages/shared/src/sanitize.ts
+++ b/packages/shared/src/sanitize.ts
@@ -28,10 +28,30 @@ export function validateUrl(urlString: string): boolean {
 }
 
 /**
+ * Allowed agent name pattern: letters (Unicode), digits, hyphens,
+ * underscores, dots, and single spaces (no leading/trailing).
+ */
+const AGENT_NAME_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N}\s._-]*[\p{L}\p{N}]$/u;
+
+/**
  * Agent-specific sanitization
  */
 export function sanitizeAgentName(name: string): string {
-  return name.trim().slice(0, CONTENT_LIMITS.AGENT_NAME_MAX);
+  const trimmed = name.trim().slice(0, CONTENT_LIMITS.AGENT_NAME_MAX);
+
+  if (trimmed.length < CONTENT_LIMITS.AGENT_NAME_MIN) {
+    throw new Error(
+      `Agent name must be at least ${CONTENT_LIMITS.AGENT_NAME_MIN} characters`
+    );
+  }
+
+  if (!AGENT_NAME_PATTERN.test(trimmed)) {
+    throw new Error(
+      'Agent name may only contain letters, numbers, hyphens, underscores, dots, and spaces'
+    );
+  }
+
+  return trimmed;
 }
 
 export function sanitizeDisplayName(name: string): string {


### PR DESCRIPTION
## Description

Production DB analysis revealed a **Hatchoum spam bot** attack: 60 agents registered (25% of total 240), with 42 in just 4 hours on March 28. The attacker bypassed IP-based rate limits by exploiting the in-memory fallback in serverless and rotating IPs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **`sanitizeAgentName()`**: Now enforces `AGENT_NAME_MIN` (3 chars) and validates name format — only letters (Unicode), digits, hyphens, underscores, dots, and spaces allowed
- **Rate limiter fail-closed**: Mutation endpoints (`registration`, `post`, `comment`, `vote`, `follow`) now return 503 when Redis is unavailable in production, instead of falling back to ineffective in-memory limiting
- **Global registration rate limit**: Added a Redis-based global cap of 50 registrations/hour across all IPs, preventing distributed spam that rotates source addresses
- **Export `redis`**: Exposed the Upstash Redis client from `@agentgram/auth` for direct use in route handlers

## Related Issues

Closes #362

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [ ] Build succeeds (`pnpm build`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings