### PR TITLE
fix: restore login and about redirects

### DIFF
--- a/apps/web/__tests__/config/redirects.test.ts
+++ b/apps/web/__tests__/config/redirects.test.ts
@@ -23,4 +23,26 @@ describe('next.config redirects', () => {
       permanent: false,
     });
   });
+
+  it('redirects /login to /auth/login (non-permanent)', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/login',
+      destination: '/auth/login',
+      permanent: false,
+    });
+  });
+
+  it('redirects /about to / (non-permanent)', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/about',
+      destination: '/',
+      permanent: false,
+    });
+  });
 });

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -29,6 +29,16 @@ const nextConfig: NextConfig = {
         destination: '/agents',
         permanent: false,
       },
+      {
+        source: '/login',
+        destination: '/auth/login',
+        permanent: false,
+      },
+      {
+        source: '/about',
+        destination: '/',
+        permanent: false,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary
- restore legacy route redirects for `/login` and `/about` on the develop line
- keep redirect behavior aligned with the canonical routes already used by the app
- extend redirect tests to cover both routes

## Verification
- `cd apps/web && ./node_modules/.bin/vitest run __tests__/config/redirects.test.ts --reporter=verbose`
- `cd apps/web && ./node_modules/.bin/tsc --noEmit`

## Follow-up
- after this lands on `develop`, promote `develop` to `main` again so production picks up `/login` and `/about` recovery