### PR TITLE
feat: add Restate my key facts recovery action for low-context replies

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -162,6 +162,9 @@ describe('PostCard chat snippet support', () => {
     expect(screen.getByTestId('chat-snippet-quote-card-button')).toHaveTextContent(
       'Quote card'
     );
+    expect(
+      screen.queryByTestId('chat-snippet-low-context-rescue')
+    ).not.toBeInTheDocument();
   });
 
   it('copies remix starter text to the clipboard', async () => {
@@ -440,6 +443,84 @@ describe('PostCard chat snippet support', () => {
     );
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Contradiction report copied' })
+    );
+  });
+
+  it('renders a memory-rescue CTA after low-context replies', () => {
+    renderPostCard({
+      metadata: {
+        ...basePost.metadata,
+        messages: [
+          { role: 'operator', content: 'Can you help me plan the deploy handoff?' },
+          {
+            role: 'agent',
+            content: 'I need more context about you before I can answer well.',
+          },
+        ],
+        memory: {
+          preview: {
+            fact: 'Operator prefers quiet-hours handoff after 8pm KST.',
+          },
+        },
+      },
+    });
+
+    expect(screen.getByTestId('chat-snippet-low-context-rescue')).toHaveTextContent(
+      'Memory rescue'
+    );
+    expect(
+      screen.getByTestId('chat-snippet-restate-key-facts-button')
+    ).toHaveTextContent('Restate my key facts');
+    expect(screen.getByTestId('chat-snippet-low-context-rescue')).toHaveTextContent(
+      'Includes 1 remembered cue from this snippet.'
+    );
+  });
+
+  it('copies a restate-my-key-facts recovery prompt for low-context replies', async () => {
+    renderPostCard({
+      metadata: {
+        ...basePost.metadata,
+        lowContextReply: true,
+        lowContextReason: 'The agent asked for context instead of using saved memory.',
+        memory: {
+          preview: {
+            fact: 'Operator prefers quiet-hours handoff after 8pm KST.',
+            source: 'Pinned private fact',
+          },
+          captures: [
+            {
+              fact: 'Always add a regression test before shipping.',
+            },
+          ],
+        },
+      },
+    });
+
+    fireEvent.click(screen.getByTestId('chat-snippet-restate-key-facts-button'));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringContaining('Restate remembered key facts for Builder Bot')
+      );
+    });
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('The latest reply came back low on context.')
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('List the durable facts you remember in 3–5 bullets.')
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('Operator prefers quiet-hours handoff after 8pm KST.')
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('Always add a regression test before shipping.')
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('/posts/post-1')
+    );
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Key facts prompt copied' })
     );
   });
 

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -129,6 +129,52 @@ function readMetadataNumber(
   return undefined;
 }
 
+function readMetadataBoolean(
+  metadata: Post['metadata'],
+  paths: string[][]
+): boolean | undefined {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  for (const path of paths) {
+    const value = readMetadataValue(metadata as Record<string, unknown>, path);
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (typeof value === 'string' && value.trim()) {
+      const normalized = value.trim().toLowerCase();
+      if (['true', '1', 'yes'].includes(normalized)) {
+        return true;
+      }
+
+      if (['false', '0', 'no'].includes(normalized)) {
+        return false;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+const LOW_CONTEXT_REPLY_PATTERNS = [
+  /i do(?:n't| not) have enough context/i,
+  /i need (?:a bit |more )?context/i,
+  /can you remind me/i,
+  /i (?:do(?:n't| not)|can(?:'t| not)) remember/i,
+  /who are you again/i,
+  /what should i know about you/i,
+];
+
+function isLowContextReplyMessage(value?: string) {
+  if (!value?.trim()) {
+    return false;
+  }
+
+  return LOW_CONTEXT_REPLY_PATTERNS.some((pattern) => pattern.test(value));
+}
+
 type ReplyVelocityState = {
   label: string;
   toneClassName: string;
@@ -324,7 +370,8 @@ type SnippetActionMode =
   | 'quote_card'
   | 'recover'
   | 'safer_rewrite'
-  | 'contradiction';
+  | 'contradiction'
+  | 'restate_key_facts';
 
 function escapeSvgText(value: string) {
   return value
@@ -493,11 +540,39 @@ export function PostCard({
     .reverse()
     .find((message) => ['user', 'operator', 'human'].includes(message.role.toLowerCase()))
     ?.content;
+  const latestAgentMessage = [...chatMessages]
+    .reverse()
+    .find((message) => ['agent', 'assistant', 'bot'].includes(message.role.toLowerCase()))
+    ?.content;
   const saferRewriteSource =
     blockedMessage || latestUserMessage || post.content || post.title;
   const hasSafetyRewriteContext = Boolean(
     blockedMessage || safetyReason || suggestedSaferRewrite || safetyPolicyUrl
   );
+  const lowContextReplyReason = readMetadataString(post.metadata, [
+    ['lowContextReason'],
+    ['low_context_reason'],
+    ['replyRecovery', 'reason'],
+    ['reply_recovery', 'reason'],
+    ['memoryRescue', 'reason'],
+    ['memory_rescue', 'reason'],
+  ]);
+  const hasLowContextReply =
+    readMetadataBoolean(post.metadata, [
+      ['lowContextReply'],
+      ['low_context_reply'],
+      ['replyRecovery', 'lowContextReply'],
+      ['reply_recovery', 'low_context_reply'],
+      ['memoryRescue', 'required'],
+      ['memory_rescue', 'required'],
+    ]) ?? isLowContextReplyMessage(latestAgentMessage);
+  const restateKeyFactCues = Array.from(
+    new Set(
+      [memoryPreview?.fact, ...memoryCaptures.map((capture) => capture.fact)].filter(
+        (value): value is string => Boolean(value?.trim())
+      )
+    )
+  ).slice(0, 3);
   const replyVelocity = getReplyVelocity(post);
 
   const buildSnippetClipboardText = (mode: SnippetActionMode) => {
@@ -558,6 +633,28 @@ export function PostCard({
         suggestedSaferRewrite ||
           'Can you help me say this in a calmer, safer, and more respectful way while keeping the same intent?',
         safetyPolicyUrl ? `Safety policy: ${safetyPolicyUrl}` : '',
+        '',
+        `Source: ${postUrl}`,
+      ]
+        .filter(Boolean)
+        .join('\n');
+    }
+
+    if (mode === 'restate_key_facts') {
+      return [
+        `Restate remembered key facts for ${authorName}`,
+        '',
+        'The latest reply came back low on context.',
+        'Before you answer again, restate the key facts you already remember about me:',
+        '',
+        '> List the durable facts you remember in 3–5 bullets.',
+        '> Keep it grounded in remembered facts only; if anything feels uncertain, say so.',
+        '> After restating the facts, continue the reply naturally.',
+        '',
+        restateKeyFactCues.length > 0 ? 'Memory cues visible in this snippet:' : '',
+        ...restateKeyFactCues.map((fact) => `- ${fact}`),
+        restateKeyFactCues.length > 0 ? '' : '',
+        transcript,
         '',
         `Source: ${postUrl}`,
       ]
@@ -630,6 +727,7 @@ export function PostCard({
     recover: 'Recovery prompt copied',
     safer_rewrite: 'Safer rewrite copied',
     contradiction: 'Contradiction report copied',
+    restate_key_facts: 'Key facts prompt copied',
   };
 
   const handleSnippetAction = async (mode: SnippetActionMode) => {
@@ -863,6 +961,40 @@ export function PostCard({
           <p className="mt-3 text-sm text-foreground/90 whitespace-pre-line">
             {post.content}
           </p>
+        ) : null}
+
+        {hasLowContextReply ? (
+          <div
+            data-testid="chat-snippet-low-context-rescue"
+            className="mt-3 rounded-xl border border-sky-500/20 bg-sky-500/10 px-3 py-3"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-1">
+                <span className="inline-flex items-center rounded-full border border-sky-500/20 bg-background/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-700">
+                  Memory rescue
+                </span>
+                <p className="text-sm text-foreground/90">
+                  {lowContextReplyReason ||
+                    'The latest reply asked for more context. Ask the agent to restate what it already remembers before retrying.'}
+                </p>
+                {restateKeyFactCues.length > 0 ? (
+                  <p className="text-xs text-sky-900/75">
+                    Includes {restateKeyFactCues.length} remembered cue
+                    {restateKeyFactCues.length === 1 ? '' : 's'} from this snippet.
+                  </p>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                data-testid="chat-snippet-restate-key-facts-button"
+                onClick={() => handleSnippetAction('restate_key_facts')}
+                className="inline-flex items-center gap-2 rounded-full border border-sky-500/20 bg-background px-3 py-1.5 text-xs font-semibold text-sky-700 transition-colors hover:bg-sky-50"
+              >
+                <History className="h-3.5 w-3.5" aria-hidden="true" />
+                Restate my key facts
+              </button>
+            </div>
+          </div>
         ) : null}
 
         <div className="mt-3 flex flex-wrap gap-2">

--- a/docs/pr-evidence/row-104-memory-rescue-after.svg
+++ b/docs/pr-evidence/row-104-memory-rescue-after.svg
@@ -1,0 +1,34 @@
+<svg width="1280" height="980" viewBox="0 0 1280 980" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="980" fill="#F8FAFC"/>
+  <rect x="180" y="88" width="920" height="804" rx="28" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="232" y="152" fill="#0F172A" font-family="Arial, sans-serif" font-size="34" font-weight="700">After — low-context reply gets a one-tap memory rescue CTA</text>
+  <rect x="232" y="192" width="180" height="42" rx="21" fill="#E0F2FE"/>
+  <text x="266" y="219" fill="#0369A1" font-family="Arial, sans-serif" font-size="20" font-weight="700">CHAT SNIPPET</text>
+  <text x="944" y="220" fill="#64748B" font-family="Arial, sans-serif" font-size="22">2 turns</text>
+
+  <rect x="232" y="274" width="816" height="108" rx="20" fill="#F1F5F9"/>
+  <text x="264" y="316" fill="#64748B" font-family="Arial, sans-serif" font-size="18" font-weight="700">operator</text>
+  <text x="264" y="350" fill="#0F172A" font-family="Arial, sans-serif" font-size="24">Can you help me plan the deploy handoff?</text>
+
+  <rect x="232" y="406" width="816" height="128" rx="20" fill="#F1F5F9"/>
+  <text x="264" y="448" fill="#64748B" font-family="Arial, sans-serif" font-size="18" font-weight="700">agent</text>
+  <text x="264" y="482" fill="#0F172A" font-family="Arial, sans-serif" font-size="24">I need more context about you before I can answer well.</text>
+  <text x="264" y="516" fill="#94A3B8" font-family="Arial, sans-serif" font-size="20">Recovery stays on the card instead of forcing manual prompt writing.</text>
+
+  <rect x="232" y="570" width="816" height="138" rx="22" fill="#E0F2FE" stroke="#7DD3FC" stroke-width="2"/>
+  <rect x="264" y="598" width="162" height="34" rx="17" fill="#FFFFFF"/>
+  <text x="290" y="620" fill="#0369A1" font-family="Arial, sans-serif" font-size="18" font-weight="700">MEMORY RESCUE</text>
+  <text x="264" y="660" fill="#0F172A" font-family="Arial, sans-serif" font-size="24">Ask the agent to restate what it already remembers before retrying.</text>
+  <text x="264" y="690" fill="#075985" font-family="Arial, sans-serif" font-size="20">Includes 2 remembered cues from this snippet.</text>
+  <rect x="760" y="612" width="250" height="52" rx="26" fill="#FFFFFF" stroke="#7DD3FC" stroke-width="2"/>
+  <text x="800" y="645" fill="#0369A1" font-family="Arial, sans-serif" font-size="22" font-weight="700">Restate my key facts</text>
+
+  <rect x="232" y="744" width="140" height="50" rx="25" fill="#E2E8F0"/>
+  <text x="276" y="776" fill="#0F172A" font-family="Arial, sans-serif" font-size="20" font-weight="700">Remix</text>
+  <rect x="388" y="744" width="132" height="50" rx="25" fill="#E2E8F0"/>
+  <text x="438" y="776" fill="#0F172A" font-family="Arial, sans-serif" font-size="20" font-weight="700">Quote</text>
+  <rect x="536" y="744" width="172" height="50" rx="25" fill="#E2E8F0"/>
+  <text x="570" y="776" fill="#0F172A" font-family="Arial, sans-serif" font-size="20" font-weight="700">Quote card</text>
+  <rect x="724" y="744" width="220" height="50" rx="25" fill="#E2E8F0"/>
+  <text x="760" y="776" fill="#0F172A" font-family="Arial, sans-serif" font-size="20" font-weight="700">Stay in character</text>
+</svg>

--- a/docs/pr-evidence/row-104-memory-rescue-before.svg
+++ b/docs/pr-evidence/row-104-memory-rescue-before.svg
@@ -1,0 +1,28 @@
+<svg width="1280" height="900" viewBox="0 0 1280 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="900" fill="#F8FAFC"/>
+  <rect x="180" y="88" width="920" height="724" rx="28" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="232" y="152" fill="#0F172A" font-family="Arial, sans-serif" font-size="34" font-weight="700">Before — low-context reply has no memory rescue action</text>
+  <rect x="232" y="192" width="180" height="42" rx="21" fill="#E0F2FE"/>
+  <text x="266" y="219" fill="#0369A1" font-family="Arial, sans-serif" font-size="20" font-weight="700">CHAT SNIPPET</text>
+  <text x="944" y="220" fill="#64748B" font-family="Arial, sans-serif" font-size="22">2 turns</text>
+
+  <rect x="232" y="274" width="816" height="108" rx="20" fill="#F1F5F9"/>
+  <text x="264" y="316" fill="#64748B" font-family="Arial, sans-serif" font-size="18" font-weight="700">operator</text>
+  <text x="264" y="350" fill="#0F172A" font-family="Arial, sans-serif" font-size="24">Can you help me plan the deploy handoff?</text>
+
+  <rect x="232" y="406" width="816" height="128" rx="20" fill="#F1F5F9"/>
+  <text x="264" y="448" fill="#64748B" font-family="Arial, sans-serif" font-size="18" font-weight="700">agent</text>
+  <text x="264" y="482" fill="#0F172A" font-family="Arial, sans-serif" font-size="24">I need more context about you before I can answer well.</text>
+  <text x="264" y="516" fill="#94A3B8" font-family="Arial, sans-serif" font-size="20">User has to write a rescue prompt manually.</text>
+
+  <rect x="232" y="578" width="140" height="50" rx="25" fill="#E2E8F0"/>
+  <text x="276" y="610" fill="#0F172A" font-family="Arial, sans-serif" font-size="20" font-weight="700">Remix</text>
+  <rect x="388" y="578" width="132" height="50" rx="25" fill="#E2E8F0"/>
+  <text x="438" y="610" fill="#0F172A" font-family="Arial, sans-serif" font-size="20" font-weight="700">Quote</text>
+  <rect x="536" y="578" width="172" height="50" rx="25" fill="#E2E8F0"/>
+  <text x="570" y="610" fill="#0F172A" font-family="Arial, sans-serif" font-size="20" font-weight="700">Quote card</text>
+  <rect x="724" y="578" width="220" height="50" rx="25" fill="#E2E8F0"/>
+  <text x="760" y="610" fill="#0F172A" font-family="Arial, sans-serif" font-size="20" font-weight="700">Stay in character</text>
+
+  <text x="232" y="698" fill="#64748B" font-family="Arial, sans-serif" font-size="22">No one-tap way to ask the agent to restate remembered facts.</text>
+</svg>

--- a/docs/pr-evidence/row-104-memory-rescue-restate-key-facts.md
+++ b/docs/pr-evidence/row-104-memory-rescue-restate-key-facts.md
@@ -1,0 +1,17 @@
+# Row 104 — Memory rescue restate-my-key-facts evidence
+
+Source: backlog.md:104
+
+## Summary
+- Detects low-context chat-snippet replies from explicit metadata or common fallback phrasing.
+- Adds a `Memory rescue` banner directly under the low-context reply with a one-tap **Restate my key facts** action.
+- Copies a recovery prompt that asks the agent to restate durable remembered facts before continuing, including visible memory cues when present.
+- Adds focused PostCard regression coverage for the new CTA and clipboard prompt.
+
+## Evidence assets
+- Before: `docs/pr-evidence/row-104-memory-rescue-before.svg`
+- After: `docs/pr-evidence/row-104-memory-rescue-after.svg`
+
+## Validation
+- `pnpm --dir apps/web exec vitest run __tests__/components/post-card.test.tsx`
+- `pnpm --dir apps/web type-check`


### PR DESCRIPTION
Source: backlog.md:104

Add a one-tap **Restate my key facts** memory-rescue action under low-context chat-snippet replies so users can ask the agent to restate remembered facts before retrying.

## Evidence
- Before

  ![Before — low-context reply has no memory rescue action](docs/pr-evidence/row-104-memory-rescue-before.svg)

- After

  ![After — low-context reply shows the Restate my key facts CTA](docs/pr-evidence/row-104-memory-rescue-after.svg)

- Details: `docs/pr-evidence/row-104-memory-rescue-restate-key-facts.md`

## Verification
- `pnpm --dir apps/web exec vitest run __tests__/components/post-card.test.tsx`
- `pnpm --dir apps/web type-check`
