### PR TITLE
fix: correct proactive availability gating banner

### DIFF
--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -290,6 +290,38 @@ describe('ProactiveControlsForm', () => {
     ).toHaveTextContent('3/day and 9/week caps');
   });
 
+  it('does not show reset-window copy when quiet hours are configured but currently inactive', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-27T04:00:00.000Z'));
+
+    render(
+      <ProactiveControlsForm
+        initialSettings={{
+          optIn: true,
+          dailyLimit: 2,
+          weeklyLimit: 8,
+          quietHoursEnabled: true,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
+          tonePreset: 'neutral',
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId('proactive-pre-send-banner-title')
+    ).toHaveTextContent('Next proactive send is available once caps allow');
+    expect(
+      screen.getByTestId('proactive-pre-send-banner-body')
+    ).toHaveTextContent('AgentGram can send again as early as Apr 27, 2026, 1:00 PM KST.');
+    expect(
+      screen.getByTestId('proactive-pre-send-banner-body')
+    ).toHaveTextContent('2/day and 8/week');
+    expect(
+      screen.getByTestId('proactive-pre-send-banner-body')
+    ).not.toHaveTextContent('Quiet hours push');
+  });
+
   it('shows an error when the save request fails', async () => {
     vi.stubGlobal(
       'fetch',

--- a/apps/web/components/dashboard/ProactiveControlsForm.tsx
+++ b/apps/web/components/dashboard/ProactiveControlsForm.tsx
@@ -75,16 +75,28 @@ export function ProactiveControlsForm({
   const nextEligibleLabel = nextEligibleSendAt
     ? formatStatusTimestamp(nextEligibleSendAt)
     : 'Waiting for opt-in';
+  const nextEligibleSendMs = nextEligibleSendAt
+    ? new Date(nextEligibleSendAt).getTime()
+    : Number.NaN;
+  const isEligibilityDelayed = Number.isFinite(nextEligibleSendMs)
+    ? nextEligibleSendMs - Date.now() > 60 * 1000
+    : false;
+  const isQuietHoursBlocking =
+    isEligibilityDelayed && settings.quietHoursEnabled && !settings.nextEligibleSendAt;
   const preSendBannerTitle = !settings.optIn
     ? 'Proactive send blocked until opt-in'
-    : settings.quietHoursEnabled
+    : isQuietHoursBlocking
       ? 'Next proactive send waits for the reset window'
-      : 'Next proactive send is available once caps allow';
+      : isEligibilityDelayed
+        ? 'Next proactive send stays queued until the next eligible window'
+        : 'Next proactive send is available once caps allow';
   const preSendBannerBody = !settings.optIn
     ? `Turn on proactive outreach before AgentGram sends the next message. When you do, it will still respect your ${settings.dailyLimit}/day and ${settings.weeklyLimit}/week caps.`
-    : settings.quietHoursEnabled
+    : isQuietHoursBlocking
       ? `Quiet hours push the next eligible send to ${nextEligibleLabel}. Once that window opens, AgentGram still respects your ${settings.dailyLimit}/day and ${settings.weeklyLimit}/week caps.`
-      : `AgentGram can send again as early as ${nextEligibleLabel}. Daily and weekly usage still stay capped at ${settings.dailyLimit}/day and ${settings.weeklyLimit}/week.`;
+      : isEligibilityDelayed
+        ? `AgentGram is still waiting for the next eligible send window at ${nextEligibleLabel}. Daily and weekly usage still stay capped at ${settings.dailyLimit}/day and ${settings.weeklyLimit}/week.`
+        : `AgentGram can send again as early as ${nextEligibleLabel}. Daily and weekly usage still stay capped at ${settings.dailyLimit}/day and ${settings.weeklyLimit}/week.`;
 
   const handleSave = async () => {
     setIsSaving(true);

--- a/apps/web/components/dashboard/ProactiveControlsForm.tsx
+++ b/apps/web/components/dashboard/ProactiveControlsForm.tsx
@@ -61,6 +61,7 @@ export function ProactiveControlsForm({
 }: ProactiveControlsFormProps) {
   const [settings, setSettings] = useState(initialSettings);
   const [isSaving, setIsSaving] = useState(false);
+  const [renderedAtMs, setRenderedAtMs] = useState(() => Date.now());
   const [status, setStatus] = useState<{
     tone: 'idle' | 'success' | 'error';
     message: string;
@@ -78,9 +79,12 @@ export function ProactiveControlsForm({
   const nextEligibleSendMs = nextEligibleSendAt
     ? new Date(nextEligibleSendAt).getTime()
     : Number.NaN;
-  const isEligibilityDelayed = Number.isFinite(nextEligibleSendMs)
-    ? nextEligibleSendMs - Date.now() > 60 * 1000
-    : false;
+  const isEligibilityDelayed =
+    Number.isFinite(nextEligibleSendMs) && nextEligibleSendMs - renderedAtMs > 60 * 1000;
+  const updateSettings = (value: Parameters<typeof setSettings>[0]) => {
+    setRenderedAtMs(Date.now());
+    setSettings(value);
+  };
   const isQuietHoursBlocking =
     isEligibilityDelayed && settings.quietHoursEnabled && !settings.nextEligibleSendAt;
   const preSendBannerTitle = !settings.optIn
@@ -120,7 +124,7 @@ export function ProactiveControlsForm({
         throw new Error('Failed to save proactive controls');
       }
 
-      setSettings(payload.data);
+      updateSettings(payload.data);
       setStatus({
         tone: 'success',
         message: 'Proactive outreach preferences saved.',
@@ -154,7 +158,7 @@ export function ProactiveControlsForm({
             checked={settings.optIn}
             className="mt-1 h-4 w-4 rounded border-input"
             onChange={(event) =>
-              setSettings((current) => ({
+              updateSettings((current) => ({
                 ...current,
                 optIn: event.target.checked,
               }))
@@ -184,7 +188,7 @@ export function ProactiveControlsForm({
               min={1}
               max={25}
               onChange={(event) =>
-                setSettings((current) => ({
+                updateSettings((current) => ({
                   ...current,
                   dailyLimit: Number(event.target.value),
                 }))
@@ -207,7 +211,7 @@ export function ProactiveControlsForm({
               min={1}
               max={100}
               onChange={(event) =>
-                setSettings((current) => ({
+                updateSettings((current) => ({
                   ...current,
                   weeklyLimit: Number(event.target.value),
                 }))
@@ -227,7 +231,7 @@ export function ProactiveControlsForm({
               checked={settings.quietHoursEnabled}
               className="mt-1 h-4 w-4 rounded border-input"
               onChange={(event) =>
-                setSettings((current) => ({
+                updateSettings((current) => ({
                   ...current,
                   quietHoursEnabled: event.target.checked,
                 }))
@@ -255,7 +259,7 @@ export function ProactiveControlsForm({
                 <Input
                   aria-label="Quiet hours start"
                   onChange={(event) =>
-                    setSettings((current) => ({
+                    updateSettings((current) => ({
                       ...current,
                       quietHoursStart: event.target.value,
                     }))
@@ -272,7 +276,7 @@ export function ProactiveControlsForm({
                 <Input
                   aria-label="Quiet hours end"
                   onChange={(event) =>
-                    setSettings((current) => ({
+                    updateSettings((current) => ({
                       ...current,
                       quietHoursEnd: event.target.value,
                     }))
@@ -308,7 +312,7 @@ export function ProactiveControlsForm({
                   className="mt-0.5 h-4 w-4"
                   name="tonePreset"
                   onChange={() =>
-                    setSettings((current) => ({
+                    updateSettings((current) => ({
                       ...current,
                       tonePreset: preset,
                     }))

--- a/docs/pr-evidence/chat-availability-usage-cap-reset-banner.md
+++ b/docs/pr-evidence/chat-availability-usage-cap-reset-banner.md
@@ -10,7 +10,7 @@
 - reuses existing `getNextEligibleSendAt(settings)` + timestamp formatting instead of adding new scheduling logic
 - explains three states:
   1. blocked until opt-in
-  2. waiting for quiet-hours reset window
+  2. waiting for quiet-hours reset window only when quiet hours are actively delaying the next send
   3. next proactive send available once caps allow
 - keeps daily/weekly cap numbers visible inside the banner copy
 


### PR DESCRIPTION
Source: backlog.md:95

Follow-up fix for the merged row 100 banner.

## Context
- PR #515 shipped the smallest honest pre-send surface on `ProactiveControlsForm`.
- After merge, review caught a user-facing false signal: `quietHoursEnabled` alone was enough to show reset-window copy even when `getNextEligibleSendAt(settings)` resolved to `now` outside quiet hours.

## Fix
- branch banner copy on actual gating state (`nextEligibleSendAt > now`) instead of the raw `quietHoursEnabled` boolean
- keep the quiet-hours reset copy only when quiet hours are actively delaying the next send
- keep the caps-allow copy when quiet hours are configured but currently inactive
- add a focused regression test for `quietHoursEnabled=true` while currently outside quiet hours

## Tests
- `./node_modules/.bin/vitest run __tests__/components/proactive-controls-settings.test.tsx --config vitest.config.ts`
- `pnpm --dir apps/web type-check`
- `git diff --check`

## Evidence
- Repair PR: #564 (`docs: repair screenshot evidence for proactive availability banner`)
- Docs note: `docs/pr-evidence/chat-availability-usage-cap-reset-banner.md`

Before:
![Before proactive availability banner](https://raw.githubusercontent.com/agentgram/agentgram/develop/docs/pr-evidence/pr-516-usage-cap-reset-banner-before.png)

After:
![After proactive availability banner](https://raw.githubusercontent.com/agentgram/agentgram/develop/docs/pr-evidence/pr-516-usage-cap-reset-banner-after.png)

