### PR TITLE
feat: add public trust bundle to agent cards

### DIFF
--- a/apps/web/__tests__/components/agent-card.test.tsx
+++ b/apps/web/__tests__/components/agent-card.test.tsx
@@ -119,6 +119,37 @@ describe('AgentCard', () => {
     );
   });
 
+  it('groups verified owner, memory consent, and last activity into a public trust bundle for verified agents', () => {
+    render(
+      <AgentCard
+        agent={{
+          id: 'agent-trust',
+          name: 'trust-builder',
+          displayName: 'Trust Builder',
+          axp: 2400,
+          verificationState: 'verified',
+          publicOwnerLabel: 'Ralph',
+          memoryPolicy: 'ephemeral_only',
+          lastActive: '2026-04-28T02:30:00.000Z',
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('agent-card-trust-bundle')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-card-owner-label')).toHaveTextContent(
+      'Verified owner: Ralph'
+    );
+    expect(screen.getByTestId('agent-card-memory-consent')).toHaveTextContent(
+      'Memory consent: Ephemeral Only'
+    );
+    expect(
+      screen.getByTestId('agent-card-trust-last-active')
+    ).toHaveTextContent('Active today');
+    expect(
+      screen.queryByTestId('agent-card-freshness-badge')
+    ).not.toBeInTheDocument();
+  });
+
   it('omits the freshness badge when last active data is missing', () => {
     render(
       <AgentCard

--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import type { Agent } from '@agentgram/shared';
 import { ProfileHeader } from '../../components/agents/ProfileHeader';
 
@@ -63,6 +63,15 @@ const baseAgent: Agent = {
 };
 
 describe('ProfileHeader', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-28T05:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders the verified agent card capability summary and permission scope badge when present', () => {
     render(
       <ProfileHeader
@@ -169,12 +178,37 @@ describe('ProfileHeader', () => {
   });
 
   it('shows remix social proof in the profile stats when remixes exist', () => {
-    render(
-      <ProfileHeader agent={{ ...baseAgent, remixCount: 4 }} />
-    );
+    render(<ProfileHeader agent={{ ...baseAgent, remixCount: 4 }} />);
 
     expect(screen.getByTestId('profile-remix-count')).toHaveTextContent(
       '4remixes'
+    );
+  });
+
+  it('shows public trust bundle details for verified profiles', () => {
+    render(
+      <ProfileHeader
+        agent={{
+          ...baseAgent,
+          verificationState: 'verified',
+          publicOwnerLabel: 'Ralph',
+          memoryPolicy: 'ephemeral_only',
+          lastActive: '2026-04-28T02:30:00.000Z',
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId('profile-public-trust-bundle')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('profile-owner-label')).toHaveTextContent(
+      'Ralph'
+    );
+    expect(
+      screen.getByTestId('profile-memory-consent-badge')
+    ).toHaveTextContent('Ephemeral Only');
+    expect(screen.getByTestId('profile-last-active-badge')).toHaveTextContent(
+      'Active today'
     );
   });
 

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -21,9 +21,21 @@ type AgentCardAgent = {
   avatar_url?: string | null;
   created_at?: string | null;
   last_active?: string | null;
+  verificationState?: 'unverified' | 'pending' | 'verified' | null;
+  publicOwnerLabel?: string | null;
+  memoryPolicy?: string | null;
   capabilities?: Partial<DirectoryCapabilities>;
   remixCount?: number | null;
 };
+
+function formatTokenLabel(value: string) {
+  return value
+    .trim()
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
 
 function getActivityFreshness(lastActive?: string | null) {
   if (!lastActive) return null;
@@ -85,6 +97,13 @@ export function AgentCard({
   const activityFreshness = getActivityFreshness(
     agent.last_active ?? agent.lastActive
   );
+  const publicOwnerLabel = agent.publicOwnerLabel?.trim();
+  const formattedMemoryPolicy = agent.memoryPolicy?.trim()
+    ? formatTokenLabel(agent.memoryPolicy)
+    : undefined;
+  const shouldShowPublicTrustBundle =
+    agent.verificationState === 'verified' &&
+    Boolean(publicOwnerLabel || formattedMemoryPolicy || activityFreshness);
 
   const isNew =
     showNewBadge &&
@@ -134,7 +153,7 @@ export function AgentCard({
             </div>
             <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
               <span className="truncate">@{agent.name}</span>
-              {activityFreshness && (
+              {activityFreshness && !shouldShowPublicTrustBundle && (
                 <span
                   data-testid="agent-card-freshness-badge"
                   className={cn(
@@ -169,19 +188,60 @@ export function AgentCard({
         )}
       </div>
 
+      {shouldShowPublicTrustBundle && (
+        <div
+          className="mt-3 rounded-xl border border-primary/15 bg-primary/5 p-3"
+          data-testid="agent-card-trust-bundle"
+        >
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+            Public trust bundle
+          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-foreground/80">
+            {publicOwnerLabel && (
+              <span
+                className="inline-flex items-center rounded-full bg-background px-2.5 py-1 font-medium"
+                data-testid="agent-card-owner-label"
+              >
+                Verified owner: {publicOwnerLabel}
+              </span>
+            )}
+            {formattedMemoryPolicy && (
+              <span
+                className="inline-flex items-center rounded-full bg-background px-2.5 py-1 font-medium"
+                data-testid="agent-card-memory-consent"
+              >
+                Memory consent: {formattedMemoryPolicy}
+              </span>
+            )}
+            {activityFreshness && (
+              <span
+                className={cn(
+                  'inline-flex items-center rounded-full px-2.5 py-1 font-medium',
+                  activityFreshness.className
+                )}
+                data-testid="agent-card-trust-last-active"
+              >
+                {activityFreshness.label}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
       {agent.capabilities && (
         <div className="mt-3 flex flex-wrap gap-2">
-          {DIRECTORY_CAPABILITY_KEYS.filter((key) => agent.capabilities?.[key])
-            .map((key) => (
-              <Badge
-                key={key}
-                variant="outline"
-                className="text-[10px] uppercase tracking-wide"
-                data-testid={`agent-capability-badge-${key}`}
-              >
-                {DIRECTORY_CAPABILITY_LABELS[key]}
-              </Badge>
-            ))}
+          {DIRECTORY_CAPABILITY_KEYS.filter(
+            (key) => agent.capabilities?.[key]
+          ).map((key) => (
+            <Badge
+              key={key}
+              variant="outline"
+              className="text-[10px] uppercase tracking-wide"
+              data-testid={`agent-capability-badge-${key}`}
+            >
+              {DIRECTORY_CAPABILITY_LABELS[key]}
+            </Badge>
+          ))}
         </div>
       )}
     </Link>

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -27,6 +27,25 @@ function formatOperatorTier(operatorTier: Agent['operatorTier']) {
   return operatorTier ? formatTokenLabel(operatorTier) : undefined;
 }
 
+function formatLastActive(lastActive?: string) {
+  if (!lastActive) return undefined;
+
+  const parsed = new Date(lastActive);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+
+  const elapsedMs = Math.max(0, Date.now() - parsed.getTime());
+  const elapsedHours = elapsedMs / (1000 * 60 * 60);
+
+  if (elapsedHours < 1) return 'Active now';
+  if (elapsedHours < 24) return 'Active today';
+
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  if (elapsedDays < 7) return `Active ${elapsedDays}d ago`;
+  if (elapsedDays < 30) return `Active ${Math.floor(elapsedDays / 7)}w ago`;
+
+  return `Active ${Math.floor(elapsedDays / 30)}mo ago`;
+}
+
 function buildOnboardHref(agent: Agent, starter?: 'group_chat') {
   const params = new URLSearchParams({ remix: agent.name });
 
@@ -66,6 +85,8 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
   const formattedMemoryPolicy = memoryPolicy
     ? formatTokenLabel(memoryPolicy)
     : undefined;
+  const publicOwnerLabel = agent.publicOwnerLabel?.trim();
+  const formattedLastActive = formatLastActive(agent.lastActive);
   const workProofUrl = agent.workProofUrl?.trim();
   const retentionDisclosure = agent.retentionPolicy?.trim();
   const formattedRetentionDisclosure = retentionDisclosure
@@ -83,19 +104,20 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
   const workProofLabel =
     agent.workProofLabel?.trim() ||
     (workProofUrl ? 'View work proof' : undefined);
+  const hasPublicTrustBundle =
+    verificationState === 'verified' &&
+    Boolean(publicOwnerLabel || formattedMemoryPolicy || formattedLastActive);
   const hasVerifiedAgentCard = Boolean(
     capabilitySummary ||
     formattedPermissionScope ||
-    verificationState !== 'unverified'
+    verificationState !== 'unverified' ||
+    hasPublicTrustBundle
   );
   const shouldShowRemixCta = agent.status === 'active';
   const shouldShowGroupConversationStarterCta =
     shouldShowRemixCta && agent.capabilities?.group_chat === true;
   const remixHref = buildOnboardHref(agent);
-  const groupConversationStarterHref = buildOnboardHref(
-    agent,
-    'group_chat'
-  );
+  const groupConversationStarterHref = buildOnboardHref(agent, 'group_chat');
 
   return (
     <div className="flex flex-col gap-6 px-4 py-8 md:flex-row md:items-start md:gap-10">
@@ -218,6 +240,78 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
                   >
                     {verificationState}
                   </span>
+                </div>
+              )}
+              {hasPublicTrustBundle && (
+                <div
+                  className="mt-3 rounded-xl border border-primary/15 bg-primary/5 p-3"
+                  data-testid="profile-public-trust-bundle"
+                >
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                    Public trust bundle
+                  </p>
+                  <div className="mt-3 space-y-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="text-sm font-medium text-foreground">
+                        Verified owner
+                      </p>
+                      {publicOwnerLabel ? (
+                        <span
+                          className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary"
+                          data-testid="profile-owner-label"
+                        >
+                          {publicOwnerLabel}
+                        </span>
+                      ) : (
+                        <span
+                          className="text-xs text-muted-foreground"
+                          data-testid="profile-owner-status"
+                        >
+                          Owner label not published
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="text-sm font-medium text-foreground">
+                        Memory consent
+                      </p>
+                      {formattedMemoryPolicy ? (
+                        <span
+                          className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary"
+                          data-testid="profile-memory-consent-badge"
+                        >
+                          {formattedMemoryPolicy}
+                        </span>
+                      ) : (
+                        <span
+                          className="text-xs text-muted-foreground"
+                          data-testid="profile-memory-consent-status"
+                        >
+                          Not disclosed
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="text-sm font-medium text-foreground">
+                        Last active
+                      </p>
+                      {formattedLastActive ? (
+                        <span
+                          className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary"
+                          data-testid="profile-last-active-badge"
+                        >
+                          {formattedLastActive}
+                        </span>
+                      ) : (
+                        <span
+                          className="text-xs text-muted-foreground"
+                          data-testid="profile-last-active-status"
+                        >
+                          Activity not published
+                        </span>
+                      )}
+                    </div>
+                  </div>
                 </div>
               )}
               {shouldShowOperatorTierSurface && (

--- a/apps/web/hooks/use-agents-directory.ts
+++ b/apps/web/hooks/use-agents-directory.ts
@@ -18,6 +18,9 @@ export type AgentsDirectoryAgent = {
   avatarUrl?: string | null;
   createdAt?: string | null;
   lastActive?: string | null;
+  verificationState?: 'unverified' | 'pending' | 'verified' | null;
+  publicOwnerLabel?: string | null;
+  memoryPolicy?: string | null;
   display_name?: string | null;
   avatar_url?: string | null;
   created_at?: string | null;

--- a/docs/pr-evidence/row-99-public-trust-bundle.md
+++ b/docs/pr-evidence/row-99-public-trust-bundle.md
@@ -1,0 +1,23 @@
+# Row 99 — public trust bundle evidence
+
+## Source
+
+- backlog.md:99
+
+## What changed
+
+- `AgentCard` now groups verified owner, memory-consent disclosure, and last-active freshness into a single `Public trust bundle` surface for verified agents.
+- `ProfileHeader` now exposes the same trio in a dedicated public trust bundle instead of leaving them split across separate trust surfaces.
+
+## UI proof from added fixtures
+
+- Agent card fixture: `Verified owner: Ralph` + `Memory consent: Ephemeral Only` + `Active today`
+- Profile header fixture: `Ralph` + `Ephemeral Only` + `Active today`
+
+## Files
+
+- `apps/web/components/agents/AgentCard.tsx`
+- `apps/web/components/agents/ProfileHeader.tsx`
+- `apps/web/hooks/use-agents-directory.ts`
+- `apps/web/__tests__/components/agent-card.test.tsx`
+- `apps/web/__tests__/components/profile-header.test.tsx`


### PR DESCRIPTION
Source: backlog.md:99

## Summary
- group verified owner, memory-consent disclosure, and last-active freshness into a single public trust bundle on explore agent cards
- surface the same public trust bundle on profile headers for verified agents
- add focused component coverage for the new trust bundle states

## Validation
- `cd apps/web && ./node_modules/.bin/vitest run __tests__/components/agent-card.test.tsx __tests__/components/profile-header.test.tsx`
- `cd apps/web && ./node_modules/.bin/tsc --noEmit`

## Evidence
- docs/example diff: `docs/pr-evidence/row-99-public-trust-bundle.md`
