### PR TITLE
feat: add operator tier card to verified profiles

### DIFF
--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -10,6 +10,21 @@ vi.mock('next/image', () => ({
   ),
 }));
 
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
 vi.mock('@/hooks/use-agents', () => ({
   useFollow: () => ({
     isPending: false,
@@ -116,6 +131,40 @@ describe('ProfileHeader', () => {
     );
   });
 
+  it('shows operator tier badge and pricing link for verified paid operators', () => {
+    render(
+      <ProfileHeader
+        agent={{
+          ...baseAgent,
+          verificationState: 'verified',
+          operatorTier: 'pro',
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('operator-tier-surface')).toBeInTheDocument();
+    expect(screen.getByTestId('operator-tier-badge')).toHaveTextContent('Pro');
+    expect(screen.getByTestId('operator-tier-link')).toHaveAttribute(
+      'href',
+      '/pricing'
+    );
+    expect(screen.getByTestId('operator-tier-link')).toHaveTextContent(
+      'Compare Operator tiers'
+    );
+  });
+
+  it('shows operator tier upgrade CTA for verified profiles without a paid tier', () => {
+    render(
+      <ProfileHeader agent={{ ...baseAgent, verificationState: 'verified' }} />
+    );
+
+    expect(screen.getByTestId('operator-tier-surface')).toBeInTheDocument();
+    expect(screen.queryByTestId('operator-tier-badge')).not.toBeInTheDocument();
+    expect(screen.getByTestId('operator-tier-link')).toHaveTextContent(
+      'See Operator tiers'
+    );
+  });
+
   it('shows verification state badge when verificationState is pending', () => {
     render(
       <ProfileHeader agent={{ ...baseAgent, verificationState: 'pending' }} />
@@ -127,6 +176,22 @@ describe('ProfileHeader', () => {
     expect(screen.getByTestId('verification-state-badge')).toHaveTextContent(
       'pending'
     );
+  });
+
+  it('hides operator tier surface when profile is not verified', () => {
+    render(
+      <ProfileHeader
+        agent={{
+          ...baseAgent,
+          verificationState: 'pending',
+          operatorTier: 'starter',
+        }}
+      />
+    );
+
+    expect(
+      screen.queryByTestId('operator-tier-surface')
+    ).not.toBeInTheDocument();
   });
 
   it('hides the verified agent card when verificationState is unverified and no other card fields', () => {

--- a/apps/web/app/(public)/agents/[name]/page.tsx
+++ b/apps/web/app/(public)/agents/[name]/page.tsx
@@ -2,14 +2,29 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getSupabaseServiceClient } from '@agentgram/db';
 import { ProfileContent } from '@/components/agents/ProfileContent';
-import {
-  transformAgent,
-  transformPersona,
-} from '@agentgram/shared';
+import { transformAgent, transformPersona } from '@agentgram/shared';
 import type { Agent, PersonaResponse } from '@agentgram/shared';
 
 interface PageProps {
   params: Promise<{ name: string }>;
+}
+
+function resolveOperatorTier(
+  plan: string | null | undefined,
+  subscriptionStatus: string | null | undefined
+): Agent['operatorTier'] | undefined {
+  if (!plan || !['starter', 'pro', 'enterprise'].includes(plan)) {
+    return undefined;
+  }
+
+  if (
+    subscriptionStatus &&
+    !['active', 'on_trial', 'trialing'].includes(subscriptionStatus)
+  ) {
+    return undefined;
+  }
+
+  return plan as Agent['operatorTier'];
 }
 
 async function getAgent(name: string): Promise<Agent | null> {
@@ -43,6 +58,19 @@ async function getAgent(name: string): Promise<Agent | null> {
 
   if (personaData) {
     agent.activePersona = transformPersona(personaData as PersonaResponse);
+  }
+
+  if (data.developer_id) {
+    const { data: developerData } = await supabase
+      .from('developers')
+      .select('plan, subscription_status')
+      .eq('id', data.developer_id)
+      .single();
+
+    agent.operatorTier = resolveOperatorTier(
+      developerData?.plan,
+      developerData?.subscription_status
+    );
   }
 
   return agent;

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Image from 'next/image';
-import { BadgeCheck, Bot } from 'lucide-react';
+import Link from 'next/link';
+import { ArrowUpRight, BadgeCheck, Bot } from 'lucide-react';
 import { Agent } from '@agentgram/shared';
 import { FollowButton } from './FollowButton';
 
@@ -9,13 +10,21 @@ interface ProfileHeaderProps {
   agent: Agent;
 }
 
-function formatPermissionScope(permissionScope: string) {
-  return permissionScope
+function formatTokenLabel(value: string) {
+  return value
     .trim()
     .split(/[_\s-]+/)
     .filter(Boolean)
     .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
     .join(' ');
+}
+
+function formatPermissionScope(permissionScope: string) {
+  return formatTokenLabel(permissionScope);
+}
+
+function formatOperatorTier(operatorTier: Agent['operatorTier']) {
+  return operatorTier ? formatTokenLabel(operatorTier) : undefined;
 }
 
 export function ProfileHeader({ agent }: ProfileHeaderProps) {
@@ -25,6 +34,12 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
     ? formatPermissionScope(permissionScope)
     : undefined;
   const verificationState = agent.verificationState;
+  const formattedOperatorTier =
+    verificationState === 'verified' &&
+    agent.operatorTier &&
+    agent.operatorTier !== 'free'
+      ? formatOperatorTier(agent.operatorTier)
+      : undefined;
   const hasVerifiedAgentCard = Boolean(
     capabilitySummary ||
     formattedPermissionScope ||
@@ -109,6 +124,43 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
                   >
                     {verificationState}
                   </span>
+                </div>
+              )}
+              {verificationState === 'verified' && (
+                <div
+                  className="mt-3 rounded-xl border border-primary/15 bg-primary/5 p-3"
+                  data-testid="operator-tier-surface"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">
+                        Operator tier
+                      </p>
+                      <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                        {formattedOperatorTier
+                          ? `${formattedOperatorTier} trust surface enabled for this verified operator profile.`
+                          : 'Verified operators can add a paid trust layer for monetization-ready profiles.'}
+                      </p>
+                    </div>
+                    {formattedOperatorTier && (
+                      <span
+                        className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary"
+                        data-testid="operator-tier-badge"
+                      >
+                        {formattedOperatorTier}
+                      </span>
+                    )}
+                  </div>
+                  <Link
+                    href="/pricing"
+                    className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary transition hover:text-primary/80"
+                    data-testid="operator-tier-link"
+                  >
+                    {formattedOperatorTier
+                      ? 'Compare Operator tiers'
+                      : 'See Operator tiers'}
+                    <ArrowUpRight className="h-3.5 w-3.5" />
+                  </Link>
                 </div>
               )}
               {formattedPermissionScope && (

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1,4 +1,5 @@
 import type { Persona } from './persona';
+import type { PlanType } from './billing';
 
 /**
  * Agent type definition
@@ -10,6 +11,7 @@ export interface Agent {
   description?: string;
   capabilitySummary?: string;
   permissionScope?: string;
+  operatorTier?: PlanType;
   publicKey?: string;
   email?: string;
   emailVerified: boolean;


### PR DESCRIPTION
Source: backlog.md:74

Add an Operator tier surface to verified agent profiles, wire paid plan data into the public profile loader, and cover the new pricing CTA/badge behavior with tests.