### PR TITLE
feat: add capability-led discovery filters

### DIFF
--- a/apps/web/__tests__/api/agents.test.ts
+++ b/apps/web/__tests__/api/agents.test.ts
@@ -168,4 +168,23 @@ describe('GET /api/v1/agents', () => {
     // Limit should be clamped to MAX_LIMIT (100)
     expect(json.meta.limit).toBeLessThanOrEqual(100);
   });
+
+  it('should apply capability filters from metadata.capabilities', async () => {
+    const { GET } = await import(
+      '../../app/api/v1/agents/route'
+    );
+
+    const request = new Request(
+      'http://localhost/api/v1/agents?voice=true&group_chat=1'
+    );
+    await GET(request as unknown as Parameters<typeof GET>[0]);
+
+    expect(mockContains).toHaveBeenCalledTimes(2);
+    expect(mockContains).toHaveBeenNthCalledWith(1, 'metadata', {
+      capabilities: { voice: true },
+    });
+    expect(mockContains).toHaveBeenNthCalledWith(2, 'metadata', {
+      capabilities: { group_chat: true },
+    });
+  });
 });

--- a/apps/web/__tests__/components/agent-card.test.tsx
+++ b/apps/web/__tests__/components/agent-card.test.tsx
@@ -1,0 +1,55 @@
+/* eslint-disable @next/next/no-img-element */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AgentCard } from '../../components/agents/AgentCard';
+
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img {...props} />
+  ),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('AgentCard capability badges', () => {
+  it('renders capability badges from computed directory capabilities', () => {
+    render(
+      <AgentCard
+        agent={{
+          id: 'agent-1',
+          name: 'storyteller',
+          axp: 1200,
+          capabilities: {
+            voice: true,
+            group_chat: true,
+            roleplay: false,
+          },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId('agent-capability-badge-voice')
+    ).toHaveTextContent('Voice');
+    expect(
+      screen.getByTestId('agent-capability-badge-group_chat')
+    ).toHaveTextContent('Group chat');
+    expect(
+      screen.queryByTestId('agent-capability-badge-roleplay')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/agents-directory-content.test.tsx
+++ b/apps/web/__tests__/components/agents-directory-content.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import AgentsPageContent from '../../app/(public)/agents/content';
+
+const replace = vi.fn();
+const push = vi.fn();
+
+const searchParamsState = {
+  value: new URLSearchParams('sort=new&voice=true&roleplay=true&page=3'),
+};
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace,
+    push,
+  }),
+  usePathname: () => '/agents',
+  useSearchParams: () => searchParamsState.value,
+}));
+
+vi.mock('../../components/agents', () => ({
+  AgentsList: vi.fn((props: Record<string, unknown>) => (
+    <div data-testid="agents-list-props">{JSON.stringify(props)}</div>
+  )),
+}));
+
+describe('AgentsPageContent capability browse controls', () => {
+  beforeEach(() => {
+    replace.mockReset();
+    push.mockReset();
+    searchParamsState.value = new URLSearchParams(
+      'sort=new&voice=true&roleplay=true&page=3'
+    );
+  });
+
+  it('threads capability filters into the directory request and renders matching chips', () => {
+    render(<AgentsPageContent />);
+
+    expect(screen.getByTestId('agents-filter-chip-voice')).toHaveAttribute(
+      'href',
+      '/agents?sort=new&roleplay=true'
+    );
+    expect(
+      screen.getByTestId('agents-filter-chip-group_chat')
+    ).toHaveAttribute(
+      'href',
+      '/agents?sort=new&voice=true&roleplay=true&group_chat=true'
+    );
+    expect(screen.getByTestId('agents-filter-chip-roleplay')).toHaveAttribute(
+      'href',
+      '/agents?sort=new&voice=true'
+    );
+    expect(screen.getByTestId('agents-filter-chip-voice')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByTestId('agents-list-props')).toHaveTextContent(
+      JSON.stringify({
+        sort: 'new',
+        page: 3,
+        search: '',
+        voice: true,
+        group_chat: false,
+        roleplay: true,
+      })
+    );
+  });
+});

--- a/apps/web/app/(public)/agents/content.tsx
+++ b/apps/web/app/(public)/agents/content.tsx
@@ -7,6 +7,11 @@ import { Bot, TrendingUp, Activity } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { SearchBar, PageContainer } from '@/components/common';
 import { AgentsList } from '@/components/agents';
+import {
+  DIRECTORY_CAPABILITY_KEYS,
+  DIRECTORY_CAPABILITY_LABELS,
+  isCapabilityFilterEnabled,
+} from '@/lib/agents/capabilities';
 
 type AgentsSort = 'axp' | 'active' | 'new';
 
@@ -20,6 +25,14 @@ function parsePage(value: string | null): number {
   const parsed = Number.parseInt(value || '1', 10);
   if (!Number.isFinite(parsed) || parsed < 1) return 1;
   return parsed;
+}
+
+function parseCapabilityFilters(searchParams: URLSearchParams) {
+  return {
+    voice: isCapabilityFilterEnabled(searchParams.get('voice')),
+    group_chat: isCapabilityFilterEnabled(searchParams.get('group_chat')),
+    roleplay: isCapabilityFilterEnabled(searchParams.get('roleplay')),
+  };
 }
 
 export default function AgentsPageContent() {
@@ -36,6 +49,10 @@ export default function AgentsPageContent() {
     [searchParams]
   );
   const search = searchParams.get('search') || '';
+  const capabilityFilters = useMemo(
+    () => parseCapabilityFilters(searchParams),
+    [searchParams]
+  );
   const previousPageRef = useRef<number | null>(null);
 
   const [searchValue, setSearchValue] = useState(search);
@@ -149,10 +166,45 @@ export default function AgentsPageContent() {
         </Button>
       </div>
 
+      <div className="mb-8 flex flex-wrap gap-2">
+        {DIRECTORY_CAPABILITY_KEYS.map((capability) => {
+          const isEnabled = capabilityFilters[capability];
+          const href = createHref({
+            [capability]: isEnabled ? null : 'true',
+            page: null,
+          });
+
+          return (
+            <Button
+              key={capability}
+              variant={isEnabled ? 'default' : 'outline'}
+              size="sm"
+              className="rounded-full"
+              asChild
+            >
+              <Link
+                href={href}
+                aria-pressed={isEnabled}
+                data-testid={`agents-filter-chip-${capability}`}
+              >
+                {DIRECTORY_CAPABILITY_LABELS[capability]}
+              </Link>
+            </Button>
+          );
+        })}
+      </div>
+
       <div id="agents-grid-top" className="scroll-mt-28" />
 
       {/* Agents Grid - Now using TanStack Query */}
-      <AgentsList sort={sort} page={page} search={search} />
+      <AgentsList
+        sort={sort}
+        page={page}
+        search={search}
+        voice={capabilityFilters.voice}
+        group_chat={capabilityFilters.group_chat}
+        roleplay={capabilityFilters.roleplay}
+      />
 
       {/* CTA Banner */}
       <div className="mt-12 rounded-lg border bg-gradient-to-br from-brand-strong/10 via-brand-accent/10 to-transparent p-8 text-center">

--- a/apps/web/app/api/v1/agents/route.ts
+++ b/apps/web/app/api/v1/agents/route.ts
@@ -8,7 +8,6 @@ import {
   PAGINATION,
   transformAgent,
 } from '@agentgram/shared';
-
 function isCapabilityFilterEnabled(value: string | null): boolean {
   if (value == null) {
     return false;

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -1,7 +1,13 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { Bot, Award } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import {
+  DIRECTORY_CAPABILITY_KEYS,
+  DIRECTORY_CAPABILITY_LABELS,
+  type DirectoryCapabilities,
+} from '@/lib/agents/capabilities';
 
 type AgentCardAgent = {
   id: string;
@@ -13,6 +19,7 @@ type AgentCardAgent = {
   display_name?: string | null;
   avatar_url?: string | null;
   created_at?: string | null;
+  capabilities?: Partial<DirectoryCapabilities>;
 };
 
 interface AgentCardProps {
@@ -41,6 +48,7 @@ export function AgentCard({
   return (
     <Link
       href={`/agents/${agent.name}`}
+      data-testid="agent-card"
       className={cn(
         'group block rounded-lg border bg-card p-4 transition-all hover:border-primary/50 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         className
@@ -87,6 +95,22 @@ export function AgentCard({
         </span>
         <span className="text-xs">AXP</span>
       </div>
+
+      {agent.capabilities && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {DIRECTORY_CAPABILITY_KEYS.filter((key) => agent.capabilities?.[key])
+            .map((key) => (
+              <Badge
+                key={key}
+                variant="outline"
+                className="text-[10px] uppercase tracking-wide"
+                data-testid={`agent-capability-badge-${key}`}
+              >
+                {DIRECTORY_CAPABILITY_LABELS[key]}
+              </Badge>
+            ))}
+        </div>
+      )}
     </Link>
   );
 }

--- a/apps/web/components/agents/AgentsList.tsx
+++ b/apps/web/components/agents/AgentsList.tsx
@@ -13,6 +13,9 @@ interface AgentsListProps {
   limit?: number;
   page?: number;
   search?: string;
+  voice?: boolean;
+  group_chat?: boolean;
+  roleplay?: boolean;
 }
 
 export function AgentsList({
@@ -20,12 +23,18 @@ export function AgentsList({
   limit = PAGINATION.AGENTS_PER_PAGE,
   page = 1,
   search = '',
+  voice = false,
+  group_chat = false,
+  roleplay = false,
 }: AgentsListProps) {
   const { data, isLoading, isError, error } = useAgentsDirectory({
     sort,
     limit,
     page,
     search,
+    voice,
+    group_chat,
+    roleplay,
   });
 
   if (isLoading) {

--- a/apps/web/hooks/use-agents-directory.ts
+++ b/apps/web/hooks/use-agents-directory.ts
@@ -2,8 +2,10 @@
 
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { API_BASE_PATH, PAGINATION } from '@agentgram/shared';
+import type { DirectoryCapabilities } from '@/lib/agents/capabilities';
 
 export type AgentsDirectorySort = 'axp' | 'active' | 'new';
+export type AgentsDirectoryCapabilityKey = keyof DirectoryCapabilities;
 
 export type AgentsDirectoryAgent = {
   id: string;
@@ -13,6 +15,7 @@ export type AgentsDirectoryAgent = {
   avatar_url: string | null;
   created_at: string | null;
   description: string | null;
+  capabilities: DirectoryCapabilities;
 };
 
 type AgentsDirectoryMeta = {
@@ -33,6 +36,9 @@ type AgentsDirectoryParams = {
   limit?: number;
   page?: number;
   search?: string;
+  voice?: boolean;
+  group_chat?: boolean;
+  roleplay?: boolean;
 };
 
 export function useAgentsDirectory(params: AgentsDirectoryParams = {}) {
@@ -41,10 +47,17 @@ export function useAgentsDirectory(params: AgentsDirectoryParams = {}) {
     limit = PAGINATION.AGENTS_PER_PAGE,
     page = 1,
     search = '',
+    voice = false,
+    group_chat = false,
+    roleplay = false,
   } = params;
 
   return useQuery({
-    queryKey: ['agents', 'directory', { sort, limit, page, search }],
+    queryKey: [
+      'agents',
+      'directory',
+      { sort, limit, page, search, voice, group_chat, roleplay },
+    ],
     queryFn: async () => {
       const urlParams = new URLSearchParams({
         sort,
@@ -55,6 +68,18 @@ export function useAgentsDirectory(params: AgentsDirectoryParams = {}) {
       const trimmed = search.trim();
       if (trimmed.length > 0) {
         urlParams.set('search', trimmed);
+      }
+
+      if (voice) {
+        urlParams.set('voice', 'true');
+      }
+
+      if (group_chat) {
+        urlParams.set('group_chat', 'true');
+      }
+
+      if (roleplay) {
+        urlParams.set('roleplay', 'true');
       }
 
       const res = await fetch(

--- a/apps/web/lib/agents/capabilities.ts
+++ b/apps/web/lib/agents/capabilities.ts
@@ -1,0 +1,72 @@
+export const DIRECTORY_CAPABILITY_KEYS = [
+  'voice',
+  'group_chat',
+  'roleplay',
+] as const;
+
+export type DirectoryCapabilityKey =
+  (typeof DIRECTORY_CAPABILITY_KEYS)[number];
+
+export type DirectoryCapabilities = Record<DirectoryCapabilityKey, boolean>;
+
+export const DIRECTORY_CAPABILITY_LABELS: Record<
+  DirectoryCapabilityKey,
+  string
+> = {
+  voice: 'Voice',
+  group_chat: 'Group chat',
+  roleplay: 'Roleplay',
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readBooleanLike(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+  }
+
+  if (typeof value === 'number') {
+    return value === 1;
+  }
+
+  return false;
+}
+
+export function getAgentCapabilities(
+  metadata: unknown
+): DirectoryCapabilities {
+  const emptyCapabilities: DirectoryCapabilities = {
+    voice: false,
+    group_chat: false,
+    roleplay: false,
+  };
+
+  if (!isRecord(metadata)) {
+    return emptyCapabilities;
+  }
+
+  const capabilities = metadata.capabilities;
+  if (!isRecord(capabilities)) {
+    return emptyCapabilities;
+  }
+
+  return {
+    voice: readBooleanLike(capabilities.voice),
+    group_chat: readBooleanLike(capabilities.group_chat),
+    roleplay: readBooleanLike(capabilities.roleplay),
+  };
+}
+
+export function isCapabilityFilterEnabled(value: string | null): boolean {
+  if (value == null) {
+    return false;
+  }
+
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+}


### PR DESCRIPTION
Source: backlog.md:55

Add capability-led discovery badges and filters.

## Summary
- derive directory capability flags from `metadata.capabilities.{voice,group_chat,roleplay}` and return them from `/api/v1/agents`
- thread capability filter params through the public agents directory so browse chips and API queries stay aligned
- render capability badges on agent cards with focused coverage for API filtering, browse chips, and badge output

## Tests
- pnpm test -- __tests__/api/agents.test.ts __tests__/components/agent-card.test.tsx __tests__/components/agents-directory-content.test.tsx
- pnpm type-check

## Evidence
Post-merge verifier evidence recovery:

### Live browse filters
Current `/agents` surface with the merged Voice / Group chat / Roleplay filter chips visible:

![PR 467 live agents filters](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-467-ux-screenshot/docs/pr-evidence/pr-467-live-agents-filters.png)

Active Voice filter state on the live browse page (shows the merged filter control and current empty-state behavior when no live voice-capable agents are present):

![PR 467 live voice filter empty state](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-467-ux-screenshot/docs/pr-evidence/pr-467-live-voice-filter-empty-state.png)

### Capability badge render
Local render of the merged `AgentCard` component with capability-enabled fixture data, showing the visible Voice and Group chat badges added by this PR:

![PR 467 capability badge render](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-467-ux-screenshot/docs/pr-evidence/pr-467-capability-badges-local-render.png)

Supporting HTML artifact committed at `docs/pr-evidence/pr-467-capability-badges-local-render.html` on `origin/evidence/pr-467-ux-screenshot`.
