### PR TITLE
fix(shared): remove redundant regex scan in validateUrl

### DIFF
--- a/apps/web/__tests__/shared/sanitize.test.ts
+++ b/apps/web/__tests__/shared/sanitize.test.ts
@@ -24,8 +24,31 @@ describe('validateUrl', () => {
     expect(validateUrl('data:text/html,<h1>hi</h1>')).toBe(false);
   });
 
+  it('rejects vbscript: protocol', () => {
+    expect(validateUrl('vbscript:MsgBox("hi")')).toBe(false);
+  });
+
+  it('rejects file: protocol', () => {
+    expect(validateUrl('file:///etc/passwd')).toBe(false);
+  });
+
   it('rejects invalid URLs', () => {
     expect(validateUrl('not-a-url')).toBe(false);
+  });
+
+  it('accepts safe URLs with dangerous-looking words in query params', () => {
+    expect(validateUrl('https://example.com/?next=javascript:alert(1)')).toBe(true);
+    expect(validateUrl('https://example.com/?redirect=data:text/html')).toBe(true);
+  });
+
+  it('accepts safe URLs with dangerous-looking words in path', () => {
+    expect(validateUrl('https://example.com/docs/data:overview')).toBe(true);
+    expect(validateUrl('https://example.com/file:specs/draft')).toBe(true);
+  });
+
+  it('accepts safe URLs with dangerous-looking words in hash', () => {
+    expect(validateUrl('https://example.com/#vbscript:demo')).toBe(true);
+    expect(validateUrl('https://example.com/#javascript:intro')).toBe(true);
   });
 });
 

--- a/packages/shared/src/sanitize.ts
+++ b/packages/shared/src/sanitize.ts
@@ -5,19 +5,16 @@
 import { CONTENT_LIMITS } from './constants';
 
 const ALLOWED_PROTOCOLS = ['http:', 'https:'];
-const DANGEROUS_PATTERNS = [/javascript:/i, /data:/i, /vbscript:/i, /file:/i];
 
 export function validateUrl(urlString: string): boolean {
   try {
     const url = new URL(urlString);
 
-    // Check protocol
+    // Protocol allowlist is sufficient — dangerous schemes (javascript:,
+    // data:, vbscript:, file:) are blocked here. No need to regex-scan
+    // the full URL string, which would false-negative on safe URLs
+    // containing those words in query/hash/path segments.
     if (!ALLOWED_PROTOCOLS.includes(url.protocol)) {
-      return false;
-    }
-
-    // Check for dangerous patterns
-    if (DANGEROUS_PATTERNS.some((pattern) => pattern.test(urlString))) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- Remove `DANGEROUS_PATTERNS` full-string regex scan from `validateUrl` — it rejected safe `https://` URLs containing words like `javascript`, `data`, `vbscript`, or `file` in query params, paths, or fragments
- The protocol allowlist (`http:`/`https:` only) already blocks all dangerous schemes, making the regex redundant
- Add test cases covering safe URLs with these substrings

## Test plan
- [x] New tests in `sanitize.test.ts` for URLs with `javascript`/`data`/`vbscript`/`file` in query/path/hash
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)