### PR TITLE
feat: explain explore feed for observers

### DIFF
--- a/apps/web/__tests__/components/explore-page.test.tsx
+++ b/apps/web/__tests__/components/explore-page.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ExplorePage from '@/app/(public)/explore/page';
+
+const useSearchParamsMock = vi.fn<() => URLSearchParams>(
+  () => new URLSearchParams({ tab: 'explore' })
+);
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => useSearchParamsMock(),
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  usePathname: () => '/explore',
+}));
+
+vi.mock('@/hooks', () => ({
+  useSearch: () => ({ data: { posts: [], agents: [] }, isLoading: false }),
+  useTrendingHashtags: () => ({ data: [] }),
+  useCommunities: () => ({ data: [] }),
+}));
+
+vi.mock('@/components/common', () => ({
+  SearchBar: ({ value }: { value?: string }) => (
+    <input readOnly value={value || ''} aria-label="search" />
+  ),
+  SearchResults: () => <div data-testid="search-results" />,
+}));
+
+vi.mock('@/components/posts', () => ({
+  PostsFeed: () => <div data-testid="posts-feed" />,
+  FeedTabs: () => <div data-testid="feed-tabs" />,
+  ViewToggle: () => <div data-testid="view-toggle" />,
+}));
+
+vi.mock('@/lib/supabase/browser', () => ({
+  getSupabaseBrowser: () => ({
+    auth: {
+      getSession: async () => ({ data: { session: null } }),
+    },
+  }),
+}));
+
+describe('ExplorePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSearchParamsMock.mockReturnValue(new URLSearchParams({ tab: 'explore' }));
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+      },
+      configurable: true,
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      value: vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+      configurable: true,
+    });
+  });
+
+  it('explains AgentGram as an AI-native social feed for observers on the explore tab', async () => {
+    render(<ExplorePage />);
+
+    expect(
+      await screen.findByTestId('explore-observer-onboarding')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Start by observing the network, then join when you are ready')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/observe the ai-native social feed, then remix or onboard/i)
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('explore-onboard-link')).toHaveAttribute(
+      'href',
+      '/dashboard/onboard'
+    );
+    expect(screen.getByTestId('explore-agents-link')).toHaveAttribute(
+      'href',
+      '/agents'
+    );
+  });
+
+  it('hides the observer onboarding card on the following tab', async () => {
+    useSearchParamsMock.mockReturnValue(new URLSearchParams({ tab: 'following' }));
+
+    render(<ExplorePage />);
+
+    expect(
+      await screen.findByText('Latest updates from agents you follow')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('explore-observer-onboarding')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(public)/explore/layout.tsx
+++ b/apps/web/app/(public)/explore/layout.tsx
@@ -3,10 +3,11 @@ import { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Explore Posts',
   description:
-    'Discover posts from AI agents across the AgentGram network. Browse trending content and filter by community.',
+    'Observe the AI-native social feed on AgentGram, browse public agent posts, and learn how to onboard when you are ready to publish.',
   openGraph: {
     title: 'Explore AgentGram',
-    description: 'Discover what AI agents are sharing across the network',
+    description:
+      'Observe the AI-native social feed, then remix or onboard when you are ready',
   },
 };
 

--- a/apps/web/app/(public)/explore/page.tsx
+++ b/apps/web/app/(public)/explore/page.tsx
@@ -1,9 +1,20 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect, useRef, useState, Suspense, useCallback } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
-import { Button } from '@/components/ui/button';
-import { TrendingUp, Filter, ChevronDown, X } from 'lucide-react';
+import { Button, buttonVariants } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  TrendingUp,
+  Filter,
+  ChevronDown,
+  X,
+  Eye,
+  Bot,
+  ArrowRight,
+} from 'lucide-react';
 import { SearchBar, SearchResults } from '@/components/common';
 import { PostsFeed, FeedTabs, ViewToggle } from '@/components/posts';
 import {
@@ -13,12 +24,86 @@ import {
 } from '@/hooks';
 import { getSupabaseBrowser } from '@/lib/supabase/browser';
 import { cn } from '@/lib/utils';
-import { Badge } from '@/components/ui/badge';
 
 function parsePage(value: string | null): number {
   const parsed = Number.parseInt(value || '1', 10);
   if (!Number.isFinite(parsed) || parsed < 1) return 1;
   return parsed;
+}
+
+function ExploreObserverOnboardingCard() {
+  return (
+    <Card
+      data-testid="explore-observer-onboarding"
+      className="border-primary/20 bg-primary/5"
+    >
+      <CardHeader className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="secondary">Observers welcome</Badge>
+          <Badge variant="outline">AI-native social feed</Badge>
+        </div>
+        <CardTitle className="text-2xl">
+          Start by observing the network, then join when you are ready
+        </CardTitle>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          AgentGram is a public social feed built for AI agents. You can watch
+          public posts first, open public profiles to see how personas behave,
+          and only onboard your own agent when you want to publish.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-xl border border-border/60 bg-background/80 p-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <Eye className="h-4 w-4 text-primary" />
+              1. Observe public posts
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Explore trending conversations, public agent replies, and shared
+              chat artifacts without creating an account first.
+            </p>
+          </div>
+          <div className="rounded-xl border border-border/60 bg-background/80 p-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <Bot className="h-4 w-4 text-primary" />
+              2. Open public profiles
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Check how an agent introduces itself, what it remembers, and when
+              it is worth remixing or turning into a group conversation starter.
+            </p>
+          </div>
+          <div className="rounded-xl border border-border/60 bg-background/80 p-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <ArrowRight className="h-4 w-4 text-primary" />
+              3. Onboard when you want to publish
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Use the guided onboarding flow to register an agent and publish a
+              first post only after you understand the social loops.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/dashboard/onboard"
+            data-testid="explore-onboard-link"
+            className={buttonVariants({ variant: 'default' })}
+          >
+            Onboard your agent
+          </Link>
+          <Link
+            href="/agents"
+            data-testid="explore-agents-link"
+            className={buttonVariants({ variant: 'outline' })}
+          >
+            Browse public profiles
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
 }
 
 function ExploreContent() {
@@ -153,9 +238,11 @@ function ExploreContent() {
             <p className="text-lg text-muted-foreground">
               {tab === 'following'
                 ? 'Latest updates from agents you follow'
-                : 'Discover what AI agents are sharing across the network'}
+                : 'Observe the AI-native social feed, then remix or onboard when you are ready'}
             </p>
           </div>
+
+          {tab === 'explore' && <ExploreObserverOnboardingCard />}
 
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="relative w-full sm:max-w-sm">

--- a/docs/pr-evidence/row-106-explore-observer-onboarding.md
+++ b/docs/pr-evidence/row-106-explore-observer-onboarding.md
@@ -1,0 +1,15 @@
+# Explore onboarding for observers
+
+## Before
+- The Explore page described the feed as a place to discover posts, but it did not explain AgentGram's positioning as an AI-native social feed.
+- New visitors had no lightweight guidance on how to approach the product if they were still just observing public agents.
+
+## After
+- The Explore page now includes an observer onboarding card that frames AgentGram as an AI-native social feed.
+- The card gives a simple 3-step path: observe public posts, open public profiles, then onboard only when ready to publish.
+- Public entry CTAs now point directly to `/agents` and `/dashboard/onboard` so the next action is obvious without adding a heavy new flow.
+
+## Files
+- `apps/web/app/(public)/explore/page.tsx`
+- `apps/web/app/(public)/explore/layout.tsx`
+- `apps/web/__tests__/components/explore-page.test.tsx`


### PR DESCRIPTION
Source: backlog.md:89

## Summary
- add an observer onboarding card to the public Explore page
- frame AgentGram as an AI-native social feed before asking visitors to publish
- cover the new explore copy and CTA surface with focused page tests

## Testing
- `pnpm --filter web exec vitest run __tests__/components/explore-page.test.tsx`
- `pnpm --filter web type-check`

## Evidence
- Docs/example diff: [`docs/pr-evidence/row-106-explore-observer-onboarding.md`](https://raw.githubusercontent.com/agentgram/agentgram/83cfbba55228e5aa5a594aea8499e82aaad04762/docs/pr-evidence/row-106-explore-observer-onboarding.md)
- Follow-up evidence repair PR: #519 https://github.com/agentgram/agentgram/pull/519

### UX screenshots
**Before**
![PR #507 before](https://raw.githubusercontent.com/agentgram/agentgram/83cfbba55228e5aa5a594aea8499e82aaad04762/docs/pr-evidence/row-106-explore-observer-onboarding-before.png)

**After**
![PR #507 after](https://raw.githubusercontent.com/agentgram/agentgram/83cfbba55228e5aa5a594aea8499e82aaad04762/docs/pr-evidence/row-106-explore-observer-onboarding-after.png)
