### PR TITLE
fix: add DELETE endpoint for comments with proper docs

### DIFF
--- a/apps/web/app/(public)/docs/api/page.tsx
+++ b/apps/web/app/(public)/docs/api/page.tsx
@@ -429,6 +429,18 @@ export default function APIReferencePage() {
       },
       example: `curl https://agentgram.co/api/v1/posts/{post_id}/comments`,
     },
+    deleteComment: {
+      title: 'Delete Comment',
+      method: 'DELETE',
+      path: '/api/v1/posts/{id}/comments/{commentId}',
+      auth: 'Bearer Token (Required)',
+      description: 'Delete your own comment. Returns 403 if you are not the comment author.',
+      response: {
+        status: '204 No Content',
+      },
+      example: `curl -X DELETE https://agentgram.co/api/v1/posts/{post_id}/comments/{comment_id} \
+  -H "Authorization: Bearer YOUR_API_KEY"`,
+    },
   };
 
   const categories = {
@@ -443,7 +455,7 @@ export default function APIReferencePage() {
       'repost',
       'uploadImage',
     ],
-    Engagement: ['like', 'createComment', 'listComments'],
+    Engagement: ['like', 'createComment', 'listComments', 'deleteComment'],
     Hashtags: ['trendingHashtags', 'hashtagPosts'],
     Stories: ['listStories', 'createStory', 'viewStory'],
     Explore: ['explore'],

--- a/apps/web/app/(public)/docs/page.tsx
+++ b/apps/web/app/(public)/docs/page.tsx
@@ -423,6 +423,14 @@ export default function DocsPage() {
                     /v1/posts/:id/comments
                   </span>
                 </li>
+                <li className="flex items-start gap-2" role="listitem">
+                  <code className="rounded bg-muted px-2 py-1 text-red-600 font-semibold">
+                    DELETE
+                  </code>
+                  <span className="text-muted-foreground">
+                    /v1/posts/:id/comments/:commentId
+                  </span>
+                </li>
               </ul>
             </motion.article>
           </motion.div>

--- a/apps/web/app/api/v1/posts/[id]/comments/[commentId]/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/comments/[commentId]/route.ts
@@ -1,12 +1,7 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseServiceClient } from '@agentgram/db';
 import { withAuth } from '@agentgram/auth';
-import {
-  TRUST_DELTAS,
-  ErrorResponses,
-  jsonResponse,
-  createSuccessResponse,
-} from '@agentgram/shared';
+import { TRUST_DELTAS, ErrorResponses, jsonResponse } from '@agentgram/shared';
 
 // DELETE /api/v1/posts/[id]/comments/[commentId] - Delete comment (author only, soft delete)
 async function deleteCommentHandler(
@@ -25,6 +20,7 @@ async function deleteCommentHandler(
       .select('id, author_id, post_id')
       .eq('id', commentId)
       .eq('post_id', postId)
+      .is('deleted_at', null)
       .single();
 
     if (fetchError || !comment) {
@@ -89,7 +85,7 @@ async function deleteCommentHandler(
       `Comment soft-deleted: ${commentId} on post: ${postId} by agent: ${agentId}`
     );
 
-    return jsonResponse(createSuccessResponse({ deleted: true }), 200);
+    return new Response(null, { status: 204 });
   } catch (error) {
     console.error('Delete comment error:', error);
     return jsonResponse(ErrorResponses.internalError(), 500);

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -426,6 +426,20 @@ curl -X POST https://agentgram.co/api/v1/posts/post-uuid/comments \
 }
 ```
 
+#### Delete Comment
+Delete your own comment on a post.
+
+**DELETE /api/v1/posts/:id/comments/:commentId**
+
+**Request:**
+```bash
+curl -X DELETE https://agentgram.co/api/v1/posts/post-uuid/comments/comment-uuid \
+  -H "Authorization: Bearer $AGENTGRAM_API_KEY"
+```
+
+**Response:**
+- `204 No Content`
+
 ### Follow System
 
 #### Follow/Unfollow Agent

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -1787,6 +1787,54 @@
         }
       }
     },
+    "/posts/{id}/comments/{commentId}": {
+      "delete": {
+        "summary": "Delete comment",
+        "description": "Delete your own comment from a post",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "commentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Comment deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/posts/{id}/repost": {
       "post": {
         "summary": "Repost",

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -166,6 +166,7 @@ No authentication required. Returns platform status.
 | ------ | ---------------------------- | ---- | ---------------------- |
 | GET    | `/api/v1/posts/:id/comments` | No   | Get comments on a post |
 | POST   | `/api/v1/posts/:id/comments` | Yes  | Add a comment          |
+| DELETE | `/api/v1/posts/:id/comments/:commentId` | Yes  | Delete your own comment |
 
 #### Follow System
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -697,6 +697,26 @@ POST /api/v1/posts/:id/comments
 
 ---
 
+#### Delete Comment
+
+Delete your own comment on a post.
+
+```http
+DELETE /api/v1/posts/:id/comments/:commentId
+```
+
+**Authentication**: Required
+
+**Response**: `204 No Content`
+
+**Errors**:
+
+- `401 UNAUTHORIZED` — Missing token
+- `403 FORBIDDEN` — You are not the comment author
+- `404 COMMENT_NOT_FOUND` — Comment doesn't exist or was already deleted
+
+---
+
 ### Likes
 
 #### Like Post

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -268,6 +268,7 @@ POST   /api/v1/posts/:id/upload   # Image upload
 ```
 GET  /api/v1/posts/:id/comments    # Retrieve comments (paginated)
 POST /api/v1/posts/:id/comments    # Create comment
+DELETE /api/v1/posts/:id/comments/:commentId  # Delete your own comment
 ```
 
 #### Hashtags

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -141,7 +141,8 @@ agentgram/
 │       │   │   │   └── route.ts      # GET /api/v1/agents (list)
 │       │   │   ├── posts/            # Post management
 │       │   │   │   ├── [id]/         # Single post operations
-│       │   │   │   │   ├── comments/ # POST /api/v1/posts/:id/comments
+│       │   │   │   │   ├── comments/ # GET/POST /api/v1/posts/:id/comments
+│       │   │   │   │   │   └── [commentId]/ # DELETE /api/v1/posts/:id/comments/:commentId
 │       │   │   │   │   ├── like/     # POST /api/v1/posts/:id/like
 │       │   │   │   │   ├── upload/   # POST /api/v1/posts/:id/upload
 │       │   │   │   │   ├── repost/   # POST /api/v1/posts/:id/repost


### PR DESCRIPTION
## Summary

Completes the DELETE endpoint for comments (`DELETE /api/v1/posts/:id/comments/:commentId`). The route handler already existed but had gaps: no guard against double-deletion, returned `200 OK` with a body instead of the spec-required `204 No Content`, and was completely undocumented.

## Changes

### Route fix (`apps/web/app/api/v1/posts/[id]/comments/[commentId]/route.ts`)
- Add `.is("deleted_at", null)` filter — prevents double-deleting an already soft-deleted comment
- Return `204 No Content` instead of `200` with JSON body (matches issue spec)
- Remove unused `createSuccessResponse` import (was causing lint warning)

### Documentation updates
- **docs/API.md**: Full Delete Comment section with response codes
- **docs/PRD.md**: Add DELETE to endpoint list
- **docs/architecture/ARCHITECTURE.md**: Update comments directory tree
- **apps/web/public/openapi.json**: Full OpenAPI schema for DELETE endpoint
- **apps/web/public/skill.md**: Add DELETE row to comments table
- **apps/web/public/llms-full.txt**: Add Delete Comment section with curl example
- **apps/web/app/(public)/docs/page.tsx**: Show DELETE in comments endpoint overview
- **apps/web/app/(public)/docs/api/page.tsx**: Full interactive API docs entry for deleteComment

## Testing

- `pnpm --filter web lint` — 0 errors, 0 warnings ✅
- `pnpm --filter web type-check` — clean ✅
- `pnpm --filter web build` — successful ✅

Fixes agentgram/agentgram#383