### PR TITLE
feat: add contradiction feedback CTA to chat snippets

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -163,12 +163,12 @@ describe('PostCard chat snippet support', () => {
       />
     );
 
-    expect(screen.getByTestId('chat-snippet-memory-reason')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('chat-snippet-memory-reason')
+    ).toBeInTheDocument();
     expect(screen.getByText('Why I remembered this')).toBeInTheDocument();
     expect(
-      screen.getByText(
-        'You previously asked for the deploy fix and follow-up.'
-      )
+      screen.getByText('You previously asked for the deploy fix and follow-up.')
     ).toBeInTheDocument();
   });
 
@@ -191,6 +191,33 @@ describe('PostCard chat snippet support', () => {
     );
   });
 
+  it('renders contradiction feedback CTA beside other snippet actions', () => {
+    render(<PostCard post={basePost} />);
+
+    expect(
+      screen.getByTestId('chat-snippet-contradiction-button')
+    ).toHaveTextContent('Flag contradiction');
+  });
+
+  it('copies contradiction report text to the clipboard', async () => {
+    render(<PostCard post={basePost} />);
+
+    fireEvent.click(screen.getByTestId('chat-snippet-contradiction-button'));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringContaining('Memory contradiction flagged')
+      );
+    });
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('/posts/post-1')
+    );
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Contradiction report copied' })
+    );
+  });
+
   it('renders the compact preview variant used by the global feed', () => {
     render(<PostCard post={basePost} variant="compact" />);
 
@@ -201,6 +228,9 @@ describe('PostCard chat snippet support', () => {
     expect(screen.getByTestId('chat-snippet-quote-button')).toBeInTheDocument();
     expect(
       screen.getByTestId('chat-snippet-recover-button')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('chat-snippet-contradiction-button')
     ).toBeInTheDocument();
     expect(
       screen.queryByTestId('chat-snippet-memory-reason')

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -12,6 +12,7 @@ import {
   Repeat2,
   Quote,
   ShieldCheck,
+  AlertTriangle,
 } from 'lucide-react';
 import { Post } from '@agentgram/shared';
 import type { PostMedia, ChatSnippetMessage } from '@agentgram/shared';
@@ -114,10 +115,25 @@ export function PostCard({
     ['memory', 'reason'],
   ]);
 
-  const buildSnippetClipboardText = (mode: 'remix' | 'quote' | 'recover') => {
+  const buildSnippetClipboardText = (
+    mode: 'remix' | 'quote' | 'recover' | 'contradiction'
+  ) => {
     const postUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/posts/${post.id}`;
     const transcript =
       chatSnippetSummary || post.content || post.title || 'Chat snippet';
+
+    if (mode === 'contradiction') {
+      return [
+        `Memory contradiction flagged in ${authorName}'s chat snippet`,
+        '',
+        'The transcript below contains a potential memory contradiction.',
+        'Review the exchange and note where prior context conflicts with new statements:',
+        '',
+        transcript,
+        '',
+        `Source: ${postUrl}`,
+      ].join('\n');
+    }
 
     if (mode === 'recover') {
       return [
@@ -155,13 +171,19 @@ export function PostCard({
     ].join('\n');
   };
 
-  const snippetActionLabels: Record<'remix' | 'quote' | 'recover', string> = {
+  const snippetActionLabels: Record<
+    'remix' | 'quote' | 'recover' | 'contradiction',
+    string
+  > = {
     remix: 'Remix copied',
     quote: 'Quote copied',
     recover: 'Recovery prompt copied',
+    contradiction: 'Contradiction report copied',
   };
 
-  const handleSnippetAction = async (mode: 'remix' | 'quote' | 'recover') => {
+  const handleSnippetAction = async (
+    mode: 'remix' | 'quote' | 'recover' | 'contradiction'
+  ) => {
     try {
       await navigator.clipboard.writeText(buildSnippetClipboardText(mode));
       analytics.clickCta(`chat_snippet_${mode}`);
@@ -270,6 +292,15 @@ export function PostCard({
           >
             <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
             Stay in character
+          </button>
+          <button
+            type="button"
+            data-testid="chat-snippet-contradiction-button"
+            onClick={() => handleSnippetAction('contradiction')}
+            className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-amber-500/30 hover:text-amber-600"
+          >
+            <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+            Flag contradiction
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Description

Add a "Flag contradiction" CTA button to chat snippet cards, letting users flag memory contradictions directly from the feed.

Source: backlog.md: Memory repair — add "contradiction" feedback CTA on chat snippet cards

## Changes Made

- `apps/web/components/posts/PostCard.tsx` — added `contradiction` mode to clipboard builder, action labels, handler, and a new `AlertTriangle`-icon button
- `apps/web/__tests__/components/post-card.test.tsx` — 2 new tests (render + clipboard copy), updated compact variant assertion

## Testing

- [x] `vitest run __tests__/components/post-card.test.tsx` — 8/8 passed

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings