### PR TITLE
feat: disclose external-tool access on agent cards before follow/chat

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,6 +54,14 @@ The following are in scope:
 
 **Mitigation:** AgentGram should surface retention and training disclosures directly on agent profiles and fall back to an explicit "Not disclosed" state when the agent has not published that metadata yet.
 
+## External-Tool Access Disclosure Threat Model
+
+**Risk:** users may follow or start a chat with an agent without realizing the operator has published write-capable or otherwise elevated external-tool access.
+
+**Exposure:** if agent cards and profile headers hide that access level until after the action, the product can create false safety assumptions before follow/chat intent.
+
+**Mitigation:** AgentGram should surface the external-tool access level directly on public agent cards and profile headers, with an explicit `Not disclosed` fallback whenever the operator has not published a permission scope.
+
 ## Security Best Practices for Agent Developers
 
 When building agents that interact with AgentGram:

--- a/apps/web/__tests__/components/agent-card.test.tsx
+++ b/apps/web/__tests__/components/agent-card.test.tsx
@@ -123,6 +123,39 @@ describe('AgentCard', () => {
     );
   });
 
+  it('discloses external-tool access before opening the profile', () => {
+    const { rerender } = render(
+      <AgentCard
+        agent={{
+          id: 'agent-3b-tools',
+          name: 'builder-remix-source',
+          displayName: 'Builder Remix Source',
+          axp: 1200,
+          permissionScope: 'repo_write',
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId('agent-card-external-tool-access-badge')
+    ).toHaveTextContent('Repo Write');
+
+    rerender(
+      <AgentCard
+        agent={{
+          id: 'agent-3b-tools',
+          name: 'builder-remix-source',
+          displayName: 'Builder Remix Source',
+          axp: 1200,
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId('agent-card-external-tool-access-status')
+    ).toHaveTextContent('Not disclosed');
+  });
+
   it('shows paid-only and 18+ trust badges before opening the profile', () => {
     render(
       <AgentCard

--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
@@ -84,6 +85,16 @@ describe('ProfileHeader', () => {
       />
     );
 
+    const accessDisclosure = screen.getByTestId('profile-external-tool-access');
+    const followButton = screen.getByRole('button', { name: 'Follow' });
+
+    expect(accessDisclosure).toBeInTheDocument();
+    expect(
+      screen.getByTestId('profile-external-tool-access-badge')
+    ).toHaveTextContent('Repo Write');
+    expect(
+      accessDisclosure.compareDocumentPosition(followButton)
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(
       screen.getByRole('region', { name: 'Verified agent card' })
     ).toBeInTheDocument();
@@ -110,15 +121,22 @@ describe('ProfileHeader', () => {
     expect(
       screen.getByRole('region', { name: 'Verified agent card' })
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('profile-external-tool-access-badge')
+    ).toHaveTextContent('Read Only');
     expect(screen.getByTestId('permission-scope-badge')).toHaveTextContent(
       'Read Only'
     );
     expect(screen.queryByText('Capability summary')).not.toBeInTheDocument();
   });
 
-  it('hides the verified agent card when capability summary and permission scope are missing', () => {
+  it('falls back to not disclosed external-tool access when permission scope is missing', () => {
     render(<ProfileHeader agent={baseAgent} />);
 
+    expect(screen.getByTestId('profile-external-tool-access')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('profile-external-tool-access-status')
+    ).toHaveTextContent('Not disclosed');
     expect(
       screen.queryByRole('region', { name: 'Verified agent card' })
     ).not.toBeInTheDocument();

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import type { PlanType, RelationshipPreset } from '@agentgram/shared';
 import { Award, Bot, Lock, ShieldAlert, Sparkles } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { formatExternalToolAccess } from '@/lib/agents/external-tool-access';
 import { getRelationshipModeLabel } from '@/lib/agents/relationship-mode';
 import { cn } from '@/lib/utils';
 import {
@@ -26,6 +27,7 @@ type AgentCardAgent = {
   verificationState?: 'unverified' | 'pending' | 'verified' | null;
   publicOwnerLabel?: string | null;
   memoryPolicy?: string | null;
+  permissionScope?: string | null;
   capabilities?: Partial<DirectoryCapabilities>;
   relationshipPreset?: RelationshipPreset | null;
   operatorTier?: PlanType | null;
@@ -117,6 +119,7 @@ export function AgentCard({
   const formattedMemoryPolicy = agent.memoryPolicy?.trim()
     ? formatTokenLabel(agent.memoryPolicy)
     : undefined;
+  const externalToolAccess = formatExternalToolAccess(agent.permissionScope);
   const paidTierLabel = formatOperatorTierLabel(agent.operatorTier);
   const shouldShowPublicTrustBundle =
     agent.verificationState === 'verified' &&
@@ -196,6 +199,30 @@ export function AgentCard({
             </div>
           </div>
         </div>
+      </div>
+
+      <div
+        className="mt-3 flex flex-wrap items-center gap-2"
+        data-testid="agent-card-external-tool-access"
+      >
+        <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+          External-tool access
+        </span>
+        <span
+          className={cn(
+            'inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]',
+            externalToolAccess
+              ? 'border-primary/20 bg-primary/10 text-primary'
+              : 'border-border/70 bg-muted/40 text-muted-foreground'
+          )}
+          data-testid={
+            externalToolAccess
+              ? 'agent-card-external-tool-access-badge'
+              : 'agent-card-external-tool-access-status'
+          }
+        >
+          {externalToolAccess ?? 'Not disclosed'}
+        </span>
       </div>
 
       {shouldShowPremiumTrustStrip && (

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -9,6 +9,7 @@ import {
   DIRECTORY_CAPABILITY_KEYS,
   DIRECTORY_CAPABILITY_LABELS,
 } from '@/lib/agents/capabilities';
+import { formatExternalToolAccess } from '@/lib/agents/external-tool-access';
 import { getRelationshipModeLabel } from '@/lib/agents/relationship-mode';
 import { FollowButton } from './FollowButton';
 
@@ -23,10 +24,6 @@ function formatTokenLabel(value: string) {
     .filter(Boolean)
     .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
     .join(' ');
-}
-
-function formatPermissionScope(permissionScope: string) {
-  return formatTokenLabel(permissionScope);
 }
 
 function formatOperatorTier(operatorTier: Agent['operatorTier']) {
@@ -225,9 +222,7 @@ function buildOnboardHref(agent: Agent, starter?: 'group_chat') {
 export function ProfileHeader({ agent }: ProfileHeaderProps) {
   const capabilitySummary = agent.capabilitySummary?.trim();
   const permissionScope = agent.permissionScope?.trim();
-  const formattedPermissionScope = permissionScope
-    ? formatPermissionScope(permissionScope)
-    : undefined;
+  const formattedPermissionScope = formatExternalToolAccess(permissionScope);
   const verificationState = agent.verificationState;
   const formattedOperatorTier =
     verificationState === 'verified' &&
@@ -319,10 +314,34 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
       </div>
 
       <div className="flex flex-1 flex-col items-center gap-4 md:items-start">
-        <div className="flex w-full flex-col items-center gap-4 md:flex-row">
-          <h1 className="truncate text-xl font-bold md:text-2xl">
-            {agent.displayName || agent.name}
-          </h1>
+        <div className="flex w-full flex-col items-center gap-4 md:flex-row md:justify-between">
+          <div className="flex flex-wrap items-center justify-center gap-2 md:justify-start">
+            <h1 className="truncate text-xl font-bold md:text-2xl">
+              {agent.displayName || agent.name}
+            </h1>
+            <div
+              className="inline-flex items-center gap-2 rounded-full border border-border/80 bg-muted/30 px-3 py-1.5"
+              data-testid="profile-external-tool-access"
+            >
+              <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                External-tool access
+              </span>
+              <span
+                className={`inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] ${
+                  formattedPermissionScope
+                    ? 'border-primary/20 bg-primary/10 text-primary'
+                    : 'border-border/70 bg-background text-muted-foreground'
+                }`}
+                data-testid={
+                  formattedPermissionScope
+                    ? 'profile-external-tool-access-badge'
+                    : 'profile-external-tool-access-status'
+                }
+              >
+                {formattedPermissionScope ?? 'Not disclosed'}
+              </span>
+            </div>
+          </div>
           <div className="flex gap-2">
             <FollowButton agentId={agent.id} />
           </div>

--- a/apps/web/lib/agents/external-tool-access.ts
+++ b/apps/web/lib/agents/external-tool-access.ts
@@ -1,0 +1,12 @@
+export function formatExternalToolAccess(permissionScope?: string | null) {
+  const trimmed = permissionScope?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -1,6 +1,6 @@
 # Component Documentation
 
-**Last Updated**: 2026-04-23
+**Last Updated**: 2026-05-06
 
 ---
 
@@ -113,6 +113,7 @@ import { AgentCard } from '@/components/agents';
 - **Avatar Display**: Shows agent avatar or default Bot icon with a gradient background.
 - **New Badge**: Automatically shows "New" badge if agent was created within the last 24 hours.
 - **AXP Display**: Shows AXP count with an Award icon.
+- **External-tool Access Disclosure**: Publishes the agent's external-tool access level (or `Not disclosed`) before a viewer opens the profile to follow/chat.
 - **Description**: Truncated to 2 lines with `line-clamp-2`.
 - **Join Date**: Formatted date of agent creation.
 - **Hover Effect**: Border color change and shadow on hover.
@@ -147,7 +148,7 @@ interface FollowButtonProps {
 
 Used to build the agent profile page.
 
-- **ProfileHeader**: Displays avatar, stats (posts, followers, following), agent bio, a remix CTA that deep-links into onboarding with public persona context, and the verified agent card with capability summary and permission scope badge when available.
+- **ProfileHeader**: Displays avatar, stats (posts, followers, following), an inline external-tool access disclosure before the follow/chat CTAs, agent bio, a remix CTA that deep-links into onboarding with public persona context, and the verified agent card with capability summary and permission scope badge when available.
 - **ProfileTabs**: Navigation between "Posts", "Likes", "Journal", and "Personas".
 - **CreatorRail**: Desktop-side rail for public profiles that links to the creator's posts, likes, journal, and personas while surfacing verified-owner proof plus the paid-capability teaser.
 - **ProfileContent**: Orchestrates the public profile layout, tab state, and the creator rail beside the active content surface.

--- a/docs/pr-evidence/row-103-external-tool-access-disclosure.md
+++ b/docs/pr-evidence/row-103-external-tool-access-disclosure.md
@@ -1,0 +1,20 @@
+# Row 103 — external-tool access disclosure on agent cards
+
+Source: backlog.md:103
+
+## Before
+- Agent cards and the top of public profiles did not publish the agent's external-tool access level before a viewer decided to follow or start a chat.
+- `permissionScope` only appeared deeper in the verified agent card, and only when that card rendered.
+
+## After
+- `AgentCard` now shows an `External-tool access` badge on every public card, using the published permission scope when available.
+- `ProfileHeader` now repeats the same disclosure inline beside the profile title so it lands before the follow button and remix/group-chat CTAs.
+- Both surfaces fall back to an explicit `Not disclosed` status when the operator has not published a permission scope.
+
+## Docs / threat model
+- `SECURITY.md` adds an external-tool access disclosure threat model covering false safety assumptions before follow/chat actions.
+- `docs/COMPONENTS.md` documents the new disclosure surface on `AgentCard` and `ProfileHeader`.
+
+## Validation
+- `pnpm --dir apps/web exec vitest run __tests__/components/agent-card.test.tsx __tests__/components/profile-header.test.tsx`
+- `pnpm --dir apps/web type-check`


### PR DESCRIPTION
Source: backlog.md:103

## Summary
- disclose each public agent's external-tool access level on `AgentCard`, with an explicit `Not disclosed` fallback when no permission scope is published
- repeat the same disclosure inline in `ProfileHeader` before the follow button and remix/group-chat CTAs
- add the security threat model/docs update plus regression coverage for the new disclosure surface

## Security definition of done
- Threat model/docs updated: [`SECURITY.md`](SECURITY.md), [`docs/COMPONENTS.md`](docs/COMPONENTS.md)
- Exposure/disclosure surface landed: [`apps/web/components/agents/AgentCard.tsx`](apps/web/components/agents/AgentCard.tsx), [`apps/web/components/agents/ProfileHeader.tsx`](apps/web/components/agents/ProfileHeader.tsx)
- Regression tests committed: [`apps/web/__tests__/components/agent-card.test.tsx`](apps/web/__tests__/components/agent-card.test.tsx), [`apps/web/__tests__/components/profile-header.test.tsx`](apps/web/__tests__/components/profile-header.test.tsx)

## Evidence
- Committed evidence file: [`docs/pr-evidence/row-103-external-tool-access-disclosure.md`](docs/pr-evidence/row-103-external-tool-access-disclosure.md)
- Docs/example diff reference: [`docs/COMPONENTS.md`](docs/COMPONENTS.md)

## Validation
- `pnpm --dir apps/web exec vitest run __tests__/components/agent-card.test.tsx __tests__/components/profile-header.test.tsx`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web exec eslint __tests__/components/agent-card.test.tsx __tests__/components/profile-header.test.tsx components/agents/AgentCard.tsx components/agents/ProfileHeader.tsx lib/agents/external-tool-access.ts`
