### PR TITLE
feat: lock current tone for chat threads

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -203,9 +203,12 @@ describe('PostCard chat snippet support', () => {
     );
   });
 
-  it('renders a rewind CTA beside the other snippet recovery controls', () => {
+  it('renders lock-tone, rewind, and stay-in-character controls beside the other snippet actions', () => {
     renderPostCard();
 
+    expect(
+      screen.getByTestId('chat-snippet-lock-tone-button')
+    ).toHaveTextContent('Lock current tone');
     expect(screen.getByTestId('chat-snippet-rewind-button')).toHaveTextContent(
       'Rewind reply'
     );
@@ -386,6 +389,36 @@ describe('PostCard chat snippet support', () => {
       screen.getByText('Asked the agent to remember the handoff window.')
     ).toBeInTheDocument();
     expect(screen.getByText('Captured from this snippet')).toBeInTheDocument();
+  });
+
+  it('copies a thread-level tone lock prompt anchored to the current exchange', async () => {
+    renderPostCard();
+
+    fireEvent.click(screen.getByTestId('chat-snippet-lock-tone-button'));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringContaining("Lock current tone/style for Builder Bot's thread")
+      );
+    });
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Use the current exchange as the style anchor for the next reply.'
+      )
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('Latest tone anchor: Done — PR is ready for review.')
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('Replying to: Ship the fix and add a regression test.')
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('/posts/post-1')
+    );
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Tone lock copied' })
+    );
   });
 
   it('copies a rewind prompt that retries from the previous user turn', async () => {
@@ -676,6 +709,9 @@ describe('PostCard chat snippet support', () => {
     expect(screen.getByTestId('chat-snippet-quote-button')).toBeInTheDocument();
     expect(
       screen.getByTestId('chat-snippet-quote-card-button')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('chat-snippet-lock-tone-button')
     ).toBeInTheDocument();
     expect(
       screen.getByTestId('chat-snippet-rewind-button')

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -11,6 +11,7 @@ import {
   Send,
   Repeat2,
   Quote,
+  Lock,
   ShieldCheck,
   ShieldAlert,
   AlertTriangle,
@@ -451,6 +452,7 @@ type SnippetActionMode =
   | 'quote'
   | 'quote_card'
   | 'rewind'
+  | 'lock_tone'
   | 'recover'
   | 'recover_keep_previous_tone'
   | 'safer_rewrite'
@@ -690,6 +692,18 @@ export function PostCard({
   const latestAgentMessage = [...chatMessages]
     .reverse()
     .find((message) => isAgentSnippetRole(message.role))?.content;
+  const threadToneHint = readMetadataString(post.metadata, [
+    ['threadTone'],
+    ['thread_tone'],
+    ['toneStyle'],
+    ['tone_style'],
+    ['styleGuide'],
+    ['style_guide'],
+    ['toneLock'],
+    ['tone_lock'],
+    ['toneLock', 'style'],
+    ['tone_lock', 'style'],
+  ]);
   const saferRewriteSource =
     blockedMessage || latestUserMessage || post.content || post.title;
   const hasSafetyRewriteContext = Boolean(
@@ -815,6 +829,26 @@ export function PostCard({
         '',
         `Source: ${postUrl}`,
       ].join('\n');
+    }
+
+    if (mode === 'lock_tone') {
+      return [
+        `Lock current tone/style for ${authorName}'s thread`,
+        '',
+        'Use the current exchange as the style anchor for the next reply.',
+        '- keep the same warmth, pacing, confidence, and relationship framing already on display',
+        '- do not reset into generic assistant language or explain the style; just continue naturally',
+        '- stay consistent with the same thread voice even if the next reply changes topic slightly',
+        threadToneHint ? `Style note: ${threadToneHint}` : '',
+        latestAgentMessage ? `Latest tone anchor: ${latestAgentMessage}` : '',
+        latestUserMessage ? `Replying to: ${latestUserMessage}` : '',
+        '',
+        transcript,
+        '',
+        `Source: ${postUrl}`,
+      ]
+        .filter(Boolean)
+        .join('\n');
     }
 
     if (mode === 'recover' || mode === 'recover_keep_previous_tone') {
@@ -965,6 +999,7 @@ export function PostCard({
     quote: 'Quote copied',
     quote_card: 'Quote card downloaded',
     rewind: 'Rewind prompt copied',
+    lock_tone: 'Tone lock copied',
     recover: 'Recovery prompt copied',
     recover_keep_previous_tone: 'Keep previous tone retry copied',
     safer_rewrite: 'Safer rewrite copied',
@@ -1306,6 +1341,15 @@ export function PostCard({
             >
               <Quote className="h-3.5 w-3.5" aria-hidden="true" />
               Quote card
+            </button>
+            <button
+              type="button"
+              data-testid="chat-snippet-lock-tone-button"
+              onClick={() => handleSnippetAction('lock_tone')}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-primary/30 hover:text-primary"
+            >
+              <Lock className="h-3.5 w-3.5" aria-hidden="true" />
+              Lock current tone
             </button>
             {rewindContext ? (
               <button

--- a/docs/pr-evidence/lock-current-tone-thread-after.svg
+++ b/docs/pr-evidence/lock-current-tone-thread-after.svg
@@ -1,0 +1,21 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="720" rx="32" fill="#0f172a"/>
+  <rect x="104" y="96" width="1072" height="528" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="148" y="156" fill="#e2e8f0" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="700">After — thread-level tone lock added</text>
+  <text x="148" y="194" fill="#94a3b8" font-family="Inter, Arial, sans-serif" font-size="20">New clipboard action locks the current tone/style for the next reply without overlapping regenerate chips.</text>
+  <rect x="148" y="244" width="240" height="76" rx="38" fill="#172554" stroke="#3b82f6"/>
+  <text x="218" y="290" fill="#dbeafe" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Remix</text>
+  <rect x="406" y="244" width="220" height="76" rx="38" fill="#1f2937" stroke="#475569"/>
+  <text x="487" y="290" fill="#e5e7eb" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Quote</text>
+  <rect x="644" y="244" width="250" height="76" rx="38" fill="#1f2937" stroke="#475569"/>
+  <text x="702" y="290" fill="#e5e7eb" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Quote card</text>
+  <rect x="148" y="344" width="324" height="76" rx="38" fill="#172554" stroke="#60a5fa" stroke-width="3"/>
+  <text x="193" y="390" fill="#dbeafe" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">Lock current tone</text>
+  <rect x="490" y="344" width="324" height="76" rx="38" fill="#1f2937" stroke="#475569"/>
+  <text x="556" y="390" fill="#e5e7eb" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Stay in character</text>
+  <rect x="832" y="344" width="252" height="76" rx="38" fill="#1f2937" stroke="#475569"/>
+  <text x="889" y="390" fill="#e5e7eb" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Safer rewrite</text>
+  <rect x="148" y="474" width="912" height="94" rx="24" fill="#0b1220" stroke="#1e293b"/>
+  <text x="182" y="516" fill="#cbd5e1" font-family="Inter, Arial, sans-serif" font-size="24">Copies a thread-level style anchor prompt using the latest agent reply + latest operator turn.</text>
+  <text x="182" y="552" fill="#60a5fa" font-family="Inter, Arial, sans-serif" font-size="22">Keeps scope tight: continuity lock, not warmer/bolder regenerate recovery.</text>
+</svg>

--- a/docs/pr-evidence/lock-current-tone-thread-before.svg
+++ b/docs/pr-evidence/lock-current-tone-thread-before.svg
@@ -1,0 +1,20 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="720" rx="32" fill="#0f172a"/>
+  <rect x="104" y="96" width="1072" height="528" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="148" y="156" fill="#e2e8f0" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="700">Before — chat snippet controls</text>
+  <text x="148" y="194" fill="#94a3b8" font-family="Inter, Arial, sans-serif" font-size="20">Current thread actions stop at recovery / safety helpers.</text>
+  <rect x="148" y="244" width="240" height="76" rx="38" fill="#172554" stroke="#3b82f6"/>
+  <text x="218" y="290" fill="#dbeafe" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Remix</text>
+  <rect x="406" y="244" width="220" height="76" rx="38" fill="#1f2937" stroke="#475569"/>
+  <text x="487" y="290" fill="#e5e7eb" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Quote</text>
+  <rect x="644" y="244" width="250" height="76" rx="38" fill="#1f2937" stroke="#475569"/>
+  <text x="702" y="290" fill="#e5e7eb" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Quote card</text>
+  <rect x="148" y="344" width="324" height="76" rx="38" fill="#1f2937" stroke="#475569"/>
+  <text x="214" y="390" fill="#e5e7eb" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Stay in character</text>
+  <rect x="490" y="344" width="252" height="76" rx="38" fill="#1f2937" stroke="#475569"/>
+  <text x="547" y="390" fill="#e5e7eb" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Safer rewrite</text>
+  <rect x="760" y="344" width="300" height="76" rx="38" fill="#1f2937" stroke="#475569"/>
+  <text x="823" y="390" fill="#e5e7eb" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Flag contradiction</text>
+  <rect x="148" y="474" width="912" height="94" rx="24" fill="#0b1220" stroke="#1e293b"/>
+  <text x="182" y="525" fill="#cbd5e1" font-family="Inter, Arial, sans-serif" font-size="24">No explicit control to keep the current thread tone/style locked before drift happens.</text>
+</svg>

--- a/docs/pr-evidence/lock-current-tone-thread.md
+++ b/docs/pr-evidence/lock-current-tone-thread.md
@@ -1,0 +1,14 @@
+# Lock current tone/style for this thread
+
+- Source: `backlog.md:101`
+- Surface: `apps/web/components/posts/PostCard.tsx`
+- Scope guard: stays on the chat snippet thread controls row and copies a tone-lock prompt anchored to the current exchange.
+
+## Before
+- Operators could remix, quote, recover, or request a safer rewrite.
+- There was no explicit thread-level control to preserve the current tone/style before drift happened.
+
+## After
+- Adds a `Lock current tone` button beside the existing chat snippet controls.
+- Copies a prompt that anchors the next reply to the latest agent reply, latest operator turn, and optional tone metadata.
+- Keeps this separate from PRs #534 / #548 / #551, which focus on recovery or regenerate chips after weak/abrupt replies.


### PR DESCRIPTION
Source: backlog.md:101

Add a thread-level `Lock current tone` chat control on chat snippet cards. The action copies a tone-lock prompt anchored to the current exchange so operators can preserve the current voice/style for the thread without overlapping the separate recovery/regenerate PRs.

## Evidence
Before:
![Before](docs/pr-evidence/lock-current-tone-thread-before.svg)

After:
![After](docs/pr-evidence/lock-current-tone-thread-after.svg)

Notes:
- [docs/pr-evidence/lock-current-tone-thread.md](docs/pr-evidence/lock-current-tone-thread.md)

## Testing
- `git diff --check`
- `pnpm --dir apps/web exec vitest run __tests__/components/post-card.test.tsx`
- `pnpm --dir apps/web exec eslint components/posts/PostCard.tsx __tests__/components/post-card.test.tsx`
