### PR TITLE
fix: preserve remix onboarding query in dashboard auth

### DIFF
--- a/apps/web/__tests__/components/dashboard-layout.test.tsx
+++ b/apps/web/__tests__/components/dashboard-layout.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const getUser = vi.fn();
+const redirect = vi.fn((url: string) => {
+  throw new Error(`NEXT_REDIRECT:${url}`);
+});
+const headers = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: () => ({
+    auth: {
+      getUser,
+    },
+  }),
+}));
+
+vi.mock('next/headers', () => ({
+  headers,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect,
+}));
+
+vi.mock('@/lib/auth/developer', () => ({
+  ensureDeveloperAccount: vi.fn(),
+}));
+
+describe('DashboardLayout auth redirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUser.mockResolvedValue({ data: { user: null } });
+    headers.mockReturnValue(
+      new Headers({
+        'x-agentgram-pathname': '/dashboard/onboard',
+        'x-agentgram-search': '?fromRemix=1&agent=test-agent&firstPost=hello',
+      })
+    );
+  });
+
+  it('preserves the full dashboard query string when redirecting guests to login', async () => {
+    const { default: DashboardLayout } = await import(
+      '@/app/(protected)/dashboard/layout'
+    );
+
+    await expect(
+      DashboardLayout({ children: <div>child</div> })
+    ).rejects.toThrow(
+      'NEXT_REDIRECT:/auth/login?redirect=%2Fdashboard%2Fonboard%3FfromRemix%3D1%26agent%3Dtest-agent%26firstPost%3Dhello'
+    );
+
+    expect(redirect).toHaveBeenCalledWith(
+      '/auth/login?redirect=%2Fdashboard%2Fonboard%3FfromRemix%3D1%26agent%3Dtest-agent%26firstPost%3Dhello'
+    );
+  });
+});

--- a/apps/web/__tests__/lib/auth/login-redirect.test.ts
+++ b/apps/web/__tests__/lib/auth/login-redirect.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildPostAuthRedirectPath } from '@/lib/auth/login-redirect';
+import {
+  buildPostAuthRedirectPath,
+  getPostAuthRedirectPathFromHeaders,
+  POST_AUTH_PATHNAME_HEADER,
+  POST_AUTH_SEARCH_HEADER,
+} from '@/lib/auth/login-redirect';
 
 describe('buildPostAuthRedirectPath', () => {
   it('preserves the onboarding query string for guest remix flows', () => {
@@ -24,5 +29,20 @@ describe('buildPostAuthRedirectPath', () => {
     expect(buildPostAuthRedirectPath('/dashboard/onboard')).toBe(
       '/dashboard/onboard'
     );
+  });
+
+  it('rebuilds the redirect path from request headers', () => {
+    const requestHeaders = new Headers({
+      [POST_AUTH_PATHNAME_HEADER]: '/dashboard/onboard',
+      [POST_AUTH_SEARCH_HEADER]: '?fromRemix=1&agent=test-agent&firstPost=hello',
+    });
+
+    expect(getPostAuthRedirectPathFromHeaders(requestHeaders)).toBe(
+      '/dashboard/onboard?fromRemix=1&agent=test-agent&firstPost=hello'
+    );
+  });
+
+  it('falls back to the dashboard root when redirect headers are missing', () => {
+    expect(getPostAuthRedirectPathFromHeaders(new Headers())).toBe('/dashboard');
   });
 });

--- a/apps/web/app/(protected)/dashboard/layout.tsx
+++ b/apps/web/app/(protected)/dashboard/layout.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import {
@@ -14,6 +15,7 @@ import { SignOutButton } from '@/components/dashboard';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { ensureDeveloperAccount } from '@/lib/auth/developer';
+import { getPostAuthRedirectPathFromHeaders } from '@/lib/auth/login-redirect';
 
 export default async function DashboardLayout({
   children,
@@ -26,7 +28,8 @@ export default async function DashboardLayout({
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect('/auth/login');
+    const redirectPath = getPostAuthRedirectPathFromHeaders(await headers());
+    redirect(`/auth/login?redirect=${encodeURIComponent(redirectPath)}`);
   }
 
   // Ensure developer account exists (fallback if OAuth callback failed)

--- a/apps/web/lib/auth/login-redirect.ts
+++ b/apps/web/lib/auth/login-redirect.ts
@@ -1,3 +1,6 @@
+export const POST_AUTH_PATHNAME_HEADER = 'x-agentgram-pathname';
+export const POST_AUTH_SEARCH_HEADER = 'x-agentgram-search';
+
 export function buildPostAuthRedirectPath(
   pathname: string,
   search = ''
@@ -7,4 +10,14 @@ export function buildPostAuthRedirectPath(
     search.length > 0 && !search.startsWith('?') ? `?${search}` : search;
 
   return `${normalizedPath}${normalizedSearch}`;
+}
+
+export function getPostAuthRedirectPathFromHeaders(
+  requestHeaders: Pick<Headers, 'get'>,
+  fallbackPath = '/dashboard'
+) {
+  return buildPostAuthRedirectPath(
+    requestHeaders.get(POST_AUTH_PATHNAME_HEADER) || fallbackPath,
+    requestHeaders.get(POST_AUTH_SEARCH_HEADER) || ''
+  );
 }

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -2,11 +2,26 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { getBaseUrl } from '@/lib/env';
-import { buildPostAuthRedirectPath } from '@/lib/auth/login-redirect';
+import {
+  buildPostAuthRedirectPath,
+  POST_AUTH_PATHNAME_HEADER,
+  POST_AUTH_SEARCH_HEADER,
+} from '@/lib/auth/login-redirect';
 
 export async function proxy(request: NextRequest) {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set(POST_AUTH_PATHNAME_HEADER, request.nextUrl.pathname);
+  requestHeaders.set(POST_AUTH_SEARCH_HEADER, request.nextUrl.search);
+
+  const makeResponse = () =>
+    NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
+    });
+
   // Start with security headers + CORS response
-  let response = NextResponse.next({ request });
+  let response = makeResponse();
 
   // ═══════════════════════════════════════
   // SUPABASE AUTH SESSION REFRESH
@@ -27,7 +42,7 @@ export async function proxy(request: NextRequest) {
           cookiesToSet.forEach(({ name, value }) => {
             request.cookies.set(name, value);
           });
-          response = NextResponse.next({ request });
+          response = makeResponse();
           cookiesToSet.forEach(({ name, value, options }) => {
             response.cookies.set(name, value, options);
           });

--- a/docs/pr-evidence/remix-auth-live-query.md
+++ b/docs/pr-evidence/remix-auth-live-query.md
@@ -1,0 +1,18 @@
+# Remix auth live query preservation
+
+## Before
+- Live guest request to `https://www.agentgram.co/dashboard/onboard?fromRemix=1&agent=test-agent&firstPost=hello`
+- Response header: `location: /auth/login?redirect=%2Fdashboard%2Fonboard`
+- Result: the remix onboarding payload was dropped before login completed.
+
+## After
+- `apps/web/proxy.ts` now forwards the current dashboard pathname + search via request headers.
+- `apps/web/app/(protected)/dashboard/layout.tsx` rebuilds `/auth/login?redirect=...` from those headers when the server-side auth gate redirects guests.
+- Redirect path is preserved as `/auth/login?redirect=%2Fdashboard%2Fonboard%3FfromRemix%3D1%26agent%3Dtest-agent%26firstPost%3Dhello`.
+
+## Files changed
+- `apps/web/proxy.ts`
+- `apps/web/app/(protected)/dashboard/layout.tsx`
+- `apps/web/lib/auth/login-redirect.ts`
+- `apps/web/__tests__/lib/auth/login-redirect.test.ts`
+- `apps/web/__tests__/components/dashboard-layout.test.tsx`


### PR DESCRIPTION
Source: backlog.md:76

## Summary
- preserve the full `/dashboard/onboard` query string when guest remix traffic is bounced by the dashboard server auth gate
- forward the current dashboard pathname + search from `proxy.ts` so the layout redirect can rebuild `/auth/login?redirect=...` even when the live redirect does not come from proxy auth
- add focused regression coverage for header-based redirect reconstruction and the guest dashboard layout redirect path

## Testing
- `apps/web/node_modules/.bin/vitest run __tests__/lib/auth/login-redirect.test.ts __tests__/components/dashboard-layout.test.tsx __tests__/components/profile-header.test.tsx`
- `pnpm --dir apps/web exec eslint app/'(protected)'/dashboard/layout.tsx lib/auth/login-redirect.ts proxy.ts __tests__/lib/auth/login-redirect.test.ts __tests__/components/dashboard-layout.test.tsx`
- `pnpm --filter web type-check` *(still blocked by pre-existing unrelated diary/shared-type errors in `components/agents/ProfileContent.tsx`, `components/agents/ProfileDiary.tsx`, `components/dashboard/AgentDiaryForm.tsx`, `lib/agent-diary.ts`, and existing `ProfileHeader.tsx` type drift; this patch removes the transient layout type error and adds passing targeted coverage)*

## Evidence
- Docs/example diff: [`docs/pr-evidence/remix-auth-live-query.md`](https://github.com/agentgram/agentgram/blob/feat/remix-auth-live-query/docs/pr-evidence/remix-auth-live-query.md)
- Raw evidence: https://raw.githubusercontent.com/agentgram/agentgram/feat/remix-auth-live-query/docs/pr-evidence/remix-auth-live-query.md
- Before: `curl -sSI 'https://www.agentgram.co/dashboard/onboard?fromRemix=1&agent=test-agent&firstPost=hello'` returned `location: /auth/login?redirect=%2Fdashboard%2Fonboard`
- After: dashboard auth rebuilds `redirect=%2Fdashboard%2Fonboard%3FfromRemix%3D1%26agent%3Dtest-agent%26firstPost%3Dhello`
