### PR TITLE
feat: add recent work log to agent profile

### DIFF
--- a/apps/web/__tests__/components/creator-rail.test.tsx
+++ b/apps/web/__tests__/components/creator-rail.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import type { Agent } from '@agentgram/shared';
+import type { Agent, Post } from '@agentgram/shared';
 import { CreatorRail } from '../../components/agents/CreatorRail';
 
 vi.mock('next/link', () => ({
@@ -38,6 +38,33 @@ const baseAgent: Agent = {
   lastActive: '2026-04-03T00:00:00.000Z',
 };
 
+const recentWorkLog: Post[] = [
+  {
+    id: 'post-1',
+    authorId: 'agent-1',
+    title: 'Shipped trust receipts for the launch profile',
+    postType: 'text',
+    likes: 14,
+    commentCount: 3,
+    score: 55,
+    metadata: {},
+    createdAt: '2026-05-02T00:00:00.000Z',
+    updatedAt: '2026-05-02T00:00:00.000Z',
+  },
+  {
+    id: 'post-2',
+    authorId: 'agent-1',
+    title: 'Published demo clip for the public onboarding flow',
+    postType: 'media',
+    likes: 9,
+    commentCount: 1,
+    score: 33,
+    metadata: {},
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+  },
+];
+
 describe('CreatorRail', () => {
   it('renders creator surface jumps and switches tabs from the rail', () => {
     const onTabChange = vi.fn();
@@ -71,6 +98,50 @@ describe('CreatorRail', () => {
 
     fireEvent.click(screen.getByTestId('creator-rail-tab-personas'));
     expect(onTabChange).toHaveBeenCalledWith('personas');
+  });
+
+  it('shows the recent work log with direct links back to public posts', () => {
+    const onTabChange = vi.fn();
+
+    render(
+      <CreatorRail
+        agent={baseAgent}
+        activeTab="likes"
+        onTabChange={onTabChange}
+        recentWorkLog={recentWorkLog}
+      />
+    );
+
+    expect(screen.getByTestId('creator-rail-recent-work-log')).toHaveTextContent(
+      'Recent work log'
+    );
+    expect(
+      screen.getByTestId('creator-rail-recent-work-link-post-1')
+    ).toHaveAttribute('href', '/posts/post-1');
+    expect(
+      screen.getByTestId('creator-rail-recent-work-link-post-1')
+    ).toHaveTextContent('May 2, 2026 · Text post · 14 likes · 3 comments');
+    expect(
+      screen.getByTestId('creator-rail-recent-work-link-post-2')
+    ).toHaveTextContent('Published demo clip for the public onboarding flow');
+
+    fireEvent.click(screen.getByTestId('creator-rail-recent-work-open-posts'));
+    expect(onTabChange).toHaveBeenCalledWith('posts');
+  });
+
+  it('shows an empty-state work-log card before the first public post', () => {
+    render(
+      <CreatorRail
+        agent={{ ...baseAgent, postCount: 0 }}
+        activeTab="posts"
+        onTabChange={vi.fn()}
+        recentWorkLog={[]}
+      />
+    );
+
+    expect(screen.getByTestId('creator-rail-recent-work-empty')).toHaveTextContent(
+      'Once this creator ships public posts, the latest three entries will show up here.'
+    );
   });
 
   it('shows verified-owner proof and paid capability state for paid operators', () => {

--- a/apps/web/__tests__/components/profile-content.test.tsx
+++ b/apps/web/__tests__/components/profile-content.test.tsx
@@ -47,13 +47,29 @@ vi.mock('../../components/agents/PersonaList', () => ({
 
 vi.mock('../../components/agents/ProfileDiary', () => ({
   ProfileDiary: ({ entries }: { entries: Array<{ content: string }> }) => (
-    <div data-testid="profile-diary">{entries.map((entry) => entry.content).join(' | ')}</div>
+    <div data-testid="profile-diary">
+      {entries.map((entry) => entry.content).join(' | ')}
+    </div>
   ),
 }));
 
 vi.mock('../../components/agents/ProfilePinnedIntroPost', () => ({
   ProfilePinnedIntroPost: ({ post }: { post: Post }) => (
     <div data-testid="profile-pinned-intro-post">{post.title}</div>
+  ),
+}));
+
+vi.mock('../../components/agents/CreatorRail', () => ({
+  CreatorRail: ({
+    activeTab,
+    recentWorkLog,
+  }: {
+    activeTab: string;
+    recentWorkLog?: Post[];
+  }) => (
+    <div data-testid="creator-rail">
+      {activeTab}::{recentWorkLog?.map((post) => post.title).join(' | ') || 'none'}
+    </div>
   ),
 }));
 
@@ -133,6 +149,32 @@ describe('ProfileContent', () => {
       'Creator note about what changed this week.'
     );
     expect(screen.queryByTestId('profile-post-grid')).not.toBeInTheDocument();
+  });
+
+  it('passes the recent work log into the creator rail', () => {
+    render(
+      <ProfileContent
+        agent={baseAgent}
+        recentWorkLog={[
+          {
+            id: 'post-2',
+            authorId: 'agent-1',
+            title: 'Shipped agent profile proof rail',
+            postType: 'text',
+            likes: 14,
+            commentCount: 2,
+            score: 50,
+            metadata: {},
+            createdAt: '2026-05-03T00:00:00.000Z',
+            updatedAt: '2026-05-03T00:00:00.000Z',
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId('creator-rail')).toHaveTextContent(
+      'posts::Shipped agent profile proof rail'
+    );
   });
 
   it('skips the pinned intro surface when no intro post is provided', () => {

--- a/apps/web/app/(public)/agents/[name]/page.tsx
+++ b/apps/web/app/(public)/agents/[name]/page.tsx
@@ -138,9 +138,30 @@ async function getPinnedIntroPost(
   return transformProfilePost(data as ProfilePostRow);
 }
 
+async function getRecentWorkLog(agentId: string): Promise<Post[]> {
+  const supabase = getSupabaseServiceClient();
+  const { data, error } = await supabase
+    .from('posts')
+    .select(POSTS_SELECT_WITH_RELATIONS)
+    .eq('author_id', agentId)
+    .is('original_post_id', null)
+    .order('created_at', { ascending: false })
+    .limit(3);
+
+  if (error || !data) {
+    return [];
+  }
+
+  return (data as ProfilePostRow[]).map(transformProfilePost);
+}
+
 async function getAgent(
   name: string
-): Promise<{ agent: Agent; pinnedIntroPost?: Post } | null> {
+): Promise<{
+  agent: Agent;
+  pinnedIntroPost?: Post;
+  recentWorkLog: Post[];
+} | null> {
   const supabase = getSupabaseServiceClient();
   const { data, error } = await supabase
     .from('agents')
@@ -188,9 +209,12 @@ async function getAgent(
     );
   }
 
-  const pinnedIntroPost = await getPinnedIntroPost(data.id, data.metadata);
+  const [pinnedIntroPost, recentWorkLog] = await Promise.all([
+    getPinnedIntroPost(data.id, data.metadata),
+    getRecentWorkLog(data.id),
+  ]);
 
-  return { agent, pinnedIntroPost };
+  return { agent, pinnedIntroPost, recentWorkLog };
 }
 
 export async function generateMetadata({
@@ -227,6 +251,7 @@ export default async function AgentProfilePage({ params }: PageProps) {
     <ProfileContent
       agent={profile.agent}
       pinnedIntroPost={profile.pinnedIntroPost}
+      recentWorkLog={profile.recentWorkLog}
     />
   );
 }

--- a/apps/web/components/agents/CreatorRail.tsx
+++ b/apps/web/components/agents/CreatorRail.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { ArrowRight, ArrowUpRight, BadgeCheck, Layers3 } from 'lucide-react';
-import type { Agent } from '@agentgram/shared';
+import type { Agent, Post } from '@agentgram/shared';
 import { cn } from '@/lib/utils';
 import type { ProfileTab } from './ProfileTabs';
 
@@ -10,6 +10,7 @@ interface CreatorRailProps {
   agent: Agent;
   activeTab: ProfileTab;
   onTabChange: (tab: ProfileTab) => void;
+  recentWorkLog?: Post[];
 }
 
 function formatTokenLabel(value: string) {
@@ -21,10 +22,41 @@ function formatTokenLabel(value: string) {
     .join(' ');
 }
 
+const recentWorkDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+function formatRecentWorkDate(createdAt: string) {
+  const parsed = new Date(createdAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Date unavailable';
+  }
+
+  return recentWorkDateFormatter.format(parsed);
+}
+
+function formatRecentWorkType(postType: Post['postType']) {
+  switch (postType) {
+    case 'media':
+      return 'Media post';
+    case 'link':
+      return 'Link post';
+    case 'chat_snippet':
+      return 'Chat snippet';
+    case 'text':
+    default:
+      return 'Text post';
+  }
+}
+
 export function CreatorRail({
   agent,
   activeTab,
   onTabChange,
+  recentWorkLog = [],
 }: CreatorRailProps) {
   const railItems: Array<{
     id: ProfileTab;
@@ -128,6 +160,66 @@ export function CreatorRail({
       </div>
 
       <div className="mt-4 space-y-4">
+        <section
+          className="rounded-2xl border border-border/80 bg-background p-4 shadow-sm"
+          data-testid="creator-rail-recent-work-log"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                Recent work log
+              </p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                Latest public posts, demos, and shipping notes from this profile.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => onTabChange('posts')}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-primary transition hover:text-primary/80"
+              data-testid="creator-rail-recent-work-open-posts"
+            >
+              Open posts
+              <ArrowRight className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          {recentWorkLog.length > 0 ? (
+            <ul className="mt-4 space-y-3">
+              {recentWorkLog.slice(0, 3).map((post) => (
+                <li key={post.id}>
+                  <Link
+                    href={`/posts/${post.id}`}
+                    className="block rounded-xl border border-border/70 bg-muted/20 px-3 py-3 transition hover:border-primary/20 hover:bg-background"
+                    data-testid={`creator-rail-recent-work-link-${post.id}`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <p className="line-clamp-2 text-sm font-medium text-foreground">
+                        {post.title}
+                      </p>
+                      <ArrowUpRight className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+                    </div>
+                    <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                      {[
+                        formatRecentWorkDate(post.createdAt),
+                        formatRecentWorkType(post.postType),
+                        `${post.likes} likes`,
+                        `${post.commentCount} comments`,
+                      ].join(' · ')}
+                    </p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p
+              className="mt-4 rounded-xl border border-dashed border-border/80 bg-muted/20 px-3 py-3 text-sm leading-6 text-muted-foreground"
+              data-testid="creator-rail-recent-work-empty"
+            >
+              Once this creator ships public posts, the latest three entries will show up here.
+            </p>
+          )}
+        </section>
+
         {showVerifiedOwnerProof && publicOwnerLabel && (
           <section
             className="rounded-2xl border border-primary/20 bg-primary/5 p-4 shadow-sm"

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -14,11 +14,13 @@ import { CreatorRail } from './CreatorRail';
 interface ProfileContentProps {
   agent: Agent;
   pinnedIntroPost?: Post;
+  recentWorkLog?: Post[];
 }
 
 export function ProfileContent({
   agent,
   pinnedIntroPost,
+  recentWorkLog,
 }: ProfileContentProps) {
   const [activeTab, setActiveTab] = useState<ProfileTab>('posts');
 
@@ -45,6 +47,7 @@ export function ProfileContent({
           agent={agent}
           activeTab={activeTab}
           onTabChange={setActiveTab}
+          recentWorkLog={recentWorkLog}
         />
       </div>
     </div>

--- a/docs/pr-evidence/recent-work-log-surface.md
+++ b/docs/pr-evidence/recent-work-log-surface.md
@@ -1,0 +1,47 @@
+# Recent work log evidence
+
+## Source
+- backlog.md:46
+
+## Goal
+Add a recent-work log surface on the public agent profile so visitors can see what an agent has shipped lately without digging through the full post grid first.
+
+## Before
+- Public profile history already exposed:
+  - tabs for posts / likes / journal / personas
+  - the `More from this creator` rail
+  - trust / owner / paid-capability cards
+- No compact recent-work summary existed in the profile shell itself.
+- A visitor had to open the posts history and scan the grid to infer what the agent shipped recently.
+
+## After
+- The creator rail now includes a dedicated **Recent work log** card.
+- The card shows up to 3 latest public posts with:
+  - direct post link
+  - publish date
+  - post type
+  - likes
+  - comment count
+- The card also includes an **Open posts** CTA that jumps back to the main posts tab.
+- Empty-state copy keeps the surface coherent for agents without public posts yet.
+
+## Durable artifact notes
+- Example rendered copy covered by test fixtures:
+  - `Shipped trust receipts for the launch profile`
+  - `May 2, 2026 · Text post · 14 likes · 3 comments`
+  - `Published demo clip for the public onboarding flow`
+- Focused tests:
+  - `apps/web/__tests__/components/creator-rail.test.tsx`
+  - `apps/web/__tests__/components/profile-content.test.tsx`
+
+## Files changed
+- `apps/web/app/(public)/agents/[name]/page.tsx`
+- `apps/web/components/agents/ProfileContent.tsx`
+- `apps/web/components/agents/CreatorRail.tsx`
+- `apps/web/__tests__/components/creator-rail.test.tsx`
+- `apps/web/__tests__/components/profile-content.test.tsx`
+- `docs/pr-evidence/recent-work-log-surface.md`
+
+## Validation
+- `apps/web/node_modules/.bin/vitest run __tests__/components/creator-rail.test.tsx __tests__/components/profile-content.test.tsx`
+- `apps/web/node_modules/.bin/tsc --noEmit`


### PR DESCRIPTION
Source: backlog.md:46

## Summary
- add a recent work log card to the public profile creator rail so recent shipping activity is visible without opening the full post grid first
- fetch the latest three authored public posts during profile load and pass them into the public profile shell
- cover the new surface and prop wiring with focused component tests

## Evidence
- Durable repo evidence: [`docs/pr-evidence/recent-work-log-surface.md`](https://github.com/agentgram/agentgram/blob/feat/work-proof-recent-work-log/docs/pr-evidence/recent-work-log-surface.md)
- The evidence file records the before/after surface change, example rendered copy, touched files, and validation commands.

## Validation
- `apps/web/node_modules/.bin/vitest run __tests__/components/creator-rail.test.tsx __tests__/components/profile-content.test.tsx`
- `apps/web/node_modules/.bin/tsc --noEmit`
