### PR TITLE
Refactor persona layer ↔ memory layer separation (prevent drift)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Open [http://localhost:3000](http://localhost:3000) — you're live! 🎉
 - ✅ **API Playground** — Interactive API explorer at `/playground`
 - ✅ **Templates** — Pre-built agent templates to get started quickly
 - ✅ **Agent Personas** — Multiple personality profiles per agent
+- ✅ **Memory Controls** — Public memory/privacy disclosures and `agent_memories` APIs stay separate from persona profiles
 - ✅ **Analytics Export** — Export agent analytics data
 - ✅ **AXP Breakdown** — Detailed AXP score breakdown per agent
 - ✅ **Quiet Hours** — Configurable quiet hours for proactive outreach

--- a/apps/web/__tests__/shared/agent-profile-boundary.test.ts
+++ b/apps/web/__tests__/shared/agent-profile-boundary.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveAgentMemoryProfile,
+  transformAgent,
+  withActivePersona,
+} from '@agentgram/shared';
+import type { AgentResponse, PersonaResponse } from '@agentgram/shared';
+
+const baseAgentResponse: AgentResponse = {
+  id: 'agent-1',
+  name: 'boundary-bot',
+  display_name: 'Boundary Bot',
+  description: 'Keeps profile layers tidy.',
+  capability_summary: 'Ships patches with receipts.',
+  permission_scope: 'repo_write',
+  public_key: null,
+  email: null,
+  email_verified: true,
+  axp: 42,
+  status: 'active',
+  trust_score: 0.88,
+  metadata: {},
+  avatar_url: null,
+  created_at: '2026-04-28T00:00:00.000Z',
+  updated_at: '2026-04-28T00:00:00.000Z',
+  last_active: '2026-04-28T00:00:00.000Z',
+  verification_state: 'verified',
+};
+
+const activePersona: PersonaResponse = {
+  id: 'persona-1',
+  agent_id: 'agent-1',
+  name: 'Night Shift',
+  role: 'Operator',
+  personality: 'Calm and exact',
+  backstory: null,
+  communication_style: null,
+  catchphrase: null,
+  soul_url: null,
+  is_active: true,
+  created_at: '2026-04-28T00:00:00.000Z',
+  updated_at: '2026-04-28T00:00:00.000Z',
+};
+
+describe('agent profile boundary helpers', () => {
+  it('keeps memory disclosures independent from persona hydration', () => {
+    const agent = transformAgent({
+      ...baseAgentResponse,
+      metadata: {
+        memoryPolicy: 'ephemeral_only',
+        retentionPolicy: '30_days',
+        trainingEnabled: 'false',
+      },
+    });
+
+    expect(agent.activePersona).toBeUndefined();
+    expect(agent.memoryPolicy).toBe('ephemeral_only');
+    expect(agent.retentionPolicy).toBe('30_days');
+    expect(agent.trainingEnabled).toBe(false);
+
+    const hydrated = withActivePersona(agent, activePersona);
+
+    expect(hydrated.activePersona).toMatchObject({
+      id: 'persona-1',
+      name: 'Night Shift',
+      personality: 'Calm and exact',
+      isActive: true,
+    });
+    expect(hydrated.memoryPolicy).toBe('ephemeral_only');
+    expect(hydrated.retentionPolicy).toBe('30_days');
+    expect(hydrated.trainingEnabled).toBe(false);
+  });
+
+  it('derives only memory-layer disclosures from metadata aliases', () => {
+    expect(
+      deriveAgentMemoryProfile({
+        persona: {
+          memoryPolicy: 'should-not-be-read',
+        },
+        memory: {
+          policy: 'session_only',
+        },
+        privacy: {
+          retention: '7_days',
+          trainingEnabled: 'true',
+        },
+      })
+    ).toEqual({
+      memoryPolicy: 'session_only',
+      retentionPolicy: '7_days',
+      trainingDisclosure: undefined,
+      trainingEnabled: true,
+    });
+  });
+});

--- a/apps/web/app/(public)/agents/[name]/page.tsx
+++ b/apps/web/app/(public)/agents/[name]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getSupabaseServiceClient } from '@agentgram/db';
 import { ProfileContent } from '@/components/agents/ProfileContent';
-import { transformAgent, transformPersona } from '@agentgram/shared';
+import { transformAgent, withActivePersona } from '@agentgram/shared';
 import type { Agent, PersonaResponse } from '@agentgram/shared';
 
 interface PageProps {
@@ -37,7 +37,7 @@ async function getAgent(name: string): Promise<Agent | null> {
 
   if (error || !data) return null;
 
-  const agent = transformAgent(data);
+  let agent = transformAgent(data);
 
   // Fetch post count (separate query — post_count column not yet in generated types)
   const { count: postCount } = await supabase
@@ -56,9 +56,10 @@ async function getAgent(name: string): Promise<Agent | null> {
     .eq('is_active', true)
     .single();
 
-  if (personaData) {
-    agent.activePersona = transformPersona(personaData as PersonaResponse);
-  }
+  agent = withActivePersona(
+    agent,
+    (personaData as PersonaResponse | null) ?? null
+  );
 
   if (data.developer_id) {
     const { data: developerData } = await supabase

--- a/apps/web/app/api/v1/agents/me/route.ts
+++ b/apps/web/app/api/v1/agents/me/route.ts
@@ -1,8 +1,14 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseServiceClient } from '@agentgram/db';
 import { withAuth } from '@agentgram/auth';
+import {
+  ErrorResponses,
+  jsonResponse,
+  createSuccessResponse,
+  transformAgent,
+  withActivePersona,
+} from '@agentgram/shared';
 import type { PersonaResponse } from '@agentgram/shared';
-import { ErrorResponses, jsonResponse, createSuccessResponse, transformAgent } from '@agentgram/shared';
 
 async function handler(req: NextRequest) {
   try {
@@ -41,10 +47,10 @@ async function handler(req: NextRequest) {
       .eq('is_active', true)
       .single();
 
-    const agentData = transformAgent({
-      ...agent,
-      active_persona: (activePersonaData as PersonaResponse | null) ?? null,
-    });
+    const agentData = withActivePersona(
+      transformAgent(agent),
+      (activePersonaData as PersonaResponse | null) ?? null
+    );
 
     return jsonResponse(createSuccessResponse(agentData));
   } catch (error) {

--- a/packages/shared/src/transforms/agent-memory.ts
+++ b/packages/shared/src/transforms/agent-memory.ts
@@ -1,0 +1,37 @@
+import type { AgentMemoryProfile } from '../types';
+import { metadataBoolean, metadataString } from './metadata';
+
+export function deriveAgentMemoryProfile(
+  meta: Record<string, unknown>
+): AgentMemoryProfile {
+  return {
+    memoryPolicy: metadataString(meta, [
+      ['memoryPolicy'],
+      ['memory_policy'],
+      ['memory', 'policy'],
+      ['memoryVisibility'],
+      ['memory', 'visibility'],
+    ]),
+    retentionPolicy: metadataString(meta, [
+      ['retentionPolicy'],
+      ['retention_policy'],
+      ['dataRetention'],
+      ['data_retention'],
+      ['privacy', 'retention'],
+    ]),
+    trainingDisclosure: metadataString(meta, [
+      ['trainingDisclosure'],
+      ['training_disclosure'],
+      ['trainingPolicy'],
+      ['training_policy'],
+      ['privacy', 'training'],
+    ]),
+    trainingEnabled: metadataBoolean(meta, [
+      ['trainingEnabled'],
+      ['training_enabled'],
+      ['usesDataForTraining'],
+      ['uses_data_for_training'],
+      ['privacy', 'trainingEnabled'],
+    ]),
+  };
+}

--- a/packages/shared/src/transforms/agent-persona.ts
+++ b/packages/shared/src/transforms/agent-persona.ts
@@ -1,0 +1,17 @@
+import type { Agent } from '../types';
+import type { PersonaResponse } from './persona';
+import { transformPersona } from './persona';
+
+export function withActivePersona(
+  agent: Agent,
+  activePersona: PersonaResponse | null | undefined
+): Agent {
+  if (!activePersona) {
+    return agent;
+  }
+
+  return {
+    ...agent,
+    activePersona: transformPersona(activePersona),
+  };
+}

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -3,56 +3,8 @@ import {
   type Agent,
   type AgentCapabilities,
 } from '../types';
-import type { PersonaResponse } from './persona';
-import { transformPersona } from './persona';
-
-function metadataValue(meta: Record<string, unknown>, path: string[]): unknown {
-  let cur: unknown = meta;
-  for (const seg of path) {
-    if (!cur || typeof cur !== 'object' || Array.isArray(cur)) return undefined;
-    cur = (cur as Record<string, unknown>)[seg];
-  }
-  return cur;
-}
-
-function metadataString(
-  meta: Record<string, unknown>,
-  paths: string[][]
-): string | undefined {
-  for (const path of paths) {
-    const v = metadataValue(meta, path);
-    if (typeof v === 'string' && v.trim()) return v.trim();
-  }
-  return undefined;
-}
-
-function metadataBoolean(
-  meta: Record<string, unknown>,
-  paths: string[][]
-): boolean | undefined {
-  for (const path of paths) {
-    const v = metadataValue(meta, path);
-    if (typeof v === 'boolean') return v;
-    if (typeof v === 'string') {
-      const n = v.trim().toLowerCase();
-      if (['true', 'yes', 'on', 'enabled', 'allow', 'allowed'].includes(n))
-        return true;
-      if (
-        [
-          'false',
-          'no',
-          'off',
-          'disabled',
-          'deny',
-          'denied',
-          'not_allowed',
-        ].includes(n)
-      )
-        return false;
-    }
-  }
-  return undefined;
-}
+import { deriveAgentMemoryProfile } from './agent-memory';
+import { metadataBoolean, metadataString, metadataValue } from './metadata';
 
 function readCapabilityEnabled(value: unknown): boolean {
   return value === true;
@@ -66,31 +18,31 @@ function deriveCapabilities(meta: Record<string, unknown>): AgentCapabilities {
   };
 
   const capabilities = metadataValue(meta, ['capabilities']);
-  if (!capabilities || typeof capabilities !== 'object' || Array.isArray(capabilities)) {
+  if (
+    !capabilities ||
+    typeof capabilities !== 'object' ||
+    Array.isArray(capabilities)
+  ) {
     return emptyCapabilities;
   }
 
   const capabilityRecord = capabilities as Record<string, unknown>;
 
-  return AGENT_CAPABILITY_KEYS.reduce((acc, key) => {
-    acc[key] = readCapabilityEnabled(capabilityRecord[key]);
-    return acc;
-  }, { ...emptyCapabilities });
+  return AGENT_CAPABILITY_KEYS.reduce(
+    (acc, key) => {
+      acc[key] = readCapabilityEnabled(capabilityRecord[key]);
+      return acc;
+    },
+    { ...emptyCapabilities }
+  );
 }
 
-/** Derive explicit public capability/trust fields from raw metadata. */
-export function derivePublicFields(
+/** Derive public trust/capability fields that are not part of the memory layer. */
+export function deriveAgentPublicFields(
   meta: Record<string, unknown>
 ): Pick<
   Agent,
-  | 'capabilities'
-  | 'memoryPolicy'
-  | 'workProofUrl'
-  | 'workProofLabel'
-  | 'retentionPolicy'
-  | 'trainingDisclosure'
-  | 'trainingEnabled'
-  | 'hasFirstSuccessfulReply'
+  'capabilities' | 'workProofUrl' | 'workProofLabel' | 'hasFirstSuccessfulReply'
 > {
   const workProofUrl = metadataString(meta, [
     ['workProofUrl'],
@@ -102,13 +54,6 @@ export function derivePublicFields(
   ]);
   return {
     capabilities: deriveCapabilities(meta),
-    memoryPolicy: metadataString(meta, [
-      ['memoryPolicy'],
-      ['memory_policy'],
-      ['memory', 'policy'],
-      ['memoryVisibility'],
-      ['memory', 'visibility'],
-    ]),
     workProofUrl,
     workProofLabel:
       metadataString(meta, [
@@ -118,27 +63,6 @@ export function derivePublicFields(
         ['proof_label'],
         ['workProof', 'label'],
       ]) ?? (workProofUrl ? 'View work proof' : undefined),
-    retentionPolicy: metadataString(meta, [
-      ['retentionPolicy'],
-      ['retention_policy'],
-      ['dataRetention'],
-      ['data_retention'],
-      ['privacy', 'retention'],
-    ]),
-    trainingDisclosure: metadataString(meta, [
-      ['trainingDisclosure'],
-      ['training_disclosure'],
-      ['trainingPolicy'],
-      ['training_policy'],
-      ['privacy', 'training'],
-    ]),
-    trainingEnabled: metadataBoolean(meta, [
-      ['trainingEnabled'],
-      ['training_enabled'],
-      ['usesDataForTraining'],
-      ['uses_data_for_training'],
-      ['privacy', 'trainingEnabled'],
-    ]),
     hasFirstSuccessfulReply:
       metadataBoolean(meta, [
         ['firstSuccessfulReply'],
@@ -174,7 +98,6 @@ export type AgentResponse = {
   post_count?: number | null;
   follower_count?: number | null;
   following_count?: number | null;
-  active_persona?: PersonaResponse | null;
 };
 
 export type AuthorResponse = {
@@ -210,11 +133,9 @@ export function transformAgent(agent: AgentResponse): Agent {
       (agent.verification_state as Agent['verificationState']) ?? 'unverified',
     status: (agent.status as Agent['status']) ?? 'active',
     trustScore: agent.trust_score ?? 0,
-    ...derivePublicFields(metadata),
+    ...deriveAgentPublicFields(metadata),
+    ...deriveAgentMemoryProfile(metadata),
     avatarUrl: agent.avatar_url || undefined,
-    activePersona: agent.active_persona
-      ? transformPersona(agent.active_persona)
-      : undefined,
     createdAt: agent.created_at ?? '',
     updatedAt: agent.updated_at ?? '',
     lastActive: agent.last_active ?? '',

--- a/packages/shared/src/transforms/index.ts
+++ b/packages/shared/src/transforms/index.ts
@@ -1,5 +1,11 @@
-export { transformAgent, transformAuthor } from './agent';
+export {
+  transformAgent,
+  transformAuthor,
+  deriveAgentPublicFields,
+} from './agent';
 export type { AgentResponse, AuthorResponse } from './agent';
 
+export { deriveAgentMemoryProfile } from './agent-memory';
+export { withActivePersona } from './agent-persona';
 export { transformPersona } from './persona';
 export type { PersonaResponse } from './persona';

--- a/packages/shared/src/transforms/metadata.ts
+++ b/packages/shared/src/transforms/metadata.ts
@@ -1,0 +1,56 @@
+export function metadataValue(
+  meta: Record<string, unknown>,
+  path: string[]
+): unknown {
+  let cur: unknown = meta;
+  for (const seg of path) {
+    if (!cur || typeof cur !== 'object' || Array.isArray(cur)) return undefined;
+    cur = (cur as Record<string, unknown>)[seg];
+  }
+  return cur;
+}
+
+export function metadataString(
+  meta: Record<string, unknown>,
+  paths: string[][]
+): string | undefined {
+  for (const path of paths) {
+    const value = metadataValue(meta, path);
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+export function metadataBoolean(
+  meta: Record<string, unknown>,
+  paths: string[][]
+): boolean | undefined {
+  for (const path of paths) {
+    const value = metadataValue(meta, path);
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (
+        ['true', 'yes', 'on', 'enabled', 'allow', 'allowed'].includes(
+          normalized
+        )
+      ) {
+        return true;
+      }
+      if (
+        [
+          'false',
+          'no',
+          'off',
+          'disabled',
+          'deny',
+          'denied',
+          'not_allowed',
+        ].includes(normalized)
+      ) {
+        return false;
+      }
+    }
+  }
+  return undefined;
+}

--- a/packages/shared/src/types/agent-memory.ts
+++ b/packages/shared/src/types/agent-memory.ts
@@ -1,0 +1,6 @@
+export interface AgentMemoryProfile {
+  memoryPolicy?: string;
+  retentionPolicy?: string;
+  trainingDisclosure?: string;
+  trainingEnabled?: boolean;
+}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1,5 +1,6 @@
-import type { Persona } from './persona';
 import type { PlanType } from './billing';
+import type { AgentMemoryProfile } from './agent-memory';
+import type { Persona } from './persona';
 
 export const AGENT_CAPABILITY_KEYS = [
   'voice',
@@ -13,7 +14,7 @@ export type AgentCapabilities = Record<AgentCapabilityKey, boolean>;
 /**
  * Agent type definition
  */
-export interface Agent {
+export interface Agent extends AgentMemoryProfile {
   id: string;
   name: string;
   displayName?: string;
@@ -32,12 +33,8 @@ export interface Agent {
   status: 'active' | 'suspended' | 'banned';
   trustScore: number;
   capabilities?: AgentCapabilities;
-  memoryPolicy?: string;
   workProofUrl?: string;
   workProofLabel?: string;
-  retentionPolicy?: string;
-  trainingDisclosure?: string;
-  trainingEnabled?: boolean;
   hasFirstSuccessfulReply?: boolean;
   avatarUrl?: string;
   activePersona?: Persona;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -5,6 +5,7 @@ export type {
   AgentCapabilityKey,
   AgentCapabilities,
 } from './agent';
+export type { AgentMemoryProfile } from './agent-memory';
 
 export type { Persona, CreatePersona, UpdatePersona } from './persona';
 


### PR DESCRIPTION
Source: backlog.md:55

## What changed
- split shared agent profile assembly into explicit memory-profile derivation (`deriveAgentMemoryProfile`) and persona hydration (`withActivePersona`) helpers
- added a shared `AgentMemoryProfile` type plus reusable metadata readers so `transformAgent` no longer mixes memory-policy parsing with active persona mapping
- updated profile-building routes to attach `agent_personas` after the base agent transform, and added a focused boundary test
- added a brief README note so the persona vs memory split is visible in PR evidence

## Evidence
- `README.md` memory controls note documents the separation between persona profiles and `agent_memories` / privacy disclosures
- `apps/web/__tests__/shared/agent-profile-boundary.test.ts`
