### PR TITLE
feat: surface proactive send window status

### DIFF
--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProactiveControlsForm } from '@/components/dashboard/ProactiveControlsForm';
 
 const mockCreateClient = vi.fn();
@@ -46,6 +46,10 @@ describe('ProactiveControlsForm', () => {
         }),
       })
     );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('shows caps and quiet hours controls and saves through the API', async () => {
@@ -121,6 +125,33 @@ describe('ProactiveControlsForm', () => {
     expect(screen.getByLabelText('Quiet hours start')).toHaveValue('21:30');
     expect(screen.getByLabelText('Quiet hours end')).toHaveValue('07:15');
     expect(screen.getByRole('radio', { name: /warm/i })).toBeChecked();
+  });
+
+  it('shows last send and next eligible window status', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-26T20:15:00.000Z'));
+
+    render(
+      <ProactiveControlsForm
+        initialSettings={{
+          optIn: true,
+          dailyLimit: 2,
+          weeklyLimit: 8,
+          quietHoursEnabled: true,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
+          tonePreset: 'neutral',
+          lastAutoMessageAt: '2026-04-27T01:30:00.000Z',
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('proactive-last-auto-message')).toHaveTextContent(
+      'Apr 27, 2026, 10:30 AM KST'
+    );
+    expect(
+      screen.getByTestId('proactive-next-eligible-send')
+    ).toHaveTextContent('Apr 27, 2026, 8:00 AM KST');
   });
 
   it('shows an error when the save request fails', async () => {

--- a/apps/web/__tests__/lib/proactive-controls.test.ts
+++ b/apps/web/__tests__/lib/proactive-controls.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_PROACTIVE_CONTROLS_SETTINGS,
+  getNextEligibleSendAt,
   TONE_PRESETS,
   normalizeProactiveControlsSettings,
   readProactiveControlsFromMetadata,
@@ -108,6 +109,8 @@ describe('proactive controls helper', () => {
           quietHoursEnd: '06:30',
           tonePreset: 'warm',
           updatedAt: '2026-04-26T00:00:00.000Z',
+          lastAutoMessageAt: '2026-04-26T02:15:00.000Z',
+          nextEligibleSendAt: '2026-04-26T06:30:00.000Z',
         },
       })
     ).toEqual({
@@ -119,6 +122,8 @@ describe('proactive controls helper', () => {
       quietHoursEnd: '06:30',
       tonePreset: 'warm',
       updatedAt: '2026-04-26T00:00:00.000Z',
+      lastAutoMessageAt: '2026-04-26T02:15:00.000Z',
+      nextEligibleSendAt: '2026-04-26T06:30:00.000Z',
     });
 
     expect(readProactiveControlsFromMetadata(null)).toEqual(
@@ -138,6 +143,8 @@ describe('proactive controls helper', () => {
           quietHoursStart: '21:00',
           quietHoursEnd: '06:00',
           tonePreset: 'warm',
+          lastAutoMessageAt: '2026-04-26T02:15:00.000Z',
+          nextEligibleSendAt: '2026-04-26T06:00:00.000Z',
         },
         '2026-04-26T03:06:00.000Z'
       )
@@ -152,7 +159,60 @@ describe('proactive controls helper', () => {
         quietHoursEnd: '06:00',
         tonePreset: 'warm',
         updatedAt: '2026-04-26T03:06:00.000Z',
+        lastAutoMessageAt: '2026-04-26T02:15:00.000Z',
+        nextEligibleSendAt: '2026-04-26T06:00:00.000Z',
       },
     });
+  });
+
+  it('derives the next eligible send time from quiet hours when no explicit timestamp exists', () => {
+    expect(
+      getNextEligibleSendAt(
+        {
+          optIn: true,
+          dailyLimit: 2,
+          weeklyLimit: 8,
+          quietHoursEnabled: true,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
+          tonePreset: 'neutral',
+        },
+        new Date('2026-04-26T20:15:00.000Z')
+      )
+    ).toBe('2026-04-26T23:00:00.000Z');
+  });
+
+  it('returns the current instant when outreach is eligible now and null when opt-in is disabled', () => {
+    const now = new Date('2026-04-27T12:45:00.000Z');
+
+    expect(
+      getNextEligibleSendAt(
+        {
+          optIn: true,
+          dailyLimit: 2,
+          weeklyLimit: 8,
+          quietHoursEnabled: false,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
+          tonePreset: 'neutral',
+        },
+        now
+      )
+    ).toBe('2026-04-27T12:45:00.000Z');
+
+    expect(
+      getNextEligibleSendAt(
+        {
+          optIn: false,
+          dailyLimit: 2,
+          weeklyLimit: 8,
+          quietHoursEnabled: false,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
+          tonePreset: 'neutral',
+        },
+        now
+      )
+    ).toBeNull();
   });
 });

--- a/apps/web/components/dashboard/ProactiveControlsForm.tsx
+++ b/apps/web/components/dashboard/ProactiveControlsForm.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import {
+  getNextEligibleSendAt,
   TONE_PRESETS,
   type ProactiveControlsSettings,
   type TonePreset,
@@ -38,6 +39,23 @@ interface ProactiveControlsFormProps {
   initialSettings: ProactiveControlsSettings;
 }
 
+function formatStatusTimestamp(value?: string | null): string {
+  if (!value) {
+    return '';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return '';
+  }
+
+  return `${new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'Asia/Seoul',
+  }).format(parsed)} KST`;
+}
+
 export function ProactiveControlsForm({
   initialSettings,
 }: ProactiveControlsFormProps) {
@@ -50,6 +68,13 @@ export function ProactiveControlsForm({
     tone: 'idle',
     message: '',
   });
+  const lastAutoMessageLabel = settings.lastAutoMessageAt
+    ? formatStatusTimestamp(settings.lastAutoMessageAt)
+    : 'No proactive message sent yet';
+  const nextEligibleSendAt = getNextEligibleSendAt(settings);
+  const nextEligibleLabel = nextEligibleSendAt
+    ? formatStatusTimestamp(nextEligibleSendAt)
+    : 'Waiting for opt-in';
 
   const handleSave = async () => {
     setIsSaving(true);
@@ -281,6 +306,44 @@ export function ProactiveControlsForm({
             ))}
           </div>
         </fieldset>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-lg border border-border/60 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Last proactive send
+            </p>
+            <p
+              className="mt-2 text-sm font-medium text-foreground"
+              data-testid="proactive-last-auto-message"
+            >
+              {lastAutoMessageLabel}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {settings.lastAutoMessageAt
+                ? 'Updated from the latest outbound proactive message metadata.'
+                : 'We will surface the most recent outbound proactive message here once one is delivered.'}
+            </p>
+          </div>
+
+          <div className="rounded-lg border border-border/60 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Next eligible send window
+            </p>
+            <p
+              className="mt-2 text-sm font-medium text-foreground"
+              data-testid="proactive-next-eligible-send"
+            >
+              {nextEligibleLabel}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {!settings.optIn
+                ? 'Enable proactive outreach before AgentGram schedules the next send window.'
+                : settings.quietHoursEnabled
+                  ? 'Quiet hours still gate delivery; once they end, daily and weekly caps apply as usual.'
+                  : 'Outside quiet hours, the next slot is available as soon as your daily and weekly caps allow.'}
+            </p>
+          </div>
+        </div>
 
         <div className="rounded-lg border border-dashed border-border/60 p-4 text-sm text-muted-foreground">
           The caps, quiet hours, and tone preset are enforced after save. If

--- a/apps/web/lib/proactive-controls.ts
+++ b/apps/web/lib/proactive-controls.ts
@@ -10,6 +10,8 @@ export interface ProactiveControlsSettings {
   quietHoursEnd: string;
   tonePreset: TonePreset;
   updatedAt?: string;
+  lastAutoMessageAt?: string;
+  nextEligibleSendAt?: string;
 }
 
 const DEFAULT_DAILY_LIMIT = 2;
@@ -42,6 +44,19 @@ function toTimeString(value: unknown, fallback: string): string {
     return value;
   }
   return fallback;
+}
+
+function toIsoTimestamp(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+
+  return parsed.toISOString();
 }
 
 function toBoundedInteger(
@@ -90,6 +105,9 @@ export function normalizeProactiveControlsSettings(
       ? (value.tonePreset as TonePreset)
       : DEFAULT_TONE_PRESET;
 
+  const lastAutoMessageAt = toIsoTimestamp(value.lastAutoMessageAt);
+  const nextEligibleSendAt = toIsoTimestamp(value.nextEligibleSendAt);
+
   return {
     optIn: value.optIn === true,
     dailyLimit,
@@ -103,6 +121,8 @@ export function normalizeProactiveControlsSettings(
     tonePreset,
     updatedAt:
       typeof value.updatedAt === 'string' ? value.updatedAt : undefined,
+    ...(lastAutoMessageAt ? { lastAutoMessageAt } : {}),
+    ...(nextEligibleSendAt ? { nextEligibleSendAt } : {}),
   };
 }
 
@@ -114,6 +134,49 @@ export function readProactiveControlsFromMetadata(
   }
 
   return normalizeProactiveControlsSettings(metadata.proactiveControls);
+}
+
+function applyTime(date: Date, hhmm: string): Date {
+  const [hours, minutes] = hhmm.split(':').map(Number);
+  const next = new Date(date);
+  next.setHours(hours, minutes, 0, 0);
+  return next;
+}
+
+export function getNextEligibleSendAt(
+  settings: ProactiveControlsSettings,
+  now: Date = new Date()
+): string | null {
+  if (!settings.optIn) {
+    return null;
+  }
+
+  if (settings.nextEligibleSendAt) {
+    return settings.nextEligibleSendAt;
+  }
+
+  if (!settings.quietHoursEnabled) {
+    return now.toISOString();
+  }
+
+  const quietStart = applyTime(now, settings.quietHoursStart);
+  const quietEnd = applyTime(now, settings.quietHoursEnd);
+  const isSameDayWindow = quietStart.getTime() <= quietEnd.getTime();
+
+  const withinQuietHours = isSameDayWindow
+    ? now >= quietStart && now < quietEnd
+    : now >= quietStart || now < quietEnd;
+
+  if (!withinQuietHours) {
+    return now.toISOString();
+  }
+
+  const nextEligible = new Date(quietEnd);
+  if (nextEligible <= now) {
+    nextEligible.setDate(nextEligible.getDate() + 1);
+  }
+
+  return nextEligible.toISOString();
 }
 
 export function writeProactiveControlsToMetadata(

--- a/apps/web/lib/proactive-controls.ts
+++ b/apps/web/lib/proactive-controls.ts
@@ -22,6 +22,7 @@ const MAX_WEEKLY_LIMIT = 100;
 const DEFAULT_QUIET_HOURS_START = '22:00';
 const DEFAULT_QUIET_HOURS_END = '08:00';
 const DEFAULT_TONE_PRESET: TonePreset = 'neutral';
+const SEOUL_UTC_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 export const DEFAULT_PROACTIVE_CONTROLS_SETTINGS: ProactiveControlsSettings = {
   optIn: false,
@@ -136,10 +137,18 @@ export function readProactiveControlsFromMetadata(
   return normalizeProactiveControlsSettings(metadata.proactiveControls);
 }
 
+function shiftToSeoul(date: Date): Date {
+  return new Date(date.getTime() + SEOUL_UTC_OFFSET_MS);
+}
+
+function shiftFromSeoul(date: Date): Date {
+  return new Date(date.getTime() - SEOUL_UTC_OFFSET_MS);
+}
+
 function applyTime(date: Date, hhmm: string): Date {
   const [hours, minutes] = hhmm.split(':').map(Number);
   const next = new Date(date);
-  next.setHours(hours, minutes, 0, 0);
+  next.setUTCHours(hours, minutes, 0, 0);
   return next;
 }
 
@@ -159,24 +168,25 @@ export function getNextEligibleSendAt(
     return now.toISOString();
   }
 
-  const quietStart = applyTime(now, settings.quietHoursStart);
-  const quietEnd = applyTime(now, settings.quietHoursEnd);
+  const seoulNow = shiftToSeoul(now);
+  const quietStart = applyTime(seoulNow, settings.quietHoursStart);
+  const quietEnd = applyTime(seoulNow, settings.quietHoursEnd);
   const isSameDayWindow = quietStart.getTime() <= quietEnd.getTime();
 
   const withinQuietHours = isSameDayWindow
-    ? now >= quietStart && now < quietEnd
-    : now >= quietStart || now < quietEnd;
+    ? seoulNow >= quietStart && seoulNow < quietEnd
+    : seoulNow >= quietStart || seoulNow < quietEnd;
 
   if (!withinQuietHours) {
     return now.toISOString();
   }
 
   const nextEligible = new Date(quietEnd);
-  if (nextEligible <= now) {
-    nextEligible.setDate(nextEligible.getDate() + 1);
+  if (nextEligible <= seoulNow) {
+    nextEligible.setUTCDate(nextEligible.getUTCDate() + 1);
   }
 
-  return nextEligible.toISOString();
+  return shiftFromSeoul(nextEligible).toISOString();
 }
 
 export function writeProactiveControlsToMetadata(

--- a/docs/pr-evidence/proactive-send-window-status.md
+++ b/docs/pr-evidence/proactive-send-window-status.md
@@ -1,0 +1,17 @@
+# Proactive send-window status evidence
+
+## Before
+- Settings page exposed opt-in, caps, quiet hours, and tone preset only.
+- Developers could not see when AgentGram last sent a proactive message.
+- Developers could not see the next eligible send window derived from quiet hours / opt-in state.
+
+## After
+- Settings page now shows **Last proactive send** with the latest stored outbound timestamp when available.
+- Settings page now shows **Next eligible send window** using stored scheduling metadata or a quiet-hours fallback derived from the current settings.
+- Empty states stay explicit: no prior send yet / waiting for opt-in.
+
+## Example state
+- `lastAutoMessageAt: 2026-04-27T01:30:00.000Z`
+- `quietHoursStart: 22:00`
+- `quietHoursEnd: 08:00`
+- rendered next eligible window: `Apr 27, 2026, 8:00 AM KST`


### PR DESCRIPTION
Source: backlog.md:80

Show proactive-outreach status on the dashboard settings surface so developers can see the last outbound proactive send and the next eligible send window without leaving the form.

## Summary
- preserve optional `lastAutoMessageAt` / `nextEligibleSendAt` metadata on proactive controls settings
- derive a quiet-hours fallback next-send timestamp when scheduling metadata is absent
- render Last proactive send + Next eligible send window status cards in `ProactiveControlsForm`
- add coverage for metadata passthrough and quiet-hours window derivation

## Tests
- `pnpm --dir apps/web exec vitest run __tests__/lib/proactive-controls.test.ts __tests__/components/proactive-controls-settings.test.tsx`
- `pnpm --dir apps/web type-check` **blocked by pre-existing develop errors unrelated to this diff** (`RELATIONSHIP_PRESETS` / `getSupabaseClient` import gaps already present on current base)

## Evidence
- docs/example diff: [`docs/pr-evidence/proactive-send-window-status.md`](https://github.com/agentgram/agentgram/blob/feat/proactive-send-window-status/docs/pr-evidence/proactive-send-window-status.md)
- follow-up evidence repair PR: #513 https://github.com/agentgram/agentgram/pull/513

### UX screenshot
![PR #501 proactive send-window status screenshot](https://raw.githubusercontent.com/agentgram/agentgram/develop/docs/pr-evidence/pr-501-proactive-send-window-status.png)
