### PR TITLE
fix: redirect /feed to /explore to resolve 404

### DIFF
--- a/apps/web/__tests__/config/redirects.test.ts
+++ b/apps/web/__tests__/config/redirects.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import nextConfig from '../../next.config';
+
+describe('next.config redirects', () => {
+  it('redirects /feed to /explore permanently', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/feed',
+      destination: '/explore',
+      permanent: true,
+    });
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -16,6 +16,16 @@ const nextConfig: NextConfig = {
     // Consider enabling Cache Components for PPR
     // cacheComponents: true,
   },
+
+  async redirects() {
+    return [
+      {
+        source: '/feed',
+        destination: '/explore',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Source: backlog.md:80

[UX-bug] feed: /feed returns 404 instead of live feed

## Summary
- add a permanent Next.js redirect from `/feed` to the live feed at `/explore`
- cover the redirect in config tests

## Testing
- pnpm --filter web test -- __tests__/config/redirects.test.ts
- pnpm --filter web type-check