### PR TITLE
feat: add agent memory visibility endpoints

### DIFF
--- a/apps/web/app/api/v1/agents/me/memories/[id]/route.ts
+++ b/apps/web/app/api/v1/agents/me/memories/[id]/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { withAuth } from '@agentgram/auth';
+import {
+  ErrorResponses,
+  jsonResponse,
+  createSuccessResponse,
+} from '@agentgram/shared';
+
+const VALUE_MAX = 2048;
+
+async function patchHandler(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const agentId = req.headers.get('x-agent-id');
+    if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
+
+    const { id } = await params;
+    const body = (await req.json()) as { value?: string; isPublic?: boolean };
+
+    let value: string | undefined;
+    if (body.value !== undefined) {
+      value = body.value.trim();
+      if (value.length === 0 || value.length > VALUE_MAX) {
+        return jsonResponse(
+          ErrorResponses.invalidInput(`value must be 1–${VALUE_MAX} chars`),
+          400
+        );
+      }
+    }
+
+    const supabase = getSupabaseServiceClient();
+    const { data, error } = await supabase
+      .from('agent_memories')
+      .update({
+        ...(value !== undefined && { value }),
+        ...(body.isPublic !== undefined && { is_public: body.isPublic }),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .eq('agent_id', agentId)
+      .select('*')
+      .single();
+
+    if (error || !data) {
+      return jsonResponse(ErrorResponses.notFound('Memory'), 404);
+    }
+
+    return jsonResponse(createSuccessResponse(data));
+  } catch (error) {
+    console.error('Update memory error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+async function deleteHandler(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const agentId = req.headers.get('x-agent-id');
+    if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
+
+    const { id } = await params;
+    const supabase = getSupabaseServiceClient();
+    const { error } = await supabase
+      .from('agent_memories')
+      .delete()
+      .eq('id', id)
+      .eq('agent_id', agentId);
+
+    if (error) {
+      console.error('Delete memory error:', error);
+      return jsonResponse(ErrorResponses.databaseError(), 500);
+    }
+
+    return jsonResponse(createSuccessResponse(null), 204);
+  } catch (error) {
+    console.error('Delete memory error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+export const PATCH = withAuth(patchHandler);
+export const DELETE = withAuth(deleteHandler);

--- a/apps/web/app/api/v1/agents/me/memories/route.ts
+++ b/apps/web/app/api/v1/agents/me/memories/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { withAuth } from '@agentgram/auth';
+import {
+  ErrorResponses,
+  jsonResponse,
+  createSuccessResponse,
+} from '@agentgram/shared';
+
+const KEY_MAX = 128;
+const VALUE_MAX = 2048;
+
+async function getHandler(req: NextRequest) {
+  try {
+    const agentId = req.headers.get('x-agent-id');
+    if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
+
+    const supabase = getSupabaseServiceClient();
+    const { data, error } = await supabase
+      .from('agent_memories')
+      .select('*')
+      .eq('agent_id', agentId)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Fetch memories error:', error);
+      return jsonResponse(ErrorResponses.databaseError(), 500);
+    }
+
+    return jsonResponse(createSuccessResponse(data));
+  } catch (error) {
+    console.error('Get memories error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+async function createHandler(req: NextRequest) {
+  try {
+    const agentId = req.headers.get('x-agent-id');
+    if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
+
+    const body = (await req.json()) as {
+      key?: string;
+      value?: string;
+      isPublic?: boolean;
+    };
+    const key = body.key?.trim();
+    const value = body.value?.trim();
+
+    if (!key || key.length === 0 || key.length > KEY_MAX) {
+      return jsonResponse(
+        ErrorResponses.invalidInput(`key must be 1–${KEY_MAX} chars`),
+        400
+      );
+    }
+    if (!value || value.length === 0 || value.length > VALUE_MAX) {
+      return jsonResponse(
+        ErrorResponses.invalidInput(`value must be 1–${VALUE_MAX} chars`),
+        400
+      );
+    }
+
+    const supabase = getSupabaseServiceClient();
+    const { data, error } = await supabase
+      .from('agent_memories')
+      .insert({
+        agent_id: agentId,
+        key,
+        value,
+        is_public: body.isPublic ?? false,
+      })
+      .select('*')
+      .single();
+
+    if (error) {
+      if (error.code === '23505') {
+        return jsonResponse(
+          ErrorResponses.invalidInput('Memory key already exists'),
+          409
+        );
+      }
+      console.error('Create memory error:', error);
+      return jsonResponse(ErrorResponses.databaseError(), 500);
+    }
+
+    return jsonResponse(createSuccessResponse(data), 201);
+  } catch (error) {
+    console.error('Create memory error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+export const GET = withAuth(getHandler);
+export const POST = withAuth(createHandler);

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -80,6 +80,44 @@ export type Database = {
           },
         ];
       };
+      agent_memories: {
+        Row: {
+          agent_id: string;
+          created_at: string;
+          id: string;
+          is_public: boolean;
+          key: string;
+          updated_at: string;
+          value: string;
+        };
+        Insert: {
+          agent_id: string;
+          created_at?: string;
+          id?: string;
+          is_public?: boolean;
+          key: string;
+          updated_at?: string;
+          value: string;
+        };
+        Update: {
+          agent_id?: string;
+          created_at?: string;
+          id?: string;
+          is_public?: boolean;
+          key?: string;
+          updated_at?: string;
+          value?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'agent_memories_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       agent_personas: {
         Row: {
           agent_id: string;

--- a/supabase/migrations/20260423000004_agent_memory_controls.sql
+++ b/supabase/migrations/20260423000004_agent_memory_controls.sql
@@ -1,0 +1,15 @@
+CREATE TABLE public.agent_memories (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES public.agents(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  value TEXT NOT NULL,
+  is_public BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(agent_id, key)
+);
+
+ALTER TABLE public.agent_memories ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "agents_own_memories" ON public.agent_memories
+  FOR ALL USING (agent_id = auth.uid());


### PR DESCRIPTION
Source: backlog.md:47

## What changed
- added authenticated CRUD endpoints for `/api/v1/agents/me/memories`
- added the `agent_memories` Supabase migration with ownership controls
- updated generated DB types so the new table type-checks cleanly

## Why
- distinguishes private vs public agent memory at the API and schema layer
- unblocks the new memory routes from failing TypeScript validation

## Validation
- `pnpm --filter web test`
- `pnpm --filter web exec tsc --noEmit --incremental false`