### PR TITLE
feat: add proactive quiet hours setting

### DIFF
--- a/apps/web/__tests__/api/developer-proactive-controls.test.ts
+++ b/apps/web/__tests__/api/developer-proactive-controls.test.ts
@@ -67,6 +67,9 @@ describe('/api/v1/developers/me/proactive-controls', () => {
         optIn: false,
         dailyLimit: 2,
         weeklyLimit: 8,
+        quietHoursEnabled: false,
+        quietHoursStart: '22:00',
+        quietHoursEnd: '08:00',
         updatedAt: '2026-04-20T00:00:00.000Z',
       },
     });
@@ -86,6 +89,9 @@ describe('/api/v1/developers/me/proactive-controls', () => {
                 optIn: false,
                 dailyLimit: 25,
                 weeklyLimit: 25,
+                quietHoursEnabled: true,
+                quietHoursStart: '21:30',
+                quietHoursEnd: '07:15',
                 updatedAt: '2026-04-26T00:00:00.000Z',
               },
             },
@@ -122,6 +128,9 @@ describe('/api/v1/developers/me/proactive-controls', () => {
         optIn: false,
         dailyLimit: 30,
         weeklyLimit: 2,
+        quietHoursEnabled: true,
+        quietHoursStart: '21:30',
+        quietHoursEnd: '07:15',
       }),
     });
 
@@ -137,6 +146,9 @@ describe('/api/v1/developers/me/proactive-controls', () => {
           optIn: false,
           dailyLimit: 25,
           weeklyLimit: 25,
+          quietHoursEnabled: true,
+          quietHoursStart: '21:30',
+          quietHoursEnd: '07:15',
         },
       },
     });
@@ -146,6 +158,9 @@ describe('/api/v1/developers/me/proactive-controls', () => {
         optIn: false,
         dailyLimit: 25,
         weeklyLimit: 25,
+        quietHoursEnabled: true,
+        quietHoursStart: '21:30',
+        quietHoursEnd: '07:15',
         updatedAt: '2026-04-26T00:00:00.000Z',
       },
     });

--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -37,6 +37,9 @@ describe('ProactiveControlsForm', () => {
             optIn: false,
             dailyLimit: 7,
             weeklyLimit: 21,
+            quietHoursEnabled: true,
+            quietHoursStart: '21:30',
+            quietHoursEnd: '07:15',
             updatedAt: '2026-04-26T00:00:00.000Z',
           },
         }),
@@ -44,13 +47,16 @@ describe('ProactiveControlsForm', () => {
     );
   });
 
-  it('shows opt-in off by default with visible daily and weekly caps and saves through the API', async () => {
+  it('shows caps and quiet hours controls and saves through the API', async () => {
     render(
       <ProactiveControlsForm
         initialSettings={{
           optIn: false,
           dailyLimit: 2,
           weeklyLimit: 8,
+          quietHoursEnabled: false,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
         }}
       />
     );
@@ -60,12 +66,24 @@ describe('ProactiveControlsForm', () => {
     ).not.toBeChecked();
     expect(screen.getByLabelText('Daily outreach cap')).toHaveValue(2);
     expect(screen.getByLabelText('Weekly outreach cap')).toHaveValue(8);
+    expect(
+      screen.getByRole('checkbox', { name: /quiet hours/i })
+    ).not.toBeChecked();
+    expect(screen.queryByLabelText('Quiet hours start')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Quiet hours end')).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Daily outreach cap'), {
       target: { value: '7' },
     });
     fireEvent.change(screen.getByLabelText('Weekly outreach cap'), {
       target: { value: '21' },
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: /quiet hours/i }));
+    fireEvent.change(screen.getByLabelText('Quiet hours start'), {
+      target: { value: '21:30' },
+    });
+    fireEvent.change(screen.getByLabelText('Quiet hours end'), {
+      target: { value: '07:15' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save controls' }));
 
@@ -81,6 +99,9 @@ describe('ProactiveControlsForm', () => {
             optIn: false,
             dailyLimit: 7,
             weeklyLimit: 21,
+            quietHoursEnabled: true,
+            quietHoursStart: '21:30',
+            quietHoursEnd: '07:15',
           }),
         })
       );
@@ -91,6 +112,9 @@ describe('ProactiveControlsForm', () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Daily outreach cap')).toHaveValue(7);
     expect(screen.getByLabelText('Weekly outreach cap')).toHaveValue(21);
+    expect(screen.getByRole('checkbox', { name: /quiet hours/i })).toBeChecked();
+    expect(screen.getByLabelText('Quiet hours start')).toHaveValue('21:30');
+    expect(screen.getByLabelText('Quiet hours end')).toHaveValue('07:15');
   });
 
   it('shows an error when the save request fails', async () => {
@@ -108,6 +132,9 @@ describe('ProactiveControlsForm', () => {
           optIn: false,
           dailyLimit: 2,
           weeklyLimit: 8,
+          quietHoursEnabled: false,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
         }}
       />
     );
@@ -155,6 +182,9 @@ describe('SettingsPage', () => {
                       optIn: false,
                       dailyLimit: 2,
                       weeklyLimit: 8,
+                      quietHoursEnabled: true,
+                      quietHoursStart: '23:00',
+                      quietHoursEnd: '06:30',
                     },
                   },
                 },
@@ -178,6 +208,10 @@ describe('SettingsPage', () => {
           optIn: false,
           dailyLimit: 2,
           weeklyLimit: 8,
+          quietHoursEnabled: true,
+          quietHoursStart: '23:00',
+          quietHoursEnd: '06:30',
+          updatedAt: undefined,
         },
       },
       undefined

--- a/apps/web/__tests__/lib/proactive-controls.test.ts
+++ b/apps/web/__tests__/lib/proactive-controls.test.ts
@@ -12,6 +12,9 @@ describe('proactive controls helper', () => {
       optIn: false,
       dailyLimit: 2,
       weeklyLimit: 8,
+      quietHoursEnabled: false,
+      quietHoursStart: '22:00',
+      quietHoursEnd: '08:00',
     });
   });
 
@@ -21,12 +24,18 @@ describe('proactive controls helper', () => {
         optIn: 'true',
         dailyLimit: 0,
         weeklyLimit: 999,
+        quietHoursEnabled: 'true',
+        quietHoursStart: '25:00',
+        quietHoursEnd: 'nope',
         updatedAt: 123,
       })
     ).toEqual({
       optIn: false,
       dailyLimit: 1,
       weeklyLimit: 100,
+      quietHoursEnabled: false,
+      quietHoursStart: '22:00',
+      quietHoursEnd: '08:00',
       updatedAt: undefined,
     });
   });
@@ -42,6 +51,30 @@ describe('proactive controls helper', () => {
       optIn: true,
       dailyLimit: 12,
       weeklyLimit: 12,
+      quietHoursEnabled: false,
+      quietHoursStart: '22:00',
+      quietHoursEnd: '08:00',
+      updatedAt: undefined,
+    });
+  });
+
+  it('keeps valid quiet hours values', () => {
+    expect(
+      normalizeProactiveControlsSettings({
+        optIn: true,
+        dailyLimit: 5,
+        weeklyLimit: 12,
+        quietHoursEnabled: true,
+        quietHoursStart: '21:30',
+        quietHoursEnd: '07:15',
+      })
+    ).toEqual({
+      optIn: true,
+      dailyLimit: 5,
+      weeklyLimit: 12,
+      quietHoursEnabled: true,
+      quietHoursStart: '21:30',
+      quietHoursEnd: '07:15',
       updatedAt: undefined,
     });
   });
@@ -53,6 +86,9 @@ describe('proactive controls helper', () => {
           optIn: true,
           dailyLimit: 3,
           weeklyLimit: 9,
+          quietHoursEnabled: true,
+          quietHoursStart: '23:00',
+          quietHoursEnd: '06:30',
           updatedAt: '2026-04-26T00:00:00.000Z',
         },
       })
@@ -60,6 +96,9 @@ describe('proactive controls helper', () => {
       optIn: true,
       dailyLimit: 3,
       weeklyLimit: 9,
+      quietHoursEnabled: true,
+      quietHoursStart: '23:00',
+      quietHoursEnd: '06:30',
       updatedAt: '2026-04-26T00:00:00.000Z',
     });
 
@@ -72,7 +111,14 @@ describe('proactive controls helper', () => {
     expect(
       writeProactiveControlsToMetadata(
         { theme: 'light' },
-        { optIn: true, dailyLimit: 4, weeklyLimit: 2 },
+        {
+          optIn: true,
+          dailyLimit: 4,
+          weeklyLimit: 2,
+          quietHoursEnabled: true,
+          quietHoursStart: '21:00',
+          quietHoursEnd: '06:00',
+        },
         '2026-04-26T03:06:00.000Z'
       )
     ).toEqual({
@@ -81,6 +127,9 @@ describe('proactive controls helper', () => {
         optIn: true,
         dailyLimit: 4,
         weeklyLimit: 4,
+        quietHoursEnabled: true,
+        quietHoursStart: '21:00',
+        quietHoursEnd: '06:00',
         updatedAt: '2026-04-26T03:06:00.000Z',
       },
     });

--- a/apps/web/components/dashboard/ProactiveControlsForm.tsx
+++ b/apps/web/components/dashboard/ProactiveControlsForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Loader2, ShieldCheck } from 'lucide-react';
+import { Clock, Loader2, ShieldCheck } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -99,9 +99,9 @@ export function ProactiveControlsForm({
               Enable proactive outreach
             </div>
             <p className="text-sm text-muted-foreground">
-              Leave this off to keep all proactive outreach disabled by
-              default. Turn it on only when you want AgentGram to initiate
-              outreach for you.
+              Leave this off to keep all proactive outreach disabled by default.
+              Turn it on only when you want AgentGram to initiate outreach for
+              you.
             </p>
           </div>
         </label>
@@ -154,10 +154,74 @@ export function ProactiveControlsForm({
           </label>
         </div>
 
+        <div className="space-y-4 rounded-lg border border-border/60 p-4">
+          <label className="flex items-start gap-3">
+            <input
+              checked={settings.quietHoursEnabled}
+              className="mt-1 h-4 w-4 rounded border-input"
+              onChange={(event) =>
+                setSettings((current) => ({
+                  ...current,
+                  quietHoursEnabled: event.target.checked,
+                }))
+              }
+              type="checkbox"
+            />
+            <div className="space-y-1">
+              <div className="flex items-center gap-2 font-medium text-foreground">
+                <Clock className="h-4 w-4 text-muted-foreground" />
+                Quiet hours
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Pause all proactive outreach during a daily window. Outreach
+                resumes automatically once quiet hours end.
+              </p>
+            </div>
+          </label>
+
+          {settings.quietHoursEnabled && (
+            <div className="grid gap-4 pl-7 md:grid-cols-2">
+              <label className="space-y-2">
+                <span className="text-sm font-medium text-foreground">
+                  Start time
+                </span>
+                <Input
+                  aria-label="Quiet hours start"
+                  onChange={(event) =>
+                    setSettings((current) => ({
+                      ...current,
+                      quietHoursStart: event.target.value,
+                    }))
+                  }
+                  type="time"
+                  value={settings.quietHoursStart}
+                />
+              </label>
+
+              <label className="space-y-2">
+                <span className="text-sm font-medium text-foreground">
+                  End time
+                </span>
+                <Input
+                  aria-label="Quiet hours end"
+                  onChange={(event) =>
+                    setSettings((current) => ({
+                      ...current,
+                      quietHoursEnd: event.target.value,
+                    }))
+                  }
+                  type="time"
+                  value={settings.quietHoursEnd}
+                />
+              </label>
+            </div>
+          )}
+        </div>
+
         <div className="rounded-lg border border-dashed border-border/60 p-4 text-sm text-muted-foreground">
-          The caps are enforced after save. If values fall outside the allowed
-          range, AgentGram will clamp them to safe limits and reflect the saved
-          numbers back here.
+          The caps and quiet hours are enforced after save. If values fall
+          outside the allowed range, AgentGram will clamp them to safe limits
+          and reflect the saved numbers back here.
         </div>
       </CardContent>
       <CardFooter className="flex flex-col items-start gap-3 border-t border-border/40 pt-6 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/lib/proactive-controls.ts
+++ b/apps/web/lib/proactive-controls.ts
@@ -2,6 +2,9 @@ export interface ProactiveControlsSettings {
   optIn: boolean;
   dailyLimit: number;
   weeklyLimit: number;
+  quietHoursEnabled: boolean;
+  quietHoursStart: string;
+  quietHoursEnd: string;
   updatedAt?: string;
 }
 
@@ -10,15 +13,29 @@ const DEFAULT_WEEKLY_LIMIT = 8;
 const MIN_DAILY_LIMIT = 1;
 const MAX_DAILY_LIMIT = 25;
 const MAX_WEEKLY_LIMIT = 100;
+const DEFAULT_QUIET_HOURS_START = '22:00';
+const DEFAULT_QUIET_HOURS_END = '08:00';
 
 export const DEFAULT_PROACTIVE_CONTROLS_SETTINGS: ProactiveControlsSettings = {
   optIn: false,
   dailyLimit: DEFAULT_DAILY_LIMIT,
   weeklyLimit: DEFAULT_WEEKLY_LIMIT,
+  quietHoursEnabled: false,
+  quietHoursStart: DEFAULT_QUIET_HOURS_START,
+  quietHoursEnd: DEFAULT_QUIET_HOURS_END,
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+const HHMM_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+function toTimeString(value: unknown, fallback: string): string {
+  if (typeof value === 'string' && HHMM_RE.test(value)) {
+    return value;
+  }
+  return fallback;
 }
 
 function toBoundedInteger(
@@ -65,7 +82,14 @@ export function normalizeProactiveControlsSettings(
     optIn: value.optIn === true,
     dailyLimit,
     weeklyLimit: Math.max(weeklyLimit, dailyLimit),
-    updatedAt: typeof value.updatedAt === 'string' ? value.updatedAt : undefined,
+    quietHoursEnabled: value.quietHoursEnabled === true,
+    quietHoursStart: toTimeString(
+      value.quietHoursStart,
+      DEFAULT_QUIET_HOURS_START
+    ),
+    quietHoursEnd: toTimeString(value.quietHoursEnd, DEFAULT_QUIET_HOURS_END),
+    updatedAt:
+      typeof value.updatedAt === 'string' ? value.updatedAt : undefined,
   };
 }
 


### PR DESCRIPTION
Source: backlog.md:50

Adds quiet-hours controls to the proactive outreach settings surface so developers can pause outbound nudges during a daily time window.

## What changed
- added `quietHoursEnabled`, `quietHoursStart`, and `quietHoursEnd` defaults + normalization in `apps/web/lib/proactive-controls.ts`
- added dashboard settings UI for enabling quiet hours and choosing start/end times in `apps/web/components/dashboard/ProactiveControlsForm.tsx`
- extended helper, API, and component tests to cover quiet-hours persistence and save behavior

## Tests
- `pnpm --filter web exec vitest run __tests__/lib/proactive-controls.test.ts __tests__/api/developer-proactive-controls.test.ts __tests__/components/proactive-controls-settings.test.tsx`
- `pnpm type-check`

## UX notes
- before: developers could cap proactive outreach volume, but could not block outreach during off-hours
- after: developers can enable a quiet-hours window and set daily start/end times from dashboard settings

## Retro UX evidence

Quiet-hours controls rendered on the dashboard settings surface with the time window expanded:

![PR #469 UX evidence — proactive quiet hours controls](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-466-468-469-ux-screens/docs/pr-evidence/pr-468-469-proactive-controls.png)
