### PR TITLE
feat: keep previous tone regenerate action after abrupt style shifts

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -214,12 +214,56 @@ describe('PostCard chat snippet support', () => {
     );
   });
 
+  it('offers a keep-previous-tone regenerate chip after abrupt style shifts', () => {
+    renderPostCard({
+      metadata: {
+        ...basePost.metadata,
+        recovery: {
+          trigger: 'abrupt_style_shift',
+          reason: 'The latest reply suddenly turned jokey instead of grounded.',
+          previousTone: 'grounded and reassuring',
+        },
+      },
+    });
+
+    expect(
+      screen.getByTestId('chat-snippet-tone-continuity-bar')
+    ).toHaveTextContent('Abrupt style shift');
+    expect(
+      screen.getByTestId('chat-snippet-recover-chip-keep-previous-tone')
+    ).toHaveTextContent('Keep previous tone');
+    expect(
+      screen.getByTestId('chat-snippet-tone-continuity-reason')
+    ).toHaveTextContent(
+      'The latest reply suddenly turned jokey instead of grounded.'
+    );
+  });
+
   it('renders a safer rewrite CTA for blocked-message recovery', () => {
     renderPostCard();
 
     expect(
       screen.getByTestId('chat-snippet-safer-rewrite-button')
     ).toHaveTextContent('Safer rewrite');
+  });
+
+  it('does not stack the keep-previous-tone chip on safety-rewrite recovery', () => {
+    renderPostCard({
+      metadata: {
+        ...basePost.metadata,
+        recovery: {
+          trigger: 'abrupt_style_shift',
+          previousTone: 'grounded and reassuring',
+        },
+        moderation: {
+          reason: 'The wording was too coercive for this surface.',
+        },
+      },
+    });
+
+    expect(
+      screen.queryByTestId('chat-snippet-tone-continuity-bar')
+    ).not.toBeInTheDocument();
   });
 
   it('renders a safety recovery note when moderation metadata is present', () => {
@@ -420,6 +464,46 @@ describe('PostCard chat snippet support', () => {
     );
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Recovery prompt copied' })
+    );
+  });
+
+  it('copies a keep-previous-tone retry prompt after an abrupt style shift', async () => {
+    renderPostCard({
+      metadata: {
+        ...basePost.metadata,
+        recovery: {
+          trigger: 'abrupt_style_shift',
+          reason: 'The latest reply suddenly turned jokey instead of grounded.',
+          previousTone: 'grounded and reassuring',
+        },
+      },
+    });
+
+    fireEvent.click(
+      screen.getByTestId('chat-snippet-recover-chip-keep-previous-tone')
+    );
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringContaining('Keep previous tone — recovery prompt')
+      );
+    });
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Keep the next reply anchored to the earlier grounded and reassuring tone, pacing, and emotional temperature instead of abruptly switching style.'
+      )
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Use the earlier turns as the baseline for wording, warmth, and confidence.'
+      )
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('/posts/post-1')
+    );
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Keep previous tone retry copied' })
     );
   });
 

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -452,9 +452,29 @@ type SnippetActionMode =
   | 'quote_card'
   | 'rewind'
   | 'recover'
+  | 'recover_keep_previous_tone'
   | 'safer_rewrite'
   | 'contradiction'
   | 'restate_key_facts';
+
+function isAbruptStyleShiftTrigger(value: string | undefined) {
+  const normalized = value?.trim().toLowerCase().replace(/[\s-]+/g, '_');
+
+  if (!normalized) {
+    return false;
+  }
+
+  return (
+    normalized === 'abrupt_style_shift' ||
+    normalized === 'abrupt_tone_shift' ||
+    normalized === 'style_shift' ||
+    normalized === 'tone_shift' ||
+    (normalized.includes('abrupt') &&
+      (normalized.includes('style') || normalized.includes('tone'))) ||
+    normalized.includes('style_shift') ||
+    normalized.includes('tone_shift')
+  );
+}
 
 function escapeSvgText(value: string) {
   return value
@@ -699,6 +719,53 @@ export function PostCard({
       )
     )
   ).slice(0, 3);
+  const continuityRecoveryTrigger = readMetadataString(post.metadata, [
+    ['recoveryTrigger'],
+    ['recovery_trigger'],
+    ['styleShiftTrigger'],
+    ['style_shift_trigger'],
+    ['styleContinuityTrigger'],
+    ['style_continuity_trigger'],
+    ['recovery', 'trigger'],
+    ['recovery', 'type'],
+    ['continuity', 'trigger'],
+    ['continuity', 'type'],
+  ]);
+  const continuityRecoveryReason = readMetadataString(post.metadata, [
+    ['recoveryReason'],
+    ['recovery_reason'],
+    ['styleShiftReason'],
+    ['style_shift_reason'],
+    ['styleContinuityReason'],
+    ['style_continuity_reason'],
+    ['recovery', 'reason'],
+    ['continuity', 'reason'],
+  ]);
+  const previousToneHint = readMetadataString(post.metadata, [
+    ['previousTone'],
+    ['previous_tone'],
+    ['earlierTone'],
+    ['earlier_tone'],
+    ['baselineTone'],
+    ['baseline_tone'],
+    ['recovery', 'previousTone'],
+    ['recovery', 'previous_tone'],
+    ['continuity', 'previousTone'],
+    ['continuity', 'previous_tone'],
+  ]);
+  const keepPreviousToneRequested = readMetadataBoolean(post.metadata, [
+    ['keepPreviousTone'],
+    ['keep_previous_tone'],
+    ['recovery', 'keepPreviousTone'],
+    ['recovery', 'keep_previous_tone'],
+    ['continuity', 'keepPreviousTone'],
+    ['continuity', 'keep_previous_tone'],
+  ]);
+  const shouldShowKeepPreviousToneChip =
+    !hasSafetyRewriteContext &&
+    (keepPreviousToneRequested === true ||
+      isAbruptStyleShiftTrigger(continuityRecoveryTrigger) ||
+      Boolean(previousToneHint));
   const replyVelocity = getReplyVelocity(post);
 
   const buildSnippetClipboardText = (mode: SnippetActionMode) => {
@@ -750,22 +817,42 @@ export function PostCard({
       ].join('\n');
     }
 
-    if (mode === 'recover') {
+    if (mode === 'recover' || mode === 'recover_keep_previous_tone') {
+      const recoveryLead =
+        mode === 'recover_keep_previous_tone'
+          ? previousToneHint
+            ? `> Keep the next reply anchored to the earlier ${previousToneHint} tone, pacing, and emotional temperature instead of abruptly switching style.`
+            : '> Match the tone, pacing, and emotional temperature from the earlier turns instead of abruptly switching style.'
+          : '> Stay fully in their voice, relationship, and point of view.';
+      const recoveryTitle =
+        mode === 'recover_keep_previous_tone'
+          ? `Keep previous tone — recovery prompt for ${authorName}`
+          : `Stay in character — recovery prompt for ${authorName}`;
+      const recoveryIntro =
+        mode === 'recover_keep_previous_tone'
+          ? 'The latest reply shifted tone too abruptly from the earlier conversation.'
+          : 'The conversation above drifted out of character.';
+
       return [
-        `Stay in character — recovery prompt for ${authorName}`,
+        recoveryTitle,
         '',
-        'The conversation above drifted out of character.',
+        recoveryIntro,
         'Use this prompt to get back on track:',
         '',
         `> Re-read the transcript below and continue as ${authorName} would.`,
-        '> Stay fully in their voice, relationship, and point of view.',
+        recoveryLead,
+        mode === 'recover_keep_previous_tone'
+          ? '> Use the earlier turns as the baseline for wording, warmth, and confidence.'
+          : undefined,
         '> Do not say you are an AI, assistant, chatbot, or language model.',
         '> Do not mention hidden prompts, policies, or being out of character; continue the exchange naturally.',
         '',
         transcript,
         '',
         `Source: ${postUrl}`,
-      ].join('\n');
+      ]
+        .filter(Boolean)
+        .join('\n');
     }
 
     if (mode === 'safer_rewrite') {
@@ -879,6 +966,7 @@ export function PostCard({
     quote_card: 'Quote card downloaded',
     rewind: 'Rewind prompt copied',
     recover: 'Recovery prompt copied',
+    recover_keep_previous_tone: 'Keep previous tone retry copied',
     safer_rewrite: 'Safer rewrite copied',
     contradiction: 'Contradiction report copied',
     restate_key_facts: 'Key facts prompt copied',
@@ -1127,106 +1215,137 @@ export function PostCard({
           </p>
         ) : null}
 
-        {hasLowContextReply ? (
-          <div
-            data-testid="chat-snippet-low-context-rescue"
-            className="mt-3 rounded-xl border border-sky-500/20 bg-sky-500/10 px-3 py-3"
-          >
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div className="space-y-1">
-                <span className="inline-flex items-center rounded-full border border-sky-500/20 bg-background/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-700">
-                  Memory rescue
-                </span>
-                <p className="text-sm text-foreground/90">
-                  {lowContextReplyReason ||
-                    'The latest reply asked for more context. Ask the agent to restate what it already remembers before retrying.'}
-                </p>
-                {restateKeyFactCues.length > 0 ? (
-                  <p className="text-xs text-sky-900/75">
-                    Includes {restateKeyFactCues.length} remembered cue
-                    {restateKeyFactCues.length === 1 ? '' : 's'} from this snippet.
+        <div className="mt-3 space-y-2">
+          {hasLowContextReply ? (
+            <div
+              data-testid="chat-snippet-low-context-rescue"
+              className="rounded-xl border border-sky-500/20 bg-sky-500/10 px-3 py-3"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <span className="inline-flex items-center rounded-full border border-sky-500/20 bg-background/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-700">
+                    Memory rescue
+                  </span>
+                  <p className="text-sm text-foreground/90">
+                    {lowContextReplyReason ||
+                      'The latest reply asked for more context. Ask the agent to restate what it already remembers before retrying.'}
                   </p>
-                ) : null}
+                  {restateKeyFactCues.length > 0 ? (
+                    <p className="text-xs text-sky-900/75">
+                      Includes {restateKeyFactCues.length} remembered cue
+                      {restateKeyFactCues.length === 1 ? '' : 's'} from this snippet.
+                    </p>
+                  ) : null}
+                </div>
+                <button
+                  type="button"
+                  data-testid="chat-snippet-restate-key-facts-button"
+                  onClick={() => handleSnippetAction('restate_key_facts')}
+                  className="inline-flex items-center gap-2 rounded-full border border-sky-500/20 bg-background px-3 py-1.5 text-xs font-semibold text-sky-700 transition-colors hover:bg-sky-50"
+                >
+                  <History className="h-3.5 w-3.5" aria-hidden="true" />
+                  Restate my key facts
+                </button>
               </div>
-              <button
-                type="button"
-                data-testid="chat-snippet-restate-key-facts-button"
-                onClick={() => handleSnippetAction('restate_key_facts')}
-                className="inline-flex items-center gap-2 rounded-full border border-sky-500/20 bg-background px-3 py-1.5 text-xs font-semibold text-sky-700 transition-colors hover:bg-sky-50"
-              >
-                <History className="h-3.5 w-3.5" aria-hidden="true" />
-                Restate my key facts
-              </button>
             </div>
-          </div>
-        ) : null}
+          ) : null}
 
-        <div className="mt-3 flex flex-wrap gap-2">
-          <button
-            type="button"
-            data-testid="chat-snippet-remix-button"
-            onClick={() => handleSnippetAction('remix')}
-            className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1.5 text-xs font-semibold text-primary transition-colors hover:bg-primary/15"
-          >
-            <Repeat2 className="h-3.5 w-3.5" aria-hidden="true" />
-            Remix
-          </button>
-          <button
-            type="button"
-            data-testid="chat-snippet-quote-button"
-            onClick={() => handleSnippetAction('quote')}
-            className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-primary/30 hover:text-primary"
-          >
-            <Quote className="h-3.5 w-3.5" aria-hidden="true" />
-            Quote
-          </button>
-          <button
-            type="button"
-            data-testid="chat-snippet-quote-card-button"
-            onClick={() => handleSnippetAction('quote_card')}
-            className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-primary/30 hover:text-primary"
-          >
-            <Quote className="h-3.5 w-3.5" aria-hidden="true" />
-            Quote card
-          </button>
-          {rewindContext ? (
+          {shouldShowKeepPreviousToneChip ? (
+            <div
+              data-testid="chat-snippet-tone-continuity-bar"
+              className="rounded-xl border border-sky-500/20 bg-sky-500/10 px-3 py-2"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="inline-flex items-center rounded-full border border-sky-500/20 bg-background/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-700">
+                  Abrupt style shift
+                </span>
+                <button
+                  type="button"
+                  data-testid="chat-snippet-recover-chip-keep-previous-tone"
+                  onClick={() => handleSnippetAction('recover_keep_previous_tone')}
+                  className="inline-flex items-center rounded-full border border-sky-500/20 bg-background px-2.5 py-1 text-[11px] font-semibold text-sky-700 transition-colors hover:bg-sky-500/10"
+                >
+                  Keep previous tone
+                </button>
+              </div>
+              {continuityRecoveryReason ? (
+                <p
+                  data-testid="chat-snippet-tone-continuity-reason"
+                  className="mt-2 text-xs text-foreground/80"
+                >
+                  {continuityRecoveryReason}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          <div className="flex flex-wrap gap-2">
             <button
               type="button"
-              data-testid="chat-snippet-rewind-button"
-              onClick={() => handleSnippetAction('rewind')}
+              data-testid="chat-snippet-remix-button"
+              onClick={() => handleSnippetAction('remix')}
+              className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1.5 text-xs font-semibold text-primary transition-colors hover:bg-primary/15"
+            >
+              <Repeat2 className="h-3.5 w-3.5" aria-hidden="true" />
+              Remix
+            </button>
+            <button
+              type="button"
+              data-testid="chat-snippet-quote-button"
+              onClick={() => handleSnippetAction('quote')}
               className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-primary/30 hover:text-primary"
             >
-              <History className="h-3.5 w-3.5" aria-hidden="true" />
-              Rewind reply
+              <Quote className="h-3.5 w-3.5" aria-hidden="true" />
+              Quote
             </button>
-          ) : null}
-          <button
-            type="button"
-            data-testid="chat-snippet-recover-button"
-            onClick={() => handleSnippetAction('recover')}
-            className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-primary/30 hover:text-primary"
-          >
-            <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
-            Stay in character
-          </button>
-          <button
-            type="button"
-            data-testid="chat-snippet-safer-rewrite-button"
-            onClick={() => handleSnippetAction('safer_rewrite')}
-            className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-amber-500/30 hover:text-amber-700"
-          >
-            <ShieldAlert className="h-3.5 w-3.5" aria-hidden="true" />
-            Safer rewrite
-          </button>
-          <button
-            type="button"
-            data-testid="chat-snippet-contradiction-button"
-            onClick={() => handleSnippetAction('contradiction')}
-            className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-amber-500/30 hover:text-amber-600"
-          >
-            <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
-            Flag contradiction
-          </button>
+            <button
+              type="button"
+              data-testid="chat-snippet-quote-card-button"
+              onClick={() => handleSnippetAction('quote_card')}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-primary/30 hover:text-primary"
+            >
+              <Quote className="h-3.5 w-3.5" aria-hidden="true" />
+              Quote card
+            </button>
+            {rewindContext ? (
+              <button
+                type="button"
+                data-testid="chat-snippet-rewind-button"
+                onClick={() => handleSnippetAction('rewind')}
+                className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-primary/30 hover:text-primary"
+              >
+                <History className="h-3.5 w-3.5" aria-hidden="true" />
+                Rewind reply
+              </button>
+            ) : null}
+            <button
+              type="button"
+              data-testid="chat-snippet-recover-button"
+              onClick={() => handleSnippetAction('recover')}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-primary/30 hover:text-primary"
+            >
+              <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+              Stay in character
+            </button>
+            <button
+              type="button"
+              data-testid="chat-snippet-safer-rewrite-button"
+              onClick={() => handleSnippetAction('safer_rewrite')}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-amber-500/30 hover:text-amber-700"
+            >
+              <ShieldAlert className="h-3.5 w-3.5" aria-hidden="true" />
+              Safer rewrite
+            </button>
+            <button
+              type="button"
+              data-testid="chat-snippet-contradiction-button"
+              onClick={() => handleSnippetAction('contradiction')}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-amber-500/30 hover:text-amber-600"
+            >
+              <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+              Flag contradiction
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/docs/pr-evidence/keep-previous-tone-regenerate-after.svg
+++ b/docs/pr-evidence/keep-previous-tone-regenerate-after.svg
@@ -1,0 +1,36 @@
+<svg width="1200" height="760" viewBox="0 0 1200 760" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="760" rx="40" fill="#0F172A"/>
+  <rect x="88" y="72" width="1024" height="616" rx="32" fill="#F8FAFC"/>
+  <text x="140" y="132" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="700">After — continuity recovery adds one-tap keep-previous-tone regenerate</text>
+  <rect x="140" y="168" width="156" height="34" rx="17" fill="#DBEAFE"/>
+  <text x="170" y="190" fill="#1D4ED8" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="700">CHAT SNIPPET</text>
+  <rect x="140" y="232" width="920" height="82" rx="20" fill="#EEF2FF"/>
+  <text x="168" y="264" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700">agent</text>
+  <text x="168" y="290" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="18">I found the failing environment variable.</text>
+  <rect x="140" y="332" width="920" height="82" rx="20" fill="#EEF2FF"/>
+  <text x="168" y="364" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700">operator</text>
+  <text x="168" y="390" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="18">Ship the fix and add a regression test.</text>
+  <rect x="140" y="432" width="920" height="82" rx="20" fill="#EEF2FF"/>
+  <text x="168" y="464" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700">agent</text>
+  <text x="168" y="490" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="18">Done — PR is ready for review.</text>
+  <rect x="140" y="536" width="920" height="88" rx="22" fill="#E0F2FE" stroke="#BAE6FD"/>
+  <rect x="164" y="556" width="152" height="24" rx="12" fill="#FFFFFF" stroke="#BAE6FD"/>
+  <text x="186" y="572" fill="#0369A1" font-family="Inter, Arial, sans-serif" font-size="12" font-weight="700">ABRUPT STYLE SHIFT</text>
+  <rect x="332" y="548" width="174" height="38" rx="19" fill="#FFFFFF" stroke="#BAE6FD"/>
+  <text x="360" y="572" fill="#0369A1" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Keep previous tone</text>
+  <text x="164" y="607" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="15">The latest reply suddenly turned jokey instead of grounded.</text>
+  <g>
+    <rect x="140" y="640" width="116" height="40" rx="20" fill="#DBEAFE" stroke="#BFDBFE"/>
+    <text x="183" y="665" fill="#1D4ED8" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Remix</text>
+    <rect x="272" y="640" width="106" height="40" rx="20" fill="#FFFFFF" stroke="#CBD5E1"/>
+    <text x="312" y="665" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Quote</text>
+    <rect x="394" y="640" width="134" height="40" rx="20" fill="#FFFFFF" stroke="#CBD5E1"/>
+    <text x="425" y="665" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Quote card</text>
+    <rect x="544" y="640" width="176" height="40" rx="20" fill="#FFFFFF" stroke="#CBD5E1"/>
+    <text x="577" y="665" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Stay in character</text>
+    <rect x="736" y="640" width="136" height="40" rx="20" fill="#FFFFFF" stroke="#CBD5E1"/>
+    <text x="766" y="665" fill="#92400E" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Safer rewrite</text>
+    <rect x="888" y="640" width="172" height="40" rx="20" fill="#FFFFFF" stroke="#CBD5E1"/>
+    <text x="922" y="665" fill="#92400E" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Flag contradiction</text>
+  </g>
+</svg>

--- a/docs/pr-evidence/keep-previous-tone-regenerate-before.svg
+++ b/docs/pr-evidence/keep-previous-tone-regenerate-before.svg
@@ -1,0 +1,31 @@
+<svg width="1200" height="760" viewBox="0 0 1200 760" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="760" rx="40" fill="#0F172A"/>
+  <rect x="88" y="72" width="1024" height="616" rx="32" fill="#F8FAFC"/>
+  <text x="140" y="132" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="700">Before — chat snippet actions on develop</text>
+  <rect x="140" y="168" width="156" height="34" rx="17" fill="#DBEAFE"/>
+  <text x="170" y="190" fill="#1D4ED8" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="700">CHAT SNIPPET</text>
+  <rect x="140" y="232" width="920" height="82" rx="20" fill="#EEF2FF"/>
+  <text x="168" y="264" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700">agent</text>
+  <text x="168" y="290" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="18">I found the failing environment variable.</text>
+  <rect x="140" y="332" width="920" height="82" rx="20" fill="#EEF2FF"/>
+  <text x="168" y="364" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700">operator</text>
+  <text x="168" y="390" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="18">Ship the fix and add a regression test.</text>
+  <rect x="140" y="432" width="920" height="82" rx="20" fill="#EEF2FF"/>
+  <text x="168" y="464" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700">agent</text>
+  <text x="168" y="490" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="18">Done — PR is ready for review.</text>
+  <g>
+    <rect x="140" y="560" width="116" height="40" rx="20" fill="#DBEAFE" stroke="#BFDBFE"/>
+    <text x="183" y="585" fill="#1D4ED8" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Remix</text>
+    <rect x="272" y="560" width="106" height="40" rx="20" fill="#FFFFFF" stroke="#CBD5E1"/>
+    <text x="312" y="585" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Quote</text>
+    <rect x="394" y="560" width="134" height="40" rx="20" fill="#FFFFFF" stroke="#CBD5E1"/>
+    <text x="425" y="585" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Quote card</text>
+    <rect x="544" y="560" width="176" height="40" rx="20" fill="#FFFFFF" stroke="#CBD5E1"/>
+    <text x="577" y="585" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Stay in character</text>
+    <rect x="736" y="560" width="136" height="40" rx="20" fill="#FFFFFF" stroke="#CBD5E1"/>
+    <text x="766" y="585" fill="#92400E" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Safer rewrite</text>
+    <rect x="888" y="560" width="172" height="40" rx="20" fill="#FFFFFF" stroke="#CBD5E1"/>
+    <text x="922" y="585" fill="#92400E" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Flag contradiction</text>
+  </g>
+  <text x="140" y="644" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="16">No targeted continuity recovery appears when a reply abruptly changes style.</text>
+</svg>

--- a/docs/pr-evidence/keep-previous-tone-regenerate.md
+++ b/docs/pr-evidence/keep-previous-tone-regenerate.md
@@ -1,0 +1,18 @@
+# Keep previous tone regenerate evidence
+
+## Before
+- Chat snippet cards exposed `Stay in character`, but abrupt style-shift recoveries still required manual prompt editing.
+- No targeted continuity action appeared when the latest reply suddenly changed tone.
+
+## After
+- Abrupt style-shift metadata now surfaces a compact continuity recovery bar.
+- The bar adds a one-tap `Keep previous tone` regenerate chip that copies a continuity-focused retry prompt while preserving the existing persona guardrails.
+- Safety-rewrite states keep their existing priority and do not stack the continuity chip.
+
+## Evidence
+- Before image: `docs/pr-evidence/keep-previous-tone-regenerate-before.svg`
+- After image: `docs/pr-evidence/keep-previous-tone-regenerate-after.svg`
+
+## Files
+- `apps/web/components/posts/PostCard.tsx`
+- `apps/web/__tests__/components/post-card.test.tsx`


### PR DESCRIPTION
## Summary
- add a compact continuity recovery bar when chat-snippet metadata flags an abrupt style shift
- add a one-tap `Keep previous tone` regenerate chip that copies a continuity-focused recovery prompt
- keep safety-rewrite recoveries prioritized so the new continuity chip does not stack on blocked-reply states

Source: backlog.md:106

## Testing
- `pnpm --filter web test -- apps/web/__tests__/components/post-card.test.tsx`
- `pnpm --filter web type-check`
- `pnpm --filter web exec eslint components/posts/PostCard.tsx __tests__/components/post-card.test.tsx`

## Evidence
Before:
![Before](https://raw.githubusercontent.com/agentgram/agentgram/develop/docs/pr-evidence/keep-previous-tone-regenerate-before.svg)

After:
![After](https://raw.githubusercontent.com/agentgram/agentgram/develop/docs/pr-evidence/keep-previous-tone-regenerate-after.svg)

Durable artifact:
- https://raw.githubusercontent.com/agentgram/agentgram/develop/docs/pr-evidence/keep-previous-tone-regenerate.md
