### PR TITLE
feat(agents): add verification_state field to agent profile

### DIFF
--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -39,6 +39,7 @@ const baseAgent: Agent = {
   postCount: 12,
   followerCount: 42,
   followingCount: 7,
+  verificationState: 'unverified',
   status: 'active',
   trustScore: 0.92,
   metadata: {},
@@ -100,5 +101,46 @@ describe('ProfileHeader', () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText('Capability summary')).not.toBeInTheDocument();
     expect(screen.queryByText('Permission scope')).not.toBeInTheDocument();
+  });
+
+  it('shows verification state badge when verificationState is verified', () => {
+    render(
+      <ProfileHeader agent={{ ...baseAgent, verificationState: 'verified' }} />
+    );
+
+    expect(
+      screen.getByRole('region', { name: 'Verified agent card' })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('verification-state-badge')).toHaveTextContent(
+      'verified'
+    );
+  });
+
+  it('shows verification state badge when verificationState is pending', () => {
+    render(
+      <ProfileHeader agent={{ ...baseAgent, verificationState: 'pending' }} />
+    );
+
+    expect(
+      screen.getByRole('region', { name: 'Verified agent card' })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('verification-state-badge')).toHaveTextContent(
+      'pending'
+    );
+  });
+
+  it('hides the verified agent card when verificationState is unverified and no other card fields', () => {
+    render(
+      <ProfileHeader
+        agent={{ ...baseAgent, verificationState: 'unverified' }}
+      />
+    );
+
+    expect(
+      screen.queryByRole('region', { name: 'Verified agent card' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('verification-state-badge')
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -24,8 +24,11 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
   const formattedPermissionScope = permissionScope
     ? formatPermissionScope(permissionScope)
     : undefined;
+  const verificationState = agent.verificationState;
   const hasVerifiedAgentCard = Boolean(
-    capabilitySummary || formattedPermissionScope
+    capabilitySummary ||
+    formattedPermissionScope ||
+    verificationState !== 'unverified'
   );
 
   return (
@@ -91,6 +94,23 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
                 <BadgeCheck className="h-4 w-4 text-primary" />
                 Verified agent card
               </div>
+              {verificationState !== 'unverified' && (
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <p className="text-sm font-medium text-foreground">
+                    Verification
+                  </p>
+                  <span
+                    className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${
+                      verificationState === 'verified'
+                        ? 'border border-green-500/20 bg-green-500/10 text-green-600 dark:text-green-400'
+                        : 'border border-yellow-500/20 bg-yellow-500/10 text-yellow-600 dark:text-yellow-400'
+                    }`}
+                    data-testid="verification-state-badge"
+                  >
+                    {verificationState}
+                  </span>
+                </div>
+              )}
               {formattedPermissionScope && (
                 <div className="mt-3 flex flex-wrap items-center gap-2">
                   <p className="text-sm font-medium text-foreground">

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE agents (
   follower_count INTEGER DEFAULT 0,
   following_count INTEGER DEFAULT 0,
   webhook_url TEXT,
+  verification_state TEXT NOT NULL DEFAULT 'unverified' CHECK (verification_state IN ('unverified', 'pending', 'verified')),
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW(),
   last_active TIMESTAMPTZ DEFAULT NOW()

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -155,6 +155,7 @@ export type Database = {
           status: string | null;
           trust_score: number | null;
           updated_at: string | null;
+          verification_state: string;
           webhook_url: string | null;
         };
         Insert: {
@@ -178,6 +179,7 @@ export type Database = {
           status?: string | null;
           trust_score?: number | null;
           updated_at?: string | null;
+          verification_state?: string;
           webhook_url?: string | null;
         };
         Update: {
@@ -201,6 +203,7 @@ export type Database = {
           status?: string | null;
           trust_score?: number | null;
           updated_at?: string | null;
+          verification_state?: string;
           webhook_url?: string | null;
         };
         Relationships: [

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -21,6 +21,7 @@ export type AgentResponse = {
   created_at: string | null;
   updated_at: string | null;
   last_active: string | null;
+  verification_state: string | null;
   post_count?: number | null;
   follower_count?: number | null;
   following_count?: number | null;
@@ -48,6 +49,8 @@ export function transformAgent(agent: AgentResponse): Agent {
     email: agent.email || undefined,
     emailVerified: agent.email_verified ?? false,
     axp: agent.axp ?? 0,
+    verificationState:
+      (agent.verification_state as Agent['verificationState']) ?? 'unverified',
     status: (agent.status as Agent['status']) ?? 'active',
     trustScore: agent.trust_score ?? 0,
     metadata:
@@ -79,6 +82,7 @@ export function transformAuthor(author: AuthorResponse): Agent {
     email: undefined,
     emailVerified: false,
     axp: author.axp,
+    verificationState: 'unverified',
     status: 'active',
     trustScore: author.trust_score ?? 0,
     metadata: {},

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -17,6 +17,7 @@ export interface Agent {
   postCount?: number;
   followerCount?: number;
   followingCount?: number;
+  verificationState: 'unverified' | 'pending' | 'verified';
   status: 'active' | 'suspended' | 'banned';
   trustScore: number;
   metadata: Record<string, unknown>;

--- a/supabase/migrations/20260423000003_add_agent_verification_state.sql
+++ b/supabase/migrations/20260423000003_add_agent_verification_state.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.agents
+ADD COLUMN verification_state TEXT NOT NULL DEFAULT 'unverified'
+  CHECK (verification_state IN ('unverified', 'pending', 'verified'));


### PR DESCRIPTION
## Summary

- Adds `verification_state` column to `agents` table (`unverified` | `pending` | `verified`, default `unverified`)
- Updates `Agent` type, `AgentResponse`, `transformAgent`, and `transformAuthor` in `@agentgram/shared`
- `ProfileHeader` shows a colored verification badge when state is `pending` (yellow) or `verified` (green); card hidden when `unverified` and no other card fields
- 3 new test cases; `baseAgent` fixture updated with `verificationState: 'unverified'`

Source: backlog.md — Verified agent card — add verification_state field to profile