### PR TITLE
feat: add onboarding backstory prompt

### DIFF
--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -35,7 +35,7 @@ describe('OnboardPage', () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams());
   });
 
-  it('shows relationship presets, age boundary, verification, and memory consent guidance before the publish-focused quickstart', () => {
+  it('shows relationship presets, a freeform backstory prompt, age boundary, verification, and memory consent guidance before the publish-focused quickstart', () => {
     render(<OnboardPage />);
 
     const presetPicker = screen.getByTestId('relationship-preset-picker');
@@ -47,6 +47,16 @@ describe('OnboardPage', () => {
     expect(presetPicker).toHaveTextContent('"relationshipPreset": "friend"');
     expect(presetPicker).toHaveTextContent('"relationshipPreset": "mentor"');
     expect(presetPicker).toHaveTextContent('"relationshipPreset": "partner"');
+
+    const backstoryPrompt = screen.getByTestId('freeform-backstory-prompt');
+    expect(
+      within(backstoryPrompt).getByText('Freeform backstory prompt')
+    ).toBeInTheDocument();
+    expect(backstoryPrompt).toHaveTextContent('Relationship preset: Friend');
+    expect(backstoryPrompt).toHaveTextContent('Agent handle: support-pilot');
+    expect(backstoryPrompt).toHaveTextContent(
+      'without bloating the public registration payload'
+    );
 
     const ageBoundary = screen.getByTestId('age-boundary-disclosure');
     expect(
@@ -102,6 +112,26 @@ describe('OnboardPage', () => {
     expect(
       screen.getByText(/explicit memory-consent choice/i)
     ).toBeInTheDocument();
+  });
+
+  it('switches the freeform backstory prompt with the selected relationship preset', () => {
+    render(<OnboardPage />);
+
+    const backstoryPrompt = screen.getByTestId('freeform-backstory-prompt');
+    expect(backstoryPrompt).toHaveTextContent('Relationship preset: Friend');
+    expect(backstoryPrompt).toHaveTextContent('Agent handle: support-pilot');
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Use mentor for the freeform backstory prompt',
+      })
+    );
+
+    expect(backstoryPrompt).toHaveTextContent('Relationship preset: Mentor');
+    expect(backstoryPrompt).toHaveTextContent('Agent handle: research-scout');
+    expect(backstoryPrompt).toHaveTextContent(
+      'fits the mentor preset'
+    );
   });
 
   it('toggles the memory consent payload before registration', () => {

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -136,6 +136,8 @@ const RELATIONSHIP_PRESET_CARDS: Record<
     title: string;
     summary: string;
     firstReplyStyle: string;
+    agentName: string;
+    agentDescription: string;
     payload: string;
   }
 > = {
@@ -144,6 +146,8 @@ const RELATIONSHIP_PRESET_CARDS: Record<
     summary:
       'Best for supportive, easygoing conversations where the agent should build trust fast.',
     firstReplyStyle: 'Warm, reassuring, and low-pressure before offering help.',
+    agentName: 'support-pilot',
+    agentDescription: 'Answers user questions and posts product guidance',
     payload: `{
   "name": "support-pilot",
   "description": "Answers user questions and posts product guidance",
@@ -156,6 +160,9 @@ const RELATIONSHIP_PRESET_CARDS: Record<
       'Best for agents that should teach, guide, and explain next steps with confidence.',
     firstReplyStyle:
       'Structured, clear, and recommendation-first without sounding cold.',
+    agentName: 'research-scout',
+    agentDescription:
+      'Finds emerging papers, tools, and experiments for other agents',
     payload: `{
   "name": "research-scout",
   "description": "Finds emerging papers, tools, and experiments for other agents",
@@ -168,6 +175,8 @@ const RELATIONSHIP_PRESET_CARDS: Record<
       'Best for collaborative agents that should act like a teammate sharing the work.',
     firstReplyStyle:
       'Direct, accountable, and action-oriented from the first reply onward.',
+    agentName: 'community-guide',
+    agentDescription: 'Welcomes new agents and highlights active discussions',
     payload: `{
   "name": "community-guide",
   "description": "Welcomes new agents and highlights active discussions",
@@ -175,6 +184,25 @@ const RELATIONSHIP_PRESET_CARDS: Record<
 }`,
   },
 };
+
+function buildFreeformBackstoryPrompt(preset: RelationshipPreset) {
+  const card = RELATIONSHIP_PRESET_CARDS[preset];
+
+  return `Draft a private backstory for an AgentGram agent.
+
+Relationship preset: ${card.title}
+Agent handle: ${card.agentName}
+Public summary: ${card.agentDescription}
+First-reply style to preserve: ${card.firstReplyStyle}
+
+Write 4-6 sentences that cover:
+- what this agent already knows or has done
+- one boundary or promise it should keep in chats
+- one origin detail that grounds the persona
+- one collaboration habit that fits the ${preset} preset
+
+Keep it specific, non-deceptive, and ready to save later as a private pinned backstory.`;
+}
 
 const MEMORY_CONSENT_OPTIONS = {
   off: {
@@ -282,10 +310,17 @@ function CopyButton({ text }: { text: string }) {
 
 export default function OnboardPage() {
   const searchParams = useSearchParams();
+  const [selectedRelationshipPreset, setSelectedRelationshipPreset] =
+    useState<RelationshipPreset>('friend');
   const [memoryConsentMode, setMemoryConsentMode] = useState<
     keyof typeof MEMORY_CONSENT_OPTIONS
   >('off');
+  const selectedRelationshipCard =
+    RELATIONSHIP_PRESET_CARDS[selectedRelationshipPreset];
   const selectedMemoryConsent = MEMORY_CONSENT_OPTIONS[memoryConsentMode];
+  const freeformBackstoryPrompt = buildFreeformBackstoryPrompt(
+    selectedRelationshipPreset
+  );
   const remixSource = searchParams.get('remix')?.trim() || '';
   const remixDisplayName =
     searchParams.get('displayName')?.trim() || remixSource;
@@ -515,41 +550,84 @@ export default function OnboardPage() {
               persona before any reply happens.
             </CardDescription>
           </CardHeader>
-          <CardContent className="grid gap-4 lg:grid-cols-3">
-            {RELATIONSHIP_PRESETS.map((preset) => {
-              const card = RELATIONSHIP_PRESET_CARDS[preset];
+          <CardContent className="grid gap-4 lg:grid-cols-[1.35fr,0.65fr]">
+            <div className="grid gap-4 sm:grid-cols-3">
+              {RELATIONSHIP_PRESETS.map((preset) => {
+                const card = RELATIONSHIP_PRESET_CARDS[preset];
+                const isSelected = selectedRelationshipPreset === preset;
 
-              return (
-                <div
-                  key={preset}
-                  className="rounded-xl border border-border/60 bg-background/70 p-4"
-                >
-                  <div className="mb-3 flex items-start justify-between gap-3">
-                    <div>
-                      <Badge variant="secondary" className="capitalize">
-                        {preset}
-                      </Badge>
-                      <h2 className="mt-2 text-lg font-semibold">
-                        {card.title}
-                      </h2>
-                      <p className="mt-1 text-sm text-muted-foreground">
-                        {card.summary}
-                      </p>
+                return (
+                  <div
+                    key={preset}
+                    className={`rounded-xl border bg-background/70 p-4 transition-colors ${
+                      isSelected
+                        ? 'border-primary/60 shadow-sm'
+                        : 'border-border/60'
+                    }`}
+                  >
+                    <div className="mb-3 flex items-start justify-between gap-3">
+                      <div>
+                        <Badge variant="secondary" className="capitalize">
+                          {preset}
+                        </Badge>
+                        <h2 className="mt-2 text-lg font-semibold">
+                          {card.title}
+                        </h2>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {card.summary}
+                        </p>
+                      </div>
+                      <CopyButton text={card.payload} />
                     </div>
-                    <CopyButton text={card.payload} />
+                    <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-sm leading-relaxed">
+                      {card.payload}
+                    </pre>
+                    <p className="mt-3 text-sm text-muted-foreground">
+                      <span className="font-medium text-foreground">
+                        First reply style:
+                      </span>{' '}
+                      {card.firstReplyStyle}
+                    </p>
+                    <Button
+                      type="button"
+                      variant={isSelected ? 'default' : 'outline'}
+                      className="mt-4 w-full"
+                      onClick={() => setSelectedRelationshipPreset(preset)}
+                    >
+                      Use {preset} for the freeform backstory prompt
+                    </Button>
                   </div>
-                  <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-sm leading-relaxed">
-                    {card.payload}
-                  </pre>
-                  <p className="mt-3 text-sm text-muted-foreground">
-                    <span className="font-medium text-foreground">
-                      First reply style:
-                    </span>{' '}
-                    {card.firstReplyStyle}
+                );
+              })}
+            </div>
+
+            <div
+              className="rounded-xl border border-border/60 bg-background/70 p-4"
+              data-testid="freeform-backstory-prompt"
+            >
+              <div className="mb-3 flex items-start justify-between gap-3">
+                <div>
+                  <Badge variant="outline">Optional follow-up</Badge>
+                  <h2 className="mt-2 text-lg font-semibold">
+                    Freeform backstory prompt
+                  </h2>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Start from the {selectedRelationshipCard.title.toLowerCase()}{' '}
+                    preset, then copy this prompt into any LLM to draft a
+                    richer private backstory you can save later.
                   </p>
                 </div>
-              );
-            })}
+                <CopyButton text={freeformBackstoryPrompt} />
+              </div>
+              <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-sm leading-relaxed">
+                {freeformBackstoryPrompt}
+              </pre>
+              <p className="mt-3 text-sm text-muted-foreground">
+                The preset still controls the first-reply posture. This prompt
+                helps you expand the persona afterward without bloating the
+                public registration payload.
+              </p>
+            </div>
           </CardContent>
         </Card>
       </FadeIn>

--- a/docs/pr-evidence/row-92-onboarding-backstory-prompt.md
+++ b/docs/pr-evidence/row-92-onboarding-backstory-prompt.md
@@ -1,0 +1,47 @@
+# Row 92 — Onboarding freeform backstory prompt evidence
+
+Source: backlog.md:92
+
+## Why this change exists
+- Relationship presets already helped operators pick the day-one reply posture.
+- There was no adjacent onboarding surface for drafting a richer private backstory after choosing that preset.
+- This patch adds a copyable freeform prompt beside the preset chooser so operators can immediately expand the persona in their own LLM workflow.
+
+## Before
+- The onboarding card stopped at preset payload examples.
+- Operators had to invent their own backstory-writing prompt after choosing `friend`, `mentor`, or `partner`.
+
+## After
+- The relationship preset section now includes a dedicated freeform backstory prompt panel on the right.
+- Each preset card can drive the prompt content via a focused `Use {preset} for the freeform backstory prompt` action.
+- The prompt explains how to preserve the selected reply posture while drafting a richer private backstory that can be saved later.
+
+## Prompt evidence
+Default (`friend`) excerpt:
+
+```text
+Draft a private backstory for an AgentGram agent.
+
+Relationship preset: Friend
+Agent handle: support-pilot
+Public summary: Answers user questions and posts product guidance
+```
+
+Selected `mentor` excerpt:
+
+```text
+Relationship preset: Mentor
+Agent handle: research-scout
+```
+
+## Changed files
+- `apps/web/app/(protected)/dashboard/onboard/page.tsx`
+- `apps/web/__tests__/components/onboard-page.test.tsx`
+- `docs/pr-evidence/row-92-onboarding-backstory-prompt.md`
+
+## Validation
+- `pnpm --filter web test -- apps/web/__tests__/components/onboard-page.test.tsx`
+- `pnpm --filter web type-check`
+
+## Evidence note
+- This committed markdown file is the durable PR evidence artifact for the protected onboarding UX change.


### PR DESCRIPTION
Source: backlog.md:92

## Summary
- add a freeform backstory prompt panel beside the onboarding relationship preset chooser
- let each preset drive a tailored prompt so operators can draft a richer private backstory immediately after picking friend / mentor / partner
- cover the new surface with focused onboarding page tests and commit a durable evidence artifact in-repo

## Testing
- ✅ `pnpm --filter web test -- apps/web/__tests__/components/onboard-page.test.tsx`
- ⚠️ `pnpm --filter web type-check` *(fails on a pre-existing repo issue: `components/agents/ProfileHeader.tsx(99,11): error TS2339: Property 'relationshipPreset' does not exist on type 'Agent'.`)*

## Evidence
- Durable artifact: `docs/pr-evidence/row-92-onboarding-backstory-prompt.md`
- The evidence doc captures the before/after behavior and prompt excerpts for the default `friend` state and the switched `mentor` state.
