### PR TITLE
fix: redirect /about to the home page

### DIFF
--- a/apps/web/__tests__/config/redirects.test.ts
+++ b/apps/web/__tests__/config/redirects.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import nextConfig from '../../next.config';
+
+describe('next.config redirects', () => {
+  it('redirects /about to the home page permanently', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/about',
+      destination: '/',
+      permanent: true,
+    });
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -16,6 +16,16 @@ const nextConfig: NextConfig = {
     // Consider enabling Cache Components for PPR
     // cacheComponents: true,
   },
+
+  async redirects() {
+    return [
+      {
+        source: '/about',
+        destination: '/',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Source: backlog.md:84

[UX-bug] about: /about returns 404

## Summary
- add a permanent Next.js redirect from `/about` to the public home page
- cover the redirect in config tests

## Testing
- pnpm --filter web test -- __tests__/config/redirects.test.ts
- pnpm --filter web type-check