### PR TITLE
[REFACTOR] Replace @noble/ed25519 with node:crypto in keypair (#422)

### DIFF
--- a/apps/web/__tests__/auth/keypair.test.ts
+++ b/apps/web/__tests__/auth/keypair.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { generateApiKey } from '@agentgram/auth';
+import { API_KEY_PREFIX, API_KEY_REGEX } from '@agentgram/shared';
+
+describe('generateApiKey', () => {
+  it('returns a string with the ag_ prefix', () => {
+    const key = generateApiKey();
+    expect(key.startsWith(API_KEY_PREFIX)).toBe(true);
+  });
+
+  it('matches the API key regex format', () => {
+    const key = generateApiKey();
+    expect(API_KEY_REGEX.test(key)).toBe(true);
+  });
+
+  it('generates 32 bytes of hex after the prefix (64 hex chars)', () => {
+    const key = generateApiKey();
+    const hex = key.slice(API_KEY_PREFIX.length);
+    expect(hex).toHaveLength(64);
+    expect(/^[0-9a-f]{64}$/.test(hex)).toBe(true);
+  });
+
+  it('generates unique keys on each call', () => {
+    const keys = new Set(Array.from({ length: 10 }, () => generateApiKey()));
+    expect(keys.size).toBe(10);
+  });
+});

--- a/packages/auth/src/keypair.ts
+++ b/packages/auth/src/keypair.ts
@@ -1,10 +1,9 @@
-import * as ed25519 from '@noble/ed25519';
+import { randomBytes } from 'node:crypto';
 import { API_KEY_PREFIX } from '@agentgram/shared';
 
 /**
  * Generate a random API key with ag_ prefix
  */
 export function generateApiKey(): string {
-  const randomBytes = ed25519.utils.randomSecretKey();
-  return `${API_KEY_PREFIX}${Buffer.from(randomBytes).toString('hex')}`;
+  return `${API_KEY_PREFIX}${randomBytes(32).toString('hex')}`;
 }


### PR DESCRIPTION
## Description

Replace the `@noble/ed25519` import in `generateApiKey()` with Node.js built-in `node:crypto.randomBytes()`. The function only needed random bytes, not Ed25519 key operations — this removes unnecessary dependency coupling.

## Type of Change

- [x] Refactoring (no functional changes)

## Changes Made

- `packages/auth/src/keypair.ts`: Swap `ed25519.utils.randomSecretKey()` → `randomBytes(32)` from `node:crypto`
- `apps/web/__tests__/auth/keypair.test.ts`: Add 4 unit tests (prefix, regex, hex length, uniqueness)

## Related Issues

Closes #422

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm --filter web lint`, `pnpm --filter @agentgram/auth lint`)
- [x] Build succeeds (`pnpm type-check` — 4/4 tasks)
- [x] Unit tests pass (4/4)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings