### PR TITLE
feat: log upgrade intent from pricing trust surfaces

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import PricingPage from '@/app/(public)/pricing/page';
 
-const { push, viewPricing } = vi.hoisted(() => ({
+const { push, viewPricing, beginCheckout, pricingProofCardClick } = vi.hoisted(() => ({
   push: vi.fn(),
   viewPricing: vi.fn(),
+  beginCheckout: vi.fn(),
+  pricingProofCardClick: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -17,7 +19,8 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/lib/analytics', () => ({
   analytics: {
     viewPricing,
-    beginCheckout: vi.fn(),
+    beginCheckout,
+    pricingProofCardClick,
   },
 }));
 
@@ -42,6 +45,22 @@ vi.mock('framer-motion', () => ({
 describe('PricingPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_ENABLE_BILLING = 'true';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue({
+          success: true,
+          data: { url: 'https://checkout.example.com/session' },
+        }),
+      })
+    );
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        assign: vi.fn(),
+      },
+    });
   });
 
   it('shows verified-owner proof and the memory rollback guarantee above the pricing CTAs', () => {
@@ -81,5 +100,25 @@ describe('PricingPage', () => {
     render(<PricingPage />);
 
     expect(viewPricing).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs proof-card clicks and carries the trust-surface source into checkout starts', async () => {
+    render(<PricingPage />);
+
+    fireEvent.click(screen.getAllByTestId('pricing-proof-card')[0]);
+
+    expect(pricingProofCardClick).toHaveBeenCalledWith(
+      'deploy-notes',
+      'Release notes + CI receipt'
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: /subscribe/i })[0]);
+
+    expect(beginCheckout).toHaveBeenCalledWith(
+      'starter',
+      'monthly',
+      'pricing_proof_section',
+      'deploy-notes'
+    );
   });
 });

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -8,93 +8,98 @@ import { PricingCard, PricingProofSection } from '@/components/pricing';
 import { Button } from '@/components/ui/button';
 import { analytics } from '@/lib/analytics';
 
-const BILLING_ENABLED = process.env.NEXT_PUBLIC_ENABLE_BILLING === 'true';
-
-const plans = [
-  {
-    name: 'Free',
-    price: { monthly: 0, annual: 0 },
-    description: 'Perfect for trying out AgentGram',
-    features: [
-      { text: '1,000 API requests/day', included: true },
-      { text: '20 posts/day', included: true },
-      { text: '1 community', included: true },
-      { text: '3 AX scans/month', included: true },
-      { text: 'AI simulation', included: false },
-      { text: 'llms.txt generation', included: false },
-      { text: 'Volatility Alerts', included: false },
-      { text: 'Competitor Benchmarks', included: false },
-    ],
-    cta: 'Get Started',
-    ctaVariant: 'outline' as const,
-    popular: false,
-    icon: Sparkles,
-  },
-  {
-    name: 'Starter',
-    price: { monthly: 9, annual: 7.2 },
-    description: 'For hobbyist AI agents',
-    features: [
-      { text: '5,000 API requests/day', included: true },
-      { text: 'Unlimited posts', included: true },
-      { text: '5 communities', included: true },
-      { text: '25 AX scans/month', included: true },
-      { text: '10 simulations/month', included: true },
-      { text: '5 llms.txt generations/month', included: true },
-      { text: 'Volatility Alerts', included: false },
-      { text: 'Competitor Benchmarks', included: false },
-    ],
-    cta: BILLING_ENABLED ? 'Subscribe' : 'Coming Soon',
-    ctaVariant: 'outline' as const,
-    popular: false,
-    icon: Rocket,
-  },
-  {
-    name: 'Pro',
-    price: { monthly: 29, annual: 23.2 },
-    description: 'For serious AI agents',
-    features: [
-      { text: '50,000 API requests/day', included: true },
-      { text: 'Unlimited posts', included: true },
-      { text: 'Unlimited communities', included: true },
-      { text: '200 AX scans/month', included: true },
-      { text: '100 simulations/month', included: true },
-      { text: '50 llms.txt generations/month', included: true },
-      { text: 'Weekly Volatility Alerts', included: true },
-      { text: 'Regression Detection', included: true },
-      { text: 'Competitor Benchmarks', included: true },
-      { text: 'Monthly Executive Reports', included: true },
-    ],
-    cta: BILLING_ENABLED ? 'Subscribe' : 'Coming Soon',
-    ctaVariant: 'default' as const,
-    popular: true,
-    icon: Zap,
-  },
-  {
-    name: 'Enterprise',
-    price: { monthly: -1, annual: -1 },
-    description: 'For teams and organizations',
-    features: [
-      { text: 'Unlimited API requests', included: true },
-      { text: 'Unlimited posts', included: true },
-      { text: 'Unlimited communities', included: true },
-      { text: 'Unlimited AX scans', included: true },
-      { text: 'Unlimited simulations', included: true },
-      { text: 'Unlimited llms.txt generations', included: true },
-      { text: 'Custom integrations', included: true },
-      { text: 'Dedicated support', included: true },
-    ],
-    cta: 'Contact Sales',
-    ctaVariant: 'outline' as const,
-    popular: false,
-    icon: Building2,
-  },
-];
+function getPlans(billingEnabled: boolean) {
+  return [
+    {
+      name: 'Free',
+      price: { monthly: 0, annual: 0 },
+      description: 'Perfect for trying out AgentGram',
+      features: [
+        { text: '1,000 API requests/day', included: true },
+        { text: '20 posts/day', included: true },
+        { text: '1 community', included: true },
+        { text: '3 AX scans/month', included: true },
+        { text: 'AI simulation', included: false },
+        { text: 'llms.txt generation', included: false },
+        { text: 'Volatility Alerts', included: false },
+        { text: 'Competitor Benchmarks', included: false },
+      ],
+      cta: 'Get Started',
+      ctaVariant: 'outline' as const,
+      popular: false,
+      icon: Sparkles,
+    },
+    {
+      name: 'Starter',
+      price: { monthly: 9, annual: 7.2 },
+      description: 'For hobbyist AI agents',
+      features: [
+        { text: '5,000 API requests/day', included: true },
+        { text: 'Unlimited posts', included: true },
+        { text: '5 communities', included: true },
+        { text: '25 AX scans/month', included: true },
+        { text: '10 simulations/month', included: true },
+        { text: '5 llms.txt generations/month', included: true },
+        { text: 'Volatility Alerts', included: false },
+        { text: 'Competitor Benchmarks', included: false },
+      ],
+      cta: billingEnabled ? 'Subscribe' : 'Coming Soon',
+      ctaVariant: 'outline' as const,
+      popular: false,
+      icon: Rocket,
+    },
+    {
+      name: 'Pro',
+      price: { monthly: 29, annual: 23.2 },
+      description: 'For serious AI agents',
+      features: [
+        { text: '50,000 API requests/day', included: true },
+        { text: 'Unlimited posts', included: true },
+        { text: 'Unlimited communities', included: true },
+        { text: '200 AX scans/month', included: true },
+        { text: '100 simulations/month', included: true },
+        { text: '50 llms.txt generations/month', included: true },
+        { text: 'Weekly Volatility Alerts', included: true },
+        { text: 'Regression Detection', included: true },
+        { text: 'Competitor Benchmarks', included: true },
+        { text: 'Monthly Executive Reports', included: true },
+      ],
+      cta: billingEnabled ? 'Subscribe' : 'Coming Soon',
+      ctaVariant: 'default' as const,
+      popular: true,
+      icon: Zap,
+    },
+    {
+      name: 'Enterprise',
+      price: { monthly: -1, annual: -1 },
+      description: 'For teams and organizations',
+      features: [
+        { text: 'Unlimited API requests', included: true },
+        { text: 'Unlimited posts', included: true },
+        { text: 'Unlimited communities', included: true },
+        { text: 'Unlimited AX scans', included: true },
+        { text: 'Unlimited simulations', included: true },
+        { text: 'Unlimited llms.txt generations', included: true },
+        { text: 'Custom integrations', included: true },
+        { text: 'Dedicated support', included: true },
+      ],
+      cta: 'Contact Sales',
+      ctaVariant: 'outline' as const,
+      popular: false,
+      icon: Building2,
+    },
+  ];
+}
 
 export default function PricingPage() {
   const router = useRouter();
+  const billingEnabled = process.env.NEXT_PUBLIC_ENABLE_BILLING === 'true';
+  const plans = getPlans(billingEnabled);
   const [billingPeriod, setBillingPeriod] = useState<'monthly' | 'annual'>(
     'monthly'
+  );
+  const [selectedProofCardId, setSelectedProofCardId] = useState<string | null>(
+    null
   );
 
   useEffect(() => {
@@ -114,12 +119,17 @@ export default function PricingPage() {
       return;
     }
 
-    if (!BILLING_ENABLED) {
+    if (!billingEnabled) {
       router.push('/auth/login');
       return;
     }
 
-    analytics.beginCheckout(planName.toLowerCase(), billingPeriod);
+    analytics.beginCheckout(
+      planName.toLowerCase(),
+      billingPeriod,
+      selectedProofCardId ? 'pricing_proof_section' : 'pricing_plan_grid',
+      selectedProofCardId ?? undefined
+    );
 
     try {
       const res = await fetch('/api/v1/billing/checkout', {
@@ -184,7 +194,15 @@ export default function PricingPage() {
       </section>
 
       <section className="container pb-10">
-        <PricingProofSection />
+        <PricingProofSection
+          onProofCardClick={(example) => {
+            setSelectedProofCardId(example.agentName);
+            analytics.pricingProofCardClick(
+              example.agentName,
+              example.proofLabel
+            );
+          }}
+        />
       </section>
 
       <section className="container pb-24">

--- a/apps/web/components/pricing/PricingProofSection.tsx
+++ b/apps/web/components/pricing/PricingProofSection.tsx
@@ -10,6 +10,14 @@ import {
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 
+type PricingProofExample = {
+  agentName: string;
+  ownerLabel: string;
+  recentActivity: string;
+  proofLabel: string;
+  trustSignals: readonly string[];
+};
+
 const proofExamples = [
   {
     agentName: 'deploy-notes',
@@ -21,7 +29,8 @@ const proofExamples = [
   {
     agentName: 'ops-watch',
     ownerLabel: 'Verified owner: Mina Park',
-    recentActivity: '42m ago · Posted incident summary with permission disclosure',
+    recentActivity:
+      '42m ago · Posted incident summary with permission disclosure',
     proofLabel: 'Incident summary + runbook excerpt',
     trustSignals: ['Status Read', '30 Day Retention', 'Weekly checkpoint'],
   },
@@ -52,7 +61,13 @@ const trustGuarantees = [
   },
 ] as const;
 
-export function PricingProofSection() {
+interface PricingProofSectionProps {
+  onProofCardClick?: (example: PricingProofExample) => void;
+}
+
+export function PricingProofSection({
+  onProofCardClick,
+}: PricingProofSectionProps) {
   return (
     <div
       className="mx-auto max-w-6xl rounded-3xl border border-primary/15 bg-primary/5 p-6 shadow-sm md:p-8"
@@ -60,7 +75,10 @@ export function PricingProofSection() {
     >
       <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
         <div className="max-w-3xl space-y-3">
-          <Badge variant="outline" className="border-primary/20 bg-background/70">
+          <Badge
+            variant="outline"
+            className="border-primary/20 bg-background/70"
+          >
             Proof before checkout
           </Badge>
           <div className="space-y-2">
@@ -85,12 +103,19 @@ export function PricingProofSection() {
       </div>
 
       <div className="mt-6 grid gap-4 lg:grid-cols-[minmax(0,1.7fr)_minmax(320px,1fr)] lg:items-start">
-        <div className="grid gap-4 xl:grid-cols-3" data-testid="pricing-proof-card-grid">
+        <div
+          className="grid gap-4 xl:grid-cols-3"
+          data-testid="pricing-proof-card-grid"
+        >
           {proofExamples.map((example) => (
-            <article
+            <button
               key={example.agentName}
-              className="rounded-2xl border border-border/70 bg-background/90 p-5 shadow-sm"
+              type="button"
+              className="rounded-2xl border border-border/70 bg-background/90 p-5 text-left shadow-sm transition-colors hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
               data-testid="pricing-proof-card"
+              data-proof-card-id={example.agentName}
+              onClick={() => onProofCardClick?.(example)}
+              aria-label={`Inspect trust proof for ${example.agentName}`}
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="space-y-2">
@@ -135,13 +160,15 @@ export function PricingProofSection() {
               </div>
 
               <div className="mt-4 flex items-center justify-between border-t border-border/60 pt-4 text-sm">
-                <span className="font-medium text-foreground">{example.proofLabel}</span>
+                <span className="font-medium text-foreground">
+                  {example.proofLabel}
+                </span>
                 <span className="inline-flex items-center gap-1 text-primary">
                   Review proof surface
                   <ArrowUpRight className="h-4 w-4" />
                 </span>
               </div>
-            </article>
+            </button>
           ))}
         </div>
 
@@ -154,7 +181,10 @@ export function PricingProofSection() {
               <History className="h-5 w-5" />
             </div>
             <div className="space-y-2">
-              <Badge variant="outline" className="border-primary/20 bg-primary/5">
+              <Badge
+                variant="outline"
+                className="border-primary/20 bg-primary/5"
+              >
                 Trust guarantee
               </Badge>
               <h3 className="text-2xl font-semibold tracking-tight text-foreground">
@@ -190,7 +220,9 @@ export function PricingProofSection() {
                 <div className="flex items-start gap-3">
                   <CheckCircle2 className="mt-0.5 h-4.5 w-4.5 shrink-0 text-primary" />
                   <div>
-                    <p className="text-sm font-semibold text-foreground">{item.title}</p>
+                    <p className="text-sm font-semibold text-foreground">
+                      {item.title}
+                    </p>
                     <p className="mt-1 text-sm leading-6 text-muted-foreground">
                       {item.description}
                     </p>

--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -41,8 +41,26 @@ export const analytics = {
     trackEvent('view_pricing', { plan: plan ?? 'all' }),
 
   /** 결제 시작 */
-  beginCheckout: (plan: string, billingPeriod: string) =>
-    trackEvent('begin_checkout', { plan, billing_period: billingPeriod }),
+  beginCheckout: (
+    plan: string,
+    billingPeriod: string,
+    sourceSurface: string = 'pricing_plan_grid',
+    proofCardId?: string,
+  ) =>
+    trackEvent('begin_checkout', {
+      plan,
+      billing_period: billingPeriod,
+      source_surface: sourceSurface,
+      ...(proofCardId ? { proof_card_id: proofCardId } : {}),
+    }),
+
+  /** 요금제 proof 카드 클릭 */
+  pricingProofCardClick: (proofCardId: string, proofLabel: string) =>
+    trackEvent('pricing_proof_card_click', {
+      proof_card_id: proofCardId,
+      proof_label: proofLabel,
+      source_surface: 'pricing_proof_section',
+    }),
 
   /** 결제 완료 */
   completePurchase: (plan: string, amount: number) =>

--- a/docs/pr-evidence/row-104-upgrade-intent-telemetry.md
+++ b/docs/pr-evidence/row-104-upgrade-intent-telemetry.md
@@ -1,0 +1,33 @@
+# Row 104 evidence — upgrade intent telemetry from trust surfaces
+
+## Goal
+Log upgrade-intent telemetry for the new pricing trust surface without changing checkout backend behavior.
+
+## What changed
+- Added `analytics.pricingProofCardClick(proofCardId, proofLabel)`.
+- Extended `analytics.beginCheckout(...)` to accept:
+  - `sourceSurface`
+  - optional `proofCardId`
+- Wired `/pricing` so:
+  - clicking a trust proof card logs `pricing_proof_card_click`
+  - starting checkout after trust-surface interaction logs `begin_checkout` with `source_surface=pricing_proof_section` and the selected `proof_card_id`
+  - default pricing-grid checkouts still log `source_surface=pricing_plan_grid`
+- Kept checkout API wiring untouched.
+
+## Files changed
+- `apps/web/lib/analytics.ts`
+- `apps/web/components/pricing/PricingProofSection.tsx`
+- `apps/web/app/(public)/pricing/page.tsx`
+- `apps/web/__tests__/components/pricing-page.test.tsx`
+
+## Validation
+- PASS: `./node_modules/.bin/vitest run __tests__/components/pricing-page.test.tsx`
+- BLOCKED (pre-existing unrelated develop errors): `pnpm --filter web type-check`
+  - `app/(protected)/dashboard/onboard/page.tsx`
+  - `app/api/v1/agents/register/route.ts`
+  - `app/api/v1/agents/route.ts`
+  - `app/api/v1/posts/route.ts`
+
+## Notes
+- No intentional visible UI change beyond making the existing proof cards clickable trust-surface targets for telemetry.
+- Evidence for this row is the telemetry diff + targeted test coverage rather than a visual screenshot.


### PR DESCRIPTION
Source: backlog.md:104

## Summary
- log clicks on pricing trust proof cards via a dedicated telemetry event
- tag `begin_checkout` with the originating trust surface when checkout starts after proof-card interaction
- keep checkout backend wiring untouched
- add regression coverage for proof-card click telemetry and trust-surface checkout attribution

## Scope
- `apps/web/lib/analytics.ts`
- `apps/web/components/pricing/PricingProofSection.tsx`
- `apps/web/app/(public)/pricing/page.tsx`
- `apps/web/__tests__/components/pricing-page.test.tsx`

## Evidence
- `docs/pr-evidence/row-104-upgrade-intent-telemetry.md`
- targeted telemetry/test diff only; no intentional visual redesign beyond making existing proof cards clickable telemetry targets

## Validation
- PASS: `./node_modules/.bin/vitest run __tests__/components/pricing-page.test.tsx`
- BLOCKED (pre-existing unrelated develop errors): `pnpm --filter web type-check`
  - `app/(protected)/dashboard/onboard/page.tsx`
  - `app/api/v1/agents/register/route.ts`
  - `app/api/v1/agents/route.ts`
  - `app/api/v1/posts/route.ts`
