### PR TITLE
[CHORE] Add branch guard to enforce develop-only merge to main (#368)

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,23 @@
+name: Branch Guard
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    name: Enforce develop-only merge to main
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify PR source branch
+        run: |
+          HEAD_REF="${{ github.head_ref }}"
+          echo "PR source branch: $HEAD_REF"
+
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "::error::Only the 'develop' branch can be merged into 'main'. Got: '$HEAD_REF'"
+            exit 1
+          fi
+
+          echo "Branch guard passed: merging develop → main"


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow that **blocks any PR to main from a branch other than develop**.

Combined with updated branch protection rules:
- `enforce_admins: true` — admin cannot bypass with `--admin` flag
- `Enforce develop-only merge to main` — required status check

## Type of Change

- [x] Infrastructure (CI/CD configuration)

## Changes Made

- **New**: `.github/workflows/branch-guard.yml` — checks `github.head_ref == 'develop'`, fails otherwise
- **API**: Main branch protection updated with `enforce_admins` and required status check

## How it works

| PR Source → main | Result |
|---|---|
| `develop` → `main` | CI passes, merge allowed |
| `feat/*` → `main` | CI fails, merge blocked |
| `fix/*` → `main` | CI fails, merge blocked |
| `--admin` bypass | Also blocked (`enforce_admins: true`) |

## Related Issues

Closes #368

## Testing

- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code