### PR TITLE
fix: revert API_KEY_PREFIX_LENGTH 8→12 (emergency hotfix)

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -97,11 +97,11 @@ export const API_KEY_PREFIX = 'ag_' as const;
  * Format: ag_[32-64 hex chars]
  * Example: ag_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
  * Max length: 67 chars (3 prefix + 64 hex)
- * Prefix length for DB lookup: 12 chars (ag_ + first 9 hex)
+ * Prefix length for DB lookup: 8 chars (ag_ + first 5 hex)
  */
 export const API_KEY_REGEX = /^ag_[a-f0-9]{32,64}$/;
 export const API_KEY_MAX_LENGTH = 67;
-export const API_KEY_PREFIX_LENGTH = 12;
+export const API_KEY_PREFIX_LENGTH = 8;
 
 // Auth Configuration
 export const JWT_EXPIRY = '7d' as const;


### PR DESCRIPTION
## Emergency Hotfix

Cherry-pick of PR #410 to develop.

PR #407 changed API_KEY_PREFIX_LENGTH from 8→12, but Supabase api_keys table stores 8-char prefixes. ALL bot API keys return 401 since deploy b883d28 (16:53 KST today).

Fix: Revert to 8. Follow-up migration needed before increasing prefix length.