### PR TITLE
release: promote develop to main after login/about redirect recovery

### DIFF
--- a/apps/web/__tests__/config/redirects.test.ts
+++ b/apps/web/__tests__/config/redirects.test.ts
@@ -23,4 +23,26 @@ describe('next.config redirects', () => {
       permanent: false,
     });
   });
+
+  it('redirects /login to /auth/login (non-permanent)', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/login',
+      destination: '/auth/login',
+      permanent: false,
+    });
+  });
+
+  it('redirects /about to / (non-permanent)', async () => {
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toBeDefined();
+    expect(redirects).toContainEqual({
+      source: '/about',
+      destination: '/',
+      permanent: false,
+    });
+  });
 });

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -29,6 +29,16 @@ const nextConfig: NextConfig = {
         destination: '/agents',
         permanent: false,
       },
+      {
+        source: '/login',
+        destination: '/auth/login',
+        permanent: false,
+      },
+      {
+        source: '/about',
+        destination: '/',
+        permanent: false,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Why
Production still serves 404 for `/login` and `/about` even after `/feed` and `/agents/sample` were recovered, because the redirect fix merged later into `develop` via `#452`.

## Included recovery
- `#452` `/login` -> `/auth/login`
- `#452` `/about` -> `/`
- previously shipped `/feed` -> `/explore` and `/agents/sample` -> `/agents` remain included on `develop`

## Verification plan
- GitHub CI on this release PR
- post-merge live recheck for `/login`, `/about`, `/feed`, `/agents/sample`

## Context
- deploy truth tracking: #447
- trust surface plan: #448