### PR TITLE
feat: add memory transparency chip

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -110,6 +110,9 @@ describe('PostCard chat snippet support', () => {
 
     expect(screen.getByTestId('chat-snippet-preview')).toBeInTheDocument();
     expect(screen.getAllByTestId('chat-snippet-message')).toHaveLength(3);
+    expect(
+      screen.queryByTestId('chat-snippet-memory-reason')
+    ).not.toBeInTheDocument();
     expect(screen.getByTestId('chat-snippet-remix-button')).toHaveTextContent(
       'Remix'
     );
@@ -145,6 +148,30 @@ describe('PostCard chat snippet support', () => {
     );
   });
 
+  it('renders a memory transparency chip when metadata includes a reason', () => {
+    render(
+      <PostCard
+        post={{
+          ...basePost,
+          metadata: {
+            ...basePost.metadata,
+            memory: {
+              reason: 'You previously asked for the deploy fix and follow-up.',
+            },
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('chat-snippet-memory-reason')).toBeInTheDocument();
+    expect(screen.getByText('Why I remembered this')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'You previously asked for the deploy fix and follow-up.'
+      )
+    ).toBeInTheDocument();
+  });
+
   it('copies recovery prompt to the clipboard', async () => {
     render(<PostCard post={basePost} />);
 
@@ -175,5 +202,8 @@ describe('PostCard chat snippet support', () => {
     expect(
       screen.getByTestId('chat-snippet-recover-button')
     ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('chat-snippet-memory-reason')
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -38,6 +38,41 @@ interface PostCardProps {
   variant?: 'feed' | 'grid' | 'compact';
 }
 
+function readMetadataValue(
+  metadata: Record<string, unknown>,
+  path: string[]
+): unknown {
+  let current: unknown = metadata;
+
+  for (const segment of path) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) {
+      return undefined;
+    }
+
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current;
+}
+
+function readMetadataString(
+  metadata: Post['metadata'],
+  paths: string[][]
+): string | undefined {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  for (const path of paths) {
+    const value = readMetadataValue(metadata as Record<string, unknown>, path);
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return undefined;
+}
+
 export function PostCard({
   post,
   className = '',
@@ -71,6 +106,13 @@ export function PostCard({
     post.postType === 'text' && (isLongTitle || isLongContent);
   const authorName =
     post.author?.display_name || post.author?.name || 'AgentGram Team';
+  const memoryExplanation = readMetadataString(post.metadata, [
+    ['memoryReason'],
+    ['memory_reason'],
+    ['rememberedBecause'],
+    ['remembered_because'],
+    ['memory', 'reason'],
+  ]);
 
   const buildSnippetClipboardText = (mode: 'remix' | 'quote' | 'recover') => {
     const postUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/posts/${post.id}`;
@@ -163,6 +205,20 @@ export function PostCard({
               : 'Preview'}
           </span>
         </div>
+
+        {memoryExplanation ? (
+          <div
+            data-testid="chat-snippet-memory-reason"
+            className="mt-3 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-3 py-2"
+          >
+            <span className="inline-flex items-center rounded-full border border-emerald-500/20 bg-background/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-emerald-700">
+              Why I remembered this
+            </span>
+            <p className="mt-2 text-sm text-foreground/90 whitespace-pre-line">
+              {memoryExplanation}
+            </p>
+          </div>
+        ) : null}
 
         {hasMessages ? (
           <div className="mt-3 space-y-2">


### PR DESCRIPTION
Source: backlog.md:78

Add a user-visible “why I remembered this” chip in chat using the repo’s existing memory/chat surface, with tests.