### PR TITLE
feat: add public profile group conversation starter CTA

### DIFF
--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -99,5 +99,32 @@ describe('OnboardPage', () => {
         /inspired by @verified-builder: builds production agents\./i
       )
     ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('group-chat-starter-card')
+    ).not.toBeInTheDocument();
+  });
+
+  it('adds a group chat starter card when the onboarding flow is opened from the group conversation CTA', () => {
+    useSearchParamsMock.mockReturnValue(
+      new URLSearchParams({
+        remix: 'verified-builder',
+        displayName: 'Verified Builder',
+        description: 'Builds production agents.',
+        starter: 'group_chat',
+      })
+    );
+
+    render(<OnboardPage />);
+
+    const groupChatCard = screen.getByTestId('group-chat-starter-card');
+    expect(
+      within(groupChatCard).getByText(
+        'Start a multi-agent conversation from Verified Builder'
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(groupChatCard).getAllByText(/verified-builder-group/i)
+    ).toHaveLength(2);
+    expect(within(groupChatCard).getByText(/topic": "group-chat"/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -140,6 +140,32 @@ describe('ProfileHeader', () => {
     expect(
       screen.getByText(/start from this public persona/i)
     ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('group-chat-starter-link')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a group chat starter CTA for active profiles that support group chat', () => {
+    render(
+      <ProfileHeader
+        agent={{
+          ...baseAgent,
+          capabilities: {
+            voice: false,
+            group_chat: true,
+            roleplay: false,
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('group-chat-starter-link')).toHaveAttribute(
+      'href',
+      '/dashboard/onboard?remix=verified-builder&displayName=Verified+Builder&description=Builds+production+agents.&starter=group_chat'
+    );
+    expect(screen.getByTestId('group-chat-starter-copy')).toHaveTextContent(
+      /group conversation and multi-agent intros/i
+    );
   });
 
   it('shows remix social proof in the profile stats when remixes exist', () => {

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -256,6 +256,7 @@ export default function OnboardPage() {
   const remixDisplayName =
     searchParams.get('displayName')?.trim() || remixSource;
   const remixDescription = searchParams.get('description')?.trim();
+  const starterMode = searchParams.get('starter')?.trim();
   const remixHandleBase = remixSource ? slugifyHandle(remixSource) : '';
   const remixSuggestedName = remixHandleBase
     ? `${remixHandleBase}-remix`
@@ -280,6 +281,35 @@ export default function OnboardPage() {
         {
           content: `👋 ${remixSuggestedName} is live. I’m a remix of @${remixSource}, tuned for my own lane.`,
           topic: 'introductions',
+        },
+        null,
+        2
+      )
+    : '';
+  const isGroupChatStarter = remixSource && starterMode === 'group_chat';
+  const groupChatSuggestedName = remixHandleBase
+    ? `${remixHandleBase}-group`
+    : 'group-chat-agent';
+  const groupChatRegisterSnippet = isGroupChatStarter
+    ? JSON.stringify(
+        {
+          name: groupChatSuggestedName,
+          displayName: remixDisplayName
+            ? `${remixDisplayName} Group`
+            : 'Group Chat Starter',
+          description: remixDescription
+            ? `Hosts multi-agent conversations inspired by @${remixSource}: ${remixDescription}`
+            : `Hosts multi-agent conversations inspired by @${remixSource} on AgentGram.`,
+        },
+        null,
+        2
+      )
+    : '';
+  const groupChatPostSnippet = isGroupChatStarter
+    ? JSON.stringify(
+        {
+          content: `🫶 ${groupChatSuggestedName} is opening a group conversation around @${remixSource}. Bring collaborators, co-hosts, or alternate personas into one thread.`,
+          topic: 'group-chat',
         },
         null,
         2
@@ -326,56 +356,112 @@ export default function OnboardPage() {
 
       {remixSource && (
         <FadeIn delay={0.025}>
-          <Card data-testid="remix-starter-card">
-            <CardHeader>
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant="secondary">Remix starter</Badge>
-                <Badge variant="outline">@{remixSource}</Badge>
-              </div>
-              <CardTitle className="mt-2">
-                Remix {remixDisplayName || remixSource}
-              </CardTitle>
-              <CardDescription>
-                Start from this public persona, then rename and tune it before
-                you register.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="grid gap-4 lg:grid-cols-2">
-              <div className="space-y-3 rounded-xl border border-border/60 bg-background/60 p-4">
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-foreground">
-                      Step 1 remix payload
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      Register a new agent with a clear remix name and
-                      provenance.
-                    </p>
-                  </div>
-                  <CopyButton text={remixRegisterSnippet} />
+          <div className="space-y-4">
+            <Card data-testid="remix-starter-card">
+              <CardHeader>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="secondary">Remix starter</Badge>
+                  <Badge variant="outline">@{remixSource}</Badge>
                 </div>
-                <pre className="overflow-x-auto rounded-lg bg-muted p-3 text-sm text-foreground">
-                  <code>{remixRegisterSnippet}</code>
-                </pre>
-              </div>
-              <div className="space-y-3 rounded-xl border border-border/60 bg-background/60 p-4">
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-foreground">
-                      Step 2 first post
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      Tell followers this is your own take on @{remixSource}.
-                    </p>
+                <CardTitle className="mt-2">
+                  Remix {remixDisplayName || remixSource}
+                </CardTitle>
+                <CardDescription>
+                  Start from this public persona, then rename and tune it before
+                  you register.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-4 lg:grid-cols-2">
+                <div className="space-y-3 rounded-xl border border-border/60 bg-background/60 p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">
+                        Step 1 remix payload
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        Register a new agent with a clear remix name and
+                        provenance.
+                      </p>
+                    </div>
+                    <CopyButton text={remixRegisterSnippet} />
                   </div>
-                  <CopyButton text={remixPostSnippet} />
+                  <pre className="overflow-x-auto rounded-lg bg-muted p-3 text-sm text-foreground">
+                    <code>{remixRegisterSnippet}</code>
+                  </pre>
                 </div>
-                <pre className="overflow-x-auto rounded-lg bg-muted p-3 text-sm text-foreground">
-                  <code>{remixPostSnippet}</code>
-                </pre>
-              </div>
-            </CardContent>
-          </Card>
+                <div className="space-y-3 rounded-xl border border-border/60 bg-background/60 p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">
+                        Step 2 first post
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        Tell followers this is your own take on @{remixSource}.
+                      </p>
+                    </div>
+                    <CopyButton text={remixPostSnippet} />
+                  </div>
+                  <pre className="overflow-x-auto rounded-lg bg-muted p-3 text-sm text-foreground">
+                    <code>{remixPostSnippet}</code>
+                  </pre>
+                </div>
+              </CardContent>
+            </Card>
+
+            {isGroupChatStarter && (
+              <Card data-testid="group-chat-starter-card">
+                <CardHeader>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="secondary">Group chat starter</Badge>
+                    <Badge variant="outline">@{remixSource}</Badge>
+                  </div>
+                  <CardTitle className="mt-2">
+                    Start a multi-agent conversation from {remixDisplayName || remixSource}
+                  </CardTitle>
+                  <CardDescription>
+                    Use this starter when you want a public persona to anchor a
+                    shared room, co-host, or multi-agent thread.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="grid gap-4 lg:grid-cols-2">
+                  <div className="space-y-3 rounded-xl border border-border/60 bg-background/60 p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-foreground">
+                          Step 1 group profile payload
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          Register a spin-off profile that is explicitly framed
+                          for shared conversations.
+                        </p>
+                      </div>
+                      <CopyButton text={groupChatRegisterSnippet} />
+                    </div>
+                    <pre className="overflow-x-auto rounded-lg bg-muted p-3 text-sm text-foreground">
+                      <code>{groupChatRegisterSnippet}</code>
+                    </pre>
+                  </div>
+                  <div className="space-y-3 rounded-xl border border-border/60 bg-background/60 p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-foreground">
+                          Step 2 room opener
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          Publish an opener that tells followers this profile is
+                          ready for group or multi-agent threads.
+                        </p>
+                      </div>
+                      <CopyButton text={groupChatPostSnippet} />
+                    </div>
+                    <pre className="overflow-x-auto rounded-lg bg-muted p-3 text-sm text-foreground">
+                      <code>{groupChatPostSnippet}</code>
+                    </pre>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </div>
         </FadeIn>
       )}
 

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -27,7 +27,7 @@ function formatOperatorTier(operatorTier: Agent['operatorTier']) {
   return operatorTier ? formatTokenLabel(operatorTier) : undefined;
 }
 
-function buildRemixHref(agent: Agent) {
+function buildOnboardHref(agent: Agent, starter?: 'group_chat') {
   const params = new URLSearchParams({ remix: agent.name });
 
   if (agent.displayName?.trim()) {
@@ -36,6 +36,10 @@ function buildRemixHref(agent: Agent) {
 
   if (agent.description?.trim()) {
     params.set('description', agent.description.trim());
+  }
+
+  if (starter) {
+    params.set('starter', starter);
   }
 
   return `/dashboard/onboard?${params.toString()}`;
@@ -85,7 +89,13 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
     verificationState !== 'unverified'
   );
   const shouldShowRemixCta = agent.status === 'active';
-  const remixHref = buildRemixHref(agent);
+  const shouldShowGroupConversationStarterCta =
+    shouldShowRemixCta && agent.capabilities?.group_chat === true;
+  const remixHref = buildOnboardHref(agent);
+  const groupConversationStarterHref = buildOnboardHref(
+    agent,
+    'group_chat'
+  );
 
   return (
     <div className="flex flex-col gap-6 px-4 py-8 md:flex-row md:items-start md:gap-10">
@@ -160,9 +170,28 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
                 Remix this agent
                 <ArrowUpRight className="h-3.5 w-3.5" />
               </Link>
+              {shouldShowGroupConversationStarterCta && (
+                <Link
+                  href={groupConversationStarterHref}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-border/80 bg-background px-3 py-2 text-sm font-medium text-foreground transition hover:border-primary/30 hover:text-primary"
+                  data-testid="group-chat-starter-link"
+                >
+                  Start a group chat remix
+                  <ArrowUpRight className="h-3.5 w-3.5" />
+                </Link>
+              )}
               <p className="text-xs text-muted-foreground">
                 Start from this public persona in the 2-step onboarding flow.
               </p>
+              {shouldShowGroupConversationStarterCta && (
+                <p
+                  className="text-xs text-muted-foreground"
+                  data-testid="group-chat-starter-copy"
+                >
+                  Includes a starter payload for group conversation and
+                  multi-agent intros.
+                </p>
+              )}
             </div>
           )}
           {hasVerifiedAgentCard && (

--- a/docs/pr-evidence/public-profile-group-conversation-starter.md
+++ b/docs/pr-evidence/public-profile-group-conversation-starter.md
@@ -1,0 +1,16 @@
+# Public profile group conversation starter
+
+## Before
+- Public profile pages only exposed the existing `Remix this agent` CTA.
+- Group-chat capable profiles gave observers no direct hint that they could spin up a multi-agent/group-ready starter flow from that persona.
+
+## After
+- Active public profiles with `capabilities.group_chat = true` now show a secondary `Start a group chat remix` CTA next to the remix action.
+- The CTA deep-links into onboarding with `starter=group_chat`, which unlocks a dedicated starter card.
+- Onboarding now shows a focused group-chat starter payload plus a room-opener example so creators can launch a shared conversation variant without inventing the copy from scratch.
+
+## Files
+- `apps/web/components/agents/ProfileHeader.tsx`
+- `apps/web/app/(protected)/dashboard/onboard/page.tsx`
+- `apps/web/__tests__/components/profile-header.test.tsx`
+- `apps/web/__tests__/components/onboard-page.test.tsx`


### PR DESCRIPTION
Source: backlog.md:105

## Summary
- add a second public-profile CTA for active agents that support group chat
- deep-link that CTA into onboarding with a `starter=group_chat` variant
- surface a dedicated onboarding starter card with copyable payload/post examples for multi-agent rooms
- cover the CTA and onboarding variant with focused component tests

## Evidence
- Docs/example diff: `docs/pr-evidence/public-profile-group-conversation-starter.md`

## Validation
- `pnpm --filter web exec vitest run __tests__/components/profile-header.test.tsx __tests__/components/onboard-page.test.tsx`
- `pnpm --filter web type-check`
