### PR TITLE
fix: support comments API when deleted_at column is absent

### DIFF
--- a/apps/web/app/api/v1/posts/[id]/comments/[commentId]/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/comments/[commentId]/route.ts
@@ -3,6 +3,10 @@ import { getSupabaseServiceClient } from '@agentgram/db';
 import { withAuth } from '@agentgram/auth';
 import { TRUST_DELTAS, ErrorResponses, jsonResponse } from '@agentgram/shared';
 
+function isMissingDeletedAtColumn(error: { message?: string } | null) {
+  return Boolean(error?.message?.toLowerCase().includes('deleted_at'));
+}
+
 // DELETE /api/v1/posts/[id]/comments/[commentId] - Delete comment (author only, soft delete)
 async function deleteCommentHandler(
   req: NextRequest,
@@ -14,14 +18,29 @@ async function deleteCommentHandler(
 
     const supabase = getSupabaseServiceClient();
 
-    // Fetch comment to verify existence and ownership
-    const { data: comment, error: fetchError } = await supabase
+    let { data: comment, error: fetchError } = await supabase
       .from('comments')
       .select('id, author_id, post_id')
       .eq('id', commentId)
       .eq('post_id', postId)
       .is('deleted_at', null)
       .single();
+
+    if (fetchError && isMissingDeletedAtColumn(fetchError)) {
+      console.warn(
+        'Comment delete fallback: comments.deleted_at missing, retrying lookup without soft-delete filter'
+      );
+
+      const fallbackResult = await supabase
+        .from('comments')
+        .select('id, author_id, post_id')
+        .eq('id', commentId)
+        .eq('post_id', postId)
+        .single();
+
+      comment = fallbackResult.data;
+      fetchError = fallbackResult.error;
+    }
 
     if (fetchError || !comment) {
       return jsonResponse(ErrorResponses.notFound('Comment'), 404);
@@ -35,11 +54,28 @@ async function deleteCommentHandler(
       );
     }
 
-    // Soft delete: set deleted_at timestamp
-    const { error: deleteError } = await supabase
+    let deleteError = null;
+
+    // Soft delete when supported, otherwise hard delete as a compatibility fallback
+    const softDeleteResult = await supabase
       .from('comments')
       .update({ deleted_at: new Date().toISOString() })
       .eq('id', commentId);
+
+    deleteError = softDeleteResult.error;
+
+    if (deleteError && isMissingDeletedAtColumn(deleteError)) {
+      console.warn(
+        'Comment delete fallback: comments.deleted_at missing, deleting row directly'
+      );
+
+      const hardDeleteResult = await supabase
+        .from('comments')
+        .delete()
+        .eq('id', commentId);
+
+      deleteError = hardDeleteResult.error;
+    }
 
     if (deleteError) {
       console.error('Comment deletion error:', deleteError);

--- a/apps/web/app/api/v1/posts/[id]/comments/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/comments/route.ts
@@ -12,6 +12,15 @@ import {
   createErrorResponse,
 } from '@agentgram/shared';
 
+const COMMENTS_SELECT = `
+  *,
+  author:agents!comments_author_id_fkey(id, name, display_name, avatar_url, axp, trust_score)
+`;
+
+function isMissingDeletedAtColumn(error: { message?: string } | null) {
+  return Boolean(error?.message?.toLowerCase().includes('deleted_at'));
+}
+
 // GET /api/v1/posts/[id]/comments - Fetch comments
 export async function GET(
   req: NextRequest,
@@ -23,17 +32,27 @@ export async function GET(
 
     const supabase = getSupabaseServiceClient();
 
-    const { data: comments, error } = await supabase
+    let { data: comments, error } = await supabase
       .from('comments')
-      .select(
-        `
-        *,
-        author:agents!comments_author_id_fkey(id, name, display_name, avatar_url, axp, trust_score)
-      `
-      )
+      .select(COMMENTS_SELECT)
       .eq('post_id', postId)
       .is('deleted_at', null)
       .order('created_at', { ascending: true });
+
+    if (error && isMissingDeletedAtColumn(error)) {
+      console.warn(
+        'Comments query fallback: comments.deleted_at missing, retrying without soft-delete filter'
+      );
+
+      const fallbackResult = await supabase
+        .from('comments')
+        .select(COMMENTS_SELECT)
+        .eq('post_id', postId)
+        .order('created_at', { ascending: true });
+
+      comments = fallbackResult.data;
+      error = fallbackResult.error;
+    }
 
     if (error) {
       console.error('Comments query error:', error);


### PR DESCRIPTION
## Summary
- add compatibility fallback for comments GET when `comments.deleted_at` is missing
- add compatibility fallback for comment delete lookup and delete path
- preserve current soft-delete behavior when the column exists

## Why
Public comments API is currently returning `500 DATABASE_ERROR` on live for multiple posts because the deployed schema appears to be missing `comments.deleted_at`. This keeps reads working before the schema is fully aligned.

## Validation
- reproduced live `GET /api/v1/posts/:id/comments` returning 500 before fix
- `pnpm -C apps/web exec eslint app/api/v1/posts/[id]/comments/route.ts app/api/v1/posts/[id]/comments/[commentId]/route.ts` on local repo with installed deps
- app type-check still fails on existing unrelated issue in `packages/auth/src/keypair.ts` (`randomSecretKey`)
