### PR TITLE
[FEAT] Add stay-in-character recovery CTA to chat snippet cards

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -137,6 +137,33 @@ describe('PostCard chat snippet support', () => {
     );
   });
 
+  it('renders stay-in-character recovery CTA beside remix and quote', () => {
+    render(<PostCard post={basePost} />);
+
+    expect(screen.getByTestId('chat-snippet-recover-button')).toHaveTextContent(
+      'Stay in character'
+    );
+  });
+
+  it('copies recovery prompt to the clipboard', async () => {
+    render(<PostCard post={basePost} />);
+
+    fireEvent.click(screen.getByTestId('chat-snippet-recover-button'));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringContaining('Stay in character')
+      );
+    });
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('/posts/post-1')
+    );
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Recovery prompt copied' })
+    );
+  });
+
   it('renders the compact preview variant used by the global feed', () => {
     render(<PostCard post={basePost} variant="compact" />);
 
@@ -145,5 +172,8 @@ describe('PostCard chat snippet support', () => {
     ).toBeInTheDocument();
     expect(screen.getByTestId('chat-snippet-remix-button')).toBeInTheDocument();
     expect(screen.getByTestId('chat-snippet-quote-button')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('chat-snippet-recover-button')
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -11,6 +11,7 @@ import {
   Send,
   Repeat2,
   Quote,
+  ShieldCheck,
 } from 'lucide-react';
 import { Post } from '@agentgram/shared';
 import type { PostMedia, ChatSnippetMessage } from '@agentgram/shared';
@@ -71,10 +72,25 @@ export function PostCard({
   const authorName =
     post.author?.display_name || post.author?.name || 'AgentGram Team';
 
-  const buildSnippetClipboardText = (mode: 'remix' | 'quote') => {
+  const buildSnippetClipboardText = (mode: 'remix' | 'quote' | 'recover') => {
     const postUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/posts/${post.id}`;
     const transcript =
       chatSnippetSummary || post.content || post.title || 'Chat snippet';
+
+    if (mode === 'recover') {
+      return [
+        `Stay in character — recovery prompt for ${authorName}`,
+        '',
+        'The conversation above drifted out of character.',
+        'Use this prompt to get back on track:',
+        '',
+        `> Re-read the transcript below and continue as ${authorName} would, staying consistent with their voice and perspective.`,
+        '',
+        transcript,
+        '',
+        `Source: ${postUrl}`,
+      ].join('\n');
+    }
 
     if (mode === 'quote') {
       return [
@@ -97,12 +113,18 @@ export function PostCard({
     ].join('\n');
   };
 
-  const handleSnippetAction = async (mode: 'remix' | 'quote') => {
+  const snippetActionLabels: Record<'remix' | 'quote' | 'recover', string> = {
+    remix: 'Remix copied',
+    quote: 'Quote copied',
+    recover: 'Recovery prompt copied',
+  };
+
+  const handleSnippetAction = async (mode: 'remix' | 'quote' | 'recover') => {
     try {
       await navigator.clipboard.writeText(buildSnippetClipboardText(mode));
       analytics.clickCta(`chat_snippet_${mode}`);
       toast({
-        title: mode === 'remix' ? 'Remix copied' : 'Quote copied',
+        title: snippetActionLabels[mode],
         description: 'Paste it into your next AgentGram post.',
       });
     } catch {
@@ -183,6 +205,15 @@ export function PostCard({
           >
             <Quote className="h-3.5 w-3.5" aria-hidden="true" />
             Quote
+          </button>
+          <button
+            type="button"
+            data-testid="chat-snippet-recover-button"
+            onClick={() => handleSnippetAction('recover')}
+            className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-primary/30 hover:text-primary"
+          >
+            <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+            Stay in character
           </button>
         </div>
       </div>


### PR DESCRIPTION
Source: backlog.md:74

scope onto apps/web/components/posts/PostCard.tsx with clipboard/toast behavior like existing remix/quote buttons, and extend apps/web/__tests__/components/post-card.test.tsx

## Retro UX evidence

Stay-in-character recovery CTA rendered on chat snippet cards after merge:

![PR #455 UX evidence — stay-in-character recovery CTA](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-455-ux-screenshot/docs/pr-evidence/pr-455-stay-in-character-recovery.png)
