### PR TITLE
feat: add Top Discussed agent directory sort

### DIFF
--- a/apps/web/__tests__/api/agents.test.ts
+++ b/apps/web/__tests__/api/agents.test.ts
@@ -13,11 +13,19 @@ const mockOrder = vi.fn().mockReturnThis();
 const mockRange = vi.fn().mockReturnThis();
 const mockOr = vi.fn().mockReturnThis();
 const mockContains = vi.fn().mockReturnThis();
+const mockIn = vi.fn();
+const mockIs = vi.fn();
 const mockRemixIlike = vi.fn();
 const mockSelect = vi.fn((columns: string) => {
   if (columns === 'description') {
     return {
       ilike: mockRemixIlike,
+    };
+  }
+
+  if (columns === 'author_id, comment_count') {
+    return {
+      in: mockIn,
     };
   }
 
@@ -51,6 +59,13 @@ describe('GET /api/v1/agents', () => {
     vi.clearAllMocks();
     mockOrder.mockReturnThis();
     mockContains.mockReturnThis();
+    mockIn.mockReturnValue({ is: mockIs });
+    mockIs.mockResolvedValue({
+      data: [
+        { author_id: 'agent-1', comment_count: 2 },
+      ],
+      error: null,
+    });
     mockRange.mockResolvedValue({
       data: [
         {
@@ -303,5 +318,106 @@ describe('GET /api/v1/agents', () => {
     expect(mockContains).toHaveBeenNthCalledWith(2, 'metadata', {
       capabilities: { group_chat: true },
     });
+  });
+
+  it('should support discussed sort using total comments received on each agent\'s posts', async () => {
+    mockRange
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 'agent-1',
+            name: 'test-agent',
+            display_name: 'Test Agent',
+            description: 'A test agent',
+            public_key: null,
+            email: null,
+            email_verified: true,
+            avatar_url: null,
+            axp: 100,
+            post_count: 2,
+            status: 'active',
+            trust_score: 0.5,
+            metadata: {},
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            last_active: '2026-01-03T00:00:00Z',
+            developer: { display_name: 'Ralph' },
+          },
+        ],
+        error: null,
+        count: 2,
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 'agent-1',
+            name: 'test-agent',
+            display_name: 'Test Agent',
+            description: 'A test agent',
+            public_key: null,
+            email: null,
+            email_verified: true,
+            avatar_url: null,
+            axp: 100,
+            post_count: 2,
+            status: 'active',
+            trust_score: 0.5,
+            metadata: {},
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            last_active: '2026-01-03T00:00:00Z',
+            developer: { display_name: 'Ralph' },
+          },
+          {
+            id: 'agent-2',
+            name: 'chatty-agent',
+            display_name: 'Chatty Agent',
+            description: 'Gets lots of replies',
+            public_key: null,
+            email: null,
+            email_verified: true,
+            avatar_url: null,
+            axp: 20,
+            post_count: 1,
+            status: 'active',
+            trust_score: 0.1,
+            metadata: {},
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            last_active: '2026-01-04T00:00:00Z',
+            developer: { display_name: 'Nori' },
+          },
+        ],
+        error: null,
+        count: 2,
+      });
+    mockIs.mockResolvedValueOnce({
+      data: [
+        { author_id: 'agent-1', comment_count: 1 },
+        { author_id: 'agent-2', comment_count: 5 },
+      ],
+      error: null,
+    });
+    mockRemixIlike.mockResolvedValueOnce({
+      data: [
+        { description: 'Inspired by @chatty-agent: first remix' },
+      ],
+      error: null,
+    });
+
+    const { GET } = await import('../../app/api/v1/agents/route');
+    const request = new Request(
+      'http://localhost/api/v1/agents?sort=discussed&limit=10'
+    );
+    const response = await GET(request as unknown as Parameters<typeof GET>[0]);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data.map((agent: { name: string }) => agent.name)).toEqual([
+      'chatty-agent',
+      'test-agent',
+    ]);
+    expect(mockIn).toHaveBeenCalledWith('author_id', ['agent-1', 'agent-2']);
+    expect(mockIs).toHaveBeenCalledWith('original_post_id', null);
   });
 });

--- a/apps/web/__tests__/api/agents.test.ts
+++ b/apps/web/__tests__/api/agents.test.ts
@@ -320,6 +320,49 @@ describe('GET /api/v1/agents', () => {
     });
   });
 
+  it('should return 500 when discussed sort full fetch fails after count succeeds', async () => {
+    mockRange
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 'agent-1',
+            name: 'test-agent',
+            display_name: 'Test Agent',
+            description: 'A test agent',
+            public_key: null,
+            email: null,
+            email_verified: true,
+            avatar_url: null,
+            axp: 100,
+            status: 'active',
+            trust_score: 0.5,
+            metadata: {},
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            last_active: '2026-01-03T00:00:00Z',
+            developer: { display_name: 'Ralph' },
+          },
+        ],
+        error: null,
+        count: 1,
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'failed full fetch' },
+        count: 1,
+      });
+
+    const { GET } = await import('../../app/api/v1/agents/route');
+    const request = new Request(
+      'http://localhost/api/v1/agents?sort=discussed&limit=10'
+    );
+    const response = await GET(request as unknown as Parameters<typeof GET>[0]);
+    const json = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(json.success).toBe(false);
+  });
+
   it('should support discussed sort using total comments received on each agent\'s posts', async () => {
     mockRange
       .mockResolvedValueOnce({

--- a/apps/web/__tests__/components/agents-directory-content.test.tsx
+++ b/apps/web/__tests__/components/agents-directory-content.test.tsx
@@ -81,4 +81,25 @@ describe('AgentsPageContent capability browse controls', () => {
       })
     );
   });
+
+  it('accepts the discussed sort and keeps it in the rendered directory props', () => {
+    searchParamsState.value = new URLSearchParams('sort=discussed&page=2');
+
+    render(<AgentsPageContent />);
+
+    expect(screen.getByRole('link', { name: /top discussed/i })).toHaveAttribute(
+      'href',
+      '/agents?sort=discussed'
+    );
+    expect(screen.getByTestId('agents-list-props')).toHaveTextContent(
+      JSON.stringify({
+        sort: 'discussed',
+        page: 2,
+        search: '',
+        voice: false,
+        group_chat: false,
+        roleplay: false,
+      })
+    );
+  });
 });

--- a/apps/web/app/(public)/agents/content.tsx
+++ b/apps/web/app/(public)/agents/content.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { Bot, TrendingUp, Activity } from 'lucide-react';
+import { Bot, TrendingUp, Activity, MessageSquareMore } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { SearchBar, PageContainer } from '@/components/common';
 import { AgentsList } from '@/components/agents';
@@ -13,10 +13,11 @@ import {
   isCapabilityFilterEnabled,
 } from '@/lib/agents/capabilities';
 
-type AgentsSort = 'axp' | 'active' | 'new';
+type AgentsSort = 'axp' | 'active' | 'discussed' | 'new';
 
 function parseSort(value: string | null): AgentsSort {
   if (value === 'active') return 'active';
+  if (value === 'discussed') return 'discussed';
   if (value === 'new') return 'new';
   return 'axp';
 }
@@ -155,6 +156,16 @@ export default function AgentsPageContent() {
           <Link href={createHref({ sort: 'active', page: null })}>
             <Activity className="h-4 w-4" />
             Most Active
+          </Link>
+        </Button>
+        <Button
+          variant={sort === 'discussed' ? 'default' : 'outline'}
+          className="gap-2"
+          asChild
+        >
+          <Link href={createHref({ sort: 'discussed', page: null })}>
+            <MessageSquareMore className="h-4 w-4" />
+            Top Discussed
           </Link>
         </Button>
         <Button

--- a/apps/web/app/api/v1/agents/route.ts
+++ b/apps/web/app/api/v1/agents/route.ts
@@ -9,6 +9,7 @@ import {
   transformAgent,
 } from '@agentgram/shared';
 import { getRemixCountsBySourceNames } from '@/lib/agents/remix-counts';
+
 function isCapabilityFilterEnabled(value: string | null): boolean {
   if (value == null) {
     return false;
@@ -17,11 +18,20 @@ function isCapabilityFilterEnabled(value: string | null): boolean {
   return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
 }
 
+function getTimestamp(value: string | null | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 // GET /api/v1/agents - Fetch agent directory
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
-    const sort = searchParams.get('sort') || 'axp';
+    const requestedSort = searchParams.get('sort') || 'axp';
+    const sort = ['axp', 'active', 'discussed', 'new'].includes(requestedSort)
+      ? requestedSort
+      : 'axp';
     const page = Math.max(
       1,
       Math.min(parseInt(searchParams.get('page') || '1', 10) || 1, 10000)
@@ -40,59 +50,134 @@ export async function GET(req: NextRequest) {
 
     const supabase = getSupabaseClient();
 
-    let query = supabase.from('agents').select(
-      `
-        id,
-        name,
-        display_name,
-        description,
-        public_key,
-        email,
-        email_verified,
-        axp,
-        status,
-        trust_score,
-        metadata,
-        avatar_url,
-        created_at,
-        updated_at,
-        last_active,
-        developer:developers(display_name)
-      `,
-      { count: 'exact' }
-    );
-
-    // Search filter (escape SQL wildcards to prevent pattern injection)
-    if (search) {
-      const escaped = search.replace(/[%_\\]/g, '\\$&');
-      query = query.or(
-        `name.ilike.%${escaped}%,display_name.ilike.%${escaped}%,description.ilike.%${escaped}%`
+    const buildAgentsQuery = () => {
+      let query = supabase.from('agents').select(
+        `
+          id,
+          name,
+          display_name,
+          description,
+          public_key,
+          email,
+          email_verified,
+          axp,
+          status,
+          trust_score,
+          metadata,
+          avatar_url,
+          created_at,
+          updated_at,
+          last_active,
+          developer:developers(display_name)
+        `,
+        { count: 'exact' }
       );
-    }
 
-    for (const capability of enabledCapabilities) {
-      query = query.contains('metadata', {
-        capabilities: {
-          [capability]: true,
-        },
-      });
-    }
+      if (search) {
+        const escaped = search.replace(/[%_\\]/g, '\\$&');
+        query = query.or(
+          `name.ilike.%${escaped}%,display_name.ilike.%${escaped}%,description.ilike.%${escaped}%`
+        );
+      }
 
-    // Sorting
-    if (sort === 'axp') {
-      query = query.order('axp', { ascending: false });
-    } else if (sort === 'active') {
-      query = query.order('last_active', { ascending: false });
-    } else if (sort === 'new') {
-      query = query.order('created_at', { ascending: false });
-    }
+      for (const capability of enabledCapabilities) {
+        query = query.contains('metadata', {
+          capabilities: {
+            [capability]: true,
+          },
+        });
+      }
+
+      return query;
+    };
 
     // Pagination
     const from = (page - 1) * limit;
     const to = from + limit - 1;
-    query = query.range(from, to);
 
-    const { data: agents, error, count } = await query;
+    let agents;
+    let error;
+    let count;
+
+    if (sort === 'discussed') {
+      const { error: countError, count: totalCount } = await buildAgentsQuery()
+        .range(0, 0);
+
+      if (countError) {
+        console.error('Agents query error:', countError);
+        return jsonResponse(
+          ErrorResponses.databaseError('Failed to fetch agents'),
+          500
+        );
+      }
+
+      count = totalCount || 0;
+      const allAgents = count === 0
+        ? []
+        : (
+            await buildAgentsQuery().range(0, Math.max(count - 1, 0))
+          ).data || [];
+      error = null;
+
+      const discussionCounts = new Map<string, number>();
+
+      if (allAgents.length > 0) {
+        const { data: discussionRows, error: discussionError } = await supabase
+          .from('posts')
+          .select('author_id, comment_count')
+          .in(
+            'author_id',
+            allAgents.map((agent) => agent.id)
+          )
+          .is('original_post_id', null);
+
+        if (discussionError) {
+          console.error('Agent discussion query error:', discussionError);
+          return jsonResponse(
+            ErrorResponses.databaseError('Failed to fetch agents'),
+            500
+          );
+        }
+
+        for (const row of discussionRows || []) {
+          if (!row.author_id) continue;
+
+          discussionCounts.set(
+            row.author_id,
+            (discussionCounts.get(row.author_id) || 0) + (row.comment_count || 0)
+          );
+        }
+      }
+
+      agents = [...allAgents]
+        .sort((a, b) => {
+          const discussionDelta =
+            (discussionCounts.get(b.id) || 0) - (discussionCounts.get(a.id) || 0);
+          if (discussionDelta !== 0) return discussionDelta;
+
+          const lastActiveDelta =
+            getTimestamp(b.last_active) - getTimestamp(a.last_active);
+          if (lastActiveDelta !== 0) return lastActiveDelta;
+
+          return (b.axp || 0) - (a.axp || 0);
+        })
+        .slice(from, to + 1);
+    } else {
+      let query = buildAgentsQuery();
+
+      if (sort === 'axp') {
+        query = query.order('axp', { ascending: false });
+      } else if (sort === 'active') {
+        query = query.order('last_active', { ascending: false });
+      } else if (sort === 'new') {
+        query = query.order('created_at', { ascending: false });
+      }
+
+      const result = await query.range(from, to);
+      agents = result.data;
+      error = result.error;
+      count = result.count;
+    }
 
     if (error) {
       console.error('Agents query error:', error);

--- a/apps/web/app/api/v1/agents/route.ts
+++ b/apps/web/app/api/v1/agents/route.ts
@@ -112,11 +112,20 @@ export async function GET(req: NextRequest) {
       }
 
       count = totalCount || 0;
-      const allAgents = count === 0
-        ? []
-        : (
-            await buildAgentsQuery().range(0, Math.max(count - 1, 0))
-          ).data || [];
+      const { data: fullFetchData, error: allAgentsError } =
+        count === 0
+          ? { data: [], error: null }
+          : await buildAgentsQuery().range(0, Math.max(count - 1, 0));
+
+      if (allAgentsError) {
+        console.error('Agents query error:', allAgentsError);
+        return jsonResponse(
+          ErrorResponses.databaseError('Failed to fetch agents'),
+          500
+        );
+      }
+
+      const allAgents = fullFetchData ?? [];
       error = null;
 
       const discussionCounts = new Map<string, number>();

--- a/apps/web/components/agents/AgentsList.tsx
+++ b/apps/web/components/agents/AgentsList.tsx
@@ -9,7 +9,7 @@ import { EmptyState, ErrorAlert } from '@/components/common';
 import { PaginationNav } from '@/components/common';
 
 interface AgentsListProps {
-  sort?: 'axp' | 'new' | 'active';
+  sort?: 'axp' | 'new' | 'active' | 'discussed';
   limit?: number;
   page?: number;
   search?: string;

--- a/apps/web/hooks/use-agents-directory.ts
+++ b/apps/web/hooks/use-agents-directory.ts
@@ -4,7 +4,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { API_BASE_PATH, PAGINATION } from '@agentgram/shared';
 import type { DirectoryCapabilities } from '@/lib/agents/capabilities';
 
-export type AgentsDirectorySort = 'axp' | 'active' | 'new';
+export type AgentsDirectorySort = 'axp' | 'active' | 'discussed' | 'new';
 export type AgentsDirectoryCapabilityKey = keyof DirectoryCapabilities;
 
 export type AgentsDirectoryAgent = {


### PR DESCRIPTION
Source: `~/.openclaw/shared/knowledge/agentgram/2026-05-02-agentgram-research.md` §핵심 발견 4 / backlog row 96

## Summary
- add a `Top Discussed` sort to the public `/agents` directory
- thread the new `discussed` sort through the page state, query hook, and list props
- rank discussed agents by total comments received across their posts after the filtered agent query

## Why
Observer-friendly discovery is still missing a “what conversations are actually getting replies?” lane. `Most Active` was already present, but there was no companion sort for agents whose posts are generating discussion.

## Validation
- `pnpm test -- --config vitest.config.ts __tests__/api/agents.test.ts __tests__/components/agents-directory-content.test.tsx`
- `pnpm type-check`
- `pnpm lint` (passes with existing repo warnings only)
- `git diff --check`
