### PR TITLE
feat: delay operator upsell until first successful reply

### DIFF
--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -175,9 +175,34 @@ describe('ProfileHeader', () => {
     expect(screen.queryByTestId('permission-scope-badge')).not.toBeInTheDocument();
   });
 
-  it('shows operator tier upgrade CTA and trust-bundle prompts for verified profiles without a paid tier', () => {
+  it('hides operator tier upsell before the first successful reply for verified profiles without a paid tier', () => {
     render(
       <ProfileHeader agent={{ ...baseAgent, verificationState: 'verified' }} />
+    );
+
+    expect(
+      screen.queryByTestId('operator-tier-surface')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('operator-trust-bundle')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('operator-tier-link')).not.toBeInTheDocument();
+    expect(screen.getByTestId('verification-state-badge')).toHaveTextContent(
+      'verified'
+    );
+  });
+
+  it('shows operator tier upgrade CTA after the first successful reply for verified profiles without a paid tier', () => {
+    render(
+      <ProfileHeader
+        agent={{
+          ...baseAgent,
+          verificationState: 'verified',
+          metadata: {
+            firstSuccessfulReply: true,
+          },
+        }}
+      />
     );
 
     expect(screen.getByTestId('operator-tier-surface')).toBeInTheDocument();
@@ -252,13 +277,16 @@ describe('ProfileHeader', () => {
     );
   });
 
-  it('uses capability summary as work-proof fallback when no external proof is linked', () => {
+  it('uses capability summary as work-proof fallback when no external proof is linked after the first successful reply', () => {
     render(
       <ProfileHeader
         agent={{
           ...baseAgent,
           verificationState: 'verified',
           capabilitySummary: 'Shares benchmark notes and shipping receipts.',
+          metadata: {
+            firstSuccessfulReply: true,
+          },
         }}
       />
     );

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -103,6 +103,18 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
     agent.operatorTier !== 'free'
       ? formatOperatorTier(agent.operatorTier)
       : undefined;
+  const hasFirstSuccessfulReply =
+    readMetadataBoolean(agent.metadata, [
+      ['firstSuccessfulReply'],
+      ['first_successful_reply'],
+      ['milestones', 'firstSuccessfulReply'],
+      ['milestones', 'first_successful_reply'],
+      ['replyMilestones', 'firstSuccessfulReply'],
+      ['reply_milestones', 'first_successful_reply'],
+    ]) === true;
+  const shouldShowOperatorTierSurface =
+    verificationState === 'verified' &&
+    (Boolean(formattedOperatorTier) || hasFirstSuccessfulReply);
   const memoryPolicy = readMetadataString(agent.metadata, [
     ['memoryPolicy'],
     ['memory_policy'],
@@ -246,7 +258,7 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
                   </span>
                 </div>
               )}
-              {verificationState === 'verified' && (
+              {shouldShowOperatorTierSurface && (
                 <div
                   className="mt-3 rounded-xl border border-primary/15 bg-primary/5 p-3"
                   data-testid="operator-tier-surface"


### PR DESCRIPTION
Source: backlog.md:54

Delay Verified Operator upsell until after first successful reply.

## Summary
- gate the unpaid verified Operator upsell surface behind a metadata-backed first-success signal
- keep verified paid operators on the existing trust-bundle surface
- add regression coverage for hidden pre-success state, visible post-success state, and capability-summary fallback after first success

## Guarded UI states
- before first successful reply: verified unpaid profiles keep the verification badge/card, but do not show the Operator upsell surface or pricing CTA
- after first successful reply: verified unpaid profiles show the existing Operator upsell surface and pricing CTA
- verified paid operators: unchanged, still show the trust bundle immediately

## Tests
- pnpm test -- __tests__/components/profile-header.test.tsx
- pnpm type-check

## Retro UX evidence

Verified unpaid profiles now keep the trust surface but hide the Operator upsell before the first successful reply; the same profile reveals the Operator tier card + CTA after the milestone is present.

![PR #466 UX evidence — delay operator upsell until first successful reply](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-466-ux-screenshot/docs/pr-evidence/pr-466-first-success-operator-cta.png)
