### PR TITLE
test: cover claim flow routes

### DIFF
--- a/apps/web/__tests__/api/agents-claim-token.test.ts
+++ b/apps/web/__tests__/api/agents-claim-token.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAgentSingle = vi.fn();
+const mockAgentEq = vi.fn();
+const mockAgentSelect = vi.fn();
+const mockClaimTokenInsert = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@agentgram/db', () => ({
+  getSupabaseServiceClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+vi.mock('@agentgram/auth', () => ({
+  withAuth: (handler: unknown) => handler,
+  withRateLimit: (_config: unknown, handler: unknown) => handler,
+}));
+
+vi.mock('bcryptjs', () => ({
+  default: { hash: vi.fn().mockResolvedValue('hashed-claim-token') },
+}));
+
+describe('POST /api/v1/agents/claim-token', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockAgentSingle.mockResolvedValue({
+      data: { id: 'agent-1', name: 'sage-bot', status: 'active' },
+      error: null,
+    });
+    mockAgentEq.mockReturnValue({ single: mockAgentSingle });
+    mockAgentSelect.mockReturnValue({ eq: mockAgentEq });
+    mockClaimTokenInsert.mockResolvedValue({ error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'agents') {
+        return {
+          select: mockAgentSelect,
+        };
+      }
+
+      if (table === 'agent_claim_tokens') {
+        return {
+          insert: mockClaimTokenInsert,
+        };
+      }
+
+      return {};
+    });
+  });
+
+  async function createClaimToken(headers: Record<string, string> = {}) {
+    const { POST } = await import('../../app/api/v1/agents/claim-token/route');
+    const request = new Request('http://localhost/api/v1/agents/claim-token', {
+      method: 'POST',
+      headers,
+    });
+
+    return POST(request as Parameters<typeof POST>[0]);
+  }
+
+  it('returns a one-time claim token and stores only hash + prefix', async () => {
+    const response = await createClaimToken({
+      'x-agent-id': 'agent-1',
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(json.data.agentName).toBe('sage-bot');
+    expect(json.data.claimToken).toMatch(/^agclaim_[a-f0-9]{64}$/);
+    expect(Date.parse(json.data.expiresAt)).not.toBeNaN();
+
+    expect(mockFrom).toHaveBeenCalledWith('agents');
+    expect(mockFrom).toHaveBeenCalledWith('agent_claim_tokens');
+    expect(mockClaimTokenInsert).toHaveBeenCalledTimes(1);
+    expect(mockClaimTokenInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent_id: 'agent-1',
+        token_hash: 'hashed-claim-token',
+        token_prefix: json.data.claimToken.substring(0, 16),
+        expires_at: expect.any(String),
+      })
+    );
+    const inserted = mockClaimTokenInsert.mock.calls[0][0];
+    expect(inserted.token_hash).not.toBe(json.data.claimToken);
+  });
+
+  it('returns 401 when the authenticated agent id is missing', async () => {
+    const response = await createClaimToken();
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('UNAUTHORIZED');
+    expect(mockClaimTokenInsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the agent record does not exist', async () => {
+    mockAgentSingle.mockResolvedValueOnce({ data: null, error: null });
+
+    const response = await createClaimToken({
+      'x-agent-id': 'missing-agent',
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('NOT_FOUND');
+    expect(mockClaimTokenInsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the agent is not active', async () => {
+    mockAgentSingle.mockResolvedValueOnce({
+      data: { id: 'agent-1', name: 'sage-bot', status: 'draft' },
+      error: null,
+    });
+
+    const response = await createClaimToken({
+      'x-agent-id': 'agent-1',
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('AGENT_INACTIVE');
+    expect(mockClaimTokenInsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/__tests__/api/developer-claim-agent.test.ts
+++ b/apps/web/__tests__/api/developer-claim-agent.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockClaimTokenIs = vi.fn();
+const mockClaimTokenEq = vi.fn();
+const mockClaimTokenSelect = vi.fn();
+const mockClaimTokenUpdateEq = vi.fn();
+const mockClaimTokenUpdate = vi.fn();
+const mockAgentUpdateEq = vi.fn();
+const mockAgentUpdate = vi.fn();
+const mockAgentSingle = vi.fn();
+const mockAgentEq = vi.fn();
+const mockAgentSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockCompare = vi.fn();
+
+vi.mock('@agentgram/db', () => ({
+  getSupabaseServiceClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+vi.mock('@agentgram/auth', () => ({
+  withRateLimit: (_config: unknown, handler: unknown) => handler,
+}));
+
+vi.mock('@/lib/auth/developer', () => ({
+  withDeveloperAuth: (handler: unknown) => handler,
+}));
+
+vi.mock('bcryptjs', () => ({
+  default: { compare: mockCompare },
+}));
+
+describe('POST /api/v1/developers/claim-agent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockClaimTokenIs.mockResolvedValue({
+      data: [
+        {
+          id: 'token-1',
+          agent_id: 'agent-1',
+          token_hash: 'stored-hash',
+          expires_at: '2099-01-01T00:00:00.000Z',
+          redeemed_at: null,
+        },
+      ],
+      error: null,
+    });
+    mockClaimTokenEq.mockReturnValue({ is: mockClaimTokenIs });
+    mockClaimTokenSelect.mockReturnValue({ eq: mockClaimTokenEq });
+    mockClaimTokenUpdateEq.mockResolvedValue({ error: null });
+    mockClaimTokenUpdate.mockReturnValue({ eq: mockClaimTokenUpdateEq });
+
+    mockAgentUpdateEq.mockResolvedValue({ error: null });
+    mockAgentUpdate.mockReturnValue({ eq: mockAgentUpdateEq });
+    mockAgentSingle.mockResolvedValue({
+      data: {
+        id: 'agent-1',
+        name: 'sage-bot',
+        display_name: 'Sage Bot',
+      },
+      error: null,
+    });
+    mockAgentEq.mockReturnValue({ single: mockAgentSingle });
+    mockAgentSelect.mockReturnValue({ eq: mockAgentEq });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'agent_claim_tokens') {
+        return {
+          select: mockClaimTokenSelect,
+          update: mockClaimTokenUpdate,
+        };
+      }
+
+      if (table === 'agents') {
+        return {
+          update: mockAgentUpdate,
+          select: mockAgentSelect,
+        };
+      }
+
+      return {};
+    });
+
+    mockCompare.mockResolvedValue(true);
+  });
+
+  async function claimAgent(
+    body: Record<string, unknown> = { claimToken: 'agclaim_1234567890abcdef' },
+    headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'x-developer-id': 'dev-1',
+      'x-user-id': 'user-1',
+    }
+  ) {
+    const { POST } = await import('../../app/api/v1/developers/claim-agent/route');
+    const request = new Request('http://localhost/api/v1/developers/claim-agent', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    return POST(request as Parameters<typeof POST>[0]);
+  }
+
+  it('redeems a valid claim token and transfers ownership', async () => {
+    const response = await claimAgent();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toEqual({
+      success: true,
+      data: {
+        agentId: 'agent-1',
+        agentName: 'sage-bot',
+        agentDisplayName: 'Sage Bot',
+        developerId: 'dev-1',
+        claimedAt: expect.any(String),
+      },
+    });
+
+    expect(mockClaimTokenEq).toHaveBeenCalledWith('token_prefix', 'agclaim_12345678');
+    expect(mockAgentUpdate).toHaveBeenCalledWith({ developer_id: 'dev-1' });
+    expect(mockAgentUpdateEq).toHaveBeenCalledWith('id', 'agent-1');
+    expect(mockClaimTokenUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redeemed_at: expect.any(String),
+        redeemed_by_user_id: 'user-1',
+      })
+    );
+    expect(mockClaimTokenUpdateEq).toHaveBeenCalledWith('id', 'token-1');
+  });
+
+  it('returns 401 when developer auth context is missing', async () => {
+    const response = await claimAgent(
+      { claimToken: 'agclaim_1234567890abcdef' },
+      { 'Content-Type': 'application/json' }
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('UNAUTHORIZED');
+    expect(mockAgentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when claimToken is missing from the request body', async () => {
+    const response = await claimAgent({});
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('INVALID_INPUT');
+    expect(mockCompare).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the token prefix lookup finds no active candidates', async () => {
+    mockClaimTokenIs.mockResolvedValueOnce({ data: [], error: null });
+
+    const response = await claimAgent();
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('INVALID_CLAIM_TOKEN');
+    expect(mockAgentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when no stored hash matches the provided claim token', async () => {
+    mockCompare.mockResolvedValueOnce(false);
+
+    const response = await claimAgent();
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('INVALID_CLAIM_TOKEN');
+    expect(mockAgentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the matched token is expired', async () => {
+    mockClaimTokenIs.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'token-1',
+          agent_id: 'agent-1',
+          token_hash: 'stored-hash',
+          expires_at: '2000-01-01T00:00:00.000Z',
+          redeemed_at: null,
+        },
+      ],
+      error: null,
+    });
+
+    const response = await claimAgent();
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('CLAIM_TOKEN_EXPIRED');
+    expect(mockAgentUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Source: backlog.md:36

Add route-level coverage for the agent claim handoff so both sides of the flow are explicitly verified. This PR adds focused tests for claim-token generation and developer claim-agent redemption, including the main auth and invalid/expired token failure paths.

## Evidence
- test diff summary:
  - `apps/web/__tests__/api/agents-claim-token.test.ts`: covers successful one-time claim-token generation, hashed token persistence with prefix-only storage, missing agent auth, missing agent record, and inactive agent rejection
  - `apps/web/__tests__/api/developer-claim-agent.test.ts`: covers successful claim-agent redemption, missing developer auth, missing `claimToken`, prefix lookup miss, bcrypt mismatch, and expired token rejection
- changed files:
  - `apps/web/__tests__/api/agents-claim-token.test.ts`
  - `apps/web/__tests__/api/developer-claim-agent.test.ts`
- commands run:
  - `pnpm --dir apps/web exec vitest run __tests__/api/agents-claim-token.test.ts __tests__/api/developer-claim-agent.test.ts`
  - `pnpm --dir apps/web type-check`