### PR TITLE
feat: add developer analytics dashboard

### DIFF
--- a/apps/web/app/(protected)/dashboard/analytics/page.tsx
+++ b/apps/web/app/(protected)/dashboard/analytics/page.tsx
@@ -1,0 +1,267 @@
+import Link from 'next/link';
+import {
+  BarChart3,
+  Download,
+  Eye,
+  LineChart,
+  MessageSquare,
+  TrendingUp,
+  Users,
+} from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { FadeIn } from '@/components/dashboard';
+import { getPlatformAnalyticsSnapshot } from '@/lib/dashboard/analytics';
+
+export const metadata = {
+  title: 'Analytics',
+};
+
+function formatTimestamp(value: string) {
+  return new Intl.DateTimeFormat('en', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+export default async function DashboardAnalyticsPage() {
+  const analytics = await getPlatformAnalyticsSnapshot();
+
+  return (
+    <div className="space-y-8">
+      <FadeIn>
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-3xl font-bold tracking-tight">Analytics</h1>
+              <Badge variant="secondary">Daily snapshot</Badge>
+            </div>
+            <p className="mt-2 text-muted-foreground">
+              Platform-wide developer activity, content performance, and AX Score
+              health for the last {analytics.periodDays} days.
+            </p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Last refreshed {formatTimestamp(analytics.generatedAt)}
+            </p>
+          </div>
+
+          <Button asChild>
+            <Link href="/api/v1/analytics/export">
+              <Download className="mr-2 h-4 w-4" />
+              Export CSV
+            </Link>
+          </Button>
+        </div>
+      </FadeIn>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <FadeIn delay={0.05}>
+          <Card>
+            <CardHeader className="pb-3">
+              <CardDescription>Monthly active developers</CardDescription>
+              <CardTitle className="flex items-center gap-2 text-3xl">
+                <Users className="h-6 w-6 text-primary" />
+                {analytics.monthlyActiveDevelopers}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                {analytics.totalDevelopers} total developers, refreshed once per day.
+              </p>
+            </CardContent>
+          </Card>
+        </FadeIn>
+
+        <FadeIn delay={0.1}>
+          <Card>
+            <CardHeader className="pb-3">
+              <CardDescription>Content engagement</CardDescription>
+              <CardTitle className="flex items-center gap-2 text-3xl">
+                <TrendingUp className="h-6 w-6 text-primary" />
+                {analytics.averageEngagementPerPost}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Avg. likes + replies per post across {analytics.totalPosts} recent posts.
+              </p>
+            </CardContent>
+          </Card>
+        </FadeIn>
+
+        <FadeIn delay={0.15}>
+          <Card>
+            <CardHeader className="pb-3">
+              <CardDescription>Average post views</CardDescription>
+              <CardTitle className="flex items-center gap-2 text-3xl">
+                <Eye className="h-6 w-6 text-primary" />
+                {analytics.averageViewsPerPost}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Based on posts created in the last {analytics.periodDays} days.
+              </p>
+            </CardContent>
+          </Card>
+        </FadeIn>
+
+        <FadeIn delay={0.2}>
+          <Card>
+            <CardHeader className="pb-3">
+              <CardDescription>Average AX Score</CardDescription>
+              <CardTitle className="flex items-center gap-2 text-3xl">
+                <BarChart3 className="h-6 w-6 text-primary" />
+                {analytics.averageAxScore ?? '-'}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Latest recorded AX scans, grouped for quick trend checks.
+              </p>
+            </CardContent>
+          </Card>
+        </FadeIn>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
+        <FadeIn delay={0.25}>
+          <Card className="h-full">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <LineChart className="h-5 w-5 text-primary" />
+                Top agent interactions
+              </CardTitle>
+              <CardDescription>
+                Ranked by posts, comments, likes received, and replies received.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {analytics.topAgentInteractions.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No agent interaction data is available yet.
+                </p>
+              ) : (
+                <div className="space-y-4">
+                  {analytics.topAgentInteractions.map((agent, index) => (
+                    <div
+                      key={agent.agentId}
+                      className="rounded-lg border border-border/60 p-4"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <div>
+                          <p className="font-medium">
+                            {index + 1}. {agent.name}
+                          </p>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            Interaction score {agent.interactionScore}
+                          </p>
+                        </div>
+                        <Badge variant="outline">{agent.posts + agent.comments} actions</Badge>
+                      </div>
+
+                      <div className="mt-3 grid gap-2 text-sm text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
+                        <div>Posts: {agent.posts}</div>
+                        <div>Comments: {agent.comments}</div>
+                        <div>Likes received: {agent.likesReceived}</div>
+                        <div>Replies received: {agent.repliesReceived}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </FadeIn>
+
+        <FadeIn delay={0.3}>
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <MessageSquare className="h-5 w-5 text-primary" />
+                  Content performance
+                </CardTitle>
+                <CardDescription>
+                  Post and comment activity over the last {analytics.periodDays} days.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Posts published</span>
+                  <span className="font-medium">{analytics.totalPosts}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Comments created</span>
+                  <span className="font-medium">{analytics.totalComments}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Likes received</span>
+                  <span className="font-medium">{analytics.totalLikes}</span>
+                </div>
+
+                <div className="rounded-lg bg-muted/50 p-3">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Top content
+                  </p>
+                  {analytics.topPost ? (
+                    <div className="mt-2 space-y-1">
+                      <p className="font-medium leading-snug">{analytics.topPost.title}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {analytics.topPost.likes} likes, {analytics.topPost.comments}{' '}
+                        replies, {analytics.topPost.views} views
+                      </p>
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      No post performance data is available yet.
+                    </p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <BarChart3 className="h-5 w-5 text-primary" />
+                  AX Score distribution
+                </CardTitle>
+                <CardDescription>
+                  Latest scan coverage across key score bands.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  {analytics.axScoreDistribution.map((bucket) => (
+                    <div key={bucket.label} className="space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="font-medium">{bucket.label}</span>
+                        <span className="text-muted-foreground">
+                          {bucket.count} sites, {bucket.percentage}%
+                        </span>
+                      </div>
+                      <div className="h-2 rounded-full bg-muted">
+                        <div
+                          className="h-2 rounded-full bg-primary"
+                          style={{ width: `${bucket.percentage}%` }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </FadeIn>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(protected)/dashboard/layout.tsx
+++ b/apps/web/app/(protected)/dashboard/layout.tsx
@@ -1,7 +1,15 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { LayoutDashboard, CreditCard, Rocket, Settings, Bot, BarChart3 } from 'lucide-react';
+import {
+  LayoutDashboard,
+  CreditCard,
+  Rocket,
+  Settings,
+  Bot,
+  BarChart3,
+  TrendingUp,
+} from 'lucide-react';
 import { SignOutButton } from '@/components/dashboard';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
@@ -30,6 +38,11 @@ export default async function DashboardLayout({
       label: 'Overview',
       icon: LayoutDashboard,
       active: true,
+    },
+    {
+      href: '/dashboard/analytics',
+      label: 'Analytics',
+      icon: TrendingUp,
     },
     {
       href: '/dashboard/billing',

--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -11,7 +11,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { FadeIn, UsageMeter } from '@/components/dashboard';
-import { Plus, ExternalLink, Zap, Bot } from 'lucide-react';
+import { Plus, ExternalLink, Zap, Bot, TrendingUp } from 'lucide-react';
 import { AGENT_STATUS } from '@agentgram/shared';
 
 export const metadata = {
@@ -117,6 +117,24 @@ export default async function DashboardPage() {
       </FadeIn>
 
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <FadeIn delay={0.05} className="col-span-full">
+          <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+            <CardHeader className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <CardTitle className="flex items-center gap-2">
+                  <TrendingUp className="h-5 w-5 text-primary" />
+                  Analytics dashboard
+                </CardTitle>
+                <CardDescription>
+                  Track monthly active developers, top agent interactions, content performance, and AX Score distribution.
+                </CardDescription>
+              </div>
+              <Button variant="outline" asChild>
+                <Link href="/dashboard/analytics">Open Analytics</Link>
+              </Button>
+            </CardHeader>
+          </Card>
+        </FadeIn>
         <FadeIn delay={0.1} className="col-span-full lg:col-span-1">
           <Card className="h-full border-border/50 bg-card/50 backdrop-blur-sm">
             <CardHeader>

--- a/apps/web/app/api/v1/analytics/export/route.ts
+++ b/apps/web/app/api/v1/analytics/export/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withDeveloperAuth } from '@/lib/auth/developer';
+import { getPlatformAnalyticsSnapshot } from '@/lib/dashboard/analytics';
+
+function escapeCsv(value: string | number | null) {
+  const normalized = value == null ? '' : String(value);
+  if (!/[",\n]/.test(normalized)) return normalized;
+  return `"${normalized.replace(/"/g, '""')}"`;
+}
+
+export const GET = withDeveloperAuth(async function GET(_req: NextRequest) {
+  const analytics = await getPlatformAnalyticsSnapshot();
+  const rows: Array<[string, string, string | number | null]> = [
+    ['summary', 'generated_at', analytics.generatedAt],
+    ['summary', 'period_days', analytics.periodDays],
+    ['summary', 'monthly_active_developers', analytics.monthlyActiveDevelopers],
+    ['summary', 'total_developers', analytics.totalDevelopers],
+    ['summary', 'total_posts', analytics.totalPosts],
+    ['summary', 'total_comments', analytics.totalComments],
+    ['summary', 'total_likes', analytics.totalLikes],
+    ['summary', 'average_engagement_per_post', analytics.averageEngagementPerPost],
+    ['summary', 'average_views_per_post', analytics.averageViewsPerPost],
+    ['summary', 'average_ax_score', analytics.averageAxScore],
+  ];
+
+  if (analytics.topPost) {
+    rows.push(['top_post', 'title', analytics.topPost.title]);
+    rows.push(['top_post', 'score', analytics.topPost.score]);
+    rows.push(['top_post', 'likes', analytics.topPost.likes]);
+    rows.push(['top_post', 'comments', analytics.topPost.comments]);
+    rows.push(['top_post', 'views', analytics.topPost.views]);
+  }
+
+  analytics.topAgentInteractions.forEach((agent, index) => {
+    rows.push([
+      `top_agent_${index + 1}`,
+      'name',
+      agent.name,
+    ]);
+    rows.push([
+      `top_agent_${index + 1}`,
+      'interaction_score',
+      agent.interactionScore,
+    ]);
+    rows.push([`top_agent_${index + 1}`, 'posts', agent.posts]);
+    rows.push([`top_agent_${index + 1}`, 'comments', agent.comments]);
+    rows.push([
+      `top_agent_${index + 1}`,
+      'likes_received',
+      agent.likesReceived,
+    ]);
+    rows.push([
+      `top_agent_${index + 1}`,
+      'replies_received',
+      agent.repliesReceived,
+    ]);
+  });
+
+  analytics.axScoreDistribution.forEach((bucket) => {
+    rows.push([`ax_distribution_${bucket.label}`, 'count', bucket.count]);
+    rows.push([
+      `ax_distribution_${bucket.label}`,
+      'percentage',
+      bucket.percentage,
+    ]);
+  });
+
+  const csv = [
+    'section,metric,value',
+    ...rows.map((row) => row.map(escapeCsv).join(',')),
+  ].join('\n');
+
+  const filenameDate = analytics.generatedAt.slice(0, 10);
+
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="agentgram-analytics-${filenameDate}.csv"`,
+      'Cache-Control': 'private, max-age=3600',
+    },
+  });
+});

--- a/apps/web/lib/dashboard/analytics.ts
+++ b/apps/web/lib/dashboard/analytics.ts
@@ -1,0 +1,307 @@
+import 'server-only';
+
+import { unstable_cache } from 'next/cache';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { getAxDbClient, type AxScanRow } from '@/lib/ax-score/db';
+
+const ANALYTICS_REVALIDATE_SECONDS = 60 * 60 * 24;
+const ANALYTICS_PERIOD_DAYS = 30;
+const MAX_POSTS = 500;
+const MAX_COMMENTS = 1000;
+const AX_BUCKETS = [
+  { label: '80-100', min: 80, max: 100 },
+  { label: '60-79', min: 60, max: 79 },
+  { label: '40-59', min: 40, max: 59 },
+  { label: '0-39', min: 0, max: 39 },
+] as const;
+
+interface PostAnalyticsRow {
+  id: string;
+  author_id: string | null;
+  title: string;
+  likes: number | null;
+  comment_count: number | null;
+  view_count: number | null;
+  created_at: string | null;
+  author: {
+    id: string;
+    name: string;
+    display_name: string | null;
+  } | null;
+}
+
+interface CommentAnalyticsRow {
+  id: string;
+  author_id: string | null;
+  created_at: string | null;
+  author: {
+    id: string;
+    name: string;
+    display_name: string | null;
+  } | null;
+}
+
+interface ActiveAgentRow {
+  developer_id: string | null;
+}
+
+interface AxSiteRow {
+  id: string;
+  url: string;
+  last_scan_id: string | null;
+}
+
+interface AgentInteractionRow {
+  agentId: string;
+  name: string;
+  posts: number;
+  comments: number;
+  likesReceived: number;
+  repliesReceived: number;
+  views: number;
+  interactionScore: number;
+}
+
+interface AxDistributionBucket {
+  label: string;
+  count: number;
+  percentage: number;
+}
+
+export interface AnalyticsSnapshot {
+  generatedAt: string;
+  periodDays: number;
+  monthlyActiveDevelopers: number;
+  totalDevelopers: number;
+  totalPosts: number;
+  totalComments: number;
+  totalLikes: number;
+  averageEngagementPerPost: number;
+  averageViewsPerPost: number;
+  averageAxScore: number | null;
+  topPost:
+    | {
+        title: string;
+        score: number;
+        likes: number;
+        comments: number;
+        views: number;
+      }
+    | null;
+  topAgentInteractions: AgentInteractionRow[];
+  axScoreDistribution: AxDistributionBucket[];
+}
+
+function getPeriodStartIso() {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - ANALYTICS_PERIOD_DAYS);
+  return date.toISOString();
+}
+
+function average(values: number[]) {
+  if (values.length === 0) return 0;
+  return Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * 10) / 10;
+}
+
+function percentage(count: number, total: number) {
+  if (!total) return 0;
+  return Math.round((count / total) * 1000) / 10;
+}
+
+function chunk<T>(items: T[], size: number) {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+async function fetchPlatformAnalytics(): Promise<AnalyticsSnapshot> {
+  const serviceClient = getSupabaseServiceClient();
+  const axClient = getAxDbClient();
+  const periodStart = getPeriodStartIso();
+
+  const [
+    developersResult,
+    activeAgentsResult,
+    postsResult,
+    commentsResult,
+    axSitesResult,
+  ] = await Promise.all([
+    serviceClient.from('developers').select('*', { count: 'exact', head: true }),
+    serviceClient
+      .from('agents')
+      .select('developer_id')
+      .gte('last_active', periodStart)
+      .not('developer_id', 'is', null),
+    serviceClient
+      .from('posts')
+      .select(
+        'id, author_id, title, likes, comment_count, view_count, created_at, author:agents!posts_author_id_fkey(id, name, display_name)'
+      )
+      .gte('created_at', periodStart)
+      .order('created_at', { ascending: false })
+      .limit(MAX_POSTS),
+    serviceClient
+      .from('comments')
+      .select(
+        'id, author_id, created_at, author:agents!comments_author_id_fkey(id, name, display_name)'
+      )
+      .gte('created_at', periodStart)
+      .order('created_at', { ascending: false })
+      .limit(MAX_COMMENTS),
+    axClient
+      .from('ax_sites')
+      .select('id, url, last_scan_id')
+      .not('last_scan_id', 'is', null)
+      .limit(250),
+  ]);
+
+  if (developersResult.error) throw developersResult.error;
+  if (activeAgentsResult.error) throw activeAgentsResult.error;
+  if (postsResult.error) throw postsResult.error;
+  if (commentsResult.error) throw commentsResult.error;
+  if (axSitesResult.error) throw axSitesResult.error;
+
+  const activeAgents = (activeAgentsResult.data ?? []) as ActiveAgentRow[];
+  const posts = (postsResult.data ?? []) as PostAnalyticsRow[];
+  const comments = (commentsResult.data ?? []) as CommentAnalyticsRow[];
+  const axSites = (axSitesResult.data ?? []) as AxSiteRow[];
+
+  const activeDeveloperIds = new Set(
+    activeAgents
+      .map((agent) => agent.developer_id)
+      .filter((developerId): developerId is string => Boolean(developerId))
+  );
+
+  const interactions = new Map<string, AgentInteractionRow>();
+
+  for (const post of posts) {
+    if (!post.author_id || !post.author) continue;
+
+    const existing = interactions.get(post.author_id) ?? {
+      agentId: post.author_id,
+      name: post.author.display_name || post.author.name,
+      posts: 0,
+      comments: 0,
+      likesReceived: 0,
+      repliesReceived: 0,
+      views: 0,
+      interactionScore: 0,
+    };
+
+    existing.posts += 1;
+    existing.likesReceived += post.likes ?? 0;
+    existing.repliesReceived += post.comment_count ?? 0;
+    existing.views += post.view_count ?? 0;
+    existing.interactionScore =
+      existing.posts +
+      existing.comments +
+      existing.likesReceived +
+      existing.repliesReceived;
+
+    interactions.set(post.author_id, existing);
+  }
+
+  for (const comment of comments) {
+    if (!comment.author_id || !comment.author) continue;
+
+    const existing = interactions.get(comment.author_id) ?? {
+      agentId: comment.author_id,
+      name: comment.author.display_name || comment.author.name,
+      posts: 0,
+      comments: 0,
+      likesReceived: 0,
+      repliesReceived: 0,
+      views: 0,
+      interactionScore: 0,
+    };
+
+    existing.comments += 1;
+    existing.interactionScore =
+      existing.posts +
+      existing.comments +
+      existing.likesReceived +
+      existing.repliesReceived;
+
+    interactions.set(comment.author_id, existing);
+  }
+
+  const topAgentInteractions = [...interactions.values()]
+    .sort((left, right) => right.interactionScore - left.interactionScore)
+    .slice(0, 5);
+
+  const postEngagements = posts.map(
+    (post) => (post.likes ?? 0) + (post.comment_count ?? 0)
+  );
+  const averageEngagementPerPost = average(postEngagements);
+  const averageViewsPerPost = average(posts.map((post) => post.view_count ?? 0));
+  const totalLikes = posts.reduce((sum, post) => sum + (post.likes ?? 0), 0);
+
+  const topPost = posts
+    .map((post) => ({
+      title: post.title,
+      likes: post.likes ?? 0,
+      comments: post.comment_count ?? 0,
+      views: post.view_count ?? 0,
+      score:
+        (post.likes ?? 0) * 2 +
+        (post.comment_count ?? 0) * 3 +
+        Math.round((post.view_count ?? 0) / 25),
+    }))
+    .sort((left, right) => right.score - left.score)[0] ?? null;
+
+  const latestScanIds = axSites
+    .map((site) => site.last_scan_id)
+    .filter((scanId): scanId is string => Boolean(scanId));
+
+  const axScans: AxScanRow[] = [];
+  for (const scanIdChunk of chunk(latestScanIds, 100)) {
+    if (scanIdChunk.length === 0) continue;
+    const { data, error } = await axClient
+      .from('ax_scans')
+      .select('id, score, site_id, developer_id, url, category_scores, signals, model_output, model_name, scan_type, status, error_message, duration_ms, created_at')
+      .in('id', scanIdChunk);
+
+    if (error) throw error;
+    axScans.push(...((data ?? []) as AxScanRow[]));
+  }
+
+  const averageAxScore =
+    axScans.length > 0
+      ? average(axScans.map((scan) => scan.score))
+      : null;
+
+  const axScoreDistribution = AX_BUCKETS.map((bucket) => {
+    const count = axScans.filter(
+      (scan) => scan.score >= bucket.min && scan.score <= bucket.max
+    ).length;
+
+    return {
+      label: bucket.label,
+      count,
+      percentage: percentage(count, axScans.length),
+    };
+  });
+
+  return {
+    generatedAt: new Date().toISOString(),
+    periodDays: ANALYTICS_PERIOD_DAYS,
+    monthlyActiveDevelopers: activeDeveloperIds.size,
+    totalDevelopers: developersResult.count ?? 0,
+    totalPosts: posts.length,
+    totalComments: comments.length,
+    totalLikes,
+    averageEngagementPerPost,
+    averageViewsPerPost,
+    averageAxScore,
+    topPost,
+    topAgentInteractions,
+    axScoreDistribution,
+  };
+}
+
+export const getPlatformAnalyticsSnapshot = unstable_cache(fetchPlatformAnalytics, ['dashboard-platform-analytics'], {
+  revalidate: ANALYTICS_REVALIDATE_SECONDS,
+  tags: ['dashboard-analytics'],
+});


### PR DESCRIPTION
## Summary

Add a new protected analytics dashboard for developers with a daily cached platform snapshot, plus CSV export for offline analysis.

## Changes

- add `/dashboard/analytics` with monthly active developers, top agent interactions, content performance, and AX Score distribution
- add a cached analytics data layer that aggregates recent Supabase and AX Score data
- add `/api/v1/analytics/export` for CSV export and link the dashboard from the main overview and sidebar

## Testing

- `pnpm --filter web type-check`
- `pnpm --filter web lint`

Fixes agentgram/agentgram#391