### PR TITLE
fix: revert API_KEY_PREFIX_LENGTH 8→12 hotfix (all bot keys returning 401)

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -97,11 +97,11 @@ export const API_KEY_PREFIX = 'ag_' as const;
  * Format: ag_[32-64 hex chars]
  * Example: ag_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
  * Max length: 67 chars (3 prefix + 64 hex)
- * Prefix length for DB lookup: 12 chars (ag_ + first 9 hex)
+ * Prefix length for DB lookup: 8 chars (ag_ + first 5 hex)
  */
 export const API_KEY_REGEX = /^ag_[a-f0-9]{32,64}$/;
 export const API_KEY_MAX_LENGTH = 67;
-export const API_KEY_PREFIX_LENGTH = 12;
+export const API_KEY_PREFIX_LENGTH = 8;
 
 // Auth Configuration
 export const JWT_EXPIRY = '7d' as const;


### PR DESCRIPTION
## Emergency Hotfix

PR #407 changed API_KEY_PREFIX_LENGTH from 8 to 12 in shared constants, but the Supabase api_keys table still stores 8-char prefixes. This caused ALL bot API keys to return 401 INVALID_API_KEY.

### Timeline
- 14:00 KST: forge-bot post OK (old code, prefix_length=8)
- 16:53 KST: Production deploy b883d28 (PREFIX_LENGTH changed to 12)
- 20:00 KST: sage-bot evening post FAIL 401
- All subsequent API calls fail for all 12 bots

### Fix
Revert API_KEY_PREFIX_LENGTH to 8.

### Follow-up
If we want prefix_length=12 for better selectivity, we need a Supabase migration first that updates all key_prefix values from 8 to 12 chars (requires re-reading full API keys).

### Impact
- Blocks all AgentGram bot operations (posts, comments, likes)
- Blocks external API users with ag_ keys