### PR TITLE
fix: replace @noble/ed25519 with node:crypto in keypair generation

### DIFF
--- a/apps/web/__tests__/auth/keypair.test.ts
+++ b/apps/web/__tests__/auth/keypair.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { generateApiKey } from '@agentgram/auth/src/keypair';
+import { API_KEY_PREFIX, API_KEY_REGEX } from '@agentgram/shared/src/constants';
+
+describe('generateApiKey', () => {
+  it('returns a string starting with the API key prefix', () => {
+    const key = generateApiKey();
+    expect(key.startsWith(API_KEY_PREFIX)).toBe(true);
+  });
+
+  it('matches the API key regex pattern', () => {
+    const key = generateApiKey();
+    expect(API_KEY_REGEX.test(key)).toBe(true);
+  });
+
+  it('generates a key with ag_ prefix and 64 hex characters', () => {
+    const key = generateApiKey();
+    expect(key).toMatch(/^ag_[a-f0-9]{64}$/);
+  });
+
+  it('generates unique keys on each call', () => {
+    const keys = new Set(Array.from({ length: 50 }, () => generateApiKey()));
+    expect(keys.size).toBe(50);
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -7,7 +7,6 @@ const nextConfig: NextConfig = {
     ignoreBuildErrors: false,
   },
   transpilePackages: ['@agentgram/auth', '@agentgram/db', '@agentgram/shared'],
-  serverExternalPackages: ['@noble/ed25519'],
 
   // Turbopack configuration (stable in Next.js 16)
   // Note: Turbopack is now the default bundler, no additional config needed

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@agentgram/shared": "workspace:*",
-    "@noble/ed25519": "^3.1.0",
+
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
     "bcryptjs": "^3.0.3"

--- a/packages/auth/src/keypair.ts
+++ b/packages/auth/src/keypair.ts
@@ -1,10 +1,9 @@
-import * as ed25519 from '@noble/ed25519';
+import { randomBytes } from 'node:crypto';
 import { API_KEY_PREFIX } from '@agentgram/shared';
 
 /**
  * Generate a random API key with ag_ prefix
  */
 export function generateApiKey(): string {
-  const randomBytes = ed25519.utils.randomSecretKey();
-  return `${API_KEY_PREFIX}${Buffer.from(randomBytes).toString('hex')}`;
+  return `${API_KEY_PREFIX}${randomBytes(32).toString('hex')}`;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,9 +169,6 @@ importers:
       '@agentgram/shared':
         specifier: workspace:*
         version: link:../shared
-      '@noble/ed25519':
-        specifier: ^3.1.0
-        version: 3.1.0
       '@upstash/ratelimit':
         specifier: ^2.0.8
         version: 2.0.8(@upstash/redis@1.37.0)
@@ -1252,9 +1249,6 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@noble/ed25519@3.1.0':
-    resolution: {integrity: sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -5672,8 +5666,6 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.3':
     optional: true
-
-  '@noble/ed25519@3.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
Closes #422

## Summary
- Replace `@noble/ed25519` with Node.js built-in `crypto.randomBytes` in `packages/auth/src/keypair.ts`
- Remove `@noble/ed25519` from dependencies and lockfile
- Remove `serverExternalPackages` workaround from `next.config.ts`
- Add unit tests for `generateApiKey` (prefix, format, uniqueness)

## Verification
- `vitest run` — 4/4 tests pass
- `tsc --noEmit` — clean typecheck