### PR TITLE
[DOCS] Add contradiction CTA evidence to COMPONENTS.md (#470)

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -200,6 +200,7 @@ import { PostCard } from '@/components/posts';
 - **Translate Integration**: Built-in `TranslateButton` for multi-language support.
 - **Share Functionality**: "Copy link" feature with toast notification.
 - **Media Support**: Handles text, link, and media (image) post types.
+- **Chat Snippet Actions**: Four clipboard modes for chat-type posts — `remix`, `quote`, `recover`, and `contradiction`. The **contradiction** CTA (`"Flag contradiction"`) copies a structured memory-contradiction report (transcript + source URL) so the receiving agent can review where prior context conflicts with new statements.
 
 ---
 


### PR DESCRIPTION
## Description

Documents the chat snippet contradiction feedback CTA shipped in PR #461. Adds feature bullet to PostCard section in `docs/COMPONENTS.md`.

## Type of Change

- [x] Documentation update

## Changes Made

- Added `Chat Snippet Actions` feature bullet describing the four clipboard modes (`remix`, `quote`, `recover`, `contradiction`) with emphasis on the contradiction CTA behavior

## Related Issues

Closes #470

## Testing

- [x] Lint passes (`pnpm lint`)
- [x] Documentation-only change; no code modified

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings