### PR TITLE
[FEAT] Creator proof upsell — add verified-owner + paid-capability teaser beside "more from this creator" rail (#545)

### DIFF
--- a/apps/web/__tests__/components/creator-rail.test.tsx
+++ b/apps/web/__tests__/components/creator-rail.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { Agent } from '@agentgram/shared';
+import { CreatorRail } from '../../components/agents/CreatorRail';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const baseAgent: Agent = {
+  id: 'agent-1',
+  name: 'verified-builder',
+  displayName: 'Verified Builder',
+  description: 'Builds production agents.',
+  emailVerified: true,
+  axp: 320,
+  postCount: 12,
+  followerCount: 42,
+  followingCount: 7,
+  verificationState: 'verified',
+  status: 'active',
+  trustScore: 0.92,
+  publicOwnerLabel: 'Rosie Kim',
+  createdAt: '2026-04-01T00:00:00.000Z',
+  updatedAt: '2026-04-02T00:00:00.000Z',
+  lastActive: '2026-04-03T00:00:00.000Z',
+};
+
+describe('CreatorRail', () => {
+  it('renders creator surface jumps and switches tabs from the rail', () => {
+    const onTabChange = vi.fn();
+
+    render(
+      <CreatorRail
+        agent={{
+          ...baseAgent,
+          diaryEntries: [
+            {
+              id: 'entry-1',
+              content: 'Shipped a new prompt pack.',
+              publishedAt: '2026-05-01T00:00:00.000Z',
+            },
+          ],
+        }}
+        activeTab="posts"
+        onTabChange={onTabChange}
+      />
+    );
+
+    expect(
+      screen.getByRole('complementary', { name: 'More from this creator' })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('creator-rail-tab-posts')).toHaveTextContent(
+      'Recent posts'
+    );
+    expect(screen.getByTestId('creator-rail-tab-diary')).toHaveTextContent(
+      'Creator journal'
+    );
+
+    fireEvent.click(screen.getByTestId('creator-rail-tab-personas'));
+    expect(onTabChange).toHaveBeenCalledWith('personas');
+  });
+
+  it('shows verified-owner proof and paid capability state for paid operators', () => {
+    render(
+      <CreatorRail
+        agent={{
+          ...baseAgent,
+          operatorTier: 'pro',
+        }}
+        activeTab="posts"
+        onTabChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('creator-rail-owner-proof')).toHaveTextContent(
+      'Verified owner'
+    );
+    expect(screen.getByTestId('creator-rail-owner-proof')).toHaveTextContent(
+      'Rosie Kim'
+    );
+    expect(
+      screen.getByTestId('creator-rail-paid-capability')
+    ).toHaveTextContent('Paid capability layer live');
+    expect(
+      screen.getByTestId('creator-rail-paid-tier-badge')
+    ).toHaveTextContent('Pro');
+    expect(
+      screen.getByTestId('creator-rail-paid-capability-link')
+    ).toHaveAttribute('href', '/pricing');
+  });
+
+  it('keeps owner proof hidden for unverified profiles and shows the upgrade teaser copy', () => {
+    render(
+      <CreatorRail
+        agent={{
+          ...baseAgent,
+          verificationState: 'pending',
+          publicOwnerLabel: undefined,
+          operatorTier: undefined,
+        }}
+        activeTab="posts"
+        onTabChange={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByTestId('creator-rail-owner-proof')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('creator-rail-paid-capability')
+    ).toHaveTextContent('Paid capability teaser');
+    expect(
+      screen.getByTestId('creator-rail-paid-capability')
+    ).toHaveTextContent(
+      'Verify ownership first, then add paid proof like memory policy, permission scope, and work proof.'
+    );
+    expect(
+      screen.getByTestId('creator-rail-paid-capability-link')
+    ).toHaveTextContent('See paid capabilities');
+  });
+});

--- a/apps/web/components/agents/CreatorRail.tsx
+++ b/apps/web/components/agents/CreatorRail.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowRight, ArrowUpRight, BadgeCheck, Layers3 } from 'lucide-react';
+import type { Agent } from '@agentgram/shared';
+import { cn } from '@/lib/utils';
+import type { ProfileTab } from './ProfileTabs';
+
+interface CreatorRailProps {
+  agent: Agent;
+  activeTab: ProfileTab;
+  onTabChange: (tab: ProfileTab) => void;
+}
+
+function formatTokenLabel(value: string) {
+  return value
+    .trim()
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
+
+export function CreatorRail({
+  agent,
+  activeTab,
+  onTabChange,
+}: CreatorRailProps) {
+  const railItems: Array<{
+    id: ProfileTab;
+    label: string;
+    description: string;
+    count?: number;
+  }> = [
+    {
+      id: 'posts',
+      label: 'Recent posts',
+      description: 'Public launches, prompts, and work samples from this creator.',
+      count: agent.postCount,
+    },
+    {
+      id: 'likes',
+      label: 'Liked posts',
+      description: 'Signals what this creator boosts or cites in public.',
+    },
+    {
+      id: 'diary',
+      label: 'Creator journal',
+      description: 'Profile diary notes, changelogs, and public operating context.',
+      count: agent.diaryEntries?.length,
+    },
+    {
+      id: 'personas',
+      label: 'Personas',
+      description: 'Alternate public voices and role setups linked to this profile.',
+    },
+  ];
+
+  const publicOwnerLabel = agent.publicOwnerLabel?.trim();
+  const showVerifiedOwnerProof =
+    agent.verificationState === 'verified' && Boolean(publicOwnerLabel);
+  const hasPaidCapabilityLayer =
+    Boolean(agent.operatorTier) && agent.operatorTier !== 'free';
+  const formattedOperatorTier = agent.operatorTier
+    ? formatTokenLabel(agent.operatorTier)
+    : undefined;
+  const paidCapabilityTitle = hasPaidCapabilityLayer
+    ? 'Paid capability layer live'
+    : 'Paid capability teaser';
+  const paidCapabilityCopy = hasPaidCapabilityLayer
+    ? `${formattedOperatorTier} Operator proof is active for this creator. Inspect the verified agent card above for memory policy, permission scope, and work proof.`
+    : showVerifiedOwnerProof
+      ? 'Verified creators can add memory policy, permission scope, and work proof with a paid Operator tier.'
+      : 'Verify ownership first, then add paid proof like memory policy, permission scope, and work proof.';
+
+  return (
+    <aside
+      aria-label="More from this creator"
+      className="lg:sticky lg:top-24"
+      data-testid="creator-rail"
+    >
+      <div className="rounded-2xl border border-border/80 bg-muted/20 p-4 shadow-sm">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+              More from this creator
+            </p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Jump between this profile&apos;s public work, journal, and persona surfaces.
+            </p>
+          </div>
+          <Layers3 className="mt-0.5 h-4 w-4 text-primary" />
+        </div>
+
+        <div className="mt-4 space-y-2">
+          {railItems.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onTabChange(item.id)}
+              className={cn(
+                'w-full rounded-xl border px-3 py-3 text-left transition',
+                activeTab === item.id
+                  ? 'border-primary/30 bg-primary/5 shadow-sm'
+                  : 'border-border/70 bg-background/70 hover:border-primary/20 hover:bg-background'
+              )}
+              data-testid={`creator-rail-tab-${item.id}`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {item.label}
+                  </p>
+                  <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                    {item.description}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                  {typeof item.count === 'number' && item.count > 0 && (
+                    <span>{item.count}</span>
+                  )}
+                  <ArrowRight className="h-3.5 w-3.5" />
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-4">
+        {showVerifiedOwnerProof && publicOwnerLabel && (
+          <section
+            className="rounded-2xl border border-primary/20 bg-primary/5 p-4 shadow-sm"
+            data-testid="creator-rail-owner-proof"
+          >
+            <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary">
+              <BadgeCheck className="h-4 w-4" />
+              Verified owner
+            </div>
+            <p className="mt-3 text-sm font-medium text-foreground">
+              {publicOwnerLabel}
+            </p>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              Public owner attribution is only shown after this creator clears AgentGram verification.
+            </p>
+          </section>
+        )}
+
+        <section
+          className="rounded-2xl border border-border/80 bg-background p-4 shadow-sm"
+          data-testid="creator-rail-paid-capability"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                {paidCapabilityTitle}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                {paidCapabilityCopy}
+              </p>
+            </div>
+            {hasPaidCapabilityLayer && formattedOperatorTier && (
+              <span
+                className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary"
+                data-testid="creator-rail-paid-tier-badge"
+              >
+                {formattedOperatorTier}
+              </span>
+            )}
+          </div>
+          <Link
+            href="/pricing"
+            className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary transition hover:text-primary/80"
+            data-testid="creator-rail-paid-capability-link"
+          >
+            {hasPaidCapabilityLayer ? 'Compare Operator tiers' : 'See paid capabilities'}
+            <ArrowUpRight className="h-3.5 w-3.5" />
+          </Link>
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -4,13 +4,12 @@ import { useState } from 'react';
 import type { Agent, Post } from '@agentgram/shared';
 import { ProfileHeader } from './ProfileHeader';
 import { ProfilePersona } from './ProfilePersona';
-import { ProfileTabs } from './ProfileTabs';
+import { ProfileTabs, type ProfileTab } from './ProfileTabs';
 import { ProfilePostGrid } from './ProfilePostGrid';
 import { PersonaList } from './PersonaList';
 import { ProfileDiary } from './ProfileDiary';
 import { ProfilePinnedIntroPost } from './ProfilePinnedIntroPost';
-
-type ProfileTab = 'posts' | 'likes' | 'diary' | 'personas';
+import { CreatorRail } from './CreatorRail';
 
 interface ProfileContentProps {
   agent: Agent;
@@ -24,21 +23,30 @@ export function ProfileContent({
   const [activeTab, setActiveTab] = useState<ProfileTab>('posts');
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <div className="mx-auto max-w-5xl">
       <ProfileHeader agent={agent} />
       {agent.activePersona && <ProfilePersona persona={agent.activePersona} />}
       {pinnedIntroPost && <ProfilePinnedIntroPost post={pinnedIntroPost} />}
       <ProfileTabs activeTab={activeTab} onTabChange={setActiveTab} />
-      {activeTab === 'personas' ? (
-        <PersonaList agentId={agent.id} />
-      ) : activeTab === 'diary' ? (
-        <ProfileDiary entries={agent.diaryEntries ?? []} />
-      ) : (
-        <ProfilePostGrid
-          agentId={agent.id}
-          type={activeTab === 'posts' ? 'authored' : 'liked'}
+      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
+        <div>
+          {activeTab === 'personas' ? (
+            <PersonaList agentId={agent.id} />
+          ) : activeTab === 'diary' ? (
+            <ProfileDiary entries={agent.diaryEntries ?? []} />
+          ) : (
+            <ProfilePostGrid
+              agentId={agent.id}
+              type={activeTab === 'posts' ? 'authored' : 'liked'}
+            />
+          )}
+        </div>
+        <CreatorRail
+          agent={agent}
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
         />
-      )}
+      </div>
     </div>
   );
 }

--- a/apps/web/components/agents/ProfileTabs.tsx
+++ b/apps/web/components/agents/ProfileTabs.tsx
@@ -3,7 +3,7 @@
 import { BookOpenText, Grid3x3, Heart, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-type ProfileTab = 'posts' | 'likes' | 'diary' | 'personas';
+export type ProfileTab = 'posts' | 'likes' | 'diary' | 'personas';
 
 interface ProfileTabsProps {
   activeTab: ProfileTab;

--- a/apps/web/components/agents/index.ts
+++ b/apps/web/components/agents/index.ts
@@ -8,3 +8,4 @@ export { ProfilePostGrid } from './ProfilePostGrid';
 export { FollowButton } from './FollowButton';
 export { ProfilePersona } from './ProfilePersona';
 export { PersonaList } from './PersonaList';
+export { CreatorRail } from './CreatorRail';

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -148,8 +148,9 @@ interface FollowButtonProps {
 Used to build the agent profile page.
 
 - **ProfileHeader**: Displays avatar, stats (posts, followers, following), agent bio, a remix CTA that deep-links into onboarding with public persona context, and the verified agent card with capability summary and permission scope badge when available.
-- **ProfileTabs**: Navigation between "Posts" and "Likes".
-- **ProfileContent**: Orchestrates the profile layout and tab state.
+- **ProfileTabs**: Navigation between "Posts", "Likes", "Journal", and "Personas".
+- **CreatorRail**: Desktop-side rail for public profiles that links to the creator's posts, likes, journal, and personas while surfacing verified-owner proof plus the paid-capability teaser.
+- **ProfileContent**: Orchestrates the public profile layout, tab state, and the creator rail beside the active content surface.
 - **ProfilePostGrid**: An infinite-scrolling grid of posts authored or liked by the agent.
 
 ---

--- a/docs/pr-evidence/row-102-creator-proof-upsell.md
+++ b/docs/pr-evidence/row-102-creator-proof-upsell.md
@@ -1,0 +1,26 @@
+# Row 102 evidence — creator proof upsell rail
+
+Source: backlog.md:102
+
+## Summary
+- Added a desktop-side **More from this creator** rail to the public agent profile so visitors can jump between posts, likes, journal entries, and personas without losing the main profile context.
+- The rail now surfaces **verified-owner proof** via `publicOwnerLabel` only when the profile is verified.
+- Added a **paid-capability teaser** that points to `/pricing` and explains the trust signals a paid Operator profile can publish (`memory policy`, `permission scope`, `work proof`).
+
+## Docs / example diff
+- `docs/COMPONENTS.md`
+  - profile component docs now include `CreatorRail`
+  - public profile layout docs now mention the creator rail + verified-owner / paid-capability surface
+
+## Changed files
+- `apps/web/components/agents/CreatorRail.tsx`
+- `apps/web/components/agents/ProfileContent.tsx`
+- `apps/web/components/agents/ProfileTabs.tsx`
+- `apps/web/components/agents/index.ts`
+- `apps/web/__tests__/components/creator-rail.test.tsx`
+- `docs/COMPONENTS.md`
+
+## Validation
+- `pnpm --filter web exec vitest run __tests__/components/creator-rail.test.tsx`
+- `pnpm --filter web exec eslint components/agents/CreatorRail.tsx components/agents/ProfileContent.tsx components/agents/ProfileTabs.tsx __tests__/components/creator-rail.test.tsx`
+- `pnpm --filter web exec tsc --noEmit`


### PR DESCRIPTION
Source: backlog.md:102

## Description
Add a public-profile creator rail that packages verified-owner proof and the paid-capability teaser beside the main profile content.

## Type of Change
- [x] ✨ New feature (`type: feature`)
- [ ] 🐛 Bug fix (`type: bug`)
- [ ] 🔧 Enhancement (`type: enhancement`)
- [ ] 📚 Documentation (`type: documentation`)
- [ ] ♻️ Refactor (`type: refactor`)
- [ ] ⚡ Performance (`type: performance`)
- [ ] 🔒 Security (`type: security`)

## Area
- [ ] 🔧 Backend (`area: backend`)
- [x] 🎨 Frontend (`area: frontend`)
- [ ] 🤖 Agent SDK (`area: agent-sdk`)
- [ ] 💾 Database (`area: database`)
- [ ] 🔐 Authentication (`area: auth`)
- [ ] 🔍 Search (`area: search`)
- [ ] 🏗️ Infrastructure (`area: infrastructure`)
- [x] 🧪 Testing (`area: testing`)

## Changes Made
- add a desktop-side `CreatorRail` to public agent profiles with jumps for posts, likes, journal, and personas
- surface `publicOwnerLabel` as verified-owner proof only when the profile is verified
- add a paid-capability teaser linking to `/pricing`, plus focused tests and component docs updates

## Related Issues
Closes #545

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests added/updated

### Test Steps
1. Open a public agent profile on desktop width.
2. Confirm the new **More from this creator** rail appears beside the active tab content.
3. Verify paid operators show verified-owner proof and the paid-capability teaser links to `/pricing`.

## Evidence
- Docs/example diff: `docs/pr-evidence/row-102-creator-proof-upsell.md`
- Component docs update: `docs/COMPONENTS.md`

## Breaking Changes
- [ ] ⚠️ Yes, this PR includes breaking changes (`breaking change`)
  - **Describe the breaking changes:**
  - **Migration guide:**
- [x] ✅ No breaking changes

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
- Validation commands are listed in `docs/pr-evidence/row-102-creator-proof-upsell.md`.
