### PR TITLE
Fix broken develop lockfile blocking capability-contract verification

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -112,3 +112,5 @@ Tests run automatically on every PR via `.github/workflows/test.yml`. The pipeli
 1. Checks out the repository
 2. Installs dependencies with `pnpm install --frozen-lockfile`
 3. Runs `pnpm --filter web exec vitest run`
+
+If step 2 fails with `ERR_PNPM_BROKEN_LOCKFILE`, use `docs/ci-lockfile-recovery.md` before retrying unrelated product verification work.

--- a/docs/ci-lockfile-recovery.md
+++ b/docs/ci-lockfile-recovery.md
@@ -1,0 +1,15 @@
+# CI lockfile recovery
+
+When GitHub Actions fails during `pnpm install --frozen-lockfile` with `ERR_PNPM_BROKEN_LOCKFILE`, check `pnpm-lock.yaml` for duplicated package keys before retrying product work.
+
+## Failure signature
+
+```text
+ERR_PNPM_BROKEN_LOCKFILE The lockfile at ".../pnpm-lock.yaml" is broken: duplicated mapping key
+```
+
+## Local recovery
+
+1. Remove the duplicated package block from `pnpm-lock.yaml`.
+2. Re-run `pnpm install --frozen-lockfile`.
+3. Only retry blocked PR verification after the base branch install step is green again.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3986,10 +3986,6 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
-    engines: {node: ^10 || ^12 || >=14}
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -8421,12 +8417,6 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1


### PR DESCRIPTION
Source: backlog.md:61

## Summary
- remove the duplicated `postcss@8.5.12` keys that broke `pnpm-lock.yaml` on `develop`
- add a small CI recovery note so future verifier follow-ups can identify `ERR_PNPM_BROKEN_LOCKFILE` quickly
- restore the base-branch install lane that blocked L2 verification for merged PR #474

## Validation
- pnpm install --frozen-lockfile

## Evidence
- docs/example diff: `docs/ci-lockfile-recovery.md` documents the exact broken-lockfile signature and the local recovery flow used here
- docs/example diff: `TESTING.md` now points CI responders at that recovery note before retrying unrelated product verification work
