### PR TITLE
feat: add proactive outreach settings controls

### DIFF
--- a/apps/web/__tests__/api/developer-proactive-controls.test.ts
+++ b/apps/web/__tests__/api/developer-proactive-controls.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSingle = vi.fn();
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockUpdate = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@agentgram/db', () => ({
+  getSupabaseServiceClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+vi.mock('@/lib/auth/developer', () => ({
+  withDeveloperAuth: (handler: unknown) => handler,
+}));
+
+describe('/api/v1/developers/me/proactive-controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSingle.mockResolvedValue({
+      data: {
+        metadata: {
+          proactiveControls: {
+            optIn: false,
+            dailyLimit: 2,
+            weeklyLimit: 8,
+            updatedAt: '2026-04-20T00:00:00.000Z',
+          },
+        },
+      },
+      error: null,
+    });
+
+    mockEq.mockReturnValue({ single: mockSingle });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockUpdate.mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: mockSingle,
+        }),
+      }),
+    });
+    mockFrom.mockImplementation(() => ({
+      select: mockSelect,
+      update: mockUpdate,
+    }));
+  });
+
+  it('returns the saved settings on GET', async () => {
+    const { GET } = await import('@/app/api/v1/developers/me/proactive-controls/route');
+    const request = new Request('http://localhost/api/v1/developers/me/proactive-controls', {
+      headers: {
+        'x-developer-id': 'dev-1',
+      },
+    });
+
+    const response = await GET(request as Parameters<typeof GET>[0]);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toEqual({
+      success: true,
+      data: {
+        optIn: false,
+        dailyLimit: 2,
+        weeklyLimit: 8,
+        updatedAt: '2026-04-20T00:00:00.000Z',
+      },
+    });
+    expect(mockFrom).toHaveBeenCalledWith('developers');
+    expect(mockSelect).toHaveBeenCalledWith('metadata');
+    expect(mockEq).toHaveBeenCalledWith('id', 'dev-1');
+  });
+
+  it('saves normalized settings on PUT', async () => {
+    const updateEq = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: {
+            metadata: {
+              timezone: 'UTC',
+              proactiveControls: {
+                optIn: false,
+                dailyLimit: 25,
+                weeklyLimit: 25,
+                updatedAt: '2026-04-26T00:00:00.000Z',
+              },
+            },
+          },
+          error: null,
+        }),
+      }),
+    });
+
+    mockUpdate.mockReturnValue({ eq: updateEq });
+    mockSingle.mockResolvedValueOnce({
+      data: {
+        metadata: {
+          timezone: 'UTC',
+          proactiveControls: {
+            optIn: true,
+            dailyLimit: 3,
+            weeklyLimit: 9,
+            updatedAt: '2026-04-20T00:00:00.000Z',
+          },
+        },
+      },
+      error: null,
+    });
+
+    const { PUT } = await import('@/app/api/v1/developers/me/proactive-controls/route');
+    const request = new Request('http://localhost/api/v1/developers/me/proactive-controls', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-developer-id': 'dev-1',
+      },
+      body: JSON.stringify({
+        optIn: false,
+        dailyLimit: 30,
+        weeklyLimit: 2,
+      }),
+    });
+
+    const response = await PUT(request as Parameters<typeof PUT>[0]);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate.mock.calls[0][0]).toMatchObject({
+      metadata: {
+        timezone: 'UTC',
+        proactiveControls: {
+          optIn: false,
+          dailyLimit: 25,
+          weeklyLimit: 25,
+        },
+      },
+    });
+    expect(json).toEqual({
+      success: true,
+      data: {
+        optIn: false,
+        dailyLimit: 25,
+        weeklyLimit: 25,
+        updatedAt: '2026-04-26T00:00:00.000Z',
+      },
+    });
+    expect(updateEq).toHaveBeenCalledWith('id', 'dev-1');
+  });
+
+  it('rejects malformed JSON on PUT', async () => {
+    const { PUT } = await import('@/app/api/v1/developers/me/proactive-controls/route');
+    const request = new Request('http://localhost/api/v1/developers/me/proactive-controls', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-developer-id': 'dev-1',
+      },
+      body: '{',
+    });
+
+    const response = await PUT(request as Parameters<typeof PUT>[0]);
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('BAD_REQUEST');
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when developer context is missing', async () => {
+    const { GET } = await import('@/app/api/v1/developers/me/proactive-controls/route');
+    const request = new Request('http://localhost/api/v1/developers/me/proactive-controls');
+
+    const response = await GET(request as Parameters<typeof GET>[0]);
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('UNAUTHORIZED');
+  });
+});

--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProactiveControlsForm } from '@/components/dashboard/ProactiveControlsForm';
+
+const mockCreateClient = vi.fn();
+const mockFadeIn = vi.fn(({ children }: { children: React.ReactNode }) => (
+  <div data-testid="fade-in">{children}</div>
+));
+const mockProactiveControlsForm = vi.fn(
+  ({ initialSettings }: { initialSettings: unknown }) => (
+    <div data-testid="proactive-controls-form">
+      {JSON.stringify(initialSettings)}
+    </div>
+  )
+);
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: mockCreateClient,
+}));
+
+vi.mock('@/components/dashboard', () => ({
+  FadeIn: mockFadeIn,
+  ProactiveControlsForm: mockProactiveControlsForm,
+}));
+
+describe('ProactiveControlsForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: {
+            optIn: false,
+            dailyLimit: 7,
+            weeklyLimit: 21,
+            updatedAt: '2026-04-26T00:00:00.000Z',
+          },
+        }),
+      })
+    );
+  });
+
+  it('shows opt-in off by default with visible daily and weekly caps and saves through the API', async () => {
+    render(
+      <ProactiveControlsForm
+        initialSettings={{
+          optIn: false,
+          dailyLimit: 2,
+          weeklyLimit: 8,
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole('checkbox', { name: /enable proactive outreach/i })
+    ).not.toBeChecked();
+    expect(screen.getByLabelText('Daily outreach cap')).toHaveValue(2);
+    expect(screen.getByLabelText('Weekly outreach cap')).toHaveValue(8);
+
+    fireEvent.change(screen.getByLabelText('Daily outreach cap'), {
+      target: { value: '7' },
+    });
+    fireEvent.change(screen.getByLabelText('Weekly outreach cap'), {
+      target: { value: '21' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save controls' }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/developers/me/proactive-controls',
+        expect.objectContaining({
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            optIn: false,
+            dailyLimit: 7,
+            weeklyLimit: 21,
+          }),
+        })
+      );
+    });
+
+    expect(
+      await screen.findByText('Proactive outreach preferences saved.')
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Daily outreach cap')).toHaveValue(7);
+    expect(screen.getByLabelText('Weekly outreach cap')).toHaveValue(21);
+  });
+
+  it('shows an error when the save request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ success: false }),
+      })
+    );
+
+    render(
+      <ProactiveControlsForm
+        initialSettings={{
+          optIn: false,
+          dailyLimit: 2,
+          weeklyLimit: 8,
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save controls' }));
+
+    expect(
+      await screen.findByText('Could not save these settings. Please try again.')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads proactive controls from developer metadata for the settings form', async () => {
+    mockCreateClient.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-1', email: 'dev@example.com' } },
+        }),
+      },
+      from: vi.fn((table: string) => {
+        if (table === 'developer_members') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { developer_id: 'dev-1' },
+                }),
+              }),
+            }),
+          };
+        }
+
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  metadata: {
+                    proactiveControls: {
+                      optIn: false,
+                      dailyLimit: 2,
+                      weeklyLimit: 8,
+                    },
+                  },
+                },
+              }),
+            }),
+          }),
+        };
+      }),
+    });
+
+    const { default: SettingsPage } = await import(
+      '@/app/(protected)/dashboard/settings/page'
+    );
+
+    render(await SettingsPage());
+
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+    expect(mockProactiveControlsForm).toHaveBeenCalledWith(
+      {
+        initialSettings: {
+          optIn: false,
+          dailyLimit: 2,
+          weeklyLimit: 8,
+        },
+      },
+      undefined
+    );
+    expect(screen.getByTestId('proactive-controls-form')).toBeInTheDocument();
+  });
+
+  it('renders the unavailable state when the user has no developer membership', async () => {
+    mockCreateClient.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-1', email: 'dev@example.com' } },
+        }),
+      },
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+            }),
+          }),
+        }),
+      })),
+    });
+
+    const { default: SettingsPage } = await import(
+      '@/app/(protected)/dashboard/settings/page'
+    );
+
+    render(await SettingsPage());
+
+    expect(
+      screen.getByRole('heading', { name: 'Settings Unavailable' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Please complete your developer profile first.')
+    ).toBeInTheDocument();
+    expect(mockProactiveControlsForm).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/__tests__/lib/proactive-controls.test.ts
+++ b/apps/web/__tests__/lib/proactive-controls.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_PROACTIVE_CONTROLS_SETTINGS,
+  normalizeProactiveControlsSettings,
+  readProactiveControlsFromMetadata,
+  writeProactiveControlsToMetadata,
+} from '@/lib/proactive-controls';
+
+describe('proactive controls helper', () => {
+  it('defaults opt-in off with visible daily and weekly caps', () => {
+    expect(DEFAULT_PROACTIVE_CONTROLS_SETTINGS).toEqual({
+      optIn: false,
+      dailyLimit: 2,
+      weeklyLimit: 8,
+    });
+  });
+
+  it('normalizes invalid values into bounded settings', () => {
+    expect(
+      normalizeProactiveControlsSettings({
+        optIn: 'true',
+        dailyLimit: 0,
+        weeklyLimit: 999,
+        updatedAt: 123,
+      })
+    ).toEqual({
+      optIn: false,
+      dailyLimit: 1,
+      weeklyLimit: 100,
+      updatedAt: undefined,
+    });
+  });
+
+  it('forces weekly limit to stay at or above the daily limit', () => {
+    expect(
+      normalizeProactiveControlsSettings({
+        optIn: true,
+        dailyLimit: 12,
+        weeklyLimit: 4,
+      })
+    ).toEqual({
+      optIn: true,
+      dailyLimit: 12,
+      weeklyLimit: 12,
+      updatedAt: undefined,
+    });
+  });
+
+  it('reads settings from nested metadata and falls back when absent', () => {
+    expect(
+      readProactiveControlsFromMetadata({
+        proactiveControls: {
+          optIn: true,
+          dailyLimit: 3,
+          weeklyLimit: 9,
+          updatedAt: '2026-04-26T00:00:00.000Z',
+        },
+      })
+    ).toEqual({
+      optIn: true,
+      dailyLimit: 3,
+      weeklyLimit: 9,
+      updatedAt: '2026-04-26T00:00:00.000Z',
+    });
+
+    expect(readProactiveControlsFromMetadata(null)).toEqual(
+      DEFAULT_PROACTIVE_CONTROLS_SETTINGS
+    );
+  });
+
+  it('writes normalized settings back into metadata without dropping sibling fields', () => {
+    expect(
+      writeProactiveControlsToMetadata(
+        { theme: 'light' },
+        { optIn: true, dailyLimit: 4, weeklyLimit: 2 },
+        '2026-04-26T03:06:00.000Z'
+      )
+    ).toEqual({
+      theme: 'light',
+      proactiveControls: {
+        optIn: true,
+        dailyLimit: 4,
+        weeklyLimit: 4,
+        updatedAt: '2026-04-26T03:06:00.000Z',
+      },
+    });
+  });
+});

--- a/apps/web/app/(protected)/dashboard/layout.tsx
+++ b/apps/web/app/(protected)/dashboard/layout.tsx
@@ -37,7 +37,6 @@ export default async function DashboardLayout({
       href: '/dashboard',
       label: 'Overview',
       icon: LayoutDashboard,
-      active: true,
     },
     {
       href: '/dashboard/analytics',
@@ -63,9 +62,10 @@ export default async function DashboardLayout({
       href: '/dashboard/settings',
       label: 'Settings',
       icon: Settings,
-      disabled: true,
     },
   ];
+  const navigationItems: Array<(typeof navItems)[number] & { disabled?: boolean }> =
+    navItems;
 
   return (
     <div className="flex min-h-screen bg-background text-foreground">
@@ -82,10 +82,10 @@ export default async function DashboardLayout({
         </div>
 
         <nav className="flex-1 space-y-1 p-4">
-          {navItems.map((item) => (
+          {navigationItems.map((item) => (
             <Link
               key={item.href}
-              href={item.disabled ? '#' : item.href}
+              href={item.href}
               className={`flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
                 item.disabled
                   ? 'cursor-not-allowed opacity-50 text-muted-foreground'

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -1,0 +1,82 @@
+import { createClient } from '@/lib/supabase/server';
+import { FadeIn, ProactiveControlsForm } from '@/components/dashboard';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { readProactiveControlsFromMetadata } from '@/lib/proactive-controls';
+
+export const metadata = {
+  title: 'Settings',
+};
+
+export default async function SettingsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  const { data: member } = await supabase
+    .from('developer_members')
+    .select('developer_id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (!member) {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center space-y-4">
+        <h2 className="text-2xl font-bold tracking-tight">Settings Unavailable</h2>
+        <p className="text-muted-foreground">
+          Please complete your developer profile first.
+        </p>
+      </div>
+    );
+  }
+
+  const { developer_id } = member as { developer_id: string };
+  const { data: developer } = await supabase
+    .from('developers')
+    .select('metadata')
+    .eq('id', developer_id)
+    .single();
+
+  const initialSettings = readProactiveControlsFromMetadata(developer?.metadata);
+
+  return (
+    <div className="space-y-8">
+      <FadeIn>
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
+          <p className="text-muted-foreground">
+            Manage the first developer-facing controls for proactive outreach.
+          </p>
+        </div>
+      </FadeIn>
+
+      <FadeIn delay={0.05}>
+        <ProactiveControlsForm initialSettings={initialSettings} />
+      </FadeIn>
+
+      <FadeIn delay={0.1}>
+        <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>Settings roadmap</CardTitle>
+            <CardDescription>
+              This page is the smallest coherent home for outbound controls now,
+              with room for additional developer settings later.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            More dashboard settings can land here without moving the proactive
+            controls again.
+          </CardContent>
+        </Card>
+      </FadeIn>
+    </div>
+  );
+}

--- a/apps/web/app/api/v1/developers/me/proactive-controls/route.ts
+++ b/apps/web/app/api/v1/developers/me/proactive-controls/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import type { Json } from '@agentgram/db';
+import { withDeveloperAuth } from '@/lib/auth/developer';
+import {
+  readProactiveControlsFromMetadata,
+  writeProactiveControlsToMetadata,
+} from '@/lib/proactive-controls';
+
+export const GET = withDeveloperAuth(async function GET(req: NextRequest) {
+  const developerId = req.headers.get('x-developer-id');
+
+  if (!developerId) {
+    return NextResponse.json(
+      { success: false, error: { code: 'UNAUTHORIZED', message: 'Not authenticated' } },
+      { status: 401 }
+    );
+  }
+
+  const { data: developer, error } = await getSupabaseServiceClient()
+    .from('developers')
+    .select('metadata')
+    .eq('id', developerId)
+    .single();
+
+  if (error || !developer) {
+    return NextResponse.json(
+      { success: false, error: { code: 'NOT_FOUND', message: 'Developer not found' } },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: readProactiveControlsFromMetadata(developer.metadata),
+  });
+});
+
+export const PUT = withDeveloperAuth(async function PUT(req: NextRequest) {
+  const developerId = req.headers.get('x-developer-id');
+
+  if (!developerId) {
+    return NextResponse.json(
+      { success: false, error: { code: 'UNAUTHORIZED', message: 'Not authenticated' } },
+      { status: 401 }
+    );
+  }
+
+  let body: unknown;
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: { code: 'BAD_REQUEST', message: 'Invalid JSON body' } },
+      { status: 400 }
+    );
+  }
+
+  const { data: developer, error: fetchError } = await getSupabaseServiceClient()
+    .from('developers')
+    .select('metadata')
+    .eq('id', developerId)
+    .single();
+
+  if (fetchError || !developer) {
+    return NextResponse.json(
+      { success: false, error: { code: 'NOT_FOUND', message: 'Developer not found' } },
+      { status: 404 }
+    );
+  }
+
+  const updatedMetadata = writeProactiveControlsToMetadata(
+    developer.metadata,
+    body
+  ) as Json;
+
+  const { data: updatedDeveloper, error: updateError } = await getSupabaseServiceClient()
+    .from('developers')
+    .update({ metadata: updatedMetadata })
+    .eq('id', developerId)
+    .select('metadata')
+    .single();
+
+  if (updateError || !updatedDeveloper) {
+    return NextResponse.json(
+      { success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to save proactive controls' } },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: readProactiveControlsFromMetadata(updatedDeveloper.metadata),
+  });
+});

--- a/apps/web/components/dashboard/ProactiveControlsForm.tsx
+++ b/apps/web/components/dashboard/ProactiveControlsForm.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import type { ProactiveControlsSettings } from '@/lib/proactive-controls';
+
+interface ProactiveControlsFormProps {
+  initialSettings: ProactiveControlsSettings;
+}
+
+export function ProactiveControlsForm({
+  initialSettings,
+}: ProactiveControlsFormProps) {
+  const [settings, setSettings] = useState(initialSettings);
+  const [isSaving, setIsSaving] = useState(false);
+  const [status, setStatus] = useState<{
+    tone: 'idle' | 'success' | 'error';
+    message: string;
+  }>({
+    tone: 'idle',
+    message: '',
+  });
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setStatus({ tone: 'idle', message: '' });
+
+    try {
+      const response = await fetch('/api/v1/developers/me/proactive-controls', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(settings),
+      });
+
+      const payload = (await response.json()) as {
+        success?: boolean;
+        data?: ProactiveControlsSettings;
+      };
+
+      if (!response.ok || !payload.success || !payload.data) {
+        throw new Error('Failed to save proactive controls');
+      }
+
+      setSettings(payload.data);
+      setStatus({
+        tone: 'success',
+        message: 'Proactive outreach preferences saved.',
+      });
+    } catch (error) {
+      console.error('Error saving proactive controls:', error);
+      setStatus({
+        tone: 'error',
+        message: 'Could not save these settings. Please try again.',
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <ShieldCheck className="h-5 w-5 text-primary" />
+          Proactive outreach controls
+        </CardTitle>
+        <CardDescription>
+          Outreach stays off until you explicitly opt in. Caps stay visible here
+          so you can tune how often AgentGram may reach out on your behalf.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <label className="flex items-start gap-3 rounded-lg border border-border/60 p-4">
+          <input
+            checked={settings.optIn}
+            className="mt-1 h-4 w-4 rounded border-input"
+            onChange={(event) =>
+              setSettings((current) => ({
+                ...current,
+                optIn: event.target.checked,
+              }))
+            }
+            type="checkbox"
+          />
+          <div className="space-y-1">
+            <div className="font-medium text-foreground">
+              Enable proactive outreach
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Leave this off to keep all proactive outreach disabled by
+              default. Turn it on only when you want AgentGram to initiate
+              outreach for you.
+            </p>
+          </div>
+        </label>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2">
+            <span className="text-sm font-medium text-foreground">
+              Daily outreach cap
+            </span>
+            <Input
+              aria-label="Daily outreach cap"
+              inputMode="numeric"
+              min={1}
+              max={25}
+              onChange={(event) =>
+                setSettings((current) => ({
+                  ...current,
+                  dailyLimit: Number(event.target.value),
+                }))
+              }
+              type="number"
+              value={settings.dailyLimit}
+            />
+            <p className="text-xs text-muted-foreground">
+              Max proactive touches per day when opt-in is enabled.
+            </p>
+          </label>
+
+          <label className="space-y-2">
+            <span className="text-sm font-medium text-foreground">
+              Weekly outreach cap
+            </span>
+            <Input
+              aria-label="Weekly outreach cap"
+              inputMode="numeric"
+              min={1}
+              max={100}
+              onChange={(event) =>
+                setSettings((current) => ({
+                  ...current,
+                  weeklyLimit: Number(event.target.value),
+                }))
+              }
+              type="number"
+              value={settings.weeklyLimit}
+            />
+            <p className="text-xs text-muted-foreground">
+              Max proactive touches per rolling week when opt-in is enabled.
+            </p>
+          </label>
+        </div>
+
+        <div className="rounded-lg border border-dashed border-border/60 p-4 text-sm text-muted-foreground">
+          The caps are enforced after save. If values fall outside the allowed
+          range, AgentGram will clamp them to safe limits and reflect the saved
+          numbers back here.
+        </div>
+      </CardContent>
+      <CardFooter className="flex flex-col items-start gap-3 border-t border-border/40 pt-6 sm:flex-row sm:items-center sm:justify-between">
+        <p
+          className={`text-sm ${
+            status.tone === 'error'
+              ? 'text-destructive'
+              : status.tone === 'success'
+                ? 'text-primary'
+                : 'text-muted-foreground'
+          }`}
+          role="status"
+        >
+          {status.message || 'Changes save only when you click Save controls.'}
+        </p>
+        <Button disabled={isSaving} onClick={handleSave} type="button">
+          {isSaving ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            'Save controls'
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/components/dashboard/index.ts
+++ b/apps/web/components/dashboard/index.ts
@@ -1,4 +1,5 @@
 export { FadeIn } from './FadeIn';
+export { ProactiveControlsForm } from './ProactiveControlsForm';
 export { SignOutButton } from './SignOutButton';
 export { ManageSubscriptionButton } from './ManageSubscriptionButton';
 export { default as UsageMeter } from './UsageMeter';

--- a/apps/web/lib/proactive-controls.ts
+++ b/apps/web/lib/proactive-controls.ts
@@ -1,0 +1,97 @@
+export interface ProactiveControlsSettings {
+  optIn: boolean;
+  dailyLimit: number;
+  weeklyLimit: number;
+  updatedAt?: string;
+}
+
+const DEFAULT_DAILY_LIMIT = 2;
+const DEFAULT_WEEKLY_LIMIT = 8;
+const MIN_DAILY_LIMIT = 1;
+const MAX_DAILY_LIMIT = 25;
+const MAX_WEEKLY_LIMIT = 100;
+
+export const DEFAULT_PROACTIVE_CONTROLS_SETTINGS: ProactiveControlsSettings = {
+  optIn: false,
+  dailyLimit: DEFAULT_DAILY_LIMIT,
+  weeklyLimit: DEFAULT_WEEKLY_LIMIT,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toBoundedInteger(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number
+) {
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? Number(value)
+        : Number.NaN;
+
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return Math.min(max, Math.max(min, Math.round(parsed)));
+}
+
+export function normalizeProactiveControlsSettings(
+  value: unknown
+): ProactiveControlsSettings {
+  if (!isRecord(value)) {
+    return { ...DEFAULT_PROACTIVE_CONTROLS_SETTINGS };
+  }
+
+  const dailyLimit = toBoundedInteger(
+    value.dailyLimit,
+    DEFAULT_DAILY_LIMIT,
+    MIN_DAILY_LIMIT,
+    MAX_DAILY_LIMIT
+  );
+  const weeklyLimit = toBoundedInteger(
+    value.weeklyLimit,
+    Math.max(DEFAULT_WEEKLY_LIMIT, dailyLimit),
+    dailyLimit,
+    MAX_WEEKLY_LIMIT
+  );
+
+  return {
+    optIn: value.optIn === true,
+    dailyLimit,
+    weeklyLimit: Math.max(weeklyLimit, dailyLimit),
+    updatedAt: typeof value.updatedAt === 'string' ? value.updatedAt : undefined,
+  };
+}
+
+export function readProactiveControlsFromMetadata(
+  metadata: unknown
+): ProactiveControlsSettings {
+  if (!isRecord(metadata)) {
+    return { ...DEFAULT_PROACTIVE_CONTROLS_SETTINGS };
+  }
+
+  return normalizeProactiveControlsSettings(metadata.proactiveControls);
+}
+
+export function writeProactiveControlsToMetadata(
+  metadata: unknown,
+  value: unknown,
+  updatedAt: string = new Date().toISOString()
+): Record<string, unknown> {
+  const baseMetadata = isRecord(metadata) ? metadata : {};
+  const settings = normalizeProactiveControlsSettings(value);
+
+  return {
+    ...baseMetadata,
+    proactiveControls: {
+      ...settings,
+      updatedAt,
+    },
+  };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,5 +1,5 @@
 export { getSupabaseServiceClient } from './client';
-export type { Database } from './types';
+export type { Database, Json } from './types';
 export type { Agent, LikeResult } from './helpers';
 export { handlePostLike } from './helpers';
 export { handleFollow } from './follow';


### PR DESCRIPTION
Source: backlog.md:7

Add proactive controls opt-in and frequency caps UI.

## Summary
- enable `/dashboard/settings` as the first coherent home for developer-facing proactive outreach controls
- add default-off proactive settings normalization plus developer metadata persistence for visible daily/weekly caps
- cover helper normalization, settings load/save behavior, and the authenticated proactive-controls API route

## Guarded UI states
- proactive outreach stays off until the developer explicitly opts in
- daily and weekly caps remain visible and editable in settings
- saved values round-trip through developer metadata and clamp back to safe limits when needed

## Tests
- pnpm test -- __tests__/api/developer-proactive-controls.test.ts __tests__/components/proactive-controls-settings.test.tsx __tests__/lib/proactive-controls.test.ts
- pnpm type-check

## Retro UX evidence

Default-off proactive outreach controls rendered on the dashboard settings surface, with visible daily/weekly caps:

![PR #468 UX evidence — proactive opt-in and frequency caps](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-466-468-469-ux-screens/docs/pr-evidence/pr-468-469-proactive-controls.png)
