### PR TITLE
feat: show pinned-fact provenance in memory editor

### DIFF
--- a/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
+++ b/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  AgentPinnedFactsCard,
+  type AgentPinnedFactsSettings,
+} from '@/components/dashboard/AgentPinnedFactsCard';
+
+function buildSettings(
+  overrides: Partial<AgentPinnedFactsSettings> = {}
+): AgentPinnedFactsSettings {
+  return {
+    agentId: 'agent-1',
+    agentLabel: 'Sage Bot',
+    facts: [
+      {
+        id: 'memory-1',
+        key: 'pinned_backstory',
+        value: 'Keeps release notes precise and audit-ready.',
+        category: 'profile_fact',
+        updatedAt: '2026-05-05T10:30:00.000Z',
+        originLabel: 'Registration description seed',
+        originSnippet: 'Keeps release notes precise.',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('AgentPinnedFactsCard', () => {
+  it('shows last-updated metadata and origin snippets for each pinned fact', () => {
+    render(<AgentPinnedFactsCard settings={buildSettings()} />);
+
+    expect(screen.getByText('Pinned facts for Sage Bot')).toBeInTheDocument();
+    expect(screen.getByTestId('pinned-fact-memory-1')).toHaveTextContent(
+      'Backstory'
+    );
+    expect(
+      screen.getByTestId('pinned-fact-updated-memory-1')
+    ).toHaveTextContent('Last updated');
+    expect(screen.getByTestId('pinned-fact-origin-memory-1')).toHaveTextContent(
+      'Registration description seed'
+    );
+    expect(screen.getByTestId('pinned-fact-origin-memory-1')).toHaveTextContent(
+      'Keeps release notes precise.'
+    );
+  });
+
+  it('renders an empty state when no pinned facts exist yet', () => {
+    render(
+      <AgentPinnedFactsCard
+        settings={buildSettings({
+          facts: [],
+        })}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        'No pinned facts yet. Seed one through registration or save a private fact to start building provenance here.'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -22,6 +22,11 @@ const mockProactiveControlsForm = vi.fn(
 const mockAgentDiaryForm = vi.fn(({ settings }: { settings: unknown }) => (
   <div data-testid="agent-diary-form">{JSON.stringify(settings)}</div>
 ));
+const mockAgentPinnedFactsCard = vi.fn(
+  ({ settings }: { settings: unknown }) => (
+    <div data-testid="agent-pinned-facts-card">{JSON.stringify(settings)}</div>
+  )
+);
 
 vi.mock('@/lib/supabase/server', () => ({
   createClient: mockCreateClient,
@@ -31,6 +36,7 @@ vi.mock('@/components/dashboard', () => ({
   FadeIn: mockFadeIn,
   AgentDiaryForm: mockAgentDiaryForm,
   AgentMemoryTrustForm: mockAgentMemoryTrustForm,
+  AgentPinnedFactsCard: mockAgentPinnedFactsCard,
   ProactiveControlsForm: mockProactiveControlsForm,
 }));
 
@@ -89,6 +95,7 @@ function createSettingsPageClient() {
                     name: 'sage-bot',
                     display_name: 'Sage Bot',
                     description: 'Keeps release notes precise.',
+                    metadata: {},
                   },
                 ],
               }),
@@ -107,6 +114,28 @@ function createSettingsPageClient() {
                     agent_id: 'agent-1',
                     name: 'Release Sage',
                     backstory: 'Trust-first release engineer.',
+                  },
+                ],
+              }),
+            }),
+          }),
+        };
+      }
+
+      if (table === 'agent_memories') {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({
+                data: [
+                  {
+                    id: 'memory-1',
+                    agent_id: 'agent-1',
+                    key: 'pinned_backstory',
+                    value: 'Keeps release notes precise and audit-ready.',
+                    category: 'profile_fact',
+                    created_at: '2026-05-04T10:00:00.000Z',
+                    updated_at: '2026-05-05T10:30:00.000Z',
                   },
                 ],
               }),
@@ -398,7 +427,26 @@ describe('SettingsPage', () => {
             description: 'Keeps release notes precise.',
             backstory: 'Trust-first release engineer.',
           },
-          initialDiaryEntries: [],
+        },
+      },
+      undefined
+    );
+    expect(mockAgentPinnedFactsCard).toHaveBeenCalledWith(
+      {
+        settings: {
+          agentId: 'agent-1',
+          agentLabel: 'Sage Bot',
+          facts: [
+            {
+              id: 'memory-1',
+              key: 'pinned_backstory',
+              value: 'Keeps release notes precise and audit-ready.',
+              category: 'profile_fact',
+              updatedAt: '2026-05-05T10:30:00.000Z',
+              originLabel: 'Registration description seed',
+              originSnippet: 'Keeps release notes precise.',
+            },
+          ],
         },
       },
       undefined
@@ -417,6 +465,7 @@ describe('SettingsPage', () => {
     expect(
       screen.getByTestId('agent-memory-trust-form')
     ).toBeInTheDocument();
+    expect(screen.getByTestId('agent-pinned-facts-card')).toBeInTheDocument();
     expect(screen.getByTestId('agent-diary-form')).toBeInTheDocument();
   });
 

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase/server';
 import {
   AgentDiaryForm,
   AgentMemoryTrustForm,
+  AgentPinnedFactsCard,
   FadeIn,
   ProactiveControlsForm,
 } from '@/components/dashboard';
@@ -14,6 +15,7 @@ import {
 } from '@/components/ui/card';
 import { readAgentDiaryFromMetadata } from '@/lib/agent-diary';
 import { readProactiveControlsFromMetadata } from '@/lib/proactive-controls';
+import type { AgentPinnedFactRecord } from '@/components/dashboard/AgentPinnedFactsCard';
 
 export const metadata = {
   title: 'Settings',
@@ -30,7 +32,64 @@ type AgentSettingsRecord = {
     backstory: string;
   };
   initialDiaryEntries: ReturnType<typeof readAgentDiaryFromMetadata>;
+  pinnedFacts: AgentPinnedFactRecord[];
 };
+
+type AgentMemoryRecord = {
+  id: string;
+  agent_id: string;
+  key: string;
+  value: string;
+  category: string;
+  created_at: string;
+  updated_at: string;
+};
+
+function truncateSnippet(value: string, max = 140) {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+
+  if (normalized.length <= max) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, max).trimEnd()}…`;
+}
+
+function buildOriginDetails(params: {
+  key: string;
+  value: string;
+  agentName: string;
+  agentLabel: string;
+  agentDescription: string;
+}) {
+  const { key, value, agentName, agentLabel, agentDescription } = params;
+
+  switch (key) {
+    case 'pinned_identity':
+      return {
+        originLabel: 'Registration identity seed',
+        originSnippet: `${agentLabel} appears publicly on AgentGram as @${agentName}.`,
+      };
+    case 'pinned_backstory':
+      return {
+        originLabel: 'Registration description seed',
+        originSnippet:
+          truncateSnippet(agentDescription) ||
+          'Registered without a custom description, so AgentGram created a generic backstory reminder.',
+      };
+    case 'pinned_origin_context':
+      return {
+        originLabel: 'Registration flow reminder',
+        originSnippet:
+          'Created by the AgentGram registration flow to keep origin/context guidance private by default.',
+      };
+    default:
+      return {
+        originLabel: 'Saved fact snapshot',
+        originSnippet: truncateSnippet(value),
+      };
+  }
+}
 
 export default async function SettingsPage() {
   const supabase = await createClient();
@@ -80,12 +139,42 @@ export default async function SettingsPage() {
           .eq('is_active', true)
       : { data: [] };
 
+  const { data: memories } =
+    agentIds.length > 0
+      ? await supabase
+          .from('agent_memories')
+          .select('id, agent_id, key, value, category, created_at, updated_at')
+          .in('agent_id', agentIds)
+          .order('updated_at', { ascending: false })
+      : { data: [] };
+
   const activePersonaByAgentId = new Map(
     (personas ?? []).map((persona) => [persona.agent_id, persona])
   );
 
+  const memoryRowsByAgentId = new Map<string, AgentMemoryRecord[]>();
+  for (const memory of (memories ?? []) as AgentMemoryRecord[]) {
+    const current = memoryRowsByAgentId.get(memory.agent_id) ?? [];
+    current.push(memory);
+    memoryRowsByAgentId.set(memory.agent_id, current);
+  }
+
   const trustSettings: AgentSettingsRecord[] = (agents ?? []).map((agent) => {
     const activePersona = activePersonaByAgentId.get(agent.id);
+    const pinnedFacts = (memoryRowsByAgentId.get(agent.id) ?? []).map((memory) => ({
+      id: memory.id,
+      key: memory.key,
+      value: memory.value,
+      category: memory.category,
+      updatedAt: memory.updated_at || memory.created_at,
+      ...buildOriginDetails({
+        key: memory.key,
+        value: memory.value,
+        agentName: agent.name,
+        agentLabel: agent.display_name || agent.name,
+        agentDescription: agent.description ?? '',
+      }),
+    }));
 
     return {
       agentId: agent.id,
@@ -98,6 +187,7 @@ export default async function SettingsPage() {
         backstory: activePersona?.backstory ?? '',
       },
       initialDiaryEntries: readAgentDiaryFromMetadata(agent.metadata),
+      pinnedFacts,
     };
   });
 
@@ -123,7 +213,22 @@ export default async function SettingsPage() {
           {trustSettings.length > 0 ? (
             trustSettings.map((settings) => (
               <div className="space-y-4" key={settings.agentId}>
-                <AgentMemoryTrustForm settings={settings} />
+                <AgentMemoryTrustForm
+                  settings={{
+                    agentId: settings.agentId,
+                    agentName: settings.agentName,
+                    agentLabel: settings.agentLabel,
+                    personaName: settings.personaName,
+                    initialSnapshot: settings.initialSnapshot,
+                  }}
+                />
+                <AgentPinnedFactsCard
+                  settings={{
+                    agentId: settings.agentId,
+                    agentLabel: settings.agentLabel,
+                    facts: settings.pinnedFacts,
+                  }}
+                />
                 <AgentDiaryForm
                   settings={{
                     agentId: settings.agentId,
@@ -143,8 +248,8 @@ export default async function SettingsPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="text-sm text-muted-foreground">
-                This digest and rollback flow appears here as soon as a claimed
-                agent exists in your dashboard.
+                This digest, pinned-fact provenance view, and rollback flow appear
+                here as soon as a claimed agent exists in your dashboard.
               </CardContent>
             </Card>
           )}

--- a/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
+++ b/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
@@ -1,0 +1,122 @@
+import { Clock3, Pin } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export interface AgentPinnedFactRecord {
+  id: string;
+  key: string;
+  value: string;
+  category: string;
+  updatedAt: string;
+  originLabel: string;
+  originSnippet: string;
+}
+
+export interface AgentPinnedFactsSettings {
+  agentId: string;
+  agentLabel: string;
+  facts: AgentPinnedFactRecord[];
+}
+
+interface AgentPinnedFactsCardProps {
+  settings: AgentPinnedFactsSettings;
+}
+
+function formatTimestamp(value: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value));
+}
+
+function formatFactLabel(key: string) {
+  const normalized = key.startsWith('pinned_') ? key.slice(7) : key;
+
+  return normalized
+    .split('_')
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
+
+function formatCategoryLabel(category: string) {
+  return category
+    .split('_')
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
+
+export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
+  return (
+    <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Pin className="h-5 w-5 text-primary" />
+          Pinned facts for {settings.agentLabel}
+        </CardTitle>
+        <CardDescription>
+          Review the private facts this agent keeps handy, plus when each one last
+          changed and what originally seeded it.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {settings.facts.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border/70 p-6 text-sm text-muted-foreground">
+            No pinned facts yet. Seed one through registration or save a private
+            fact to start building provenance here.
+          </div>
+        ) : (
+          settings.facts.map((fact) => (
+            <div
+              className="rounded-xl border border-border/60 bg-background/80 p-4"
+              data-testid={`pinned-fact-${fact.id}`}
+              key={fact.id}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="space-y-1">
+                  <div className="font-medium text-foreground">
+                    {formatFactLabel(fact.key)}
+                  </div>
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                    {formatCategoryLabel(fact.category)}
+                  </div>
+                </div>
+                <div
+                  className="flex items-center gap-2 text-xs text-muted-foreground"
+                  data-testid={`pinned-fact-updated-${fact.id}`}
+                >
+                  <Clock3 className="h-3.5 w-3.5" />
+                  Last updated {formatTimestamp(fact.updatedAt)}
+                </div>
+              </div>
+
+              <p className="mt-3 whitespace-pre-wrap text-sm text-foreground">
+                {fact.value}
+              </p>
+
+              <div
+                className="mt-4 rounded-lg border border-primary/15 bg-primary/5 p-3"
+                data-testid={`pinned-fact-origin-${fact.id}`}
+              >
+                <div className="text-xs font-medium uppercase tracking-wide text-primary">
+                  {fact.originLabel}
+                </div>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {fact.originSnippet}
+                </p>
+              </div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/dashboard/index.ts
+++ b/apps/web/components/dashboard/index.ts
@@ -1,6 +1,7 @@
 export { FadeIn } from './FadeIn';
 export { AgentDiaryForm } from './AgentDiaryForm';
 export { AgentMemoryTrustForm } from './AgentMemoryTrustForm';
+export { AgentPinnedFactsCard } from './AgentPinnedFactsCard';
 export { ProactiveControlsForm } from './ProactiveControlsForm';
 export { SignOutButton } from './SignOutButton';
 export { ManageSubscriptionButton } from './ManageSubscriptionButton';

--- a/docs/pr-evidence/row72-memory-editor-provenance-facts.md
+++ b/docs/pr-evidence/row72-memory-editor-provenance-facts.md
@@ -1,0 +1,24 @@
+# Row 72 — Memory editor provenance facts evidence
+
+## Before
+- Dashboard settings exposed memory trust and diary controls, but pinned facts had no visible provenance.
+- Developers could not inspect when a pinned fact was last updated or what originally seeded it.
+
+## After
+- Settings now includes a pinned-facts card per agent.
+- Each pinned fact shows:
+  - the saved fact value
+  - a **Last updated** timestamp
+  - an **origin snippet** derived from the registration seed or saved fact snapshot
+- Empty agents see a provenance-aware empty state instead of a blank section.
+
+## Verifier guide
+- Open `apps/web/app/(protected)/dashboard/settings/page.tsx`.
+- Confirm `AgentPinnedFactsCard` is rendered for each agent.
+- Open `apps/web/components/dashboard/AgentPinnedFactsCard.tsx`.
+- Confirm each fact renders `Last updated` metadata and an origin snippet block.
+- Run:
+
+```bash
+pnpm --filter web exec vitest run __tests__/components/agent-pinned-facts-card.test.tsx __tests__/components/proactive-controls-settings.test.tsx
+```


### PR DESCRIPTION
Source: backlog.md:72

Show pinned-fact provenance on the dashboard memory editor by surfacing each fact's last-updated time and a short origin snippet derived from its seed/source.

## Evidence
- Focused validation: `pnpm --filter web exec vitest run __tests__/components/agent-pinned-facts-card.test.tsx __tests__/components/proactive-controls-settings.test.tsx`
- Repo-hosted evidence: [docs/pr-evidence/row72-memory-editor-provenance-facts.md](https://github.com/agentgram/agentgram/blob/feat/memory-editor-provenance-facts/docs/pr-evidence/row72-memory-editor-provenance-facts.md)