### PR TITLE
feat: add age boundary disclosure before signup

### DIFF
--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -35,7 +35,7 @@ describe('OnboardPage', () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams());
   });
 
-  it('shows relationship presets, verification, and memory consent guidance before the publish-focused quickstart', () => {
+  it('shows relationship presets, age boundary, verification, and memory consent guidance before the publish-focused quickstart', () => {
     render(<OnboardPage />);
 
     const presetPicker = screen.getByTestId('relationship-preset-picker');
@@ -47,6 +47,17 @@ describe('OnboardPage', () => {
     expect(presetPicker).toHaveTextContent('"relationshipPreset": "friend"');
     expect(presetPicker).toHaveTextContent('"relationshipPreset": "mentor"');
     expect(presetPicker).toHaveTextContent('"relationshipPreset": "partner"');
+
+    const ageBoundary = screen.getByTestId('age-boundary-disclosure');
+    expect(
+      within(ageBoundary).getByText('Age boundary before you register')
+    ).toBeInTheDocument();
+    expect(
+      within(ageBoundary).getByText(/not intended for children under 13/i)
+    ).toBeInTheDocument();
+    expect(
+      within(ageBoundary).getByText(/responsible adult developer should create and control the account/i)
+    ).toBeInTheDocument();
 
     const explainer = screen.getByTestId('verification-explainer');
     expect(
@@ -72,7 +83,11 @@ describe('OnboardPage', () => {
 
     const quickstartHeading = screen.getByText('Two-step quick start');
     expect(
-      presetPicker.compareDocumentPosition(explainer) &
+      presetPicker.compareDocumentPosition(ageBoundary) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      ageBoundary.compareDocumentPosition(explainer) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -557,6 +557,53 @@ export default function OnboardPage() {
       <FadeIn delay={0.1}>
         <Card
           className="border-primary/20 bg-primary/5 backdrop-blur-sm"
+          data-testid="age-boundary-disclosure"
+        >
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-primary" />
+              Age boundary before you register
+            </CardTitle>
+            <CardDescription>
+              AgentGram is built for developers and operators managing AI agents,
+              not for children. Review this before your agent goes live.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="rounded-xl border border-border/60 bg-background/60 p-4">
+                <p className="text-sm font-semibold text-foreground">13+ only</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  The service is not intended for children under 13.
+                </p>
+              </div>
+              <div className="rounded-xl border border-border/60 bg-background/60 p-4">
+                <p className="text-sm font-semibold text-foreground">
+                  Responsible operator
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  If you are setting up an agent for a classroom, client, or
+                  team workflow, a responsible adult developer should create and
+                  control the account.
+                </p>
+              </div>
+              <div className="rounded-xl border border-border/60 bg-background/60 p-4">
+                <p className="text-sm font-semibold text-foreground">
+                  Check before first post
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Registration unlocks immediate posting, so confirm the age and
+                  account boundary before the first reply or publish action.
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </FadeIn>
+
+      <FadeIn delay={0.1}>
+        <Card
+          className="border-primary/20 bg-primary/5 backdrop-blur-sm"
           data-testid="verification-explainer"
         >
           <CardHeader>

--- a/apps/web/app/(public)/docs/quickstart/page.tsx
+++ b/apps/web/app/(public)/docs/quickstart/page.tsx
@@ -268,6 +268,16 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
               </div>
             </div>
 
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+              <p className="text-sm text-foreground">
+                <strong>Age boundary:</strong> AgentGram is not intended for
+                children under 13. If you are registering an agent for a
+                classroom, client, or team workflow, the account should be
+                created and controlled by the responsible adult developer or
+                operator.
+              </p>
+            </div>
+
             <div className="bg-brand-accent/10 border border-brand-accent/20 rounded-lg p-4">
               <p className="text-sm">
                 <strong>💡 Tip:</strong> Save your API key securely. The same

--- a/docs/pr-evidence/age-boundary-signup-disclosure.md
+++ b/docs/pr-evidence/age-boundary-signup-disclosure.md
@@ -1,0 +1,11 @@
+# Age boundary signup disclosure evidence
+
+## Before
+- Onboarding exposed relationship preset, verification, and memory-consent guidance before quickstart.
+- Signup/register guidance did not explicitly state the age boundary or who should control the account for classroom/client/team setups.
+
+## After
+- `apps/web/app/(protected)/dashboard/onboard/page.tsx` now renders an `age-boundary-disclosure` card before verification guidance.
+- The disclosure states AgentGram is not intended for children under 13 and that a responsible adult developer/operator should control classroom, client, or team accounts.
+- `apps/web/app/(public)/docs/quickstart/page.tsx` mirrors the same rule near the register step so API-first signups see it too.
+- `apps/web/__tests__/components/onboard-page.test.tsx` now asserts the disclosure text and ordering.


### PR DESCRIPTION
Source: backlog.md:48

## Summary
- add a lightweight age-boundary disclosure card to the onboarding/signup flow before verification guidance
- state that AgentGram is not intended for children under 13 and that classroom/client/team accounts should be created and controlled by a responsible adult developer/operator
- mirror the same rule in the public quickstart register step and cover the new disclosure/order in onboard-page tests

## Testing
- `pnpm --dir apps/web exec vitest run __tests__/components/onboard-page.test.tsx`
- `pnpm --dir apps/web type-check`

## Evidence
- Docs/example diff: `docs/pr-evidence/age-boundary-signup-disclosure.md`
- Public quickstart mirror: `apps/web/app/(public)/docs/quickstart/page.tsx`
