### PR TITLE
feat: add proactive send availability banner

### DIFF
--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -253,6 +253,41 @@ describe('ProactiveControlsForm', () => {
     expect(
       screen.getByTestId('proactive-next-eligible-send')
     ).toHaveTextContent('Apr 27, 2026, 8:00 AM KST');
+    expect(
+      screen.getByTestId('proactive-pre-send-banner-title')
+    ).toHaveTextContent('Next proactive send waits for the reset window');
+    expect(
+      screen.getByTestId('proactive-pre-send-banner-body')
+    ).toHaveTextContent('Quiet hours push the next eligible send to Apr 27, 2026, 8:00 AM KST.');
+    expect(
+      screen.getByTestId('proactive-pre-send-banner-body')
+    ).toHaveTextContent('2/day and 8/week caps');
+  });
+
+  it('shows an opt-in gate banner before proactive outreach is enabled', () => {
+    render(
+      <ProactiveControlsForm
+        initialSettings={{
+          optIn: false,
+          dailyLimit: 3,
+          weeklyLimit: 9,
+          quietHoursEnabled: false,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
+          tonePreset: 'neutral',
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId('proactive-pre-send-banner-title')
+    ).toHaveTextContent('Proactive send blocked until opt-in');
+    expect(
+      screen.getByTestId('proactive-pre-send-banner-body')
+    ).toHaveTextContent('Turn on proactive outreach before AgentGram sends the next message.');
+    expect(
+      screen.getByTestId('proactive-pre-send-banner-body')
+    ).toHaveTextContent('3/day and 9/week caps');
   });
 
   it('shows an error when the save request fails', async () => {

--- a/apps/web/components/dashboard/ProactiveControlsForm.tsx
+++ b/apps/web/components/dashboard/ProactiveControlsForm.tsx
@@ -75,6 +75,16 @@ export function ProactiveControlsForm({
   const nextEligibleLabel = nextEligibleSendAt
     ? formatStatusTimestamp(nextEligibleSendAt)
     : 'Waiting for opt-in';
+  const preSendBannerTitle = !settings.optIn
+    ? 'Proactive send blocked until opt-in'
+    : settings.quietHoursEnabled
+      ? 'Next proactive send waits for the reset window'
+      : 'Next proactive send is available once caps allow';
+  const preSendBannerBody = !settings.optIn
+    ? `Turn on proactive outreach before AgentGram sends the next message. When you do, it will still respect your ${settings.dailyLimit}/day and ${settings.weeklyLimit}/week caps.`
+    : settings.quietHoursEnabled
+      ? `Quiet hours push the next eligible send to ${nextEligibleLabel}. Once that window opens, AgentGram still respects your ${settings.dailyLimit}/day and ${settings.weeklyLimit}/week caps.`
+      : `AgentGram can send again as early as ${nextEligibleLabel}. Daily and weekly usage still stay capped at ${settings.dailyLimit}/day and ${settings.weeklyLimit}/week.`;
 
   const handleSave = async () => {
     setIsSaving(true);
@@ -306,6 +316,24 @@ export function ProactiveControlsForm({
             ))}
           </div>
         </fieldset>
+
+        <div
+          className="rounded-lg border border-primary/20 bg-primary/5 p-4"
+          data-testid="proactive-pre-send-banner"
+        >
+          <p
+            className="text-xs font-semibold uppercase tracking-wide text-primary"
+            data-testid="proactive-pre-send-banner-title"
+          >
+            {preSendBannerTitle}
+          </p>
+          <p
+            className="mt-2 text-sm text-foreground"
+            data-testid="proactive-pre-send-banner-body"
+          >
+            {preSendBannerBody}
+          </p>
+        </div>
 
         <div className="grid gap-4 md:grid-cols-2">
           <div className="rounded-lg border border-border/60 p-4">

--- a/docs/pr-evidence/chat-availability-usage-cap-reset-banner.md
+++ b/docs/pr-evidence/chat-availability-usage-cap-reset-banner.md
@@ -1,0 +1,25 @@
+# Chat availability — usage cap/reset banner before message send
+
+## Scope choice
+- Current `apps/web` has proactive outreach controls but no standalone chat composer/message-send surface.
+- To avoid inventing a missing chat UI, this patch adds the smallest honest pre-send surface on the existing proactive controls card.
+- The banner sits directly above `Last proactive send` / `Next eligible send window`, reusing the same scheduling metadata that would gate the next outbound message.
+
+## Summary
+- adds a pre-send availability banner to `ProactiveControlsForm`
+- reuses existing `getNextEligibleSendAt(settings)` + timestamp formatting instead of adding new scheduling logic
+- explains three states:
+  1. blocked until opt-in
+  2. waiting for quiet-hours reset window
+  3. next proactive send available once caps allow
+- keeps daily/weekly cap numbers visible inside the banner copy
+
+## UX contract
+- `proactive-pre-send-banner`
+- `proactive-pre-send-banner-title`
+- `proactive-pre-send-banner-body`
+
+## Validation
+- `./node_modules/.bin/vitest run __tests__/components/proactive-controls-settings.test.tsx --config vitest.config.ts`
+- `pnpm --dir apps/web type-check`
+- `git diff --check`


### PR DESCRIPTION
Source: backlog.md:100

Chat availability — show free-tier usage cap/reset banner before message send

## Scope
- `apps/web` currently has proactive outreach controls but no standalone chat composer/message-send surface.
- This patch lands the smallest honest pre-send surface on the existing proactive controls card instead of inventing a missing chat UI.

## Summary
- add a pre-send availability banner to `ProactiveControlsForm`
- reuse existing `getNextEligibleSendAt(settings)` + timestamp formatting from the proactive status cards
- explain three states: blocked until opt-in, waiting for quiet-hours reset window, or next proactive send available once caps allow
- keep daily/weekly cap numbers visible in the banner copy so send availability and usage caps stay legible together

## Tests
- `./node_modules/.bin/vitest run __tests__/components/proactive-controls-settings.test.tsx --config vitest.config.ts`
- `pnpm --dir apps/web type-check`
- `git diff --check`

## Evidence
- docs note: `docs/pr-evidence/chat-availability-usage-cap-reset-banner.md`
