### PR TITLE
fix: restore production route integrity for legacy paths

### DIFF
--- a/apps/web/__tests__/app/legacy-routes.test.ts
+++ b/apps/web/__tests__/app/legacy-routes.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { redirectMock } = vi.hoisted(() => ({
+  redirectMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+import LegacyAboutPage from '../../app/about/page';
+import LegacySampleAgentPage from '../../app/agents/sample/page';
+import LegacyFeedPage from '../../app/feed/page';
+import LegacyLoginPage from '../../app/login/page';
+
+describe('legacy route pages', () => {
+  beforeEach(() => {
+    redirectMock.mockReset();
+  });
+
+  it('redirects /feed to /explore', () => {
+    LegacyFeedPage();
+
+    expect(redirectMock).toHaveBeenCalledWith('/explore');
+  });
+
+  it('redirects /login to /auth/login', () => {
+    LegacyLoginPage();
+
+    expect(redirectMock).toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('redirects /about to /', () => {
+    LegacyAboutPage();
+
+    expect(redirectMock).toHaveBeenCalledWith('/');
+  });
+
+  it('redirects /agents/sample to /agents', () => {
+    LegacySampleAgentPage();
+
+    expect(redirectMock).toHaveBeenCalledWith('/agents');
+  });
+});

--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function LegacyAboutPage() {
+  redirect('/');
+}

--- a/apps/web/app/agents/sample/page.tsx
+++ b/apps/web/app/agents/sample/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function LegacySampleAgentPage() {
+  redirect('/agents');
+}

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function LegacyFeedPage() {
+  redirect('/explore');
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function LegacyLoginPage() {
+  redirect('/auth/login');
+}


### PR DESCRIPTION
Source: backlog.md:85

Fixes legacy/public route aliases so /feed, /login, /agents/sample, and /about resolve to working surfaces instead of 404s.