### PR TITLE
refactor: require verification artifact pack in PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,26 @@
 
 <!-- Provide a brief description of the changes in this PR -->
 
+## Verification Artifact Pack
+
+<!-- Required before review/merge. See docs/pr-evidence/row-97-verification-artifact-pack.md for examples. -->
+
+## Source
+
+Source: backlog.md:ROW or #ISSUE
+
+## Evidence
+
+- Docs/example diff:
+- Screenshot/live-proof:
+- Validation:
+
+## Auth-only Proof
+
+<!-- Auth-gated lanes must paste an authenticated curl/test snippet here. Non-auth lanes must write explicit N/A. -->
+
+N/A
+
 ## Type of Change
 
 <!-- Mark the relevant option(s) with an "x" -->
@@ -31,9 +51,9 @@
 
 <!-- List the main changes in this PR -->
 
-- 
-- 
-- 
+-
+-
+-
 
 ## Related Issues
 
@@ -54,9 +74,9 @@
 
 <!-- Provide steps for reviewers to test your changes -->
 
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 ## Breaking Changes
 
@@ -74,16 +94,12 @@
 
 - [ ] My code follows the project's code style
 - [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have added the required source, evidence, and auth-only proof above
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published
-
-## Screenshots (if applicable)
-
-<!-- Add screenshots or GIFs to help explain your changes -->
 
 ## Additional Notes
 

--- a/.github/workflows/pr-artifact-pack.yml
+++ b/.github/workflows/pr-artifact-pack.yml
@@ -1,0 +1,31 @@
+name: PR Artifact Pack Guard
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+    branches: [main, develop]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-pr-artifact-pack:
+    name: Validate PR verification artifact pack
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Validate PR body
+        run: node scripts/validate-pr-body.mjs
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}

--- a/docs/pr-evidence/row-97-verification-artifact-pack.md
+++ b/docs/pr-evidence/row-97-verification-artifact-pack.md
@@ -1,0 +1,55 @@
+# Row 97 — PR verification artifact pack
+
+Source: backlog.md:97
+
+## What this refactor enforces
+
+- Every PR must declare a concrete source: backlog row or issue.
+- Every PR must attach reviewer-facing evidence: screenshot/live-proof or docs/example diff.
+- Every PR must fill `## Auth-only Proof` with either:
+  - an authenticated curl/test snippet for auth-gated lanes, or
+  - explicit `N/A` for non-auth lanes.
+
+## Auth-gated lane rule
+
+A PR is treated as auth-gated when any of these are true:
+
+- the PR has the `area: auth` label
+- the `🔐 Authentication (`area: auth`)` checkbox is checked in the PR body
+- the PR title/body explicitly says `auth-gated`
+
+Auth-gated PRs cannot leave `## Auth-only Proof` as `N/A`.
+
+## Acceptable evidence examples
+
+- Docs/example diff: `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/pr-artifact-pack.yml`, `scripts/validate-pr-body.mjs`
+- Screenshot/live-proof: `docs/pr-evidence/pr-446-live-explore.png`
+- Validation command: `node --test scripts/__tests__/validate-pr-body.test.mjs`
+
+## Auth-only Proof examples
+
+### Non-auth lane
+
+```md
+## Auth-only Proof
+
+N/A
+```
+
+### Auth-gated lane
+
+````md
+## Auth-only Proof
+
+```bash
+curl -H "Authorization: Bearer $SESSION_TOKEN" https://agentgram.local/api/private/me
+pnpm --filter web exec vitest run __tests__/api/agents-register.test.ts
+```
+````
+
+## Files that implement the guard
+
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/workflows/pr-artifact-pack.yml`
+- `scripts/validate-pr-body.mjs`
+- `scripts/__tests__/validate-pr-body.test.mjs`

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
     "test": "turbo run test",
+    "test:pr-body-guard": "node --test scripts/__tests__/validate-pr-body.test.mjs",
+    "verify:pr-body": "node scripts/validate-pr-body.mjs",
     "verify:legacy-routes": "node scripts/verify-legacy-routes.mjs",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "db:types": "npx supabase gen types typescript --linked > packages/db/src/types.ts",

--- a/scripts/__tests__/validate-pr-body.test.mjs
+++ b/scripts/__tests__/validate-pr-body.test.mjs
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { validatePrArtifactPack } from '../validate-pr-body.mjs';
+
+const nonAuthBody = `## Source
+Source: backlog.md:97
+
+## Evidence
+- Docs/example diff: docs/pr-evidence/row-97-verification-artifact-pack.md
+- Validation: \`node --test scripts/__tests__/validate-pr-body.test.mjs\`
+
+## Auth-only Proof
+N/A
+`;
+
+test('passes a non-auth PR with docs diff evidence and explicit N/A auth proof', () => {
+  const result = validatePrArtifactPack({
+    title: 'refactor: require verification artifact pack in PRs',
+    body: nonAuthBody,
+    labels: ['type: refactor'],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.authGated, false);
+});
+
+test('fails when source does not cite a backlog row or issue', () => {
+  const result = validatePrArtifactPack({
+    title: 'refactor: require verification artifact pack in PRs',
+    body: nonAuthBody.replace(
+      'Source: backlog.md:97',
+      'Source: follow-up cleanup'
+    ),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(
+    result.errors.join('\n'),
+    /## Source must cite a backlog row or issue/
+  );
+});
+
+test('fails when evidence is placeholder-only', () => {
+  const result = validatePrArtifactPack({
+    title: 'refactor: require verification artifact pack in PRs',
+    body: nonAuthBody.replace(
+      '- Docs/example diff: docs/pr-evidence/row-97-verification-artifact-pack.md\n- Validation: `node --test scripts/__tests__/validate-pr-body.test.mjs`',
+      '-'
+    ),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /## Evidence must be filled/);
+});
+
+test('fails auth-gated PRs that mark auth proof as N/A', () => {
+  const result = validatePrArtifactPack({
+    title: 'feat: auth-gated rollout',
+    body: nonAuthBody,
+    labels: ['area: auth'],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.authGated, true);
+  assert.match(result.errors.join('\n'), /cannot be `N\/A`/);
+});
+
+test('passes auth-gated PRs with an authenticated curl snippet', () => {
+  const result = validatePrArtifactPack({
+    title: 'feat: tighten auth proof checks',
+    labels: ['area: auth'],
+    body: `## Source
+Source: #97
+
+## Evidence
+- Screenshot/live-proof: docs/pr-evidence/pr-446-live-explore.png
+- Validation: \`pnpm --filter web exec vitest run\`
+
+## Auth-only Proof
+\`\`\`bash
+curl -H "Authorization: Bearer $SESSION_TOKEN" https://agentgram.local/api/private/me
+\`\`\`
+`,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.authGated, true);
+});

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REQUIRED_SECTION_TITLES = ['Source', 'Evidence', 'Auth-only Proof'];
+const PLACEHOLDER_LINE_PATTERNS = [
+  /^[-*]\s*$/,
+  /^tbd$/i,
+  /^todo$/i,
+  /^same as above$/i,
+  /^fill (this )?in$/i,
+  /^placeholder$/i,
+  /^coming soon$/i,
+];
+const SOURCE_REFERENCE_PATTERN =
+  /(Source:\s*)?(backlog\.md:\d+|#\d+|https?:\/\/\S+)/i;
+const EVIDENCE_SIGNAL_PATTERN =
+  /(docs\/|\.png\b|\.jpe?g\b|\.gif\b|\.webp\b|\.html\b|\.md\b|screenshot|live[- ]proof|docs\/example diff|diff|validation|test)/i;
+const AUTH_SNIPPET_SIGNAL_PATTERN =
+  /```[\s\S]+```|`[^`]+`|\bcurl\b|\bpnpm\b|\bvitest\b|\bplaywright\b|\bauthorization\b|\bbearer\b|\bcookie\b|\bsession\b|\btoken\b/i;
+const EXPLICIT_NA_PATTERN =
+  /^(?:[-*]\s*)?(?:`)?(?:n\/a|na|not applicable)(?:`)?$/i;
+
+function stripComments(text) {
+  return text.replace(/<!--[\s\S]*?-->/g, '').trim();
+}
+
+function normalizeSectionContent(text) {
+  return stripComments(text)
+    .replace(/\r/g, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+}
+
+function isPlaceholderOnly(text) {
+  const normalized = normalizeSectionContent(text);
+  if (!normalized) {
+    return true;
+  }
+
+  const lines = normalized
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.every((line) =>
+    PLACEHOLDER_LINE_PATTERNS.some((pattern) => pattern.test(line))
+  );
+}
+
+function isExplicitNa(text) {
+  const normalized = normalizeSectionContent(text);
+  if (!normalized) {
+    return false;
+  }
+
+  const lines = normalized
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return (
+    lines.length > 0 && lines.every((line) => EXPLICIT_NA_PATTERN.test(line))
+  );
+}
+
+function parseSections(body) {
+  const buckets = Object.fromEntries(
+    REQUIRED_SECTION_TITLES.map((title) => [title, []])
+  );
+  let currentTitle = null;
+
+  for (const line of body.replace(/\r/g, '').split('\n')) {
+    const headingMatch = line.match(/^##\s+(.*?)\s*$/);
+    if (headingMatch) {
+      const candidate = headingMatch[1].trim();
+      currentTitle = REQUIRED_SECTION_TITLES.includes(candidate)
+        ? candidate
+        : null;
+      continue;
+    }
+
+    if (currentTitle) {
+      buckets[currentTitle].push(line);
+    }
+  }
+
+  return Object.fromEntries(
+    REQUIRED_SECTION_TITLES.map((title) => [
+      title,
+      buckets[title].join('\n').trim(),
+    ])
+  );
+}
+
+function hasCheckedAuthArea(body) {
+  return /^- \[[xX]\].*`area: auth`/m.test(body);
+}
+
+function isAuthGated({
+  title = '',
+  body = '',
+  labels = [],
+  requireAuthProof,
+} = {}) {
+  if (typeof requireAuthProof === 'boolean') {
+    return requireAuthProof;
+  }
+
+  const normalizedLabels = labels.map((label) =>
+    String(label).trim().toLowerCase()
+  );
+  return (
+    normalizedLabels.includes('area: auth') ||
+    hasCheckedAuthArea(body) ||
+    /\bauth[- ]gated\b/i.test(`${title}\n${body}`)
+  );
+}
+
+export function validatePrArtifactPack({
+  title = '',
+  body = '',
+  labels = [],
+  requireAuthProof,
+} = {}) {
+  const errors = [];
+  const normalizedBody = String(body || '')
+    .replace(/\r/g, '')
+    .trim();
+
+  if (!normalizedBody) {
+    return {
+      ok: false,
+      authGated: isAuthGated({ title, body, labels, requireAuthProof }),
+      errors: [
+        'PR body is empty. Fill out the required verification artifact pack sections.',
+      ],
+      sections: parseSections(''),
+    };
+  }
+
+  const sections = parseSections(normalizedBody);
+  const authGated = isAuthGated({
+    title,
+    body: normalizedBody,
+    labels,
+    requireAuthProof,
+  });
+
+  const source = sections.Source;
+  if (
+    !source ||
+    isPlaceholderOnly(source) ||
+    !SOURCE_REFERENCE_PATTERN.test(source)
+  ) {
+    errors.push(
+      '## Source must cite a backlog row or issue (for example `Source: backlog.md:97` or `Source: #123`).'
+    );
+  }
+
+  const evidence = sections.Evidence;
+  if (!evidence || isPlaceholderOnly(evidence) || isExplicitNa(evidence)) {
+    errors.push(
+      '## Evidence must be filled with screenshot/live-proof or docs/example diff details.'
+    );
+  } else if (!EVIDENCE_SIGNAL_PATTERN.test(evidence)) {
+    errors.push(
+      '## Evidence must reference a concrete artifact such as a docs/example diff, screenshot, live-proof, or validation command.'
+    );
+  }
+
+  const authProof = sections['Auth-only Proof'];
+  if (!authProof || isPlaceholderOnly(authProof)) {
+    errors.push(
+      '## Auth-only Proof is required. Use an authenticated curl/test snippet for auth-gated lanes, otherwise write explicit `N/A`.'
+    );
+  } else if (authGated) {
+    if (isExplicitNa(authProof)) {
+      errors.push(
+        '## Auth-only Proof cannot be `N/A` when the PR is auth-gated (`area: auth` label/checkbox or auth-gated title/body).'
+      );
+    } else if (!AUTH_SNIPPET_SIGNAL_PATTERN.test(authProof)) {
+      errors.push(
+        '## Auth-only Proof must include an authenticated curl/test snippet when the PR is auth-gated.'
+      );
+    }
+  } else if (
+    !(isExplicitNa(authProof) || AUTH_SNIPPET_SIGNAL_PATTERN.test(authProof))
+  ) {
+    errors.push(
+      '## Auth-only Proof must be explicit `N/A` for non-auth lanes or include an authenticated curl/test snippet.'
+    );
+  }
+
+  return { ok: errors.length === 0, authGated, errors, sections };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) {
+      continue;
+    }
+
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (next && !next.startsWith('--')) {
+      args[key] = next;
+      index += 1;
+    } else {
+      args[key] = 'true';
+    }
+  }
+  return args;
+}
+
+function loadEventPayload() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(readFileSync(eventPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function coerceBoolean(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value === 'true';
+}
+
+function loadInput(argv) {
+  const args = parseArgs(argv);
+  const event = loadEventPayload();
+  const eventPr = event?.pull_request;
+  const bodyFromFile = args['body-file']
+    ? readFileSync(resolve(args['body-file']), 'utf8')
+    : undefined;
+  const labelsFromJson = args['labels-json'] ?? process.env.PR_LABELS_JSON;
+
+  return {
+    title: args.title ?? process.env.PR_TITLE ?? eventPr?.title ?? '',
+    body:
+      bodyFromFile ?? args.body ?? process.env.PR_BODY ?? eventPr?.body ?? '',
+    labels: labelsFromJson
+      ? JSON.parse(labelsFromJson)
+      : (eventPr?.labels ?? []).map((label) => label.name),
+    requireAuthProof: coerceBoolean(
+      args['auth-gated'] ?? process.env.PR_AUTH_GATED
+    ),
+  };
+}
+
+function main() {
+  const result = validatePrArtifactPack(loadInput(process.argv.slice(2)));
+
+  if (!result.ok) {
+    console.error('PR artifact pack validation failed:');
+    for (const error of result.errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `PR artifact pack validation passed (${result.authGated ? 'auth-gated' : 'non-auth'} lane).`
+  );
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+) {
+  main();
+}


### PR DESCRIPTION
## Description
Require a verification artifact pack in every PR so review/merge cannot advance without source, reviewer evidence, and auth-only proof coverage.

## Verification Artifact Pack

## Source
Source: backlog.md:97

## Evidence
- Docs/example diff: `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/pr-artifact-pack.yml`, `docs/pr-evidence/row-97-verification-artifact-pack.md`
- Validation: `node --test scripts/__tests__/validate-pr-body.test.mjs`, `node scripts/validate-pr-body.mjs --title 'refactor: require verification artifact pack in PRs' --body-file /tmp/pr-body-row-97.md`

## Auth-only Proof
N/A

## Type of Change
- [x] ♻️ Refactor (`type: refactor`)
- [x] 📚 Documentation (`type: documentation`)
- [x] 🧪 Testing (`area: testing`)

## Changes Made
- Added required Source / Evidence / Auth-only Proof sections to the PR template.
- Added a PR-body validator script, tests, and a workflow that fails placeholder-only submissions.
- Added a `docs/pr-evidence` helper with acceptable evidence and auth-gated proof examples.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Steps
1. `node --test scripts/__tests__/validate-pr-body.test.mjs`
2. `node scripts/validate-pr-body.mjs --title 'refactor: require verification artifact pack in PRs' --body-file /tmp/pr-body-row-97.md`

## Breaking Changes
- [x] ✅ No breaking changes

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added the required source, evidence, and auth-only proof above
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
