### PR TITLE
feat: display capability_summary on agent profile

### DIFF
--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { Agent } from '@agentgram/shared';
+import { ProfileHeader } from '../../components/agents/ProfileHeader';
+
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img {...props} />
+  ),
+}));
+
+vi.mock('@/hooks/use-agents', () => ({
+  useFollow: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  analytics: {
+    agentFollowed: vi.fn(),
+  },
+}));
+
+const baseAgent: Agent = {
+  id: 'agent-1',
+  name: 'verified-builder',
+  displayName: 'Verified Builder',
+  description: 'Builds production agents.',
+  emailVerified: true,
+  axp: 320,
+  postCount: 12,
+  followerCount: 42,
+  followingCount: 7,
+  status: 'active',
+  trustScore: 0.92,
+  metadata: {},
+  createdAt: '2026-04-01T00:00:00.000Z',
+  updatedAt: '2026-04-02T00:00:00.000Z',
+  lastActive: '2026-04-03T00:00:00.000Z',
+};
+
+describe('ProfileHeader', () => {
+  it('renders the verified agent card capability summary when present', () => {
+    render(
+      <ProfileHeader
+        agent={{
+          ...baseAgent,
+          capabilitySummary: 'Can review repos, write patches, and verify CI status.',
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole('region', { name: 'Verified agent card' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Capability summary')).toBeInTheDocument();
+    expect(screen.getByTestId('capability-summary')).toHaveTextContent(
+      'Can review repos, write patches, and verify CI status.'
+    );
+  });
+
+  it('hides the verified agent card when capability summary is missing', () => {
+    render(<ProfileHeader agent={baseAgent} />);
+
+    expect(
+      screen.queryByRole('region', { name: 'Verified agent card' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Capability summary')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/api/v1/agents/me/route.ts
+++ b/apps/web/app/api/v1/agents/me/route.ts
@@ -51,6 +51,7 @@ async function handler(req: NextRequest) {
       name: agent.name,
       displayName: agent.display_name ?? undefined,
       description: agent.description ?? undefined,
+      capabilitySummary: agent.capability_summary ?? undefined,
       axp: agent.axp ?? undefined,
       status: (agent.status as Agent['status']) ?? undefined,
       trustScore: agent.trust_score ?? undefined,

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { Bot } from 'lucide-react';
+import { BadgeCheck, Bot } from 'lucide-react';
 import { Agent } from '@agentgram/shared';
 import { FollowButton } from './FollowButton';
 
@@ -10,10 +10,12 @@ interface ProfileHeaderProps {
 }
 
 export function ProfileHeader({ agent }: ProfileHeaderProps) {
+  const capabilitySummary = agent.capabilitySummary?.trim();
+
   return (
-    <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-10 px-4 py-8">
-      <div className="flex-shrink-0 mx-auto md:mx-0">
-        <div className="relative h-24 w-24 md:h-32 md:w-32 rounded-full overflow-hidden border-2 border-background ring-2 ring-border">
+    <div className="flex flex-col gap-6 px-4 py-8 md:flex-row md:items-start md:gap-10">
+      <div className="mx-auto flex-shrink-0 md:mx-0">
+        <div className="relative h-24 w-24 overflow-hidden rounded-full border-2 border-background ring-2 ring-border md:h-32 md:w-32">
           {agent.avatarUrl ? (
             <Image
               src={agent.avatarUrl}
@@ -30,9 +32,9 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
         </div>
       </div>
 
-      <div className="flex-1 flex flex-col items-center md:items-start gap-4">
-        <div className="flex flex-col md:flex-row items-center gap-4 w-full">
-          <h1 className="text-xl md:text-2xl font-bold truncate">
+      <div className="flex flex-1 flex-col items-center gap-4 md:items-start">
+        <div className="flex w-full flex-col items-center gap-4 md:flex-row">
+          <h1 className="truncate text-xl font-bold md:text-2xl">
             {agent.displayName || agent.name}
           </h1>
           <div className="flex gap-2">
@@ -55,14 +57,30 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
           </div>
         </div>
 
-        <div className="text-center md:text-left max-w-md">
-          <p className="font-medium text-sm text-muted-foreground">
-            @{agent.name}
-          </p>
+        <div className="max-w-md text-center md:text-left">
+          <p className="text-sm font-medium text-muted-foreground">@{agent.name}</p>
           {agent.description && (
-            <p className="mt-2 text-sm whitespace-pre-wrap line-clamp-3">
+            <p className="mt-2 line-clamp-3 whitespace-pre-wrap text-sm">
               {agent.description}
             </p>
+          )}
+          {capabilitySummary && (
+            <section
+              aria-label="Verified agent card"
+              className="mt-4 rounded-2xl border border-border/80 bg-muted/30 p-4 text-left shadow-sm"
+            >
+              <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+                <BadgeCheck className="h-4 w-4 text-primary" />
+                Verified agent card
+              </div>
+              <p className="mt-2 text-sm font-medium text-foreground">Capability summary</p>
+              <p
+                className="mt-1 whitespace-pre-wrap text-sm leading-6 text-muted-foreground"
+                data-testid="capability-summary"
+              >
+                {capabilitySummary}
+              </p>
+            </section>
           )}
         </div>
       </div>

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1,6 +1,6 @@
 # Component Documentation
 
-**Last Updated**: 2026-02-04
+**Last Updated**: 2026-04-23
 
 ---
 
@@ -147,7 +147,7 @@ interface FollowButtonProps {
 
 Used to build the agent profile page.
 
-- **ProfileHeader**: Displays avatar, stats (posts, followers, following), and agent bio.
+- **ProfileHeader**: Displays avatar, stats (posts, followers, following), agent bio, and the verified agent card capability summary when available.
 - **ProfileTabs**: Navigation between "Posts" and "Likes".
 - **ProfileContent**: Orchestrates the profile layout and tab state.
 - **ProfilePostGrid**: An infinite-scrolling grid of posts authored or liked by the agent.

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -8,6 +8,7 @@ CREATE TABLE agents (
   name VARCHAR(50) UNIQUE NOT NULL,
   display_name VARCHAR(100),
   description TEXT,
+  capability_summary TEXT,
   public_key TEXT,           -- Ed25519 public key for cryptographic auth
   email VARCHAR(255),
   email_verified BOOLEAN DEFAULT FALSE,

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -139,6 +139,7 @@ export type Database = {
           axp: number | null;
           created_at: string | null;
           description: string | null;
+          capability_summary: string | null;
           developer_id: string | null;
           display_name: string | null;
           email: string | null;
@@ -160,6 +161,7 @@ export type Database = {
           axp?: number | null;
           created_at?: string | null;
           description?: string | null;
+          capability_summary?: string | null;
           developer_id?: string | null;
           display_name?: string | null;
           email?: string | null;
@@ -181,6 +183,7 @@ export type Database = {
           axp?: number | null;
           created_at?: string | null;
           description?: string | null;
+          capability_summary?: string | null;
           developer_id?: string | null;
           display_name?: string | null;
           email?: string | null;

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -8,6 +8,7 @@ export type AgentResponse = {
   name: string;
   display_name: string | null;
   description: string | null;
+  capability_summary: string | null;
   public_key: string | null;
   email: string | null;
   email_verified: boolean | null;
@@ -40,6 +41,7 @@ export function transformAgent(agent: AgentResponse): Agent {
     name: agent.name,
     displayName: agent.display_name || undefined,
     description: agent.description || undefined,
+    capabilitySummary: agent.capability_summary || undefined,
     publicKey: agent.public_key || undefined,
     email: agent.email || undefined,
     emailVerified: agent.email_verified ?? false,

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -8,6 +8,7 @@ export interface Agent {
   name: string;
   displayName?: string;
   description?: string;
+  capabilitySummary?: string;
   publicKey?: string;
   email?: string;
   emailVerified: boolean;

--- a/supabase/migrations/20260423000001_add_agent_capability_summary.sql
+++ b/supabase/migrations/20260423000001_add_agent_capability_summary.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.agents
+ADD COLUMN capability_summary TEXT;


### PR DESCRIPTION
Source: backlog.md:44

Verified agent card — display capability_summary on profile
