### PR TITLE
fix: stop public CSP font errors and unauthenticated 401 noise

### DIFF
--- a/apps/web/__tests__/components/notification-bell.test.tsx
+++ b/apps/web/__tests__/components/notification-bell.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNotifications } from '@/hooks/use-notifications';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not fetch when disabled for unauthenticated surfaces', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+
+    const { result } = renderHook(() => useNotifications({ limit: 5, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetches when enabled for authenticated surfaces', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+
+    const { result } = renderHook(() => useNotifications({ limit: 5, enabled: true }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toMatch(/\/api\/v1\/notifications/);
+  });
+});

--- a/apps/web/__tests__/components/root-layout-fonts.test.tsx
+++ b/apps/web/__tests__/components/root-layout-fonts.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import RootLayout from '@/app/layout';
+
+vi.mock('@/components/GoogleAnalytics', () => ({
+  GoogleAnalytics: () => <div data-testid="google-analytics" />,
+}));
+
+vi.mock('@/components/PageTransition', () => ({
+  PageTransition: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ui/toaster', () => ({
+  Toaster: () => <div data-testid="toaster" />,
+}));
+
+vi.mock('@/components/common', () => ({
+  Header: () => <header data-testid="header" />,
+  Footer: () => <footer data-testid="footer" />,
+  BottomNav: () => <nav data-testid="bottom-nav" />,
+}));
+
+vi.mock('@/app/providers', () => ({
+  Providers: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/lib/env', () => ({
+  getBaseUrl: () => 'https://www.agentgram.co',
+}));
+
+describe('RootLayout font loading', () => {
+  it('does not inject external font stylesheet links into the document head', () => {
+    const markup = renderToStaticMarkup(
+      <RootLayout>
+        <div>child</div>
+      </RootLayout>
+    );
+
+    expect(markup).not.toContain('api.fontshare.com');
+    expect(markup).not.toContain('cdn.jsdelivr.net/npm/geist');
+    expect(markup).not.toContain('rel="preconnect"');
+  });
+});

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -106,9 +106,9 @@
   --color-like: #10B981;
   --color-brand-glow: #10B981;
 
-  --font-sans: 'Geist', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  --font-display: 'Satoshi', 'Geist', sans-serif;
-  --font-mono: 'Geist Mono', ui-monospace, SFMono-Regular, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-display: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
 }
 
 * {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -95,28 +95,6 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <head>
-        <link
-          rel="preconnect"
-          href="https://api.fontshare.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          rel="preconnect"
-          href="https://cdn.jsdelivr.net"
-          crossOrigin="anonymous"
-        />
-        <link
-          href="https://api.fontshare.com/v2/css?f[]=satoshi@700,500,400&display=swap"
-          rel="stylesheet"
-        />
-        <link
-          href="https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-sans/style.min.css"
-          rel="stylesheet"
-        />
-        <link
-          href="https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-mono/style.min.css"
-          rel="stylesheet"
-        />
         {googleSiteVerification && (
           <meta
             name="google-site-verification"

--- a/apps/web/components/common/NotificationBell.tsx
+++ b/apps/web/components/common/NotificationBell.tsx
@@ -13,7 +13,10 @@ export function NotificationBell() {
   const [isOpen, setIsOpen] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  const { data, isLoading } = useNotifications({ limit: 5 });
+  const { data, isLoading } = useNotifications({
+    limit: 5,
+    enabled: isAuthenticated,
+  });
   const markRead = useMarkNotificationsRead();
 
   useEffect(() => {

--- a/apps/web/hooks/use-notifications.ts
+++ b/apps/web/hooks/use-notifications.ts
@@ -4,12 +4,18 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { Notification, ApiResponse } from '@agentgram/shared';
 
 export function useNotifications(
-  params: { unread?: boolean; page?: number; limit?: number } = {}
+  params: {
+    unread?: boolean;
+    page?: number;
+    limit?: number;
+    enabled?: boolean;
+  } = {}
 ) {
-  const { unread = false, page = 0, limit = 20 } = params;
+  const { unread = false, page = 0, limit = 20, enabled = true } = params;
 
   return useQuery({
     queryKey: ['notifications', { unread, page, limit }],
+    enabled,
     queryFn: async () => {
       const url = new URL('/api/v1/notifications', window.location.origin);
       if (unread) url.searchParams.set('unread', 'true');

--- a/docs/pr-evidence/row-89-console-csp-resource-errors.md
+++ b/docs/pr-evidence/row-89-console-csp-resource-errors.md
@@ -1,0 +1,28 @@
+# Row 89 evidence — console/CSP font stylesheets + public-page 401 noise
+
+## Before
+
+### Broken external font resources
+- `https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-sans/style.min.css` → `404 text/plain`
+  - body starts with: `Couldn't find the requested file /dist/fonts/geist-sans/style.min.css in geist.`
+- `https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-mono/style.min.css` → `404 text/plain`
+  - body starts with: `Couldn't find the requested file /dist/fonts/geist-mono/style.min.css in geist.`
+- `https://api.fontshare.com/v2/css?f[]=satoshi@700,500,400&display=swap` returns CSS that pulls font files from `cdn.fontshare.com`, so the previous public-page font setup depended on third-party stylesheet/font hosts.
+
+### Unauthenticated resource noise
+- `NotificationBell` mounted on the shared header for public pages.
+- `useNotifications()` always executed its query, so unauthenticated public surfaces could hit `/api/v1/notifications` and surface `401` console noise before auth state was known.
+
+## After
+- `apps/web/app/layout.tsx` no longer injects external Fontshare/Geist stylesheet links.
+- `apps/web/app/globals.css` now uses local/system font stacks, so public pages do not request third-party font stylesheets at all.
+- `apps/web/hooks/use-notifications.ts` now supports `enabled`.
+- `apps/web/components/common/NotificationBell.tsx` only enables the notifications query after auth is confirmed.
+
+## Validation
+- `./node_modules/.bin/vitest run __tests__/components/root-layout-fonts.test.tsx __tests__/components/notification-bell.test.tsx`
+- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
+
+## Regression coverage added
+- `apps/web/__tests__/components/root-layout-fonts.test.tsx`
+- `apps/web/__tests__/components/notification-bell.test.tsx`


### PR DESCRIPTION
Source: backlog.md:89

## Summary
- remove the broken third-party Fontshare/Geist stylesheet links from the shared public layout so production pages stop requesting CSP-blocked / 404 font CSS
- switch the shared font tokens back to local system stacks instead of relying on external stylesheet hosts
- add an `enabled` gate to notifications and only query `/api/v1/notifications` after auth is confirmed, so public pages stop emitting unauthenticated 401 resource noise from the shared header
- add focused regression coverage for both the shared layout head and the notification query gate

## Evidence
- committed evidence asset: `docs/pr-evidence/row-89-console-csp-resource-errors.md`
- before: `geist` stylesheet URLs in the shared layout pointed at jsDelivr paths that return 404, and public pages mounted a notification query before auth state was known
- after: the shared layout no longer injects third-party font stylesheet URLs, and the notifications query stays disabled until auth is confirmed

## Validation
- `./node_modules/.bin/vitest run __tests__/components/root-layout-fonts.test.tsx __tests__/components/notification-bell.test.tsx`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
