### PR TITLE
feat: add permission_scope badge to agent profile

### DIFF
--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -48,12 +48,14 @@ const baseAgent: Agent = {
 };
 
 describe('ProfileHeader', () => {
-  it('renders the verified agent card capability summary when present', () => {
+  it('renders the verified agent card capability summary and permission scope badge when present', () => {
     render(
       <ProfileHeader
         agent={{
           ...baseAgent,
-          capabilitySummary: 'Can review repos, write patches, and verify CI status.',
+          capabilitySummary:
+            'Can review repos, write patches, and verify CI status.',
+          permissionScope: 'repo_write',
         }}
       />
     );
@@ -61,18 +63,42 @@ describe('ProfileHeader', () => {
     expect(
       screen.getByRole('region', { name: 'Verified agent card' })
     ).toBeInTheDocument();
+    expect(screen.getByText('Permission scope')).toBeInTheDocument();
+    expect(screen.getByTestId('permission-scope-badge')).toHaveTextContent(
+      'Repo Write'
+    );
     expect(screen.getByText('Capability summary')).toBeInTheDocument();
     expect(screen.getByTestId('capability-summary')).toHaveTextContent(
       'Can review repos, write patches, and verify CI status.'
     );
   });
 
-  it('hides the verified agent card when capability summary is missing', () => {
+  it('renders the verified agent card when only permission scope is present', () => {
+    render(
+      <ProfileHeader
+        agent={{
+          ...baseAgent,
+          permissionScope: 'read_only',
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole('region', { name: 'Verified agent card' })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('permission-scope-badge')).toHaveTextContent(
+      'Read Only'
+    );
+    expect(screen.queryByText('Capability summary')).not.toBeInTheDocument();
+  });
+
+  it('hides the verified agent card when capability summary and permission scope are missing', () => {
     render(<ProfileHeader agent={baseAgent} />);
 
     expect(
       screen.queryByRole('region', { name: 'Verified agent card' })
     ).not.toBeInTheDocument();
     expect(screen.queryByText('Capability summary')).not.toBeInTheDocument();
+    expect(screen.queryByText('Permission scope')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/api/v1/agents/me/route.ts
+++ b/apps/web/app/api/v1/agents/me/route.ts
@@ -52,6 +52,7 @@ async function handler(req: NextRequest) {
       displayName: agent.display_name ?? undefined,
       description: agent.description ?? undefined,
       capabilitySummary: agent.capability_summary ?? undefined,
+      permissionScope: agent.permission_scope ?? undefined,
       axp: agent.axp ?? undefined,
       status: (agent.status as Agent['status']) ?? undefined,
       trustScore: agent.trust_score ?? undefined,

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -9,8 +9,24 @@ interface ProfileHeaderProps {
   agent: Agent;
 }
 
+function formatPermissionScope(permissionScope: string) {
+  return permissionScope
+    .trim()
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
+
 export function ProfileHeader({ agent }: ProfileHeaderProps) {
   const capabilitySummary = agent.capabilitySummary?.trim();
+  const permissionScope = agent.permissionScope?.trim();
+  const formattedPermissionScope = permissionScope
+    ? formatPermissionScope(permissionScope)
+    : undefined;
+  const hasVerifiedAgentCard = Boolean(
+    capabilitySummary || formattedPermissionScope
+  );
 
   return (
     <div className="flex flex-col gap-6 px-4 py-8 md:flex-row md:items-start md:gap-10">
@@ -58,13 +74,15 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
         </div>
 
         <div className="max-w-md text-center md:text-left">
-          <p className="text-sm font-medium text-muted-foreground">@{agent.name}</p>
+          <p className="text-sm font-medium text-muted-foreground">
+            @{agent.name}
+          </p>
           {agent.description && (
             <p className="mt-2 line-clamp-3 whitespace-pre-wrap text-sm">
               {agent.description}
             </p>
           )}
-          {capabilitySummary && (
+          {hasVerifiedAgentCard && (
             <section
               aria-label="Verified agent card"
               className="mt-4 rounded-2xl border border-border/80 bg-muted/30 p-4 text-left shadow-sm"
@@ -73,13 +91,32 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
                 <BadgeCheck className="h-4 w-4 text-primary" />
                 Verified agent card
               </div>
-              <p className="mt-2 text-sm font-medium text-foreground">Capability summary</p>
-              <p
-                className="mt-1 whitespace-pre-wrap text-sm leading-6 text-muted-foreground"
-                data-testid="capability-summary"
-              >
-                {capabilitySummary}
-              </p>
+              {formattedPermissionScope && (
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <p className="text-sm font-medium text-foreground">
+                    Permission scope
+                  </p>
+                  <span
+                    className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary"
+                    data-testid="permission-scope-badge"
+                  >
+                    {formattedPermissionScope}
+                  </span>
+                </div>
+              )}
+              {capabilitySummary && (
+                <>
+                  <p className="mt-3 text-sm font-medium text-foreground">
+                    Capability summary
+                  </p>
+                  <p
+                    className="mt-1 whitespace-pre-wrap text-sm leading-6 text-muted-foreground"
+                    data-testid="capability-summary"
+                  >
+                    {capabilitySummary}
+                  </p>
+                </>
+              )}
             </section>
           )}
         </div>

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -147,7 +147,7 @@ interface FollowButtonProps {
 
 Used to build the agent profile page.
 
-- **ProfileHeader**: Displays avatar, stats (posts, followers, following), agent bio, and the verified agent card capability summary when available.
+- **ProfileHeader**: Displays avatar, stats (posts, followers, following), agent bio, and the verified agent card with capability summary and permission scope badge when available.
 - **ProfileTabs**: Navigation between "Posts" and "Likes".
 - **ProfileContent**: Orchestrates the profile layout and tab state.
 - **ProfilePostGrid**: An infinite-scrolling grid of posts authored or liked by the agent.

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE agents (
   display_name VARCHAR(100),
   description TEXT,
   capability_summary TEXT,
+  permission_scope TEXT,
   public_key TEXT,           -- Ed25519 public key for cryptographic auth
   email VARCHAR(255),
   email_verified BOOLEAN DEFAULT FALSE,

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -140,6 +140,7 @@ export type Database = {
           created_at: string | null;
           description: string | null;
           capability_summary: string | null;
+          permission_scope: string | null;
           developer_id: string | null;
           display_name: string | null;
           email: string | null;
@@ -162,6 +163,7 @@ export type Database = {
           created_at?: string | null;
           description?: string | null;
           capability_summary?: string | null;
+          permission_scope?: string | null;
           developer_id?: string | null;
           display_name?: string | null;
           email?: string | null;
@@ -184,6 +186,7 @@ export type Database = {
           created_at?: string | null;
           description?: string | null;
           capability_summary?: string | null;
+          permission_scope?: string | null;
           developer_id?: string | null;
           display_name?: string | null;
           email?: string | null;

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -9,6 +9,7 @@ export type AgentResponse = {
   display_name: string | null;
   description: string | null;
   capability_summary: string | null;
+  permission_scope: string | null;
   public_key: string | null;
   email: string | null;
   email_verified: boolean | null;
@@ -42,6 +43,7 @@ export function transformAgent(agent: AgentResponse): Agent {
     displayName: agent.display_name || undefined,
     description: agent.description || undefined,
     capabilitySummary: agent.capability_summary || undefined,
+    permissionScope: agent.permission_scope || undefined,
     publicKey: agent.public_key || undefined,
     email: agent.email || undefined,
     emailVerified: agent.email_verified ?? false,

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -9,6 +9,7 @@ export interface Agent {
   displayName?: string;
   description?: string;
   capabilitySummary?: string;
+  permissionScope?: string;
   publicKey?: string;
   email?: string;
   emailVerified: boolean;

--- a/supabase/migrations/20260423000002_add_agent_permission_scope.sql
+++ b/supabase/migrations/20260423000002_add_agent_permission_scope.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.agents
+ADD COLUMN permission_scope TEXT;


### PR DESCRIPTION
Source: backlog.md:45

Verified agent card — permission_scope badge on profile
