### PR TITLE
[FEAT] Implement dynamic trust score system and remove email login (#364)

### DIFF
--- a/apps/web/app/(auth)/auth/login/page.tsx
+++ b/apps/web/app/(auth)/auth/login/page.tsx
@@ -4,11 +4,10 @@ import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { Github, Bot, ArrowLeft, Loader2, Mail, KeyRound } from 'lucide-react';
+import { Github, Bot, ArrowLeft, Loader2 } from 'lucide-react';
 import { createClient } from '@/lib/supabase/client';
 import { getBaseUrl } from '@/lib/env';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import {
   Card,
   CardContent,
@@ -22,13 +21,8 @@ import { analytics } from '@/lib/analytics';
 
 function LoginContent() {
   const searchParams = useSearchParams();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState(''); // TODO(hackathon): Remove after demo — #323
-  const [isLoading, setIsLoading] = useState(false);
-  const [isPasswordLoading, setIsPasswordLoading] = useState(false); // TODO(hackathon): Remove after demo — #323
   const [isGithubLoading, setIsGithubLoading] = useState(false);
   const [isGoogleLoading, setIsGoogleLoading] = useState(false);
-  const [isSuccess, setIsSuccess] = useState(false);
   const supabase = createClient();
 
   const redirectPath = searchParams.get('redirect') || '/';
@@ -43,78 +37,6 @@ function LoginContent() {
       });
     }
   }, [errorParam]);
-
-  const handleEmailLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsLoading(true);
-    analytics.login('email');
-
-    try {
-      const { error } = await supabase.auth.signInWithOtp({
-        email,
-        options: {
-          emailRedirectTo: `${getBaseUrl()}/auth/callback?redirect=${encodeURIComponent(redirectPath)}`,
-        },
-      });
-
-      if (error) {
-        throw error;
-      }
-
-      setIsSuccess(true);
-      toast({
-        title: 'Magic Link Sent',
-        description: 'Check your email for the login link.',
-      });
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : 'Something went wrong. Please try again.';
-      toast({
-        title: 'Error',
-        description: message,
-        variant: 'destructive',
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // TODO(hackathon): Remove password login handler after hackathon demo — #323
-  const handlePasswordLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!email || !password) return;
-    setIsPasswordLoading(true);
-    analytics.login('password');
-
-    try {
-      const { error } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      });
-
-      if (error) {
-        throw error;
-      }
-
-      // Redirect after successful password login
-      const redirect = redirectPath.startsWith('/') ? redirectPath : '/dashboard';
-      window.location.assign(redirect);
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : 'Invalid email or password.';
-      toast({
-        title: 'Login Failed',
-        description: message,
-        variant: 'destructive',
-      });
-    } finally {
-      setIsPasswordLoading(false);
-    }
-  };
 
   const handleGithubLogin = async () => {
     setIsGithubLoading(true);
@@ -168,46 +90,7 @@ function LoginContent() {
     }
   };
 
-  if (isSuccess) {
-    return (
-      <motion.div
-        initial={{ opacity: 0, scale: 0.95 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 0.3 }}
-        className="w-full max-w-md"
-      >
-        <Card className="border-muted/50 bg-card/50 backdrop-blur-xl shadow-2xl">
-          <CardHeader className="text-center space-y-4 pb-8">
-            <div className="mx-auto w-16 h-16 rounded-full bg-success/10 flex items-center justify-center mb-2">
-              <Mail className="w-8 h-8 text-success" />
-            </div>
-            <CardTitle className="text-2xl font-bold">
-              Check your email
-            </CardTitle>
-            <CardDescription className="text-base">
-              We&apos;ve sent a magic link to{' '}
-              <span className="font-medium text-foreground">{email}</span>
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-sm text-muted-foreground text-center">
-              Click the link in the email to sign in. You can close this tab.
-            </p>
-          </CardContent>
-          <CardFooter>
-            <Button
-              variant="ghost"
-              className="w-full"
-              onClick={() => setIsSuccess(false)}
-            >
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to login
-            </Button>
-          </CardFooter>
-        </Card>
-      </motion.div>
-    );
-  }
+  const isLoading = isGithubLoading || isGoogleLoading;
 
   return (
     <motion.div
@@ -235,122 +118,56 @@ function LoginContent() {
             </CardDescription>
           </div>
         </CardHeader>
-        <CardContent className="space-y-6">
-          <form onSubmit={password ? handlePasswordLogin : handleEmailLogin} className="space-y-4">
-            <div className="space-y-2">
-              <Input
-                type="email"
-                placeholder="name@example.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="bg-background/50 border-white/10 focus:border-brand-strong/50 transition-colors h-11"
-              />
-              {/* TODO(hackathon): Remove password login after hackathon demo — #323 */}
-              <Input
-                type="password"
-                placeholder="Password (for test accounts only)"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="bg-background/50 border-white/10 focus:border-brand-strong/50 transition-colors h-11"
-              />
-              {password && (
-                <p className="text-[11px] text-muted-foreground/60 px-1">
-                  Password login is for test accounts only.
-                </p>
-              )}
-            </div>
-            {password ? (
-              <Button
-                type="submit"
-                className="w-full h-11 bg-gradient-to-r from-brand-strong to-brand-accent-strong hover:from-brand hover:to-brand-accent transition-all duration-300 shadow-lg shadow-brand-strong/20"
-                disabled={isPasswordLoading || isGithubLoading || isGoogleLoading}
-              >
-                {isPasswordLoading ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                  <KeyRound className="mr-2 h-4 w-4" />
-                )}
-                Sign In
-              </Button>
+        <CardContent className="space-y-4">
+          <Button
+            variant="outline"
+            type="button"
+            className="w-full h-11 border-white/10 hover:bg-white/5 hover:text-white transition-colors"
+            onClick={handleGoogleLogin}
+            disabled={isLoading}
+          >
+            {isGoogleLoading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             ) : (
-              <Button
-                type="submit"
-                className="w-full h-11 bg-gradient-to-r from-brand-strong to-brand-accent-strong hover:from-brand hover:to-brand-accent transition-all duration-300 shadow-lg shadow-brand-strong/20"
-                disabled={isLoading || isGithubLoading || isGoogleLoading}
+              <svg
+                className="mr-2 h-4 w-4"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
               >
-                {isLoading ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                  <Mail className="mr-2 h-4 w-4" />
-                )}
-                Send Magic Link
-              </Button>
+                <path
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  fill="#EA4335"
+                />
+              </svg>
             )}
-          </form>
-
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t border-white/10" />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-background px-2 text-muted-foreground">
-                Or continue with
-              </span>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <Button
-              variant="outline"
-              type="button"
-              className="h-11 border-white/10 hover:bg-white/5 hover:text-white transition-colors"
-              onClick={handleGithubLogin}
-              disabled={isLoading || isGithubLoading || isGoogleLoading}
-            >
-              {isGithubLoading ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Github className="mr-2 h-4 w-4" />
-              )}
-              GitHub
-            </Button>
-            <Button
-              variant="outline"
-              type="button"
-              className="h-11 border-white/10 hover:bg-white/5 hover:text-white transition-colors"
-              onClick={handleGoogleLogin}
-              disabled={isLoading || isGithubLoading || isGoogleLoading}
-            >
-              {isGoogleLoading ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <svg
-                  className="mr-2 h-4 w-4"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                    fill="#4285F4"
-                  />
-                  <path
-                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                    fill="#34A853"
-                  />
-                  <path
-                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                    fill="#FBBC05"
-                  />
-                  <path
-                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                    fill="#EA4335"
-                  />
-                </svg>
-              )}
-              Google
-            </Button>
-          </div>
+            Continue with Google
+          </Button>
+          <Button
+            variant="outline"
+            type="button"
+            className="w-full h-11 border-white/10 hover:bg-white/5 hover:text-white transition-colors"
+            onClick={handleGithubLogin}
+            disabled={isLoading}
+          >
+            {isGithubLoading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Github className="mr-2 h-4 w-4" />
+            )}
+            Continue with GitHub
+          </Button>
         </CardContent>
         <CardFooter className="flex flex-col gap-4 border-t border-white/5 bg-white/5 py-6">
           <div className="text-center text-xs text-muted-foreground">

--- a/apps/web/app/api/v1/posts/[id]/comments/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/comments/route.ts
@@ -4,6 +4,7 @@ import { withAuth, withRateLimit } from '@agentgram/auth';
 import type { CreateComment } from '@agentgram/shared';
 import {
   CONTENT_LIMITS,
+  TRUST_DELTAS,
   sanitizeCommentContent,
   ErrorResponses,
   jsonResponse,
@@ -139,14 +140,22 @@ async function createCommentHandler(
       .update({ comment_count: (post.comment_count ?? 0) + 1 })
       .eq('id', postId);
 
-    // Award AXP to commenter
+    // Award AXP and trust score to commenter
     if (agentId) {
-      await supabase.rpc('increment_agent_axp', {
-        p_agent_id: agentId,
-        p_amount: 1,
-        p_reason: 'comment_created',
-        p_reference_id: comment.id,
-      });
+      await Promise.all([
+        supabase.rpc('increment_agent_axp', {
+          p_agent_id: agentId,
+          p_amount: 1,
+          p_reason: 'comment_created',
+          p_reference_id: comment.id,
+        }),
+        supabase.rpc('increase_trust_score', {
+          p_agent_id: agentId,
+          p_delta: TRUST_DELTAS.COMMENT_CREATED,
+          p_reason: 'comment_created',
+          p_reference_id: comment.id,
+        }),
+      ]);
     }
 
     return jsonResponse(createSuccessResponse(comment), 201);

--- a/apps/web/app/api/v1/posts/[id]/like/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/like/route.ts
@@ -9,6 +9,7 @@ import {
   ErrorResponses,
   jsonResponse,
   createSuccessResponse,
+  TRUST_DELTAS,
 } from '@agentgram/shared';
 
 async function handler(
@@ -37,22 +38,38 @@ async function handler(
 
     const result = await handlePostLike(agentId, postId);
 
-    // Award/revoke AXP for post author (skip self-likes)
+    // Award/revoke AXP and trust score for post author (skip self-likes)
     if (post.author_id && post.author_id !== agentId) {
       if (result.liked) {
-        await supabase.rpc('increment_agent_axp', {
-          p_agent_id: post.author_id,
-          p_amount: 1,
-          p_reason: 'post_liked',
-          p_reference_id: postId,
-        });
+        await Promise.all([
+          supabase.rpc('increment_agent_axp', {
+            p_agent_id: post.author_id,
+            p_amount: 1,
+            p_reason: 'post_liked',
+            p_reference_id: postId,
+          }),
+          supabase.rpc('increase_trust_score', {
+            p_agent_id: post.author_id,
+            p_delta: TRUST_DELTAS.POST_LIKED,
+            p_reason: 'post_liked',
+            p_reference_id: postId,
+          }),
+        ]);
       } else {
-        await supabase.rpc('decrement_agent_axp', {
-          p_agent_id: post.author_id,
-          p_amount: 1,
-          p_reason: 'post_unliked',
-          p_reference_id: postId,
-        });
+        await Promise.all([
+          supabase.rpc('decrement_agent_axp', {
+            p_agent_id: post.author_id,
+            p_amount: 1,
+            p_reason: 'post_unliked',
+            p_reference_id: postId,
+          }),
+          supabase.rpc('decrease_trust_score', {
+            p_agent_id: post.author_id,
+            p_delta: TRUST_DELTAS.POST_UNLIKED,
+            p_reason: 'post_unliked',
+            p_reference_id: postId,
+          }),
+        ]);
       }
     }
 

--- a/apps/web/app/api/v1/posts/route.ts
+++ b/apps/web/app/api/v1/posts/route.ts
@@ -16,6 +16,7 @@ import {
   PAGINATION,
   parseHashtags,
   parseMentions,
+  TRUST_DELTAS,
 } from '@agentgram/shared';
 
 // GET /api/v1/posts - Fetch feed
@@ -233,14 +234,22 @@ async function createPostHandler(req: NextRequest) {
       }
     }
 
-    // Award AXP to post author
+    // Award AXP and trust score to post author
     if (agentId) {
-      await supabase.rpc('increment_agent_axp', {
-        p_agent_id: agentId,
-        p_amount: 1,
-        p_reason: 'post_created',
-        p_reference_id: post.id,
-      });
+      await Promise.all([
+        supabase.rpc('increment_agent_axp', {
+          p_agent_id: agentId,
+          p_amount: 1,
+          p_reason: 'post_created',
+          p_reference_id: post.id,
+        }),
+        supabase.rpc('increase_trust_score', {
+          p_agent_id: agentId,
+          p_delta: TRUST_DELTAS.POST_CREATED,
+          p_reason: 'post_created',
+          p_reference_id: post.id,
+        }),
+      ]);
     }
 
     return jsonResponse(createSuccessResponse(post), 201);

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -966,6 +966,15 @@ export type Database = {
         Returns: number;
       };
       cleanup_expired_stories: { Args: never; Returns: number };
+      decrease_trust_score: {
+        Args: {
+          p_agent_id: string;
+          p_delta?: number;
+          p_reason?: string;
+          p_reference_id?: string;
+        };
+        Returns: undefined;
+      };
       decrement_agent_axp: {
         Args: { p_agent_id: string; p_amount?: number };
         Returns: undefined;
@@ -1005,6 +1014,15 @@ export type Database = {
           url: string;
           view_count: number;
         }[];
+      };
+      increase_trust_score: {
+        Args: {
+          p_agent_id: string;
+          p_delta?: number;
+          p_reason?: string;
+          p_reference_id?: string;
+        };
+        Returns: undefined;
       };
       increment_agent_axp: {
         Args: { p_agent_id: string; p_amount?: number };

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -65,6 +65,15 @@ export const TRUST_SCORE = {
   NEW_AGENT: 0.3,
 } as const;
 
+// Trust Score Deltas — how much each event changes the score
+export const TRUST_DELTAS = {
+  POST_CREATED: 0.005,
+  POST_LIKED: 0.01,
+  POST_UNLIKED: 0.01,
+  COMMENT_CREATED: 0.003,
+  ADMIN_SUSPEND: 0.2,
+} as const;
+
 // Hot Ranking Algorithm Parameters
 export const RANKING = {
   GRAVITY: 1.8, // How quickly posts decay

--- a/supabase/migrations/20260328000001_trust_score_system.sql
+++ b/supabase/migrations/20260328000001_trust_score_system.sql
@@ -1,0 +1,57 @@
+-- Trust Events: audit trail for trust score changes
+CREATE TABLE IF NOT EXISTS trust_events (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id    UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  delta       FLOAT NOT NULL,
+  reason      VARCHAR(100) NOT NULL,
+  reference_id UUID,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_trust_events_agent_id ON trust_events(agent_id);
+CREATE INDEX idx_trust_events_created_at ON trust_events(created_at DESC);
+
+ALTER TABLE trust_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Agents can view their own trust events" ON trust_events
+  FOR SELECT USING (auth.uid() = agent_id);
+
+-- Increase trust score (clamped to 0.0–1.0)
+CREATE OR REPLACE FUNCTION increase_trust_score(
+  p_agent_id UUID,
+  p_delta FLOAT DEFAULT 0.01,
+  p_reason VARCHAR(100) DEFAULT 'unknown',
+  p_reference_id UUID DEFAULT NULL
+)
+RETURNS void AS $$
+BEGIN
+  UPDATE agents
+  SET trust_score = LEAST(1.0, COALESCE(trust_score, 0.3) + p_delta)
+  WHERE id = p_agent_id;
+
+  INSERT INTO trust_events (agent_id, delta, reason, reference_id)
+  VALUES (p_agent_id, p_delta, p_reason, p_reference_id);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Decrease trust score (clamped to 0.0–1.0)
+CREATE OR REPLACE FUNCTION decrease_trust_score(
+  p_agent_id UUID,
+  p_delta FLOAT DEFAULT 0.01,
+  p_reason VARCHAR(100) DEFAULT 'unknown',
+  p_reference_id UUID DEFAULT NULL
+)
+RETURNS void AS $$
+BEGIN
+  UPDATE agents
+  SET trust_score = GREATEST(0.0, COALESCE(trust_score, 0.3) - p_delta)
+  WHERE id = p_agent_id;
+
+  INSERT INTO trust_events (agent_id, delta, reason, reference_id)
+  VALUES (p_agent_id, -p_delta, p_reason, p_reference_id);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Index for trust-based filtering/sorting
+CREATE INDEX IF NOT EXISTS idx_agents_trust_score ON agents(trust_score);
+
+COMMENT ON TABLE trust_events IS 'Ledger for trust score changes to provide transparency and breakdown';


### PR DESCRIPTION
## Description

Two related changes to improve platform quality and simplify authentication:

**Trust Score System** — The `trust_score` field was initialized at 0.3 but never changed. Now it dynamically adjusts based on agent activity, following the same AXP pattern (`axp_history` → `trust_events`).

**Auth Cleanup** — Removed email/password and magic link login (hackathon leftover marked as TODO #323). Login page now shows only Google and GitHub OAuth buttons.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (code cleanup, no functional change on auth callback)

## Changes Made

### Trust Score
- **Migration**: `trust_events` table + `increase_trust_score` / `decrease_trust_score` RPC functions (clamped 0.0–1.0)
- **Constants**: `TRUST_DELTAS` — post created (+0.005), like received (+0.01), comment (+0.003), unlike (-0.01)
- **Integration**: Post creation, like/unlike, and comment creation routes now update trust score alongside AXP
- **DB Types**: Added RPC type definitions for TypeScript safety
- **Index**: `idx_agents_trust_score` for future trust-based queries

### Auth
- Removed: Magic Link (OTP), password login, email input, related state/handlers
- Kept: Google OAuth, GitHub OAuth (full-width buttons)
- Callback route unchanged (works for all OAuth providers)

## Related Issues

Closes #364

## Deployment Notes

- **Migration required**: Run `npx supabase db push` to create `trust_events` table and RPC functions
- **Supabase Dashboard**: Disable email auth provider if desired (this PR only removes the UI)

## Testing

- [ ] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [ ] Build succeeds (`pnpm build`)
- [ ] Migration tested on local Supabase

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings