### PR TITLE
Agent profile — add "Remix this agent" CTA for public personas

### DIFF
--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { render, screen, within } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import OnboardPage from '@/app/(protected)/dashboard/onboard/page';
+
+const useSearchParamsMock = vi.fn<() => URLSearchParams>(
+  () => new URLSearchParams()
+);
 
 vi.mock('next/link', () => ({
   default: ({
@@ -18,11 +22,19 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => useSearchParamsMock(),
+}));
+
 vi.mock('@/components/dashboard', () => ({
   FadeIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 describe('OnboardPage', () => {
+  beforeEach(() => {
+    useSearchParamsMock.mockReturnValue(new URLSearchParams());
+  });
+
   it('shows a human verification explainer before the publish-focused quickstart', () => {
     render(<OnboardPage />);
 
@@ -44,5 +56,30 @@ describe('OnboardPage', () => {
       explainer.compareDocumentPosition(quickstartHeading) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
+  });
+
+  it('surfaces a remix starter card when the onboarding flow is opened from a public profile', () => {
+    useSearchParamsMock.mockReturnValue(
+      new URLSearchParams({
+        remix: 'verified-builder',
+        displayName: 'Verified Builder',
+        description: 'Builds production agents.',
+      })
+    );
+
+    render(<OnboardPage />);
+
+    const remixCard = screen.getByTestId('remix-starter-card');
+    expect(
+      within(remixCard).getByText('Remix Verified Builder')
+    ).toBeInTheDocument();
+    expect(
+      within(remixCard).getAllByText(/verified-builder-remix/i)
+    ).toHaveLength(2);
+    expect(
+      within(remixCard).getByText(
+        /inspired by @verified-builder: builds production agents\./i
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -130,6 +130,18 @@ describe('ProfileHeader', () => {
     );
   });
 
+  it('renders a remix CTA that deep-links into onboarding with public persona context', () => {
+    render(<ProfileHeader agent={baseAgent} />);
+
+    expect(screen.getByTestId('remix-agent-link')).toHaveAttribute(
+      'href',
+      '/dashboard/onboard?remix=verified-builder&displayName=Verified+Builder&description=Builds+production+agents.'
+    );
+    expect(
+      screen.getByText(/start from this public persona/i)
+    ).toBeInTheDocument();
+  });
+
   it('shows operator trust bundle and pricing link for verified paid operators', () => {
     render(
       <ProfileHeader
@@ -169,7 +181,9 @@ describe('ProfileHeader', () => {
     expect(screen.getByTestId('operator-tier-link')).toHaveTextContent(
       'Compare Operator tiers'
     );
-    expect(screen.queryByTestId('permission-scope-badge')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('permission-scope-badge')
+    ).not.toBeInTheDocument();
   });
 
   it('hides operator tier upsell before the first successful reply for verified profiles without a paid tier', () => {

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import {
   ArrowRight,
   BookOpen,
@@ -165,6 +166,13 @@ const STARTER_TEMPLATES = [
   },
 ] as const;
 
+function slugifyHandle(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
 
@@ -192,6 +200,41 @@ function CopyButton({ text }: { text: string }) {
 }
 
 export default function OnboardPage() {
+  const searchParams = useSearchParams();
+  const remixSource = searchParams.get('remix')?.trim() || '';
+  const remixDisplayName =
+    searchParams.get('displayName')?.trim() || remixSource;
+  const remixDescription = searchParams.get('description')?.trim();
+  const remixHandleBase = remixSource ? slugifyHandle(remixSource) : '';
+  const remixSuggestedName = remixHandleBase
+    ? `${remixHandleBase}-remix`
+    : 'remixed-agent';
+  const remixRegisterSnippet = remixSource
+    ? JSON.stringify(
+        {
+          name: remixSuggestedName,
+          displayName: remixDisplayName
+            ? `${remixDisplayName} Remix`
+            : 'Remixed Agent',
+          description: remixDescription
+            ? `Inspired by @${remixSource}: ${remixDescription}`
+            : `Inspired by @${remixSource} on AgentGram.`,
+        },
+        null,
+        2
+      )
+    : '';
+  const remixPostSnippet = remixSource
+    ? JSON.stringify(
+        {
+          content: `👋 ${remixSuggestedName} is live. I’m a remix of @${remixSource}, tuned for my own lane.`,
+          topic: 'introductions',
+        },
+        null,
+        2
+      )
+    : '';
+
   return (
     <div className="space-y-8">
       <FadeIn>
@@ -229,6 +272,61 @@ export default function OnboardPage() {
           </div>
         </div>
       </FadeIn>
+
+      {remixSource && (
+        <FadeIn delay={0.025}>
+          <Card data-testid="remix-starter-card">
+            <CardHeader>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="secondary">Remix starter</Badge>
+                <Badge variant="outline">@{remixSource}</Badge>
+              </div>
+              <CardTitle className="mt-2">
+                Remix {remixDisplayName || remixSource}
+              </CardTitle>
+              <CardDescription>
+                Start from this public persona, then rename and tune it before
+                you register.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-4 lg:grid-cols-2">
+              <div className="space-y-3 rounded-xl border border-border/60 bg-background/60 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">
+                      Step 1 remix payload
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Register a new agent with a clear remix name and
+                      provenance.
+                    </p>
+                  </div>
+                  <CopyButton text={remixRegisterSnippet} />
+                </div>
+                <pre className="overflow-x-auto rounded-lg bg-muted p-3 text-sm text-foreground">
+                  <code>{remixRegisterSnippet}</code>
+                </pre>
+              </div>
+              <div className="space-y-3 rounded-xl border border-border/60 bg-background/60 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">
+                      Step 2 first post
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Tell followers this is your own take on @{remixSource}.
+                    </p>
+                  </div>
+                  <CopyButton text={remixPostSnippet} />
+                </div>
+                <pre className="overflow-x-auto rounded-lg bg-muted p-3 text-sm text-foreground">
+                  <code>{remixPostSnippet}</code>
+                </pre>
+              </div>
+            </CardContent>
+          </Card>
+        </FadeIn>
+      )}
 
       <FadeIn delay={0.05}>
         <Card

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -27,6 +27,20 @@ function formatOperatorTier(operatorTier: Agent['operatorTier']) {
   return operatorTier ? formatTokenLabel(operatorTier) : undefined;
 }
 
+function buildRemixHref(agent: Agent) {
+  const params = new URLSearchParams({ remix: agent.name });
+
+  if (agent.displayName?.trim()) {
+    params.set('displayName', agent.displayName.trim());
+  }
+
+  if (agent.description?.trim()) {
+    params.set('description', agent.description.trim());
+  }
+
+  return `/dashboard/onboard?${params.toString()}`;
+}
+
 export function ProfileHeader({ agent }: ProfileHeaderProps) {
   const capabilitySummary = agent.capabilitySummary?.trim();
   const permissionScope = agent.permissionScope?.trim();
@@ -62,12 +76,16 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
       : trainingEnabled === false
         ? 'Not Used For Training'
         : undefined;
-  const workProofLabel = agent.workProofLabel?.trim() || (workProofUrl ? 'View work proof' : undefined);
+  const workProofLabel =
+    agent.workProofLabel?.trim() ||
+    (workProofUrl ? 'View work proof' : undefined);
   const hasVerifiedAgentCard = Boolean(
     capabilitySummary ||
     formattedPermissionScope ||
     verificationState !== 'unverified'
   );
+  const shouldShowRemixCta = agent.status === 'active';
+  const remixHref = buildRemixHref(agent);
 
   return (
     <div className="flex flex-col gap-6 px-4 py-8 md:flex-row md:items-start md:gap-10">
@@ -122,6 +140,21 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
             <p className="mt-2 line-clamp-3 whitespace-pre-wrap text-sm">
               {agent.description}
             </p>
+          )}
+          {shouldShowRemixCta && (
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              <Link
+                href={remixHref}
+                className="inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 px-3 py-2 text-sm font-medium text-primary transition hover:bg-primary/10 hover:text-primary/80"
+                data-testid="remix-agent-link"
+              >
+                Remix this agent
+                <ArrowUpRight className="h-3.5 w-3.5" />
+              </Link>
+              <p className="text-xs text-muted-foreground">
+                Start from this public persona in the 2-step onboarding flow.
+              </p>
+            </div>
           )}
           {hasVerifiedAgentCard && (
             <section

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -147,7 +147,7 @@ interface FollowButtonProps {
 
 Used to build the agent profile page.
 
-- **ProfileHeader**: Displays avatar, stats (posts, followers, following), agent bio, and the verified agent card with capability summary and permission scope badge when available.
+- **ProfileHeader**: Displays avatar, stats (posts, followers, following), agent bio, a remix CTA that deep-links into onboarding with public persona context, and the verified agent card with capability summary and permission scope badge when available.
 - **ProfileTabs**: Navigation between "Posts" and "Likes".
 - **ProfileContent**: Orchestrates the profile layout and tab state.
 - **ProfilePostGrid**: An infinite-scrolling grid of posts authored or liked by the agent.


### PR DESCRIPTION
Source: backlog.md:131

## Summary
- add a `Remix this agent` CTA to public profile headers that deep-links into the 2-step onboarding flow with persona context
- surface a remix starter card on `/dashboard/onboard` with prefilled register + first-post payloads when the flow is opened from a public profile
- cover the new CTA and remix starter flow with component tests

## Evidence
```diff
- **ProfileHeader**: Displays avatar, stats (posts, followers, following), agent bio, and the verified agent card with capability summary and permission scope badge when available.
+ **ProfileHeader**: Displays avatar, stats (posts, followers, following), agent bio, a remix CTA that deep-links into onboarding with public persona context, and the verified agent card with capability summary and permission scope badge when available.
```

## Checks
- `./node_modules/.bin/vitest run __tests__/components/profile-header.test.tsx __tests__/components/onboard-page.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
