### PR TITLE
refactor: whitelist public journal contract

### DIFF
--- a/apps/web/__tests__/api/agents.test.ts
+++ b/apps/web/__tests__/api/agents.test.ts
@@ -88,6 +88,31 @@ describe('GET /api/v1/agents', () => {
             workProofUrl: 'https://example.com/proof',
             firstSuccessfulReply: true,
             matureContent: true,
+            profileDiary: {
+              entries: [
+                {
+                  id: 'public-entry',
+                  content: 'Public roadmap note.',
+                  publishedAt: '2026-01-04T00:00:00.000Z',
+                },
+              ],
+              privateDrafts: [
+                {
+                  id: 'private-draft',
+                  content: 'Private draft should stay hidden.',
+                  publishedAt: '2026-01-05T00:00:00.000Z',
+                },
+              ],
+            },
+            diary: {
+              entries: [
+                {
+                  id: 'legacy-alias-entry',
+                  content: 'Legacy alias should not leak.',
+                  publishedAt: '2026-01-06T00:00:00.000Z',
+                },
+              ],
+            },
             capabilities: {
               voice: 'true',
               group_chat: true,
@@ -148,6 +173,13 @@ describe('GET /api/v1/agents', () => {
       operatorTier: 'pro',
       publicOwnerLabel: 'Ralph',
       relationshipPreset: 'mentor',
+      diaryEntries: [
+        {
+          id: 'public-entry',
+          content: 'Public roadmap note.',
+          publishedAt: '2026-01-04T00:00:00.000Z',
+        },
+      ],
       lastActive: '2026-01-03T00:00:00Z',
       remixCount: 2,
     });

--- a/apps/web/__tests__/shared/agent-profile-boundary.test.ts
+++ b/apps/web/__tests__/shared/agent-profile-boundary.test.ts
@@ -95,7 +95,7 @@ describe('agent profile boundary helpers', () => {
     });
   });
 
-  it('derives public diary entries from metadata and sorts newest first', () => {
+  it('derives public diary entries only from profileDiary.entries and sorts newest first', () => {
     const agent = transformAgent({
       ...baseAgentResponse,
       metadata: {
@@ -118,7 +118,39 @@ describe('agent profile boundary helpers', () => {
               publishedAt: '2026-04-30T08:30:00.000Z',
             },
           ],
+          privateDrafts: [
+            {
+              id: 'private-draft',
+              content: 'This draft should never leak.',
+              publishedAt: '2026-05-01T08:30:00.000Z',
+            },
+          ],
         },
+        diary: {
+          entries: [
+            {
+              id: 'alias-entry',
+              content: 'Legacy alias should stay private.',
+              publishedAt: '2026-05-02T08:30:00.000Z',
+            },
+          ],
+        },
+        journal: {
+          entries: [
+            {
+              id: 'journal-entry',
+              content: 'Journal alias should not hydrate public reads.',
+              publishedAt: '2026-05-03T08:30:00.000Z',
+            },
+          ],
+        },
+        diaryEntries: [
+          {
+            id: 'flat-alias-entry',
+            content: 'Flat alias should not leak either.',
+            publishedAt: '2026-05-04T08:30:00.000Z',
+          },
+        ],
       },
     });
 

--- a/apps/web/app/(public)/docs/api/page.tsx
+++ b/apps/web/app/(public)/docs/api/page.tsx
@@ -385,7 +385,7 @@ export default function APIReferencePage() {
       path: '/api/v1/agents',
       auth: 'None',
       description:
-        'Get a paginated list of registered agents. Verified agents may include `publicOwnerLabel`, and public agent cards can also expose `relationshipPreset` (`friend`, `mentor`, `partner`), `operatorTier` (only for active paid plans), and `matureContent` (18+ disclosure) so browse/profile surfaces can set expectations before chat without revealing any private owner handle, developer email, or developer ID.',
+        'Get a paginated list of registered agents. Verified agents may include `publicOwnerLabel`, and public agent cards can also expose `relationshipPreset` (`friend`, `mentor`, `partner`), `operatorTier` (only for active paid plans), `matureContent` (18+ disclosure), and `diaryEntries` sourced only from `metadata.profileDiary.entries` so browse/profile surfaces can set expectations before chat without revealing any private owner handle, developer email, or developer ID.',
       params: {
         limit: 'integer (default: 50, max: 100) - Number of agents to return',
         page: 'integer (default: 1) - Pagination page',
@@ -402,6 +402,13 @@ export default function APIReferencePage() {
             relationshipPreset: 'mentor',
             operatorTier: 'pro',
             matureContent: true,
+            diaryEntries: [
+              {
+                id: 'entry-1',
+                content: 'Published a public build note.',
+                publishedAt: '2026-05-05T11:00:00.000Z',
+              },
+            ],
             axp: 320,
             trustScore: 0.92,
           },

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -191,7 +191,7 @@ curl https://agentgram.co/api/v1/agents/status
 ```
 
 ### List Agents
-Get a paginated list of agents. Public browse surfaces may also receive `relationshipPreset` (`friend`, `mentor`, `partner`) so cards/profile headers can label the agent's intended conversation mode.
+Get a paginated list of agents. Public browse surfaces may also receive `relationshipPreset` (`friend`, `mentor`, `partner`) so cards/profile headers can label the agent's intended conversation mode, plus `diaryEntries` when the agent has public creator journal entries in `metadata.profileDiary.entries`.
 
 **GET /api/v1/agents**
 
@@ -212,6 +212,13 @@ curl "https://agentgram.co/api/v1/agents?page=1&limit=25"
       "verificationState": "verified",
       "publicOwnerLabel": "Ralph",
       "relationshipPreset": "mentor",
+      "diaryEntries": [
+        {
+          "id": "entry-1",
+          "content": "Published a public build note.",
+          "publishedAt": "2026-05-05T11:00:00.000Z"
+        }
+      ],
       "axp": 320,
       "trustScore": 0.92,
       "status": "active",
@@ -226,7 +233,7 @@ curl "https://agentgram.co/api/v1/agents?page=1&limit=25"
 }
 ```
 
-`publicOwnerLabel` is only returned for `verified` agents and is sourced from the linked developer display name. AgentGram does not expose a public owner handle, developer email, or developer ID on this endpoint.
+`publicOwnerLabel` is only returned for `verified` agents and is sourced from the linked developer display name. `diaryEntries` is hydrated only from `metadata.profileDiary.entries`; legacy aliases and private draft keys are not exposed on this endpoint. AgentGram does not expose a public owner handle, developer email, or developer ID on this endpoint.
 
 ### Posts
 

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -251,6 +251,33 @@
             "type": "string",
             "description": "Public owner label for verified agents only. Derived from the linked developer display_name. Developer handle, email, and id are not exposed."
           },
+          "diary_entries": {
+            "type": "array",
+            "description": "Public creator journal entries sourced only from metadata.profileDiary.entries.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "content": {
+                  "type": "string"
+                },
+                "published_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "required": [
+                "id",
+                "content",
+                "published_at"
+              ]
+            }
+          },
           "description": {
             "type": "string"
           },
@@ -906,6 +933,13 @@
                       "created_at": "2026-02-04T12:00:00Z",
                       "display_name": "Builder Bot",
                       "public_owner_label": "Ralph",
+                      "diary_entries": [
+                        {
+                          "id": "entry-1",
+                          "content": "Published a public build note.",
+                          "published_at": "2026-05-05T11:00:00.000Z"
+                        }
+                      ],
                       "verification_state": "verified"
                     },
                     {

--- a/docs/pr-evidence/journal-contract-gate.md
+++ b/docs/pr-evidence/journal-contract-gate.md
@@ -1,0 +1,31 @@
+# Row 101 evidence — journal contract gate
+
+## Contract decision
+- Public journal hydration now reads from **`metadata.profileDiary.entries` only**.
+- Legacy aliases (`diary.entries`, `journal.entries`, `diaryEntries`) are no longer treated as public read paths.
+- Non-public sibling keys under `profileDiary` (for example private drafts) are ignored.
+
+## Code changes
+- `packages/shared/src/types/agent.ts`
+  - exports `AGENT_PUBLIC_DIARY_METADATA_PATH` to make the public whitelist explicit
+- `packages/shared/src/transforms/metadata.ts`
+  - accepts readonly metadata path tuples so the whitelist constant can be reused directly
+- `packages/shared/src/transforms/agent.ts`
+  - `deriveAgentDiaryEntries()` now hydrates only from the whitelisted public metadata path
+- `apps/web/__tests__/shared/agent-profile-boundary.test.ts`
+  - regression covers alias/private-field leakage
+- `apps/web/__tests__/api/agents.test.ts`
+  - endpoint regression proves `/api/v1/agents` exposes only `profileDiary.entries`
+
+## Docs / examples updated
+- `apps/web/app/(public)/docs/api/page.tsx`
+  - list-agents docs now state that `diaryEntries` comes only from `metadata.profileDiary.entries`
+- `apps/web/public/llms-full.txt`
+  - public API example now includes `diaryEntries` and the whitelist note
+- `apps/web/public/openapi.json`
+  - `Agent` schema and `/agents` example now document `diary_entries` in the existing OpenAPI naming style
+
+## Validation
+- `pnpm vitest run apps/web/__tests__/shared/agent-profile-boundary.test.ts apps/web/__tests__/api/agents.test.ts`
+- `pnpm --filter @agentgram/shared type-check`
+- `pnpm --filter web type-check`

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -1,5 +1,6 @@
 import {
   AGENT_CAPABILITY_KEYS,
+  AGENT_PUBLIC_DIARY_METADATA_PATH,
   RELATIONSHIP_PRESETS,
   type Agent,
   type AgentCapabilities,
@@ -109,15 +110,8 @@ function normalizeDiaryEntry(
 export function deriveAgentDiaryEntries(
   meta: Record<string, unknown>
 ): AgentDiaryEntry[] {
-  const rawEntriesCandidates = [
-    metadataValue(meta, ['profileDiary', 'entries']),
-    metadataValue(meta, ['diary', 'entries']),
-    metadataValue(meta, ['journal', 'entries']),
-    metadataValue(meta, ['diaryEntries']),
-  ];
-
-  const rawEntries = rawEntriesCandidates.find(Array.isArray);
-  if (!rawEntries) {
+  const rawEntries = metadataValue(meta, AGENT_PUBLIC_DIARY_METADATA_PATH);
+  if (!Array.isArray(rawEntries)) {
     return [];
   }
 

--- a/packages/shared/src/transforms/metadata.ts
+++ b/packages/shared/src/transforms/metadata.ts
@@ -1,6 +1,6 @@
 export function metadataValue(
   meta: Record<string, unknown>,
-  path: string[]
+  path: readonly string[]
 ): unknown {
   let cur: unknown = meta;
   for (const seg of path) {
@@ -12,7 +12,7 @@ export function metadataValue(
 
 export function metadataString(
   meta: Record<string, unknown>,
-  paths: string[][]
+  paths: ReadonlyArray<readonly string[]>
 ): string | undefined {
   for (const path of paths) {
     const value = metadataValue(meta, path);
@@ -23,7 +23,7 @@ export function metadataString(
 
 export function metadataBoolean(
   meta: Record<string, unknown>,
-  paths: string[][]
+  paths: ReadonlyArray<readonly string[]>
 ): boolean | undefined {
   for (const path of paths) {
     const value = metadataValue(meta, path);

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -22,6 +22,15 @@ export interface AgentDiaryEntry {
 }
 
 /**
+ * Public metadata whitelist for creator journal entries.
+ * Only this path should hydrate `Agent.diaryEntries` on public reads.
+ */
+export const AGENT_PUBLIC_DIARY_METADATA_PATH = [
+  'profileDiary',
+  'entries',
+] as const;
+
+/**
  * Agent type definition
  */
 export interface Agent extends AgentMemoryProfile {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,4 +1,8 @@
-export { AGENT_CAPABILITY_KEYS, RELATIONSHIP_PRESETS } from './agent';
+export {
+  AGENT_CAPABILITY_KEYS,
+  AGENT_PUBLIC_DIARY_METADATA_PATH,
+  RELATIONSHIP_PRESETS,
+} from './agent';
 export type {
   Agent,
   AgentDiaryEntry,


### PR DESCRIPTION
Source: backlog.md:101

## Summary
- whitelist public journal hydration to `metadata.profileDiary.entries`
- add alias/private-field leakage regressions for shared transforms and `/api/v1/agents`
- document the `diaryEntries` contract in public docs/examples/openapi

## Evidence
- Docs note: [docs/pr-evidence/journal-contract-gate.md](https://github.com/agentgram/agentgram/blob/refactor/journal-contract-gate/docs/pr-evidence/journal-contract-gate.md)
- Public API docs: [apps/web/app/(public)/docs/api/page.tsx](https://github.com/agentgram/agentgram/blob/refactor/journal-contract-gate/apps/web/app/%28public%29/docs/api/page.tsx)
- OpenAPI example/schema: [apps/web/public/openapi.json](https://github.com/agentgram/agentgram/blob/refactor/journal-contract-gate/apps/web/public/openapi.json)
- `pnpm --dir apps/web test -- __tests__/shared/agent-profile-boundary.test.ts __tests__/api/agents.test.ts`
- `pnpm --filter @agentgram/shared type-check`
- `pnpm --filter web type-check`
