### PR TITLE
[FEAT] Add category field to agent memories (#459)

### DIFF
--- a/apps/web/__tests__/api/memories.test.ts
+++ b/apps/web/__tests__/api/memories.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const AGENT_ID = 'agent-test-123';
+
+const mockSingle = vi.fn();
+const mockSelect = vi.fn().mockReturnThis();
+const mockInsert = vi.fn().mockReturnThis();
+const mockUpdate = vi.fn().mockReturnThis();
+const mockDelete = vi.fn().mockReturnThis();
+const mockEq = vi.fn().mockReturnThis();
+const mockOrder = vi.fn();
+
+vi.mock('@agentgram/db', () => ({
+  getSupabaseServiceClient: () => ({
+    from: () => ({
+      select: mockSelect,
+      insert: mockInsert,
+      update: mockUpdate,
+      delete: mockDelete,
+      eq: mockEq,
+      order: mockOrder,
+    }),
+  }),
+}));
+
+vi.mock('@agentgram/auth', () => ({
+  withAuth: (handler: Function) => handler,
+}));
+
+function makeReq(url: string, init?: RequestInit): NextRequest {
+  const req = new NextRequest(url, init);
+  req.headers.set('x-agent-id', AGENT_ID);
+  return req;
+}
+
+describe('POST /api/v1/agents/me/memories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelect.mockReturnThis();
+    mockInsert.mockReturnThis();
+    mockEq.mockReturnThis();
+  });
+
+  it('should reject missing category', async () => {
+    const { POST } = await import('../../app/api/v1/agents/me/memories/route');
+
+    const req = makeReq('http://localhost/api/v1/agents/me/memories', {
+      method: 'POST',
+      body: JSON.stringify({ key: 'k', value: 'v' }),
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.message).toContain('category');
+  });
+
+  it('should reject invalid category value', async () => {
+    const { POST } = await import('../../app/api/v1/agents/me/memories/route');
+
+    const req = makeReq('http://localhost/api/v1/agents/me/memories', {
+      method: 'POST',
+      body: JSON.stringify({
+        key: 'k',
+        value: 'v',
+        category: 'invalid_cat',
+      }),
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error.message).toContain('profile_fact');
+    expect(json.error.message).toContain('relationship_context');
+  });
+
+  it('should accept profile_fact and pass to insert', async () => {
+    const { POST } = await import('../../app/api/v1/agents/me/memories/route');
+
+    mockSingle.mockResolvedValue({
+      data: {
+        id: 'mem-1',
+        key: 'fav_color',
+        value: 'blue',
+        is_public: false,
+        category: 'profile_fact',
+      },
+      error: null,
+    });
+    mockSelect.mockReturnValue({ single: mockSingle });
+
+    const req = makeReq('http://localhost/api/v1/agents/me/memories', {
+      method: 'POST',
+      body: JSON.stringify({
+        key: 'fav_color',
+        value: 'blue',
+        category: 'profile_fact',
+      }),
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'profile_fact' })
+    );
+  });
+
+  it('should accept relationship_context', async () => {
+    const { POST } = await import('../../app/api/v1/agents/me/memories/route');
+
+    mockSingle.mockResolvedValue({
+      data: {
+        id: 'mem-2',
+        key: 'ally',
+        value: 'agent-x',
+        is_public: true,
+        category: 'relationship_context',
+      },
+      error: null,
+    });
+    mockSelect.mockReturnValue({ single: mockSingle });
+
+    const req = makeReq('http://localhost/api/v1/agents/me/memories', {
+      method: 'POST',
+      body: JSON.stringify({
+        key: 'ally',
+        value: 'agent-x',
+        isPublic: true,
+        category: 'relationship_context',
+      }),
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'relationship_context',
+        is_public: true,
+      })
+    );
+  });
+});
+
+describe('GET /api/v1/agents/me/memories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelect.mockReturnThis();
+    mockEq.mockReturnThis();
+  });
+
+  it('should reject invalid category filter', async () => {
+    const { GET } = await import('../../app/api/v1/agents/me/memories/route');
+
+    const req = makeReq(
+      'http://localhost/api/v1/agents/me/memories?category=bad'
+    );
+
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error.message).toContain('category');
+  });
+
+  it('should pass valid category filter to query', async () => {
+    const { GET } = await import('../../app/api/v1/agents/me/memories/route');
+
+    mockOrder.mockResolvedValue({ data: [], error: null });
+
+    const req = makeReq(
+      'http://localhost/api/v1/agents/me/memories?category=profile_fact'
+    );
+
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    // eq called for agent_id + category
+    expect(mockEq).toHaveBeenCalledWith('category', 'profile_fact');
+  });
+
+  it('should return all when no category filter', async () => {
+    const { GET } = await import('../../app/api/v1/agents/me/memories/route');
+
+    mockOrder.mockResolvedValue({ data: [], error: null });
+
+    const req = makeReq('http://localhost/api/v1/agents/me/memories');
+
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    // eq should only be called with agent_id, not category
+    const categoryCalls = mockEq.mock.calls.filter(
+      (c: unknown[]) => c[0] === 'category'
+    );
+    expect(categoryCalls).toHaveLength(0);
+  });
+});
+
+describe('PATCH /api/v1/agents/me/memories/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdate.mockReturnThis();
+    mockEq.mockReturnThis();
+    mockSelect.mockReturnThis();
+  });
+
+  it('should reject invalid category on update', async () => {
+    const { PATCH } =
+      await import('../../app/api/v1/agents/me/memories/[id]/route');
+
+    const req = makeReq('http://localhost/api/v1/agents/me/memories/mem-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ category: 'wrong' }),
+    });
+
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: 'mem-1' }),
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error.message).toContain('category');
+  });
+
+  it('should accept valid category on update', async () => {
+    const { PATCH } =
+      await import('../../app/api/v1/agents/me/memories/[id]/route');
+
+    mockSingle.mockResolvedValue({
+      data: {
+        id: 'mem-1',
+        key: 'k',
+        value: 'v',
+        is_public: false,
+        category: 'relationship_context',
+      },
+      error: null,
+    });
+    mockSelect.mockReturnValue({ single: mockSingle });
+
+    const req = makeReq('http://localhost/api/v1/agents/me/memories/mem-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ category: 'relationship_context' }),
+    });
+
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: 'mem-1' }),
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'relationship_context' })
+    );
+  });
+});

--- a/apps/web/__tests__/api/memories.test.ts
+++ b/apps/web/__tests__/api/memories.test.ts
@@ -25,7 +25,7 @@ vi.mock('@agentgram/db', () => ({
 }));
 
 vi.mock('@agentgram/auth', () => ({
-  withAuth: (handler: Function) => handler,
+  withAuth: <T extends (...args: never[]) => unknown>(handler: T) => handler,
 }));
 
 function makeReq(url: string, init?: RequestInit): NextRequest {

--- a/apps/web/app/api/v1/agents/me/memories/[id]/route.ts
+++ b/apps/web/app/api/v1/agents/me/memories/[id]/route.ts
@@ -8,6 +8,7 @@ import {
 } from '@agentgram/shared';
 
 const VALUE_MAX = 2048;
+const VALID_CATEGORIES = ['profile_fact', 'relationship_context'] as const;
 
 async function patchHandler(
   req: NextRequest,
@@ -18,7 +19,11 @@ async function patchHandler(
     if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
 
     const { id } = await params;
-    const body = (await req.json()) as { value?: string; isPublic?: boolean };
+    const body = (await req.json()) as {
+      value?: string;
+      isPublic?: boolean;
+      category?: string;
+    };
 
     let value: string | undefined;
     if (body.value !== undefined) {
@@ -31,12 +36,25 @@ async function patchHandler(
       }
     }
 
+    if (
+      body.category !== undefined &&
+      !(VALID_CATEGORIES as readonly string[]).includes(body.category)
+    ) {
+      return jsonResponse(
+        ErrorResponses.invalidInput(
+          `category must be one of: ${VALID_CATEGORIES.join(', ')}`
+        ),
+        400
+      );
+    }
+
     const supabase = getSupabaseServiceClient();
     const { data, error } = await supabase
       .from('agent_memories')
       .update({
         ...(value !== undefined && { value }),
         ...(body.isPublic !== undefined && { is_public: body.isPublic }),
+        ...(body.category !== undefined && { category: body.category }),
         updated_at: new Date().toISOString(),
       })
       .eq('id', id)

--- a/apps/web/app/api/v1/agents/me/memories/route.ts
+++ b/apps/web/app/api/v1/agents/me/memories/route.ts
@@ -9,18 +9,38 @@ import {
 
 const KEY_MAX = 128;
 const VALUE_MAX = 2048;
+const VALID_CATEGORIES = ['profile_fact', 'relationship_context'] as const;
+type MemoryCategory = (typeof VALID_CATEGORIES)[number];
 
 async function getHandler(req: NextRequest) {
   try {
     const agentId = req.headers.get('x-agent-id');
     if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
 
+    const url = new URL(req.url);
+    const categoryFilter = url.searchParams.get('category');
+
     const supabase = getSupabaseServiceClient();
-    const { data, error } = await supabase
+    let query = supabase
       .from('agent_memories')
       .select('*')
-      .eq('agent_id', agentId)
-      .order('created_at', { ascending: false });
+      .eq('agent_id', agentId);
+
+    if (categoryFilter) {
+      if (!(VALID_CATEGORIES as readonly string[]).includes(categoryFilter)) {
+        return jsonResponse(
+          ErrorResponses.invalidInput(
+            `category must be one of: ${VALID_CATEGORIES.join(', ')}`
+          ),
+          400
+        );
+      }
+      query = query.eq('category', categoryFilter);
+    }
+
+    const { data, error } = await query.order('created_at', {
+      ascending: false,
+    });
 
     if (error) {
       console.error('Fetch memories error:', error);
@@ -43,9 +63,11 @@ async function createHandler(req: NextRequest) {
       key?: string;
       value?: string;
       isPublic?: boolean;
+      category?: string;
     };
     const key = body.key?.trim();
     const value = body.value?.trim();
+    const category = body.category as MemoryCategory | undefined;
 
     if (!key || key.length === 0 || key.length > KEY_MAX) {
       return jsonResponse(
@@ -59,6 +81,14 @@ async function createHandler(req: NextRequest) {
         400
       );
     }
+    if (!category || !VALID_CATEGORIES.includes(category)) {
+      return jsonResponse(
+        ErrorResponses.invalidInput(
+          `category must be one of: ${VALID_CATEGORIES.join(', ')}`
+        ),
+        400
+      );
+    }
 
     const supabase = getSupabaseServiceClient();
     const { data, error } = await supabase
@@ -68,6 +98,7 @@ async function createHandler(req: NextRequest) {
         key,
         value,
         is_public: body.isPublic ?? false,
+        category,
       })
       .select('*')
       .single();

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -83,6 +83,7 @@ export type Database = {
       agent_memories: {
         Row: {
           agent_id: string;
+          category: string;
           created_at: string;
           id: string;
           is_public: boolean;
@@ -92,6 +93,7 @@ export type Database = {
         };
         Insert: {
           agent_id: string;
+          category: string;
           created_at?: string;
           id?: string;
           is_public?: boolean;
@@ -101,6 +103,7 @@ export type Database = {
         };
         Update: {
           agent_id?: string;
+          category?: string;
           created_at?: string;
           id?: string;
           is_public?: boolean;

--- a/supabase/migrations/20260423000004_agent_memory_controls.sql
+++ b/supabase/migrations/20260423000004_agent_memory_controls.sql
@@ -4,8 +4,6 @@ CREATE TABLE public.agent_memories (
   key TEXT NOT NULL,
   value TEXT NOT NULL,
   is_public BOOLEAN NOT NULL DEFAULT false,
-  category TEXT NOT NULL DEFAULT 'profile_fact'
-    CHECK (category IN ('profile_fact', 'relationship_context')),
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   UNIQUE(agent_id, key)

--- a/supabase/migrations/20260423000004_agent_memory_controls.sql
+++ b/supabase/migrations/20260423000004_agent_memory_controls.sql
@@ -4,6 +4,8 @@ CREATE TABLE public.agent_memories (
   key TEXT NOT NULL,
   value TEXT NOT NULL,
   is_public BOOLEAN NOT NULL DEFAULT false,
+  category TEXT NOT NULL DEFAULT 'profile_fact'
+    CHECK (category IN ('profile_fact', 'relationship_context')),
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   UNIQUE(agent_id, key)

--- a/supabase/migrations/20260430064500_agent_memory_category.sql
+++ b/supabase/migrations/20260430064500_agent_memory_category.sql
@@ -1,0 +1,9 @@
+ALTER TABLE public.agent_memories
+  ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT 'profile_fact';
+
+ALTER TABLE public.agent_memories
+  DROP CONSTRAINT IF EXISTS agent_memories_category_check;
+
+ALTER TABLE public.agent_memories
+  ADD CONSTRAINT agent_memories_category_check
+  CHECK (category IN ('profile_fact', 'relationship_context'));


### PR DESCRIPTION
## Description

Add a `category` field to `agent_memories` table with enum validation (`profile_fact`, `relationship_context`). Enables agents to classify and filter their stored memories by type.

## Type of Change

- [x] New feature

## Changes Made

- Add `category TEXT NOT NULL` column with CHECK constraint to migration
- Update DB types (Row, Insert, Update)
- Validate category on POST (required) and PATCH (optional)
- Support `?category=` query filter on GET
- Add 9 unit tests covering all validation paths

## Related Issues

Closes #459

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Tests pass (`pnpm --filter web exec vitest run __tests__/api/memories.test.ts` — 9/9)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)