### PR TITLE
Add proactive outreach tone presets

### DIFF
--- a/apps/web/__tests__/api/developer-proactive-controls.test.ts
+++ b/apps/web/__tests__/api/developer-proactive-controls.test.ts
@@ -70,6 +70,7 @@ describe('/api/v1/developers/me/proactive-controls', () => {
         quietHoursEnabled: false,
         quietHoursStart: '22:00',
         quietHoursEnd: '08:00',
+        tonePreset: 'neutral',
         updatedAt: '2026-04-20T00:00:00.000Z',
       },
     });
@@ -92,6 +93,7 @@ describe('/api/v1/developers/me/proactive-controls', () => {
                 quietHoursEnabled: true,
                 quietHoursStart: '21:30',
                 quietHoursEnd: '07:15',
+                tonePreset: 'brief',
                 updatedAt: '2026-04-26T00:00:00.000Z',
               },
             },
@@ -131,6 +133,7 @@ describe('/api/v1/developers/me/proactive-controls', () => {
         quietHoursEnabled: true,
         quietHoursStart: '21:30',
         quietHoursEnd: '07:15',
+        tonePreset: 'brief',
       }),
     });
 
@@ -149,6 +152,7 @@ describe('/api/v1/developers/me/proactive-controls', () => {
           quietHoursEnabled: true,
           quietHoursStart: '21:30',
           quietHoursEnd: '07:15',
+          tonePreset: 'brief',
         },
       },
     });
@@ -161,6 +165,7 @@ describe('/api/v1/developers/me/proactive-controls', () => {
         quietHoursEnabled: true,
         quietHoursStart: '21:30',
         quietHoursEnd: '07:15',
+        tonePreset: 'brief',
         updatedAt: '2026-04-26T00:00:00.000Z',
       },
     });

--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -40,6 +40,7 @@ describe('ProactiveControlsForm', () => {
             quietHoursEnabled: true,
             quietHoursStart: '21:30',
             quietHoursEnd: '07:15',
+            tonePreset: 'warm',
             updatedAt: '2026-04-26T00:00:00.000Z',
           },
         }),
@@ -57,6 +58,7 @@ describe('ProactiveControlsForm', () => {
           quietHoursEnabled: false,
           quietHoursStart: '22:00',
           quietHoursEnd: '08:00',
+          tonePreset: 'neutral',
         }}
       />
     );
@@ -71,6 +73,7 @@ describe('ProactiveControlsForm', () => {
     ).not.toBeChecked();
     expect(screen.queryByLabelText('Quiet hours start')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Quiet hours end')).not.toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /neutral/i })).toBeChecked();
 
     fireEvent.change(screen.getByLabelText('Daily outreach cap'), {
       target: { value: '7' },
@@ -85,6 +88,7 @@ describe('ProactiveControlsForm', () => {
     fireEvent.change(screen.getByLabelText('Quiet hours end'), {
       target: { value: '07:15' },
     });
+    fireEvent.click(screen.getByRole('radio', { name: /warm/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Save controls' }));
 
     await waitFor(() => {
@@ -102,6 +106,7 @@ describe('ProactiveControlsForm', () => {
             quietHoursEnabled: true,
             quietHoursStart: '21:30',
             quietHoursEnd: '07:15',
+            tonePreset: 'warm',
           }),
         })
       );
@@ -115,6 +120,7 @@ describe('ProactiveControlsForm', () => {
     expect(screen.getByRole('checkbox', { name: /quiet hours/i })).toBeChecked();
     expect(screen.getByLabelText('Quiet hours start')).toHaveValue('21:30');
     expect(screen.getByLabelText('Quiet hours end')).toHaveValue('07:15');
+    expect(screen.getByRole('radio', { name: /warm/i })).toBeChecked();
   });
 
   it('shows an error when the save request fails', async () => {
@@ -135,6 +141,7 @@ describe('ProactiveControlsForm', () => {
           quietHoursEnabled: false,
           quietHoursStart: '22:00',
           quietHoursEnd: '08:00',
+          tonePreset: 'neutral',
         }}
       />
     );
@@ -185,6 +192,7 @@ describe('SettingsPage', () => {
                       quietHoursEnabled: true,
                       quietHoursStart: '23:00',
                       quietHoursEnd: '06:30',
+                      tonePreset: 'brief',
                     },
                   },
                 },
@@ -211,6 +219,7 @@ describe('SettingsPage', () => {
           quietHoursEnabled: true,
           quietHoursStart: '23:00',
           quietHoursEnd: '06:30',
+          tonePreset: 'brief',
           updatedAt: undefined,
         },
       },

--- a/apps/web/__tests__/lib/proactive-controls.test.ts
+++ b/apps/web/__tests__/lib/proactive-controls.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_PROACTIVE_CONTROLS_SETTINGS,
+  TONE_PRESETS,
   normalizeProactiveControlsSettings,
   readProactiveControlsFromMetadata,
   writeProactiveControlsToMetadata,
@@ -15,6 +16,7 @@ describe('proactive controls helper', () => {
       quietHoursEnabled: false,
       quietHoursStart: '22:00',
       quietHoursEnd: '08:00',
+      tonePreset: 'neutral',
     });
   });
 
@@ -27,6 +29,7 @@ describe('proactive controls helper', () => {
         quietHoursEnabled: 'true',
         quietHoursStart: '25:00',
         quietHoursEnd: 'nope',
+        tonePreset: 'loud',
         updatedAt: 123,
       })
     ).toEqual({
@@ -36,8 +39,19 @@ describe('proactive controls helper', () => {
       quietHoursEnabled: false,
       quietHoursStart: '22:00',
       quietHoursEnd: '08:00',
+      tonePreset: 'neutral',
       updatedAt: undefined,
     });
+  });
+
+  it('preserves valid tone presets', () => {
+    for (const tonePreset of TONE_PRESETS) {
+      expect(
+        normalizeProactiveControlsSettings({
+          tonePreset,
+        }).tonePreset
+      ).toBe(tonePreset);
+    }
   });
 
   it('forces weekly limit to stay at or above the daily limit', () => {
@@ -54,6 +68,7 @@ describe('proactive controls helper', () => {
       quietHoursEnabled: false,
       quietHoursStart: '22:00',
       quietHoursEnd: '08:00',
+      tonePreset: 'neutral',
       updatedAt: undefined,
     });
   });
@@ -67,6 +82,7 @@ describe('proactive controls helper', () => {
         quietHoursEnabled: true,
         quietHoursStart: '21:30',
         quietHoursEnd: '07:15',
+        tonePreset: 'brief',
       })
     ).toEqual({
       optIn: true,
@@ -75,6 +91,7 @@ describe('proactive controls helper', () => {
       quietHoursEnabled: true,
       quietHoursStart: '21:30',
       quietHoursEnd: '07:15',
+      tonePreset: 'brief',
       updatedAt: undefined,
     });
   });
@@ -89,6 +106,7 @@ describe('proactive controls helper', () => {
           quietHoursEnabled: true,
           quietHoursStart: '23:00',
           quietHoursEnd: '06:30',
+          tonePreset: 'warm',
           updatedAt: '2026-04-26T00:00:00.000Z',
         },
       })
@@ -99,6 +117,7 @@ describe('proactive controls helper', () => {
       quietHoursEnabled: true,
       quietHoursStart: '23:00',
       quietHoursEnd: '06:30',
+      tonePreset: 'warm',
       updatedAt: '2026-04-26T00:00:00.000Z',
     });
 
@@ -118,6 +137,7 @@ describe('proactive controls helper', () => {
           quietHoursEnabled: true,
           quietHoursStart: '21:00',
           quietHoursEnd: '06:00',
+          tonePreset: 'warm',
         },
         '2026-04-26T03:06:00.000Z'
       )
@@ -130,6 +150,7 @@ describe('proactive controls helper', () => {
         quietHoursEnabled: true,
         quietHoursStart: '21:00',
         quietHoursEnd: '06:00',
+        tonePreset: 'warm',
         updatedAt: '2026-04-26T03:06:00.000Z',
       },
     });

--- a/apps/web/components/dashboard/ProactiveControlsForm.tsx
+++ b/apps/web/components/dashboard/ProactiveControlsForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Clock, Loader2, ShieldCheck } from 'lucide-react';
+import { Clock, Loader2, MessageSquare, ShieldCheck } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -12,7 +12,27 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import type { ProactiveControlsSettings } from '@/lib/proactive-controls';
+import {
+  TONE_PRESETS,
+  type ProactiveControlsSettings,
+  type TonePreset,
+} from '@/lib/proactive-controls';
+
+const TONE_LABELS: Record<TonePreset, { label: string; description: string }> =
+  {
+    warm: {
+      label: 'Warm',
+      description: 'Friendly and conversational',
+    },
+    neutral: {
+      label: 'Neutral',
+      description: 'Balanced and professional',
+    },
+    brief: {
+      label: 'Brief',
+      description: 'Short and to the point',
+    },
+  };
 
 interface ProactiveControlsFormProps {
   initialSettings: ProactiveControlsSettings;
@@ -218,10 +238,54 @@ export function ProactiveControlsForm({
           )}
         </div>
 
+        <fieldset className="space-y-3 rounded-lg border border-border/60 p-4">
+          <legend className="flex items-center gap-2 px-1 font-medium text-foreground">
+            <MessageSquare className="h-4 w-4 text-muted-foreground" />
+            Tone preset
+          </legend>
+          <p className="text-sm text-muted-foreground">
+            Choose the default tone for proactive outreach messages.
+          </p>
+          <div className="grid gap-3 md:grid-cols-3">
+            {TONE_PRESETS.map((preset) => (
+              <label
+                className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors ${
+                  settings.tonePreset === preset
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border/60 hover:border-border'
+                }`}
+                key={preset}
+              >
+                <input
+                  checked={settings.tonePreset === preset}
+                  className="mt-0.5 h-4 w-4"
+                  name="tonePreset"
+                  onChange={() =>
+                    setSettings((current) => ({
+                      ...current,
+                      tonePreset: preset,
+                    }))
+                  }
+                  type="radio"
+                  value={preset}
+                />
+                <div className="space-y-0.5">
+                  <div className="text-sm font-medium text-foreground">
+                    {TONE_LABELS[preset].label}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {TONE_LABELS[preset].description}
+                  </p>
+                </div>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
         <div className="rounded-lg border border-dashed border-border/60 p-4 text-sm text-muted-foreground">
-          The caps and quiet hours are enforced after save. If values fall
-          outside the allowed range, AgentGram will clamp them to safe limits
-          and reflect the saved numbers back here.
+          The caps, quiet hours, and tone preset are enforced after save. If
+          values fall outside the allowed range, AgentGram will clamp them to
+          safe limits and reflect the saved values back here.
         </div>
       </CardContent>
       <CardFooter className="flex flex-col items-start gap-3 border-t border-border/40 pt-6 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/lib/proactive-controls.ts
+++ b/apps/web/lib/proactive-controls.ts
@@ -1,3 +1,6 @@
+export const TONE_PRESETS = ['warm', 'neutral', 'brief'] as const;
+export type TonePreset = (typeof TONE_PRESETS)[number];
+
 export interface ProactiveControlsSettings {
   optIn: boolean;
   dailyLimit: number;
@@ -5,6 +8,7 @@ export interface ProactiveControlsSettings {
   quietHoursEnabled: boolean;
   quietHoursStart: string;
   quietHoursEnd: string;
+  tonePreset: TonePreset;
   updatedAt?: string;
 }
 
@@ -15,6 +19,7 @@ const MAX_DAILY_LIMIT = 25;
 const MAX_WEEKLY_LIMIT = 100;
 const DEFAULT_QUIET_HOURS_START = '22:00';
 const DEFAULT_QUIET_HOURS_END = '08:00';
+const DEFAULT_TONE_PRESET: TonePreset = 'neutral';
 
 export const DEFAULT_PROACTIVE_CONTROLS_SETTINGS: ProactiveControlsSettings = {
   optIn: false,
@@ -23,6 +28,7 @@ export const DEFAULT_PROACTIVE_CONTROLS_SETTINGS: ProactiveControlsSettings = {
   quietHoursEnabled: false,
   quietHoursStart: DEFAULT_QUIET_HOURS_START,
   quietHoursEnd: DEFAULT_QUIET_HOURS_END,
+  tonePreset: DEFAULT_TONE_PRESET,
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -78,6 +84,12 @@ export function normalizeProactiveControlsSettings(
     MAX_WEEKLY_LIMIT
   );
 
+  const tonePreset: TonePreset =
+    typeof value.tonePreset === 'string' &&
+    (TONE_PRESETS as readonly string[]).includes(value.tonePreset)
+      ? (value.tonePreset as TonePreset)
+      : DEFAULT_TONE_PRESET;
+
   return {
     optIn: value.optIn === true,
     dailyLimit,
@@ -88,6 +100,7 @@ export function normalizeProactiveControlsSettings(
       DEFAULT_QUIET_HOURS_START
     ),
     quietHoursEnd: toTimeString(value.quietHoursEnd, DEFAULT_QUIET_HOURS_END),
+    tonePreset,
     updatedAt:
       typeof value.updatedAt === 'string' ? value.updatedAt : undefined,
   };


### PR DESCRIPTION
Source: backlog.md:51

## Summary
- add warm/neutral/brief tone preset support to proactive controls defaults, normalization, metadata read/write, and dashboard UI
- extend proactive controls lib, API, and component tests to cover tone preset persistence and selection
- note for UX verification: capture dashboard settings before/after showing the new tone preset card and selected state

## Validation
- pnpm --dir apps/web test -- __tests__/lib/proactive-controls.test.ts __tests__/components/proactive-controls-settings.test.tsx __tests__/api/developer-proactive-controls.test.ts
- pnpm --dir apps/web type-check

## Retro UX evidence

Rosie-approved post-merge evidence recovery: reuse the hosted proactive-controls dashboard settings screenshot from the same panel family used to verify PR #468/#469. For this stuck-recovery pass, the goal is to prove the shipped proactive-controls settings surface landed on `develop`, not to reopen implementation work.

![PR #473 UX evidence — proactive controls dashboard settings surface](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-466-468-469-ux-screens/docs/pr-evidence/pr-468-469-proactive-controls.png)

## Retro UX evidence

Proactive outreach controls rendered on the dashboard settings surface with the new tone preset choices and selected-state recovery:

![PR #473 UX evidence — proactive tone presets](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-473-ux-screenshot/docs/pr-evidence/pr-473-proactive-tone-presets.png)
