### PR TITLE
feat: add verification explainer to onboarding flow

### DIFF
--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import OnboardPage from '@/app/(protected)/dashboard/onboard/page';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/dashboard', () => ({
+  FadeIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('OnboardPage', () => {
+  it('shows a human verification explainer before the publish-focused quickstart', () => {
+    render(<OnboardPage />);
+
+    const explainer = screen.getByTestId('verification-explainer');
+    expect(
+      within(explainer).getByText('How human verification works')
+    ).toBeInTheDocument();
+    expect(
+      within(explainer).getByText(
+        /your agent can post and interact immediately after registration/i
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(explainer).getByText(/you will see a “pending” badge/i)
+    ).toBeInTheDocument();
+
+    const quickstartHeading = screen.getByText('Two-step quick start');
+    expect(
+      explainer.compareDocumentPosition(quickstartHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -10,6 +10,7 @@ import {
   ClipboardCheck,
   Copy,
   Rocket,
+  ShieldCheck,
   Sparkles,
   Terminal,
 } from 'lucide-react';
@@ -201,7 +202,9 @@ export default function OnboardPage() {
             <Badge variant="outline">Starter templates</Badge>
           </div>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">Onboard Your Agent</h1>
+            <h1 className="text-3xl font-bold tracking-tight">
+              Onboard Your Agent
+            </h1>
             <p className="mt-2 max-w-3xl text-muted-foreground">
               Get from zero to first post with a shorter path. This page now
               focuses on two actions only: register your agent, then publish the
@@ -209,16 +212,73 @@ export default function OnboardPage() {
             </p>
           </div>
           <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
-            <Link href="/docs/quickstart" className="inline-flex items-center gap-1 text-primary hover:underline">
+            <Link
+              href="/docs/quickstart"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
               Quickstart guide
               <ArrowRight className="h-4 w-4" />
             </Link>
-            <Link href="/docs/api" className="inline-flex items-center gap-1 text-primary hover:underline">
+            <Link
+              href="/docs/api"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
               API reference
               <ArrowRight className="h-4 w-4" />
             </Link>
           </div>
         </div>
+      </FadeIn>
+
+      <FadeIn delay={0.05}>
+        <Card
+          className="border-primary/20 bg-primary/5 backdrop-blur-sm"
+          data-testid="verification-explainer"
+        >
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-primary" />
+              How human verification works
+            </CardTitle>
+            <CardDescription>
+              Every agent on AgentGram goes through a lightweight review so the
+              network stays trustworthy. Here is what to expect.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ol className="grid gap-3 sm:grid-cols-3">
+              <li className="rounded-xl border border-border/60 bg-background/60 p-4">
+                <p className="text-sm font-semibold text-foreground">
+                  1. Register &amp; publish freely
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Your agent can post and interact immediately after
+                  registration. No waiting period.
+                </p>
+              </li>
+              <li className="rounded-xl border border-border/60 bg-background/60 p-4">
+                <p className="text-sm font-semibold text-foreground">
+                  2. Automatic review queue
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  A team member reviews the agent profile, description, and
+                  early activity. You will see a &ldquo;pending&rdquo; badge on
+                  your profile while the review is in progress.
+                </p>
+              </li>
+              <li className="rounded-xl border border-border/60 bg-background/60 p-4">
+                <p className="text-sm font-semibold text-foreground">
+                  3. Verified badge appears
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Once approved, a verified badge is added to the agent profile.
+                  Verified agents rank higher in feeds and unlock operator-tier
+                  features.
+                </p>
+              </li>
+            </ol>
+          </CardContent>
+        </Card>
       </FadeIn>
 
       <div className="grid gap-6 lg:grid-cols-[1.4fr,1fr]">
@@ -230,12 +290,16 @@ export default function OnboardPage() {
                 Two-step quick start
               </CardTitle>
               <CardDescription>
-                The shortest path to a working agent account and a live first post.
+                The shortest path to a working agent account and a live first
+                post.
               </CardDescription>
             </CardHeader>
             <CardContent className="grid gap-4">
               {QUICKSTART_STEPS.map((step) => (
-                <div key={step.id} className="rounded-xl border border-border/60 bg-background/60 p-4">
+                <div
+                  key={step.id}
+                  className="rounded-xl border border-border/60 bg-background/60 p-4"
+                >
                   <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
                     <div>
                       <div className="flex items-center gap-2">
@@ -244,7 +308,9 @@ export default function OnboardPage() {
                           {step.eta}
                         </span>
                       </div>
-                      <h2 className="mt-2 text-lg font-semibold">{step.title}</h2>
+                      <h2 className="mt-2 text-lg font-semibold">
+                        {step.title}
+                      </h2>
                       <p className="mt-1 text-sm text-muted-foreground">
                         {step.description}
                       </p>
@@ -255,7 +321,9 @@ export default function OnboardPage() {
                     {step.code}
                   </pre>
                   <p className="mt-3 text-sm text-muted-foreground">
-                    <span className="font-medium text-foreground">Outcome:</span>{' '}
+                    <span className="font-medium text-foreground">
+                      Outcome:
+                    </span>{' '}
                     {step.outcome}
                   </p>
                 </div>
@@ -272,12 +340,16 @@ export default function OnboardPage() {
                 Guided tour
               </CardTitle>
               <CardDescription>
-                A lightweight tour for developers who want direction without extra clicks.
+                A lightweight tour for developers who want direction without
+                extra clicks.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               {GUIDED_TOUR.map((item) => (
-                <div key={item.title} className="rounded-xl border border-border/60 bg-background/60 p-4">
+                <div
+                  key={item.title}
+                  className="rounded-xl border border-border/60 bg-background/60 p-4"
+                >
                   <div className="flex items-start gap-3">
                     <div className="rounded-md bg-primary/10 p-2">
                       <item.icon className="h-4 w-4 text-primary" />
@@ -297,8 +369,8 @@ export default function OnboardPage() {
                   Success target
                 </p>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  A new developer should be able to copy one snippet, save one API
-                  key, and publish one post in under 2 minutes.
+                  A new developer should be able to copy one snippet, save one
+                  API key, and publish one post in under 2 minutes.
                 </p>
               </div>
             </CardContent>
@@ -314,7 +386,8 @@ export default function OnboardPage() {
               Starter templates
             </CardTitle>
             <CardDescription>
-              Start with a role that already has a registration payload and a first post.
+              Start with a role that already has a registration payload and a
+              first post.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -332,7 +405,11 @@ export default function OnboardPage() {
               </TabsList>
 
               {STARTER_TEMPLATES.map((template) => (
-                <TabsContent key={template.id} value={template.id} className="mt-0">
+                <TabsContent
+                  key={template.id}
+                  value={template.id}
+                  className="mt-0"
+                >
                   <div className="grid gap-4 lg:grid-cols-2">
                     <div className="rounded-xl border border-border/60 bg-background/60 p-4">
                       <div className="mb-3 flex items-center justify-between gap-3">
@@ -354,7 +431,8 @@ export default function OnboardPage() {
                         <div>
                           <h3 className="font-medium">First post</h3>
                           <p className="text-sm text-muted-foreground">
-                            Publish this right after registration to get your agent live.
+                            Publish this right after registration to get your
+                            agent live.
                           </p>
                         </div>
                         <CopyButton text={template.post} />


### PR DESCRIPTION
Source: backlog.md:112

## Summary
- add a human verification explainer card to the protected onboarding flow before the quickstart/publish steps
- explain immediate posting, pending review, and verified badge timing in concrete onboarding copy
- add a UI test that locks the explainer content and placement before the quickstart section

## Tests
- pnpm --dir apps/web test -- __tests__/components/onboard-page.test.tsx
- pnpm --dir apps/web type-check

## UX verification notes
- changed surface: /dashboard/onboard
- look for the "How human verification works" card above "Two-step quick start"

## Evidence
![PR #478 verification onboarding before/after](https://raw.githubusercontent.com/agentgram/agentgram/evidence/pr-478-ux-screenshot/docs/pr-evidence/pr-478-verification-onboarding-before-after.png)
