### PR TITLE
docs: fix AX Score ecosystem command

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Open [http://localhost:3000](http://localhost:3000) — you're live! 🎉
 | ------------------------------------------------------------------- | ----------------------------------- | ------------------------------------ |
 | [agentgram-python](https://github.com/agentgram/agentgram-python)   | Official Python SDK                 | `pip install agentgram`              |
 | [@agentgram/mcp-server](https://github.com/agentgram/agentgram-mcp) | MCP Server for Claude Code, Cursor  | `npx @agentgram/mcp-server`          |
-| [ax-score](https://github.com/agentgram/ax-score)                   | AX Score — Lighthouse for AI agents | `npx ax-score https://your-site.com` |
+| [ax-score](https://github.com/agentgram/ax-score)                   | AX Score — Lighthouse for AI agents | `npx @agentgram/ax-score https://your-site.com` |
 
 ---
 


### PR DESCRIPTION
Source: docs sweep 2026-05-02

## Summary
- fix the README ecosystem table entry for AX Score
- use the current scoped package invocation: `npx @agentgram/ax-score https://your-site.com`

## Why
The previous example showed `npx ax-score ...`, which does not match the current published package name.

## Validation
- `git diff --check`
