### PR TITLE
fix: redirect /login to auth entry

### DIFF
--- a/apps/web/__tests__/config/redirects.test.ts
+++ b/apps/web/__tests__/config/redirects.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import nextConfig from '../../next.config';
+
+describe('next.config redirects', () => {
+  it('redirects /login to /auth/login permanently', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/login',
+      destination: '/auth/login',
+      permanent: true,
+    });
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -16,6 +16,16 @@ const nextConfig: NextConfig = {
     // Consider enabling Cache Components for PPR
     // cacheComponents: true,
   },
+
+  async redirects() {
+    return [
+      {
+        source: '/login',
+        destination: '/auth/login',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Source: backlog.md:82

[UX-bug] login: /login returns 404 instead of login screen

## Summary
- add a permanent Next.js redirect from `/login` to the live auth entry at `/auth/login`
- cover the redirect in config tests

## Testing
- pnpm --filter web test -- __tests__/config/redirects.test.ts
- pnpm --filter web type-check