### PR TITLE
[UX-bug] redirect /agents/sample to the live agents directory

### DIFF
--- a/apps/web/__tests__/config/redirects.test.ts
+++ b/apps/web/__tests__/config/redirects.test.ts
@@ -12,4 +12,15 @@ describe('next.config redirects', () => {
       permanent: true,
     });
   });
+
+  it('redirects /agents/sample to /agents (non-permanent)', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/agents/sample',
+      destination: '/agents',
+      permanent: false,
+    });
+  });
 });

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -24,6 +24,11 @@ const nextConfig: NextConfig = {
         destination: '/explore',
         permanent: true,
       },
+      {
+        source: '/agents/sample',
+        destination: '/agents',
+        permanent: false,
+      },
     ];
   },
 };


### PR DESCRIPTION
Source: backlog.md: [UX-bug] sample agent profile: /agents/sample returns 404

ux-sweep-2026-04-24 16:37

## Summary
- add a non-permanent redirect from `/agents/sample` to `/agents`
- cover the redirect in the Next config redirect test suite

## Testing
- pnpm --filter web test -- __tests__/config/redirects.test.ts
- pnpm --filter web type-check

## Retro UX evidence

Live `/agents/sample` check now resolves to the agents directory surface (`/agents`) instead of 404:

![PR #444 UX evidence — agents sample redirect recovery](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-444-ux-screenshot/docs/pr-evidence/pr-444-agents-sample.png)
