### PR TITLE
Align public capability contract and stop metadata leakage

### DIFF
--- a/apps/web/__tests__/api/agents.test.ts
+++ b/apps/web/__tests__/api/agents.test.ts
@@ -13,6 +13,7 @@ const mockSelect = vi.fn().mockReturnThis();
 const mockOrder = vi.fn().mockReturnThis();
 const mockRange = vi.fn().mockReturnThis();
 const mockOr = vi.fn().mockReturnThis();
+const mockContains = vi.fn().mockReturnThis();
 
 vi.mock('@agentgram/db', () => ({
   getSupabaseServiceClient: () => ({
@@ -21,6 +22,7 @@ vi.mock('@agentgram/db', () => ({
       order: mockOrder,
       range: mockRange,
       or: mockOr,
+      contains: mockContains,
     }),
   }),
 }));
@@ -30,6 +32,7 @@ describe('GET /api/v1/agents', () => {
     vi.clearAllMocks();
     mockSelect.mockReturnThis();
     mockOrder.mockReturnThis();
+    mockContains.mockReturnThis();
     mockRange.mockResolvedValue({
       data: [
         {
@@ -37,10 +40,29 @@ describe('GET /api/v1/agents', () => {
           name: 'test-agent',
           display_name: 'Test Agent',
           description: 'A test agent',
+          capability_summary: 'Can review CI and ship patches.',
+          permission_scope: 'repo_write',
+          public_key: null,
+          email: null,
+          email_verified: true,
           avatar_url: null,
           axp: 100,
+          status: 'active',
           trust_score: 0.5,
+          metadata: {
+            memoryPolicy: 'ephemeral_only',
+            workProofUrl: 'https://example.com/proof',
+            firstSuccessfulReply: true,
+            capabilities: {
+              voice: 'true',
+              group_chat: true,
+              roleplay: 1,
+            },
+          },
           created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z',
+          last_active: '2026-01-03T00:00:00Z',
+          verification_state: 'verified',
         },
       ],
       error: null,
@@ -62,6 +84,20 @@ describe('GET /api/v1/agents', () => {
     expect(json.data).toBeInstanceOf(Array);
     expect(json.meta).toBeDefined();
     expect(json.meta.page).toBe(1);
+    expect(json.data[0]).toMatchObject({
+      name: 'test-agent',
+      capabilitySummary: 'Can review CI and ship patches.',
+      permissionScope: 'repo_write',
+      capabilities: {
+        voice: false,
+        group_chat: true,
+        roleplay: false,
+      },
+      memoryPolicy: 'ephemeral_only',
+      workProofUrl: 'https://example.com/proof',
+      hasFirstSuccessfulReply: true,
+    });
+    expect(json.data[0]).not.toHaveProperty('metadata');
   });
 
   it('should escape SQL wildcards in search parameter', async () => {
@@ -80,6 +116,25 @@ describe('GET /api/v1/agents', () => {
       expect(orArg).not.toContain('test%injection');
       expect(orArg).toContain('test\\%injection');
     }
+  });
+
+  it('should filter by enabled capability params', async () => {
+    const { GET } = await import(
+      '../../app/api/v1/agents/route'
+    );
+
+    const request = new Request(
+      'http://localhost/api/v1/agents?voice=true&group_chat=1'
+    );
+    await GET(request as unknown as Parameters<typeof GET>[0]);
+
+    expect(mockContains).toHaveBeenCalledTimes(2);
+    expect(mockContains).toHaveBeenNthCalledWith(1, 'metadata', {
+      capabilities: { voice: true },
+    });
+    expect(mockContains).toHaveBeenNthCalledWith(2, 'metadata', {
+      capabilities: { group_chat: true },
+    });
   });
 
   it('should clamp page parameter to valid range', async () => {

--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -57,7 +57,6 @@ const baseAgent: Agent = {
   verificationState: 'unverified',
   status: 'active',
   trustScore: 0.92,
-  metadata: {},
   createdAt: '2026-04-01T00:00:00.000Z',
   updatedAt: '2026-04-02T00:00:00.000Z',
   lastActive: '2026-04-03T00:00:00.000Z',
@@ -140,11 +139,9 @@ describe('ProfileHeader', () => {
           operatorTier: 'pro',
           permissionScope: 'repo_write',
           capabilitySummary: 'Publishes shipping notes and CI receipts.',
-          metadata: {
-            memoryPolicy: 'ephemeral_only',
-            workProofUrl: 'https://example.com/proof',
-            workProofLabel: 'Review work proof',
-          },
+          memoryPolicy: 'ephemeral_only',
+          workProofUrl: 'https://example.com/proof',
+          workProofLabel: 'Review work proof',
         }}
       />
     );
@@ -198,9 +195,7 @@ describe('ProfileHeader', () => {
         agent={{
           ...baseAgent,
           verificationState: 'verified',
-          metadata: {
-            firstSuccessfulReply: true,
-          },
+          hasFirstSuccessfulReply: true,
         }}
       />
     );
@@ -240,10 +235,8 @@ describe('ProfileHeader', () => {
       <ProfileHeader
         agent={{
           ...baseAgent,
-          metadata: {
-            retentionPolicy: '30_days',
-            trainingEnabled: false,
-          },
+          retentionPolicy: '30_days',
+          trainingEnabled: false,
         }}
       />
     );
@@ -284,9 +277,7 @@ describe('ProfileHeader', () => {
           ...baseAgent,
           verificationState: 'verified',
           capabilitySummary: 'Shares benchmark notes and shipping receipts.',
-          metadata: {
-            firstSuccessfulReply: true,
-          },
+          hasFirstSuccessfulReply: true,
         }}
       />
     );

--- a/apps/web/app/api/v1/agents/me/route.ts
+++ b/apps/web/app/api/v1/agents/me/route.ts
@@ -1,13 +1,8 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseServiceClient } from '@agentgram/db';
 import { withAuth } from '@agentgram/auth';
-import type { Agent, PersonaResponse } from '@agentgram/shared';
-import {
-  ErrorResponses,
-  jsonResponse,
-  createSuccessResponse,
-  transformPersona,
-} from '@agentgram/shared';
+import type { PersonaResponse } from '@agentgram/shared';
+import { ErrorResponses, jsonResponse, createSuccessResponse, transformAgent } from '@agentgram/shared';
 
 async function handler(req: NextRequest) {
   try {
@@ -46,26 +41,10 @@ async function handler(req: NextRequest) {
       .eq('is_active', true)
       .single();
 
-    const agentData: Partial<Agent> = {
-      id: agent.id,
-      name: agent.name,
-      displayName: agent.display_name ?? undefined,
-      description: agent.description ?? undefined,
-      capabilitySummary: agent.capability_summary ?? undefined,
-      permissionScope: agent.permission_scope ?? undefined,
-      axp: agent.axp ?? undefined,
-      status: (agent.status as Agent['status']) ?? undefined,
-      trustScore: agent.trust_score ?? undefined,
-      createdAt: agent.created_at ?? undefined,
-      avatarUrl: agent.avatar_url ?? undefined,
-      lastActive: agent.last_active ?? undefined,
-      emailVerified: agent.email_verified ?? undefined,
-      metadata: (agent.metadata as Record<string, unknown>) ?? undefined,
-      updatedAt: agent.updated_at ?? undefined,
-      activePersona: activePersonaData
-        ? transformPersona(activePersonaData as PersonaResponse)
-        : undefined,
-    };
+    const agentData = transformAgent({
+      ...agent,
+      active_persona: (activePersonaData as PersonaResponse | null) ?? null,
+    });
 
     return jsonResponse(createSuccessResponse(agentData));
   } catch (error) {

--- a/apps/web/app/api/v1/agents/route.ts
+++ b/apps/web/app/api/v1/agents/route.ts
@@ -1,11 +1,21 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseServiceClient } from '@agentgram/db';
 import {
+  AGENT_CAPABILITY_KEYS,
   ErrorResponses,
   jsonResponse,
   createSuccessResponse,
   PAGINATION,
+  transformAgent,
 } from '@agentgram/shared';
+
+function isCapabilityFilterEnabled(value: string | null): boolean {
+  if (value == null) {
+    return false;
+  }
+
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+}
 
 // GET /api/v1/agents - Fetch agent directory
 export async function GET(req: NextRequest) {
@@ -24,6 +34,9 @@ export async function GET(req: NextRequest) {
       PAGINATION.MAX_LIMIT
     );
     const search = searchParams.get('search') || undefined;
+    const enabledCapabilities = AGENT_CAPABILITY_KEYS.filter((key) =>
+      isCapabilityFilterEnabled(searchParams.get(key))
+    );
 
     const supabase = getSupabaseServiceClient();
 
@@ -33,10 +46,20 @@ export async function GET(req: NextRequest) {
         name,
         display_name,
         description,
-        avatar_url,
+        capability_summary,
+        permission_scope,
+        public_key,
+        email,
+        email_verified,
         axp,
+        status,
         trust_score,
-        created_at
+        metadata,
+        avatar_url,
+        created_at,
+        updated_at,
+        last_active,
+        verification_state
       `,
       { count: 'exact' }
     );
@@ -47,6 +70,14 @@ export async function GET(req: NextRequest) {
       query = query.or(
         `name.ilike.%${escaped}%,display_name.ilike.%${escaped}%,description.ilike.%${escaped}%`
       );
+    }
+
+    for (const capability of enabledCapabilities) {
+      query = query.contains('metadata', {
+        capabilities: {
+          [capability]: true,
+        },
+      });
     }
 
     // Sorting
@@ -74,7 +105,7 @@ export async function GET(req: NextRequest) {
     }
 
     return jsonResponse(
-      createSuccessResponse(agents || [], {
+      createSuccessResponse((agents || []).map(transformAgent), {
         page,
         limit,
         total: count || 0,

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -27,69 +27,6 @@ function formatOperatorTier(operatorTier: Agent['operatorTier']) {
   return operatorTier ? formatTokenLabel(operatorTier) : undefined;
 }
 
-function readMetadataValue(
-  metadata: Record<string, unknown>,
-  path: string[]
-): unknown {
-  let current: unknown = metadata;
-
-  for (const segment of path) {
-    if (!current || typeof current !== 'object' || Array.isArray(current)) {
-      return undefined;
-    }
-
-    current = (current as Record<string, unknown>)[segment];
-  }
-
-  return current;
-}
-
-function readMetadataString(
-  metadata: Agent['metadata'],
-  paths: string[][]
-): string | undefined {
-  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
-    return undefined;
-  }
-
-  for (const path of paths) {
-    const value = readMetadataValue(metadata as Record<string, unknown>, path);
-    if (typeof value === 'string' && value.trim()) {
-      return value.trim();
-    }
-  }
-
-  return undefined;
-}
-
-function readMetadataBoolean(
-  metadata: Agent['metadata'],
-  paths: string[][]
-): boolean | undefined {
-  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
-    return undefined;
-  }
-
-  for (const path of paths) {
-    const value = readMetadataValue(metadata as Record<string, unknown>, path);
-    if (typeof value === 'boolean') {
-      return value;
-    }
-
-    if (typeof value === 'string') {
-      const normalized = value.trim().toLowerCase();
-      if (['true', 'yes', 'on', 'enabled', 'allow', 'allowed'].includes(normalized)) {
-        return true;
-      }
-      if (['false', 'no', 'off', 'disabled', 'deny', 'denied', 'not_allowed'].includes(normalized)) {
-        return false;
-      }
-    }
-  }
-
-  return undefined;
-}
-
 export function ProfileHeader({ agent }: ProfileHeaderProps) {
   const capabilitySummary = agent.capabilitySummary?.trim();
   const permissionScope = agent.permissionScope?.trim();
@@ -103,60 +40,21 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
     agent.operatorTier !== 'free'
       ? formatOperatorTier(agent.operatorTier)
       : undefined;
-  const hasFirstSuccessfulReply =
-    readMetadataBoolean(agent.metadata, [
-      ['firstSuccessfulReply'],
-      ['first_successful_reply'],
-      ['milestones', 'firstSuccessfulReply'],
-      ['milestones', 'first_successful_reply'],
-      ['replyMilestones', 'firstSuccessfulReply'],
-      ['reply_milestones', 'first_successful_reply'],
-    ]) === true;
+  const hasFirstSuccessfulReply = agent.hasFirstSuccessfulReply === true;
   const shouldShowOperatorTierSurface =
     verificationState === 'verified' &&
     (Boolean(formattedOperatorTier) || hasFirstSuccessfulReply);
-  const memoryPolicy = readMetadataString(agent.metadata, [
-    ['memoryPolicy'],
-    ['memory_policy'],
-    ['memory', 'policy'],
-    ['memoryVisibility'],
-    ['memory', 'visibility'],
-  ]);
+  const memoryPolicy = agent.memoryPolicy?.trim();
   const formattedMemoryPolicy = memoryPolicy
     ? formatTokenLabel(memoryPolicy)
     : undefined;
-  const workProofUrl = readMetadataString(agent.metadata, [
-    ['workProofUrl'],
-    ['work_proof_url'],
-    ['proofUrl'],
-    ['proof_url'],
-    ['workProof', 'url'],
-    ['workProof'],
-  ]);
-  const retentionDisclosure = readMetadataString(agent.metadata, [
-    ['retentionPolicy'],
-    ['retention_policy'],
-    ['dataRetention'],
-    ['data_retention'],
-    ['privacy', 'retention'],
-  ]);
+  const workProofUrl = agent.workProofUrl?.trim();
+  const retentionDisclosure = agent.retentionPolicy?.trim();
   const formattedRetentionDisclosure = retentionDisclosure
     ? formatTokenLabel(retentionDisclosure)
     : undefined;
-  const trainingDisclosure = readMetadataString(agent.metadata, [
-    ['trainingDisclosure'],
-    ['training_disclosure'],
-    ['trainingPolicy'],
-    ['training_policy'],
-    ['privacy', 'training'],
-  ]);
-  const trainingEnabled = readMetadataBoolean(agent.metadata, [
-    ['trainingEnabled'],
-    ['training_enabled'],
-    ['usesDataForTraining'],
-    ['uses_data_for_training'],
-    ['privacy', 'trainingEnabled'],
-  ]);
+  const trainingDisclosure = agent.trainingDisclosure?.trim();
+  const trainingEnabled = agent.trainingEnabled;
   const formattedTrainingDisclosure = trainingDisclosure
     ? formatTokenLabel(trainingDisclosure)
     : trainingEnabled === true
@@ -164,14 +62,7 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
       : trainingEnabled === false
         ? 'Not Used For Training'
         : undefined;
-  const workProofLabel =
-    readMetadataString(agent.metadata, [
-      ['workProofLabel'],
-      ['work_proof_label'],
-      ['proofLabel'],
-      ['proof_label'],
-      ['workProof', 'label'],
-    ]) ?? (workProofUrl ? 'View work proof' : undefined);
+  const workProofLabel = agent.workProofLabel?.trim() || (workProofUrl ? 'View work proof' : undefined);
   const hasVerifiedAgentCard = Boolean(
     capabilitySummary ||
     formattedPermissionScope ||

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -1,6 +1,155 @@
-import type { Agent } from '../types';
+import {
+  AGENT_CAPABILITY_KEYS,
+  type Agent,
+  type AgentCapabilities,
+} from '../types';
 import type { PersonaResponse } from './persona';
 import { transformPersona } from './persona';
+
+function metadataValue(meta: Record<string, unknown>, path: string[]): unknown {
+  let cur: unknown = meta;
+  for (const seg of path) {
+    if (!cur || typeof cur !== 'object' || Array.isArray(cur)) return undefined;
+    cur = (cur as Record<string, unknown>)[seg];
+  }
+  return cur;
+}
+
+function metadataString(
+  meta: Record<string, unknown>,
+  paths: string[][]
+): string | undefined {
+  for (const path of paths) {
+    const v = metadataValue(meta, path);
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return undefined;
+}
+
+function metadataBoolean(
+  meta: Record<string, unknown>,
+  paths: string[][]
+): boolean | undefined {
+  for (const path of paths) {
+    const v = metadataValue(meta, path);
+    if (typeof v === 'boolean') return v;
+    if (typeof v === 'string') {
+      const n = v.trim().toLowerCase();
+      if (['true', 'yes', 'on', 'enabled', 'allow', 'allowed'].includes(n))
+        return true;
+      if (
+        [
+          'false',
+          'no',
+          'off',
+          'disabled',
+          'deny',
+          'denied',
+          'not_allowed',
+        ].includes(n)
+      )
+        return false;
+    }
+  }
+  return undefined;
+}
+
+function readCapabilityEnabled(value: unknown): boolean {
+  return value === true;
+}
+
+function deriveCapabilities(meta: Record<string, unknown>): AgentCapabilities {
+  const emptyCapabilities: AgentCapabilities = {
+    voice: false,
+    group_chat: false,
+    roleplay: false,
+  };
+
+  const capabilities = metadataValue(meta, ['capabilities']);
+  if (!capabilities || typeof capabilities !== 'object' || Array.isArray(capabilities)) {
+    return emptyCapabilities;
+  }
+
+  const capabilityRecord = capabilities as Record<string, unknown>;
+
+  return AGENT_CAPABILITY_KEYS.reduce((acc, key) => {
+    acc[key] = readCapabilityEnabled(capabilityRecord[key]);
+    return acc;
+  }, { ...emptyCapabilities });
+}
+
+/** Derive explicit public capability/trust fields from raw metadata. */
+export function derivePublicFields(
+  meta: Record<string, unknown>
+): Pick<
+  Agent,
+  | 'capabilities'
+  | 'memoryPolicy'
+  | 'workProofUrl'
+  | 'workProofLabel'
+  | 'retentionPolicy'
+  | 'trainingDisclosure'
+  | 'trainingEnabled'
+  | 'hasFirstSuccessfulReply'
+> {
+  const workProofUrl = metadataString(meta, [
+    ['workProofUrl'],
+    ['work_proof_url'],
+    ['proofUrl'],
+    ['proof_url'],
+    ['workProof', 'url'],
+    ['workProof'],
+  ]);
+  return {
+    capabilities: deriveCapabilities(meta),
+    memoryPolicy: metadataString(meta, [
+      ['memoryPolicy'],
+      ['memory_policy'],
+      ['memory', 'policy'],
+      ['memoryVisibility'],
+      ['memory', 'visibility'],
+    ]),
+    workProofUrl,
+    workProofLabel:
+      metadataString(meta, [
+        ['workProofLabel'],
+        ['work_proof_label'],
+        ['proofLabel'],
+        ['proof_label'],
+        ['workProof', 'label'],
+      ]) ?? (workProofUrl ? 'View work proof' : undefined),
+    retentionPolicy: metadataString(meta, [
+      ['retentionPolicy'],
+      ['retention_policy'],
+      ['dataRetention'],
+      ['data_retention'],
+      ['privacy', 'retention'],
+    ]),
+    trainingDisclosure: metadataString(meta, [
+      ['trainingDisclosure'],
+      ['training_disclosure'],
+      ['trainingPolicy'],
+      ['training_policy'],
+      ['privacy', 'training'],
+    ]),
+    trainingEnabled: metadataBoolean(meta, [
+      ['trainingEnabled'],
+      ['training_enabled'],
+      ['usesDataForTraining'],
+      ['uses_data_for_training'],
+      ['privacy', 'trainingEnabled'],
+    ]),
+    hasFirstSuccessfulReply:
+      metadataBoolean(meta, [
+        ['firstSuccessfulReply'],
+        ['first_successful_reply'],
+        ['milestones', 'firstSuccessfulReply'],
+        ['milestones', 'first_successful_reply'],
+        ['replyMilestones', 'firstSuccessfulReply'],
+        ['reply_milestones', 'first_successful_reply'],
+      ]) === true,
+  };
+}
 
 // Type for agent response from Supabase (nullable fields match DB schema)
 export type AgentResponse = {
@@ -39,6 +188,13 @@ export type AuthorResponse = {
 };
 
 export function transformAgent(agent: AgentResponse): Agent {
+  const metadata =
+    agent.metadata != null &&
+    typeof agent.metadata === 'object' &&
+    !Array.isArray(agent.metadata)
+      ? (agent.metadata as Record<string, unknown>)
+      : {};
+
   return {
     id: agent.id,
     name: agent.name,
@@ -54,12 +210,7 @@ export function transformAgent(agent: AgentResponse): Agent {
       (agent.verification_state as Agent['verificationState']) ?? 'unverified',
     status: (agent.status as Agent['status']) ?? 'active',
     trustScore: agent.trust_score ?? 0,
-    metadata:
-      agent.metadata != null &&
-      typeof agent.metadata === 'object' &&
-      !Array.isArray(agent.metadata)
-        ? (agent.metadata as Record<string, unknown>)
-        : {},
+    ...derivePublicFields(metadata),
     avatarUrl: agent.avatar_url || undefined,
     activePersona: agent.active_persona
       ? transformPersona(agent.active_persona)
@@ -87,7 +238,6 @@ export function transformAuthor(author: AuthorResponse): Agent {
       (author.verification_state as Agent['verificationState']) ?? 'unverified',
     status: 'active',
     trustScore: author.trust_score ?? 0,
-    metadata: {},
     avatarUrl: author.avatar_url || undefined,
     createdAt: '',
     updatedAt: '',

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1,6 +1,15 @@
 import type { Persona } from './persona';
 import type { PlanType } from './billing';
 
+export const AGENT_CAPABILITY_KEYS = [
+  'voice',
+  'group_chat',
+  'roleplay',
+] as const;
+
+export type AgentCapabilityKey = (typeof AGENT_CAPABILITY_KEYS)[number];
+export type AgentCapabilities = Record<AgentCapabilityKey, boolean>;
+
 /**
  * Agent type definition
  */
@@ -22,7 +31,14 @@ export interface Agent {
   verificationState: 'unverified' | 'pending' | 'verified';
   status: 'active' | 'suspended' | 'banned';
   trustScore: number;
-  metadata: Record<string, unknown>;
+  capabilities?: AgentCapabilities;
+  memoryPolicy?: string;
+  workProofUrl?: string;
+  workProofLabel?: string;
+  retentionPolicy?: string;
+  trainingDisclosure?: string;
+  trainingEnabled?: boolean;
+  hasFirstSuccessfulReply?: boolean;
   avatarUrl?: string;
   activePersona?: Persona;
   createdAt: string;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,4 +1,10 @@
-export type { Agent, AgentRegistration } from './agent';
+export { AGENT_CAPABILITY_KEYS } from './agent';
+export type {
+  Agent,
+  AgentRegistration,
+  AgentCapabilityKey,
+  AgentCapabilities,
+} from './agent';
 
 export type { Persona, CreatePersona, UpdatePersona } from './persona';
 


### PR DESCRIPTION
## Summary
- derive explicit public trust/capability fields from agent metadata in one shared transform
- stop returning raw metadata from `/api/v1/agents` and `/api/v1/agents/me`
- update `ProfileHeader` and focused tests to use the explicit public contract

## Validation
- pnpm --dir apps/web test -- __tests__/api/agents.test.ts __tests__/components/profile-header.test.tsx
- pnpm --dir apps/web type-check