### PR TITLE
deploy: promote comments API deleted_at compatibility fix to main

### DIFF
--- a/apps/web/app/api/v1/posts/[id]/comments/[commentId]/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/comments/[commentId]/route.ts
@@ -3,6 +3,10 @@ import { getSupabaseServiceClient } from '@agentgram/db';
 import { withAuth } from '@agentgram/auth';
 import { TRUST_DELTAS, ErrorResponses, jsonResponse } from '@agentgram/shared';
 
+function isMissingDeletedAtColumn(error: { message?: string } | null) {
+  return Boolean(error?.message?.toLowerCase().includes('deleted_at'));
+}
+
 // DELETE /api/v1/posts/[id]/comments/[commentId] - Delete comment (author only, soft delete)
 async function deleteCommentHandler(
   req: NextRequest,
@@ -14,14 +18,29 @@ async function deleteCommentHandler(
 
     const supabase = getSupabaseServiceClient();
 
-    // Fetch comment to verify existence and ownership
-    const { data: comment, error: fetchError } = await supabase
+    let { data: comment, error: fetchError } = await supabase
       .from('comments')
       .select('id, author_id, post_id')
       .eq('id', commentId)
       .eq('post_id', postId)
       .is('deleted_at', null)
       .single();
+
+    if (fetchError && isMissingDeletedAtColumn(fetchError)) {
+      console.warn(
+        'Comment delete fallback: comments.deleted_at missing, retrying lookup without soft-delete filter'
+      );
+
+      const fallbackResult = await supabase
+        .from('comments')
+        .select('id, author_id, post_id')
+        .eq('id', commentId)
+        .eq('post_id', postId)
+        .single();
+
+      comment = fallbackResult.data;
+      fetchError = fallbackResult.error;
+    }
 
     if (fetchError || !comment) {
       return jsonResponse(ErrorResponses.notFound('Comment'), 404);
@@ -35,11 +54,28 @@ async function deleteCommentHandler(
       );
     }
 
-    // Soft delete: set deleted_at timestamp
-    const { error: deleteError } = await supabase
+    let deleteError = null;
+
+    // Soft delete when supported, otherwise hard delete as a compatibility fallback
+    const softDeleteResult = await supabase
       .from('comments')
       .update({ deleted_at: new Date().toISOString() })
       .eq('id', commentId);
+
+    deleteError = softDeleteResult.error;
+
+    if (deleteError && isMissingDeletedAtColumn(deleteError)) {
+      console.warn(
+        'Comment delete fallback: comments.deleted_at missing, deleting row directly'
+      );
+
+      const hardDeleteResult = await supabase
+        .from('comments')
+        .delete()
+        .eq('id', commentId);
+
+      deleteError = hardDeleteResult.error;
+    }
 
     if (deleteError) {
       console.error('Comment deletion error:', deleteError);

--- a/apps/web/app/api/v1/posts/[id]/comments/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/comments/route.ts
@@ -12,6 +12,15 @@ import {
   createErrorResponse,
 } from '@agentgram/shared';
 
+const COMMENTS_SELECT = `
+  *,
+  author:agents!comments_author_id_fkey(id, name, display_name, avatar_url, axp, trust_score)
+`;
+
+function isMissingDeletedAtColumn(error: { message?: string } | null) {
+  return Boolean(error?.message?.toLowerCase().includes('deleted_at'));
+}
+
 // GET /api/v1/posts/[id]/comments - Fetch comments
 export async function GET(
   req: NextRequest,
@@ -23,17 +32,27 @@ export async function GET(
 
     const supabase = getSupabaseServiceClient();
 
-    const { data: comments, error } = await supabase
+    let { data: comments, error } = await supabase
       .from('comments')
-      .select(
-        `
-        *,
-        author:agents!comments_author_id_fkey(id, name, display_name, avatar_url, axp, trust_score)
-      `
-      )
+      .select(COMMENTS_SELECT)
       .eq('post_id', postId)
       .is('deleted_at', null)
       .order('created_at', { ascending: true });
+
+    if (error && isMissingDeletedAtColumn(error)) {
+      console.warn(
+        'Comments query fallback: comments.deleted_at missing, retrying without soft-delete filter'
+      );
+
+      const fallbackResult = await supabase
+        .from('comments')
+        .select(COMMENTS_SELECT)
+        .eq('post_id', postId)
+        .order('created_at', { ascending: true });
+
+      comments = fallbackResult.data;
+      error = fallbackResult.error;
+    }
 
     if (error) {
       console.error('Comments query error:', error);


### PR DESCRIPTION
## Summary
- promote the live comments API compatibility fix from develop to main
- restores `/api/v1/posts/:id/comments` when the `comments.deleted_at` column is absent
- includes the matching delete fallback for the same schema mismatch

## Why
- production is still returning `500 DATABASE_ERROR` on comments fetch
- PR #415 is already merged to `develop`, but production deploys from `main`

## Validation
- diff vs main is only the comments compatibility patch
- develop PR checks passed: CI, tests, Vercel preview
- live issue reproduced before promotion on production API
