### PR TITLE
fix: show verified badge on feed post cards

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -69,7 +69,11 @@ vi.mock('@/lib/analytics', () => ({
 }));
 
 const basePost: Post & {
-  author: { name: string; display_name: string };
+  author: {
+    name: string;
+    display_name: string;
+    verificationState?: 'verified' | 'pending' | 'unverified';
+  };
 } = {
   id: 'post-1',
   authorId: 'agent-1',
@@ -95,6 +99,22 @@ const basePost: Post & {
   },
 };
 
+const renderPostCard = (
+  overrides: Partial<typeof basePost> = {},
+  variant?: 'feed' | 'grid' | 'compact'
+) => {
+  const post = {
+    ...basePost,
+    ...overrides,
+    author: {
+      ...basePost.author,
+      ...overrides.author,
+    },
+  };
+
+  return render(<PostCard post={post} variant={variant} />);
+};
+
 describe('PostCard chat snippet support', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -106,7 +126,7 @@ describe('PostCard chat snippet support', () => {
   });
 
   it('renders chat snippet preview messages with remix and quote CTAs on feed cards', () => {
-    render(<PostCard post={basePost} />);
+    renderPostCard();
 
     expect(screen.getByTestId('chat-snippet-preview')).toBeInTheDocument();
     expect(screen.getAllByTestId('chat-snippet-message')).toHaveLength(3);
@@ -122,7 +142,7 @@ describe('PostCard chat snippet support', () => {
   });
 
   it('copies remix starter text to the clipboard', async () => {
-    render(<PostCard post={basePost} />);
+    renderPostCard();
 
     fireEvent.click(screen.getByTestId('chat-snippet-remix-button'));
 
@@ -141,7 +161,7 @@ describe('PostCard chat snippet support', () => {
   });
 
   it('renders stay-in-character recovery CTA beside remix and quote', () => {
-    render(<PostCard post={basePost} />);
+    renderPostCard();
 
     expect(screen.getByTestId('chat-snippet-recover-button')).toHaveTextContent(
       'Stay in character'
@@ -149,19 +169,14 @@ describe('PostCard chat snippet support', () => {
   });
 
   it('renders a memory transparency chip when metadata includes a reason', () => {
-    render(
-      <PostCard
-        post={{
-          ...basePost,
-          metadata: {
-            ...basePost.metadata,
-            memory: {
-              reason: 'You previously asked for the deploy fix and follow-up.',
-            },
-          },
-        }}
-      />
-    );
+    renderPostCard({
+      metadata: {
+        ...basePost.metadata,
+        memory: {
+          reason: 'You previously asked for the deploy fix and follow-up.',
+        },
+      },
+    });
 
     expect(
       screen.getByTestId('chat-snippet-memory-reason')
@@ -173,7 +188,7 @@ describe('PostCard chat snippet support', () => {
   });
 
   it('copies recovery prompt to the clipboard', async () => {
-    render(<PostCard post={basePost} />);
+    renderPostCard();
 
     fireEvent.click(screen.getByTestId('chat-snippet-recover-button'));
 
@@ -192,7 +207,7 @@ describe('PostCard chat snippet support', () => {
   });
 
   it('renders contradiction feedback CTA beside other snippet actions', () => {
-    render(<PostCard post={basePost} />);
+    renderPostCard();
 
     expect(
       screen.getByTestId('chat-snippet-contradiction-button')
@@ -200,7 +215,7 @@ describe('PostCard chat snippet support', () => {
   });
 
   it('copies contradiction report text to the clipboard', async () => {
-    render(<PostCard post={basePost} />);
+    renderPostCard();
 
     fireEvent.click(screen.getByTestId('chat-snippet-contradiction-button'));
 
@@ -219,7 +234,7 @@ describe('PostCard chat snippet support', () => {
   });
 
   it('renders the compact preview variant used by the global feed', () => {
-    render(<PostCard post={basePost} variant="compact" />);
+    renderPostCard({}, 'compact');
 
     expect(
       screen.getByTestId('chat-snippet-preview-compact')
@@ -235,5 +250,68 @@ describe('PostCard chat snippet support', () => {
     expect(
       screen.queryByTestId('chat-snippet-memory-reason')
     ).not.toBeInTheDocument();
+  });
+
+  it('shows a verified badge on feed cards only for verified authors', () => {
+    const { rerender } = render(
+      <PostCard
+        post={{
+          ...basePost,
+          author: {
+            ...basePost.author,
+            verificationState: 'verified',
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('verified-badge')).toBeInTheDocument();
+    expect(screen.getByLabelText('Verified agent')).toBeInTheDocument();
+
+    rerender(
+      <PostCard
+        post={{
+          ...basePost,
+          author: {
+            ...basePost.author,
+            verificationState: 'unverified',
+          },
+        }}
+      />
+    );
+
+    expect(screen.queryByTestId('verified-badge')).not.toBeInTheDocument();
+  });
+
+  it('shows a verified badge on compact cards only for verified authors', () => {
+    const { rerender } = render(
+      <PostCard
+        post={{
+          ...basePost,
+          author: {
+            ...basePost.author,
+            verificationState: 'verified',
+          },
+        }}
+        variant="compact"
+      />
+    );
+
+    expect(screen.getByTestId('verified-badge')).toBeInTheDocument();
+
+    rerender(
+      <PostCard
+        post={{
+          ...basePost,
+          author: {
+            ...basePost.author,
+            verificationState: 'pending',
+          },
+        }}
+        variant="compact"
+      />
+    );
+
+    expect(screen.queryByTestId('verified-badge')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -13,6 +13,7 @@ import {
   Quote,
   ShieldCheck,
   AlertTriangle,
+  BadgeCheck,
 } from 'lucide-react';
 import { Post } from '@agentgram/shared';
 import type { PostMedia, ChatSnippetMessage } from '@agentgram/shared';
@@ -30,6 +31,7 @@ interface PostCardProps {
       avatar_url?: string;
       display_name?: string;
       name?: string;
+      verificationState?: string;
     };
     community?: {
       name?: string;
@@ -410,6 +412,13 @@ export function PostCard({
               >
                 {authorName}
               </Link>
+              {post.author?.verificationState === 'verified' && (
+                <BadgeCheck
+                  data-testid="verified-badge"
+                  className="h-3.5 w-3.5 text-primary"
+                  aria-label="Verified agent"
+                />
+              )}
               <span aria-hidden="true">•</span>
               <span>{formatTimeAgo(post.createdAt)}</span>
               {post.community?.name && (
@@ -485,6 +494,13 @@ export function PostCard({
               >
                 {authorName}
               </Link>
+              {post.author?.verificationState === 'verified' && (
+                <BadgeCheck
+                  data-testid="verified-badge"
+                  className="h-3.5 w-3.5 text-primary"
+                  aria-label="Verified agent"
+                />
+              )}
               <span className="text-muted-foreground text-xs">
                 • {formatTimeAgo(post.createdAt)}
               </span>

--- a/apps/web/hooks/use-posts.ts
+++ b/apps/web/hooks/use-posts.ts
@@ -38,6 +38,7 @@ export type PostResponse = {
     avatar_url: string | null;
     axp: number;
     trust_score: number | null;
+    verification_state?: string | null;
   };
   community?: {
     id: string;
@@ -149,6 +150,7 @@ export function usePostsFeed(params: FeedParams = {}) {
           author_avatar_url: string | null;
           author_axp: number;
           author_trust_score: number | null;
+          author_verification_state: string | null;
           community_name: string | null;
           community_display_name: string | null;
         };
@@ -186,6 +188,7 @@ export function usePostsFeed(params: FeedParams = {}) {
               avatar_url: row.author_avatar_url,
               axp: row.author_axp,
               trust_score: row.author_trust_score,
+              verification_state: row.author_verification_state,
             },
             community: row.community_name
               ? {

--- a/packages/db/src/queries/posts.ts
+++ b/packages/db/src/queries/posts.ts
@@ -4,6 +4,6 @@
  */
 export const POSTS_SELECT_WITH_RELATIONS = `
   *,
-  author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, axp, trust_score),
+  author:agents!posts_author_id_fkey(id, name, display_name, avatar_url, axp, trust_score, verification_state),
   community:communities(id, name, display_name)
 ` as const;

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1044,6 +1044,7 @@ export type Database = {
           author_display_name: string;
           author_id: string;
           author_name: string;
+          author_verification_state: string;
           comment_count: number;
           community_display_name: string;
           community_id: string;

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -35,6 +35,7 @@ export type AuthorResponse = {
   avatar_url: string | null;
   axp: number;
   trust_score: number | null;
+  verification_state?: string | null;
 };
 
 export function transformAgent(agent: AgentResponse): Agent {
@@ -82,7 +83,8 @@ export function transformAuthor(author: AuthorResponse): Agent {
     email: undefined,
     emailVerified: false,
     axp: author.axp,
-    verificationState: 'unverified',
+    verificationState:
+      (author.verification_state as Agent['verificationState']) ?? 'unverified',
     status: 'active',
     trustScore: author.trust_score ?? 0,
     metadata: {},

--- a/supabase/migrations/20260425000001_feed_rpc_add_verification_state.sql
+++ b/supabase/migrations/20260425000001_feed_rpc_add_verification_state.sql
@@ -1,0 +1,75 @@
+-- Add author_verification_state to get_following_feed RPC
+DROP FUNCTION IF EXISTS get_following_feed(UUID, INTEGER, INTEGER);
+
+CREATE OR REPLACE FUNCTION get_following_feed(
+  p_follower_id UUID,
+  p_limit INTEGER DEFAULT 25,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS TABLE (
+  id UUID,
+  author_id UUID,
+  community_id UUID,
+  title VARCHAR(300),
+  content TEXT,
+  url TEXT,
+  post_type VARCHAR(20),
+  likes INTEGER,
+  comment_count INTEGER,
+  score FLOAT,
+  metadata JSONB,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  post_kind VARCHAR(20),
+  original_post_id UUID,
+  repost_count INTEGER,
+  view_count INTEGER,
+  expires_at TIMESTAMPTZ,
+  author_name VARCHAR(50),
+  author_display_name VARCHAR(100),
+  author_avatar_url TEXT,
+  author_axp INTEGER,
+  author_trust_score FLOAT,
+  author_verification_state TEXT,
+  community_name VARCHAR(50),
+  community_display_name VARCHAR(100)
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.author_id,
+    p.community_id,
+    p.title,
+    p.content,
+    p.url,
+    p.post_type,
+    p.likes,
+    p.comment_count,
+    p.score,
+    p.metadata,
+    p.created_at,
+    p.updated_at,
+    p.post_kind,
+    p.original_post_id,
+    p.repost_count,
+    p.view_count,
+    p.expires_at,
+    a.name AS author_name,
+    a.display_name AS author_display_name,
+    a.avatar_url AS author_avatar_url,
+    a.axp AS author_axp,
+    a.trust_score AS author_trust_score,
+    a.verification_state AS author_verification_state,
+    c.name AS community_name,
+    c.display_name AS community_display_name
+  FROM posts p
+  INNER JOIN follows f ON f.following_id = p.author_id
+  INNER JOIN agents a ON a.id = p.author_id
+  LEFT JOIN communities c ON c.id = p.community_id
+  WHERE f.follower_id = p_follower_id
+  ORDER BY p.created_at DESC
+  LIMIT p_limit
+  OFFSET p_offset;
+END;
+$$ LANGUAGE plpgsql STABLE;


### PR DESCRIPTION
Source: backlog.md:96

Resume feed trust item: plumb author verification_state through feed queries/RPCs and render verified badge on PostCard with focused regression tests.

## Retro UX evidence

Verified author badge rendered on compact and feed PostCard variants after the verification_state plumbing landed:

![PR #462 UX evidence — verified badge on post cards](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-462-ux-screenshot/docs/pr-evidence/pr-462-verified-post-badge.png)
