### PR TITLE
[FIX] CSP policy, custom 404, GoTrueClient duplicate (#375)

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+      <h1 className="text-6xl font-bold">404</h1>
+      <p className="text-lg text-muted-foreground">
+        This page could not be found.
+      </p>
+      <Button asChild>
+        <Link href="/">Go back home</Link>
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/lib/supabase/browser.ts
+++ b/apps/web/lib/supabase/browser.ts
@@ -19,8 +19,10 @@ export function getSupabaseBrowser() {
 
   supabaseBrowserClient = createClient(supabaseUrl, supabaseAnonKey, {
     auth: {
-      persistSession: false, // No auth session persistence for public read-only access
+      persistSession: false,
       autoRefreshToken: false,
+      detectSessionInUrl: false,
+      storageKey: 'agentgram-browser-public',
     },
   });
 

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -56,7 +56,7 @@ export async function proxy(request: NextRequest) {
     style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
     img-src 'self' blob: data: https: http:;
     font-src 'self' https://fonts.gstatic.com data:;
-    connect-src 'self' https://*.supabase.co https://api.lemonsqueezy.com https://www.google-analytics.com;
+    connect-src 'self' https://*.supabase.co https://api.lemonsqueezy.com https://www.google-analytics.com https://www.googletagmanager.com;
     frame-src 'self' https://*.lemonsqueezy.com;
     object-src 'none';
     base-uri 'self';


### PR DESCRIPTION
## Description

Fixes 3 bugs found during QA audit of agentgram.co.

## Type of Change

- [x] Bug fix

## Changes Made

- **CSP fix**: Added `https://www.googletagmanager.com` to `connect-src` in `proxy.ts`. GA events were silently dropped because the GTM domain wasn't whitelisted.
- **Custom 404**: Created `apps/web/app/not-found.tsx` with branding and navigation. Previously showed default Next.js 404 with no way back.
- **GoTrueClient**: Added unique `storageKey` and `detectSessionInUrl: false` to the browser-side Supabase client to prevent duplicate instance warnings.

## Related Issues

Closes #375

## Testing

- [x] Manual testing performed
- [x] Lint passes (`pnpm lint`)
- [x] Type check passes

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings