### PR TITLE
feat: show remix counts on agent cards and profiles

### DIFF
--- a/apps/web/__tests__/api/agents.test.ts
+++ b/apps/web/__tests__/api/agents.test.ts
@@ -9,11 +9,25 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  */
 
 // Mock Supabase
-const mockSelect = vi.fn().mockReturnThis();
 const mockOrder = vi.fn().mockReturnThis();
 const mockRange = vi.fn().mockReturnThis();
 const mockOr = vi.fn().mockReturnThis();
 const mockContains = vi.fn().mockReturnThis();
+const mockRemixIlike = vi.fn();
+const mockSelect = vi.fn((columns: string) => {
+  if (columns === 'description') {
+    return {
+      ilike: mockRemixIlike,
+    };
+  }
+
+  return {
+    order: mockOrder,
+    range: mockRange,
+    or: mockOr,
+    contains: mockContains,
+  };
+});
 
 vi.mock('@agentgram/db', () => {
   const createMockClient = () => ({
@@ -35,7 +49,6 @@ vi.mock('@agentgram/db', () => {
 describe('GET /api/v1/agents', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSelect.mockReturnThis();
     mockOrder.mockReturnThis();
     mockContains.mockReturnThis();
     mockRange.mockResolvedValue({
@@ -76,6 +89,14 @@ describe('GET /api/v1/agents', () => {
       error: null,
       count: 1,
     });
+    mockRemixIlike.mockResolvedValue({
+      data: [
+        { description: 'Inspired by @test-agent: First remix' },
+        { description: 'Inspired by @test-agent on AgentGram.' },
+        { description: 'Inspired by @someone-else: Ignore me' },
+      ],
+      error: null,
+    });
   });
 
   it('should return paginated agents', async () => {
@@ -106,6 +127,7 @@ describe('GET /api/v1/agents', () => {
       hasFirstSuccessfulReply: true,
       publicOwnerLabel: 'Ralph',
       lastActive: '2026-01-03T00:00:00Z',
+      remixCount: 2,
     });
     expect(json.data[0]).not.toHaveProperty('metadata');
   });

--- a/apps/web/__tests__/components/agent-card.test.tsx
+++ b/apps/web/__tests__/components/agent-card.test.tsx
@@ -101,6 +101,24 @@ describe('AgentCard', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('shows remix social proof when remix count is available', () => {
+    render(
+      <AgentCard
+        agent={{
+          id: 'agent-3b',
+          name: 'builder-remix-source',
+          displayName: 'Builder Remix Source',
+          axp: 1200,
+          remixCount: 3,
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('agent-card-remix-count')).toHaveTextContent(
+      '3 remixes'
+    );
+  });
+
   it('omits the freshness badge when last active data is missing', () => {
     render(
       <AgentCard

--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -142,6 +142,16 @@ describe('ProfileHeader', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows remix social proof in the profile stats when remixes exist', () => {
+    render(
+      <ProfileHeader agent={{ ...baseAgent, remixCount: 4 }} />
+    );
+
+    expect(screen.getByTestId('profile-remix-count')).toHaveTextContent(
+      '4remixes'
+    );
+  });
+
   it('shows operator trust bundle and pricing link for verified paid operators', () => {
     render(
       <ProfileHeader

--- a/apps/web/__tests__/lib/remix-counts.test.ts
+++ b/apps/web/__tests__/lib/remix-counts.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getRemixCountsBySourceNames,
+  parseRemixSourceHandle,
+} from '../../lib/agents/remix-counts';
+
+describe('remix-counts', () => {
+  it('parses remix source handles using the current agent name contract', () => {
+    expect(
+      parseRemixSourceHandle('Inspired by @agent.alpha: Builds production agents.')
+    ).toBe('agent.alpha');
+    expect(
+      parseRemixSourceHandle('Inspired by @Agent Alpha on AgentGram.')
+    ).toBe('agent alpha');
+    expect(
+      parseRemixSourceHandle('Inspired by @에이전트 고양이: 한국어 이름도 허용.')
+    ).toBe('에이전트 고양이');
+  });
+
+  it('counts only requested remix sources even when names contain dots, spaces, or unicode', async () => {
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          ilike: async () => ({
+            data: [
+              { description: 'Inspired by @agent.alpha: First remix' },
+              { description: 'Inspired by @Agent Alpha on AgentGram.' },
+              { description: 'Inspired by @에이전트 고양이: 셋째 리믹스' },
+              { description: 'Inspired by @someone-else: Ignore me' },
+            ],
+            error: null,
+          }),
+        }),
+      }),
+    };
+
+    await expect(
+      getRemixCountsBySourceNames(supabase, [
+        'agent.alpha',
+        'Agent Alpha',
+        '에이전트 고양이',
+      ])
+    ).resolves.toEqual({
+      'agent.alpha': 1,
+      'agent alpha': 1,
+      '에이전트 고양이': 1,
+    });
+  });
+});

--- a/apps/web/app/(public)/agents/[name]/page.tsx
+++ b/apps/web/app/(public)/agents/[name]/page.tsx
@@ -4,6 +4,7 @@ import { getSupabaseServiceClient } from '@agentgram/db';
 import { ProfileContent } from '@/components/agents/ProfileContent';
 import { transformAgent, withActivePersona } from '@agentgram/shared';
 import type { Agent, PersonaResponse } from '@agentgram/shared';
+import { getRemixCountForSourceName } from '@/lib/agents/remix-counts';
 
 interface PageProps {
   params: Promise<{ name: string }>;
@@ -47,6 +48,7 @@ async function getAgent(name: string): Promise<Agent | null> {
     .is('original_post_id', null);
 
   agent.postCount = postCount ?? 0;
+  agent.remixCount = await getRemixCountForSourceName(supabase, data.name);
 
   // Fetch active persona
   const { data: personaData } = await supabase

--- a/apps/web/app/api/v1/agents/route.ts
+++ b/apps/web/app/api/v1/agents/route.ts
@@ -8,6 +8,7 @@ import {
   PAGINATION,
   transformAgent,
 } from '@agentgram/shared';
+import { getRemixCountsBySourceNames } from '@/lib/agents/remix-counts';
 function isCapabilityFilterEnabled(value: string | null): boolean {
   if (value == null) {
     return false;
@@ -101,12 +102,23 @@ export async function GET(req: NextRequest) {
       );
     }
 
+    const remixCountsByName = await getRemixCountsBySourceNames(
+      supabase,
+      (agents || []).map((agent) => agent.name)
+    );
+
     return jsonResponse(
-      createSuccessResponse((agents || []).map(transformAgent), {
-        page,
-        limit,
-        total: count || 0,
-      }),
+      createSuccessResponse(
+        (agents || []).map((agent) => ({
+          ...transformAgent(agent),
+          remixCount: remixCountsByName[agent.name.toLowerCase()] ?? 0,
+        })),
+        {
+          page,
+          limit,
+          total: count || 0,
+        }
+      ),
       200
     );
   } catch (error) {

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { Bot, Award } from 'lucide-react';
+import { Bot, Award, Sparkles } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import {
@@ -22,6 +22,7 @@ type AgentCardAgent = {
   created_at?: string | null;
   last_active?: string | null;
   capabilities?: Partial<DirectoryCapabilities>;
+  remixCount?: number | null;
 };
 
 function getActivityFreshness(lastActive?: string | null) {
@@ -149,12 +150,23 @@ export function AgentCard({
         </div>
       </div>
 
-      <div className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
-        <Award className="h-3.5 w-3.5" />
-        <span className="font-medium text-foreground/90">
-          {(agent.axp || 0).toLocaleString()}
-        </span>
-        <span className="text-xs">AXP</span>
+      <div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <Award className="h-3.5 w-3.5" />
+          <span className="font-medium text-foreground/90">
+            {(agent.axp || 0).toLocaleString()}
+          </span>
+          <span className="text-xs">AXP</span>
+        </div>
+        {(agent.remixCount ?? 0) > 0 && (
+          <div
+            className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-2 py-1 text-xs font-medium text-foreground/80"
+            data-testid="agent-card-remix-count"
+          >
+            <Sparkles className="h-3.5 w-3.5 text-primary" />
+            <span>{(agent.remixCount ?? 0).toLocaleString()} remixes</span>
+          </div>
+        )}
       </div>
 
       {agent.capabilities && (

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -130,6 +130,15 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
             <span className="font-bold">{agent.followingCount || 0}</span>
             <span className="text-muted-foreground">following</span>
           </div>
+          {(agent.remixCount || 0) > 0 && (
+            <div
+              className="flex flex-col items-center md:flex-row md:gap-1"
+              data-testid="profile-remix-count"
+            >
+              <span className="font-bold">{agent.remixCount || 0}</span>
+              <span className="text-muted-foreground">remixes</span>
+            </div>
+          )}
         </div>
 
         <div className="max-w-md text-center md:text-left">

--- a/apps/web/hooks/use-agents-directory.ts
+++ b/apps/web/hooks/use-agents-directory.ts
@@ -13,6 +13,7 @@ export type AgentsDirectoryAgent = {
   axp: number | null;
   description: string | null;
   capabilities: DirectoryCapabilities;
+  remixCount?: number | null;
   displayName?: string | null;
   avatarUrl?: string | null;
   createdAt?: string | null;

--- a/apps/web/lib/agents/remix-counts.ts
+++ b/apps/web/lib/agents/remix-counts.ts
@@ -1,0 +1,71 @@
+const REMIX_SOURCE_RE = /^Inspired by @([a-z0-9_-]+)/i;
+
+function normalizeHandle(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function parseRemixSourceHandle(
+  description?: string | null
+): string | null {
+  if (!description) {
+    return null;
+  }
+
+  const trimmed = description.trim();
+  const match = trimmed.match(REMIX_SOURCE_RE);
+  return match?.[1] ? normalizeHandle(match[1]) : null;
+}
+
+export async function getRemixCountsBySourceNames(
+  supabase: {
+    from: (table: string) => {
+      select: (columns: string) => {
+        ilike: (column: string, pattern: string) => PromiseLike<{
+          data: Array<{ description: string | null }> | null;
+          error: unknown;
+        }>;
+      };
+    };
+  },
+  sourceNames: string[]
+): Promise<Record<string, number>> {
+  const normalizedNames = Array.from(
+    new Set(sourceNames.map(normalizeHandle).filter(Boolean))
+  );
+
+  if (normalizedNames.length === 0) {
+    return {};
+  }
+
+  const { data, error } = await supabase
+    .from('agents')
+    .select('description')
+    .ilike('description', 'Inspired by @%');
+
+  if (error) {
+    throw error;
+  }
+
+  const counts = Object.fromEntries(
+    normalizedNames.map((name) => [name, 0])
+  ) as Record<string, number>;
+
+  for (const row of data ?? []) {
+    const handle = parseRemixSourceHandle(row.description);
+    if (!handle || !(handle in counts)) {
+      continue;
+    }
+
+    counts[handle] += 1;
+  }
+
+  return counts;
+}
+
+export async function getRemixCountForSourceName(
+  supabase: Parameters<typeof getRemixCountsBySourceNames>[0],
+  sourceName: string
+): Promise<number> {
+  const counts = await getRemixCountsBySourceNames(supabase, [sourceName]);
+  return counts[normalizeHandle(sourceName)] ?? 0;
+}

--- a/apps/web/lib/agents/remix-counts.ts
+++ b/apps/web/lib/agents/remix-counts.ts
@@ -1,4 +1,5 @@
-const REMIX_SOURCE_RE = /^Inspired by @([a-z0-9_-]+)/i;
+const REMIX_SOURCE_RE =
+  /^Inspired by @([\p{L}\p{N}][\p{L}\p{N}\s._-]*[\p{L}\p{N}])(?=:| on AgentGram\.|$)/u;
 
 function normalizeHandle(value: string): string {
   return value.trim().toLowerCase();

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -106,6 +106,7 @@ export type AgentResponse = {
   post_count?: number | null;
   follower_count?: number | null;
   following_count?: number | null;
+  remix_count?: number | null;
 };
 
 function derivePublicOwnerLabel(agent: AgentResponse): string | undefined {
@@ -163,6 +164,7 @@ export function transformAgent(agent: AgentResponse): Agent {
     postCount: agent.post_count ?? 0,
     followerCount: agent.follower_count ?? 0,
     followingCount: agent.following_count ?? 0,
+    remixCount: agent.remix_count ?? 0,
   };
 }
 

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -33,6 +33,7 @@ export interface Agent extends AgentMemoryProfile {
   postCount?: number;
   followerCount?: number;
   followingCount?: number;
+  remixCount?: number;
   verificationState: 'unverified' | 'pending' | 'verified';
   status: 'active' | 'suspended' | 'banned';
   trustScore: number;


### PR DESCRIPTION
## Summary
- count public remix descendants from the existing `Inspired by @handle...` onboarding copy pattern
- thread `remixCount` through the shared agent shape and directory/profile fetch paths
- show remix social proof on agent cards and in the profile header stats, with focused tests

## Validation
- pnpm --filter web exec vitest run __tests__/api/agents.test.ts __tests__/components/agent-card.test.tsx __tests__/components/profile-header.test.tsx __tests__/components/agents-directory-content.test.tsx __tests__/components/onboard-page.test.tsx
- pnpm --filter web type-check