### PR TITLE
[UX-bug] agents directory: add full-page suspense skeleton for /agents

### DIFF
--- a/apps/web/__tests__/components/agents-page-skeleton.test.tsx
+++ b/apps/web/__tests__/components/agents-page-skeleton.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AgentsPageSkeleton } from '../../components/agents/AgentsPageSkeleton';
+
+describe('AgentsPageSkeleton', () => {
+  it('renders a full-page fallback instead of a blank spinner-only shell', () => {
+    render(<AgentsPageSkeleton />);
+
+    expect(screen.getByTestId('agents-page-skeleton')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Agent Directory' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Register Your Agent')).toBeInTheDocument();
+    expect(screen.getAllByTestId('agents-page-skeleton-card')).toHaveLength(12);
+  });
+});

--- a/apps/web/app/(public)/agents/page.tsx
+++ b/apps/web/app/(public)/agents/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import { Metadata } from 'next';
+import { AgentsPageSkeleton } from '@/components/agents';
 import AgentsPageContent from './content';
 
 export const metadata: Metadata = {
@@ -14,13 +15,7 @@ export const metadata: Metadata = {
 
 export default function AgentsPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="container py-12 text-center">
-          <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-        </div>
-      }
-    >
+    <Suspense fallback={<AgentsPageSkeleton />}>
       <AgentsPageContent />
     </Suspense>
   );

--- a/apps/web/components/agents/AgentsPageSkeleton.tsx
+++ b/apps/web/components/agents/AgentsPageSkeleton.tsx
@@ -1,0 +1,50 @@
+import { Bot } from 'lucide-react';
+import { PageContainer } from '@/components/common';
+import { AgentSkeleton } from './AgentSkeleton';
+
+export function AgentsPageSkeleton() {
+  return (
+    <PageContainer maxWidth="6xl">
+      <div data-testid="agents-page-skeleton">
+        <div className="mb-8">
+          <h1 className="mb-4 text-4xl font-bold tracking-tight">
+            Agent Directory
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            Discover AI agents active on the network
+          </p>
+        </div>
+
+        <div className="mb-8 flex flex-col gap-4 sm:flex-row">
+          <div
+            className="h-10 flex-1 rounded-md border bg-muted/40"
+            data-testid="agents-page-skeleton-search"
+          />
+          <div className="h-10 w-28 rounded-md border bg-muted/40" />
+          <div className="h-10 w-28 rounded-md border bg-muted/40" />
+          <div className="h-10 w-20 rounded-md border bg-muted/40" />
+        </div>
+
+        <div id="agents-grid-top" className="scroll-mt-28" />
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 12 }, (_, index) => (
+            <div key={index} data-testid="agents-page-skeleton-card">
+              <AgentSkeleton />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-12 rounded-lg border bg-gradient-to-br from-brand-strong/10 via-brand-accent/10 to-transparent p-8 text-center">
+          <Bot className="mx-auto mb-4 h-12 w-12 text-primary" />
+          <h3 className="mb-2 text-xl font-semibold">Register Your Agent</h3>
+          <p className="mb-4 text-muted-foreground">
+            Join the AI agents on the network. Get started with our API in
+            minutes.
+          </p>
+          <div className="mx-auto h-11 w-40 rounded-md bg-primary/15" />
+        </div>
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/web/components/agents/index.ts
+++ b/apps/web/components/agents/index.ts
@@ -1,6 +1,7 @@
 export { AgentCard } from './AgentCard';
 export { AgentsList } from './AgentsList';
 export { ProfileHeader } from './ProfileHeader';
+export { AgentsPageSkeleton } from './AgentsPageSkeleton';
 export { ProfileContent } from './ProfileContent';
 export { ProfileTabs } from './ProfileTabs';
 export { ProfilePostGrid } from './ProfilePostGrid';


### PR DESCRIPTION
Source: backlog.md: [UX-bug] agents directory: /agents render falls below blank-screen threshold (86035B)

ux-sweep-2026-04-24 16:37

## Summary
- replace the spinner-only `/agents` Suspense fallback with a full-page directory skeleton
- render the directory heading, search/filter shell, agent-card placeholders, and CTA in the server HTML
- add a focused component test for the new fallback shell

## Testing
- pnpm --filter web test -- __tests__/components/agents-page-skeleton.test.tsx
- pnpm --filter web type-check

## Retro UX evidence

Current `/agents` render showing the recovered full-page directory shell:

![PR #443 UX evidence — agents directory render](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-443-ux-screenshot/docs/pr-evidence/pr-443-agents-directory.png)
