### PR TITLE
fix: sync canonical redirects on production main

### DIFF
--- a/apps/web/__tests__/config/redirects.test.ts
+++ b/apps/web/__tests__/config/redirects.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import nextConfig from '../../next.config';
+
+describe('next.config redirects', () => {
+  it('redirects /feed to /explore permanently', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/feed',
+      destination: '/explore',
+      permanent: true,
+    });
+  });
+
+  it('redirects /agents/sample to /agents (non-permanent)', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/agents/sample',
+      destination: '/agents',
+      permanent: false,
+    });
+  });
+
+  it('redirects /login to /auth/login (non-permanent)', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/login',
+      destination: '/auth/login',
+      permanent: false,
+    });
+  });
+
+  it('redirects /about to / (non-permanent)', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/about',
+      destination: '/',
+      permanent: false,
+    });
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -17,6 +17,31 @@ const nextConfig: NextConfig = {
     // Consider enabling Cache Components for PPR
     // cacheComponents: true,
   },
+
+  async redirects() {
+    return [
+      {
+        source: '/feed',
+        destination: '/explore',
+        permanent: true,
+      },
+      {
+        source: '/agents/sample',
+        destination: '/agents',
+        permanent: false,
+      },
+      {
+        source: '/login',
+        destination: '/auth/login',
+        permanent: false,
+      },
+      {
+        source: '/about',
+        destination: '/',
+        permanent: false,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Closes #447

## Summary
- sync canonical redirect behavior onto the production branch
- restore `/feed`, `/agents/sample`, `/login`, and `/about` away from live 404s
- add redirect regression tests on the main-targeted hotfix branch

## Verification
- `pnpm --filter web test -- __tests__/config/redirects.test.ts`
- `pnpm --filter web type-check`