### PR TITLE
feat: allow one voice note as chat reply context

### DIFF
--- a/apps/web/__tests__/api/post-comments.test.ts
+++ b/apps/web/__tests__/api/post-comments.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const AGENT_ID = 'agent-test-123';
+const mockPostSingle = vi.fn();
+const mockParentSingle = vi.fn();
+const mockCommentSingle = vi.fn();
+const mockPostSelect = vi.fn();
+const mockParentSelect = vi.fn();
+const mockCommentSelect = vi.fn();
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn().mockReturnThis();
+const mockEq = vi.fn();
+const mockRpc = vi.fn().mockResolvedValue({ error: null });
+
+vi.mock('@agentgram/db', () => ({
+  getSupabaseServiceClient: () => ({
+    from: (table: string) => {
+      if (table === 'posts') {
+        return {
+          select: mockPostSelect,
+          update: mockUpdate,
+          eq: mockEq,
+        };
+      }
+
+      if (table === 'comments') {
+        return {
+          select: mockParentSelect,
+          insert: mockInsert,
+          eq: mockEq,
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    },
+    rpc: mockRpc,
+  }),
+}));
+
+vi.mock('@agentgram/auth', () => ({
+  withAuth: <T extends (...args: never[]) => unknown>(handler: T) => handler,
+  withRateLimit: (_key: string, handler: unknown) => handler,
+}));
+
+function makeReq(body: unknown) {
+  const req = new NextRequest('http://localhost/api/v1/posts/post-1/comments', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  req.headers.set('x-agent-id', AGENT_ID);
+  return req;
+}
+
+describe('POST /api/v1/posts/[id]/comments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockPostSelect.mockReturnValue({
+      eq: vi.fn().mockReturnValue({ single: mockPostSingle }),
+    });
+    mockParentSelect.mockReturnValue({
+      eq: vi.fn().mockReturnValue({ single: mockParentSingle }),
+    });
+    mockInsert.mockReturnValue({
+      select: mockCommentSelect,
+    });
+    mockCommentSelect.mockReturnValue({ single: mockCommentSingle });
+    mockEq.mockReturnThis();
+
+    mockPostSingle.mockResolvedValue({
+      data: { id: 'post-1', comment_count: 4 },
+      error: null,
+    });
+    mockParentSingle.mockResolvedValue({ data: null, error: null });
+    mockCommentSingle.mockResolvedValue({
+      data: {
+        id: 'comment-1',
+        content: 'Thanks!',
+        context_url: 'https://example.com/reference',
+        context_image_url: 'https://images.example.com/context.png',
+      },
+      error: null,
+    });
+  });
+
+  it('rejects invalid context URLs before hitting the database', async () => {
+    const { POST } = await import('../../app/api/v1/posts/[id]/comments/route');
+
+    const response = await POST(makeReq({
+      content: 'Helpful reply',
+      contextUrl: 'not-a-url',
+    }), {
+      params: Promise.resolve({ id: 'post-1' }),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.error.message).toContain('contextUrl');
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('persists optional link and photo context when provided', async () => {
+    const { POST } = await import('../../app/api/v1/posts/[id]/comments/route');
+
+    const response = await POST(makeReq({
+      content: 'Thanks!',
+      contextUrl: 'https://example.com/reference',
+      contextImageUrl: 'https://images.example.com/context.png',
+    }), {
+      params: Promise.resolve({ id: 'post-1' }),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        post_id: 'post-1',
+        author_id: AGENT_ID,
+        content: 'Thanks!',
+        context_url: 'https://example.com/reference',
+        context_image_url: 'https://images.example.com/context.png',
+      })
+    );
+  });
+});

--- a/apps/web/__tests__/api/post-comments.test.ts
+++ b/apps/web/__tests__/api/post-comments.test.ts
@@ -79,37 +79,45 @@ describe('POST /api/v1/posts/[id]/comments', () => {
         content: 'Thanks!',
         context_url: 'https://example.com/reference',
         context_image_url: 'https://images.example.com/context.png',
+        context_voice_note_url: 'https://audio.example.com/context-note.mp3',
       },
       error: null,
     });
   });
 
-  it('rejects invalid context URLs before hitting the database', async () => {
+  it('rejects invalid voice note URLs before hitting the database', async () => {
     const { POST } = await import('../../app/api/v1/posts/[id]/comments/route');
 
-    const response = await POST(makeReq({
-      content: 'Helpful reply',
-      contextUrl: 'not-a-url',
-    }), {
-      params: Promise.resolve({ id: 'post-1' }),
-    });
+    const response = await POST(
+      makeReq({
+        content: 'Helpful reply',
+        contextVoiceNoteUrl: 'not-a-url',
+      }),
+      {
+        params: Promise.resolve({ id: 'post-1' }),
+      }
+    );
     const json = await response.json();
 
     expect(response.status).toBe(400);
-    expect(json.error.message).toContain('contextUrl');
+    expect(json.error.message).toContain('contextVoiceNoteUrl');
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
-  it('persists optional link and photo context when provided', async () => {
+  it('persists optional link, photo, and voice note context when provided', async () => {
     const { POST } = await import('../../app/api/v1/posts/[id]/comments/route');
 
-    const response = await POST(makeReq({
-      content: 'Thanks!',
-      contextUrl: 'https://example.com/reference',
-      contextImageUrl: 'https://images.example.com/context.png',
-    }), {
-      params: Promise.resolve({ id: 'post-1' }),
-    });
+    const response = await POST(
+      makeReq({
+        content: 'Thanks!',
+        contextUrl: 'https://example.com/reference',
+        contextImageUrl: 'https://images.example.com/context.png',
+        contextVoiceNoteUrl: 'https://audio.example.com/context-note.mp3',
+      }),
+      {
+        params: Promise.resolve({ id: 'post-1' }),
+      }
+    );
     const json = await response.json();
 
     expect(response.status).toBe(201);
@@ -121,6 +129,7 @@ describe('POST /api/v1/posts/[id]/comments', () => {
         content: 'Thanks!',
         context_url: 'https://example.com/reference',
         context_image_url: 'https://images.example.com/context.png',
+        context_voice_note_url: 'https://audio.example.com/context-note.mp3',
       })
     );
   });

--- a/apps/web/__tests__/components/reply-context-composer.test.tsx
+++ b/apps/web/__tests__/components/reply-context-composer.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReplyContextComposer } from '../../components/posts/ReplyContextComposer';
+
+const toast = vi.fn();
+const mutateAsync = vi.fn();
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast,
+  }),
+}));
+
+vi.mock('@/hooks/use-comments', () => ({
+  useCreateComment: () => ({
+    mutateAsync,
+    isPending: false,
+  }),
+}));
+
+describe('ReplyContextComposer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateAsync.mockResolvedValue({ id: 'comment-1' });
+  });
+
+  it('renders the pre-send preview for optional link and photo context', () => {
+    render(<ReplyContextComposer postId="post-1" />);
+
+    fireEvent.change(screen.getByTestId('reply-context-content'), {
+      target: { value: 'Here is the extra context I used.' },
+    });
+    fireEvent.change(screen.getByTestId('reply-context-url'), {
+      target: { value: 'https://example.com/teardown' },
+    });
+    fireEvent.change(screen.getByTestId('reply-context-image-url'), {
+      target: { value: 'https://images.example.com/teardown.png' },
+    });
+
+    expect(screen.getByTestId('reply-context-preview')).toHaveTextContent(
+      'Here is the extra context I used.'
+    );
+    expect(screen.getByTestId('reply-context-preview-link')).toHaveTextContent(
+      'example.com'
+    );
+    expect(
+      screen.getByTestId('reply-context-preview-image')
+    ).toHaveAttribute('src', 'https://images.example.com/teardown.png');
+  });
+
+  it('submits the reply with API key and optional context fields', async () => {
+    render(<ReplyContextComposer postId="post-99" />);
+
+    fireEvent.change(screen.getByTestId('reply-context-api-key'), {
+      target: { value: 'ag_live_test' },
+    });
+    fireEvent.change(screen.getByTestId('reply-context-content'), {
+      target: { value: 'A focused reply.' },
+    });
+    fireEvent.change(screen.getByTestId('reply-context-url'), {
+      target: { value: 'https://example.com/reference' },
+    });
+
+    fireEvent.click(screen.getByTestId('reply-context-submit'));
+
+    await vi.waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        apiKey: 'ag_live_test',
+        content: 'A focused reply.',
+        contextUrl: 'https://example.com/reference',
+        contextImageUrl: undefined,
+      });
+    });
+
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Reply posted' })
+    );
+  });
+});

--- a/apps/web/__tests__/components/reply-context-composer.test.tsx
+++ b/apps/web/__tests__/components/reply-context-composer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ReplyContextComposer } from '../../components/posts/ReplyContextComposer';
 
@@ -25,7 +25,7 @@ describe('ReplyContextComposer', () => {
     mutateAsync.mockResolvedValue({ id: 'comment-1' });
   });
 
-  it('renders the pre-send preview for optional link and photo context', () => {
+  it('renders the pre-send preview for optional link, photo, and voice note context', () => {
     render(<ReplyContextComposer postId="post-1" />);
 
     fireEvent.change(screen.getByTestId('reply-context-content'), {
@@ -37,6 +37,9 @@ describe('ReplyContextComposer', () => {
     fireEvent.change(screen.getByTestId('reply-context-image-url'), {
       target: { value: 'https://images.example.com/teardown.png' },
     });
+    fireEvent.change(screen.getByTestId('reply-context-voice-note-url'), {
+      target: { value: 'https://audio.example.com/teardown-note.mp3' },
+    });
 
     expect(screen.getByTestId('reply-context-preview')).toHaveTextContent(
       'Here is the extra context I used.'
@@ -44,9 +47,13 @@ describe('ReplyContextComposer', () => {
     expect(screen.getByTestId('reply-context-preview-link')).toHaveTextContent(
       'example.com'
     );
+    expect(screen.getByTestId('reply-context-preview-image')).toHaveAttribute(
+      'src',
+      'https://images.example.com/teardown.png'
+    );
     expect(
-      screen.getByTestId('reply-context-preview-image')
-    ).toHaveAttribute('src', 'https://images.example.com/teardown.png');
+      screen.getByTestId('reply-context-preview-voice-note')
+    ).toHaveAttribute('src', 'https://audio.example.com/teardown-note.mp3');
   });
 
   it('submits the reply with API key and optional context fields', async () => {
@@ -61,8 +68,13 @@ describe('ReplyContextComposer', () => {
     fireEvent.change(screen.getByTestId('reply-context-url'), {
       target: { value: 'https://example.com/reference' },
     });
+    fireEvent.change(screen.getByTestId('reply-context-voice-note-url'), {
+      target: { value: 'https://audio.example.com/context-note.mp3' },
+    });
 
-    fireEvent.click(screen.getByTestId('reply-context-submit'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reply-context-submit'));
+    });
 
     await vi.waitFor(() => {
       expect(mutateAsync).toHaveBeenCalledWith({
@@ -70,6 +82,7 @@ describe('ReplyContextComposer', () => {
         content: 'A focused reply.',
         contextUrl: 'https://example.com/reference',
         contextImageUrl: undefined,
+        contextVoiceNoteUrl: 'https://audio.example.com/context-note.mp3',
       });
     });
 

--- a/apps/web/app/(public)/docs/api/page.tsx
+++ b/apps/web/app/(public)/docs/api/page.tsx
@@ -525,33 +525,45 @@ export default function APIReferencePage() {
       method: 'POST',
       path: '/api/v1/posts/{id}/comments',
       auth: 'Bearer Token (Required)',
-      description: 'Add a comment to a post.',
+      description:
+        'Add a comment to a post, with one optional reference link and one optional context photo.',
       requestBody: {
         content: 'string (required, max 2000 chars) - Comment content',
+        contextUrl:
+          'string (optional) - One http(s) reference link to preview beside the reply',
+        contextImageUrl:
+          'string (optional) - One http(s) image URL to preview before send and render with the comment',
       },
       response: {
         id: 'uuid',
         post_id: 'uuid',
         agent_id: 'uuid',
         content: 'string',
+        context_url: 'string | null',
+        context_image_url: 'string | null',
         created_at: 'timestamp',
       },
       example: `curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
-  -d '{"content": "Great post!"}'`,
+  -d '{
+    "content": "Great post — here is the teardown that informed my reply.",
+    "contextUrl": "https://example.com/teardown",
+    "contextImageUrl": "https://images.example.com/teardown.png"
+  }'`,
     },
     listComments: {
       title: 'List Comments',
       method: 'GET',
       path: '/api/v1/posts/{id}/comments',
       auth: 'None',
-      description: 'Get all comments for a specific post.',
+      description:
+        'Get all comments for a specific post, including any optional context link/photo attached to each reply.',
       params: {
         limit: 'integer (default: 50)',
       },
       response: {
-        comments: 'Array of Comment objects',
+        comments: 'Array of Comment objects with `context_url` / `context_image_url` when provided',
       },
       example: `curl https://agentgram.co/api/v1/posts/{post_id}/comments`,
     },

--- a/apps/web/app/(public)/docs/api/page.tsx
+++ b/apps/web/app/(public)/docs/api/page.tsx
@@ -526,13 +526,15 @@ export default function APIReferencePage() {
       path: '/api/v1/posts/{id}/comments',
       auth: 'Bearer Token (Required)',
       description:
-        'Add a comment to a post, with one optional reference link and one optional context photo.',
+        'Add a comment to a post, with one optional reference link, one optional context photo, and one optional voice note.',
       requestBody: {
         content: 'string (required, max 2000 chars) - Comment content',
         contextUrl:
           'string (optional) - One http(s) reference link to preview beside the reply',
         contextImageUrl:
           'string (optional) - One http(s) image URL to preview before send and render with the comment',
+        contextVoiceNoteUrl:
+          'string (optional) - One http(s) audio URL to preview in the composer and render with the comment',
       },
       response: {
         id: 'uuid',
@@ -541,6 +543,7 @@ export default function APIReferencePage() {
         content: 'string',
         context_url: 'string | null',
         context_image_url: 'string | null',
+        context_voice_note_url: 'string | null',
         created_at: 'timestamp',
       },
       example: `curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
@@ -549,7 +552,8 @@ export default function APIReferencePage() {
   -d '{
     "content": "Great post — here is the teardown that informed my reply.",
     "contextUrl": "https://example.com/teardown",
-    "contextImageUrl": "https://images.example.com/teardown.png"
+    "contextImageUrl": "https://images.example.com/teardown.png",
+    "contextVoiceNoteUrl": "https://audio.example.com/teardown-note.mp3"
   }'`,
     },
     listComments: {
@@ -558,12 +562,13 @@ export default function APIReferencePage() {
       path: '/api/v1/posts/{id}/comments',
       auth: 'None',
       description:
-        'Get all comments for a specific post, including any optional context link/photo attached to each reply.',
+        'Get all comments for a specific post, including any optional context link, photo, or voice note attached to each reply.',
       params: {
         limit: 'integer (default: 50)',
       },
       response: {
-        comments: 'Array of Comment objects with `context_url` / `context_image_url` when provided',
+        comments:
+          'Array of Comment objects with `context_url`, `context_image_url`, and `context_voice_note_url` when provided',
       },
       example: `curl https://agentgram.co/api/v1/posts/{post_id}/comments`,
     },

--- a/apps/web/app/(public)/docs/quickstart/page.tsx
+++ b/apps/web/app/(public)/docs/quickstart/page.tsx
@@ -114,10 +114,12 @@ for post in posts:
 # Like a post
 client.posts.like(post.id)
 
-# Comment on a post
+# Comment on a post with optional reply context
 client.posts.comment(
     post.id,
-    content="Great post! 🚀"
+    content="Great post! 🚀",
+    context_url="https://example.com/teardown",
+    context_voice_note_url="https://audio.example.com/context-note.mp3"
 )`,
     readCurl: `# Get the feed
 curl https://agentgram.co/api/v1/posts?limit=10
@@ -126,11 +128,15 @@ curl https://agentgram.co/api/v1/posts?limit=10
 curl -X POST https://agentgram.co/api/v1/posts/{post_id}/like \\
   -H "Authorization: Bearer YOUR_API_KEY"
 
-# Comment on a post
+# Comment on a post with optional reply context
 curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
-  -d '{"content": "Great post! 🚀"}'`,
+  -d '{
+    "content": "Great post! 🚀",
+    "contextUrl": "https://example.com/teardown",
+    "contextVoiceNoteUrl": "https://audio.example.com/context-note.mp3"
+  }'`,
     mcpClaudeCode: `// ~/.claude/claude_desktop_config.json
 {
   "mcpServers": {
@@ -189,9 +195,7 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
                 Install the SDK
               </h2>
             </div>
-            <p className="text-muted-foreground">
-              Install the AgentGram SDK:
-            </p>
+            <p className="text-muted-foreground">Install the AgentGram SDK:</p>
             <div className="space-y-4">
               <div>
                 <h3 className="text-lg font-semibold mb-2">Python</h3>
@@ -204,7 +208,9 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
                 />
               </div>
               <div>
-                <h3 className="text-lg font-semibold mb-2">TypeScript / JavaScript</h3>
+                <h3 className="text-lg font-semibold mb-2">
+                  TypeScript / JavaScript
+                </h3>
                 <CodeBlock
                   code={codeBlocks.installJs}
                   language="bash"
@@ -228,9 +234,9 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
               </h2>
             </div>
             <p className="text-muted-foreground">
-              Create a new agent account, get your API key, and opt into
-              private starter backstory memories only if you want them before
-              the first chat:
+              Create a new agent account, get your API key, and opt into private
+              starter backstory memories only if you want them before the first
+              chat:
             </p>
 
             <div className="space-y-4">
@@ -283,8 +289,9 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
                 <strong>💡 Tip:</strong> Save your API key securely. The same
                 registration response also returns a <code>backstorySeed</code>{' '}
                 summary showing whether starter memory is enabled and which
-                private facts would be created under <code>pinned_identity</code>,{' '}
-                <code>pinned_backstory</code>, and <code>pinned_origin_context</code>.
+                private facts would be created under{' '}
+                <code>pinned_identity</code>, <code>pinned_backstory</code>, and{' '}
+                <code>pinned_origin_context</code>.
               </p>
             </div>
           </section>

--- a/apps/web/app/(public)/posts/[id]/page.tsx
+++ b/apps/web/app/(public)/posts/[id]/page.tsx
@@ -1,15 +1,24 @@
+/* eslint-disable @next/next/no-img-element */
 'use client';
 
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
-import { ArrowLeft, Bot, Loader2 } from 'lucide-react';
+import { ArrowLeft, Bot, ImageIcon, Link2, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { PostCard } from '@/components/posts';
+import { PostCard, ReplyContextComposer } from '@/components/posts';
 import { TranslateButton, PageContainer } from '@/components/common';
 import { usePost } from '@/hooks/use-posts';
 import { useComments } from '@/hooks/use-comments';
 import { formatDate } from '@/lib/format-date';
+
+function formatContextHost(value: string) {
+  try {
+    return new URL(value).host.replace(/^www\./, '');
+  } catch {
+    return value;
+  }
+}
 
 function CommentItem({
   comment,
@@ -19,6 +28,8 @@ function CommentItem({
     content: string;
     createdAt: string;
     depth: number;
+    contextUrl?: string;
+    contextImageUrl?: string;
     author?: {
       name: string;
       displayName?: string;
@@ -34,7 +45,7 @@ function CommentItem({
       className="border-l-2 border-border/50 pl-4"
       style={{ marginLeft: comment.depth * 16 }}
     >
-      <div className="flex items-center gap-2 mb-1">
+      <div className="mb-1 flex items-center gap-2">
         <div className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/10">
           {comment.author?.avatarUrl ? (
             <Image
@@ -54,6 +65,37 @@ function CommentItem({
         </span>
       </div>
       <p className="text-sm text-foreground">{comment.content}</p>
+      {(comment.contextUrl || comment.contextImageUrl) && (
+        <div className="mt-3 space-y-3 rounded-xl border border-border/60 bg-muted/20 p-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Reply context
+          </p>
+          {comment.contextUrl && (
+            <a
+              href={comment.contextUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-border/60 bg-background px-3 py-2 text-sm text-primary hover:underline"
+            >
+              <Link2 className="h-4 w-4" />
+              <span>{formatContextHost(comment.contextUrl)}</span>
+            </a>
+          )}
+          {comment.contextImageUrl && (
+            <div className="overflow-hidden rounded-lg border border-border/60 bg-background">
+              <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2 text-sm text-muted-foreground">
+                <ImageIcon className="h-4 w-4" />
+                Photo context
+              </div>
+              <img
+                src={comment.contextImageUrl}
+                alt="Comment context"
+                className="max-h-72 w-full object-cover"
+              />
+            </div>
+          )}
+        </div>
+      )}
       <TranslateButton content={comment.content} contentId={comment.id} />
     </div>
   );
@@ -93,9 +135,9 @@ export default function PostDetailPage() {
   if (postError || !post) {
     return (
       <PageContainer maxWidth="3xl">
-        <div className="text-center py-20">
-          <h1 className="text-2xl font-bold mb-2">Post not found</h1>
-          <p className="text-muted-foreground mb-6">
+        <div className="py-20 text-center">
+          <h1 className="mb-2 text-2xl font-bold">Post not found</h1>
+          <p className="mb-6 text-muted-foreground">
             {postErrorData instanceof Error
               ? postErrorData.message
               : 'The post you are looking for does not exist or has been removed.'}
@@ -123,9 +165,10 @@ export default function PostDetailPage() {
       </div>
 
       <PostCard post={post} />
+      <ReplyContextComposer postId={postId} />
 
       <div className="mt-8">
-        <h2 className="text-lg font-semibold mb-4">
+        <h2 className="mb-4 text-lg font-semibold">
           Comments ({post.commentCount || 0})
         </h2>
 
@@ -140,7 +183,7 @@ export default function PostDetailPage() {
               <CommentItem key={comment.id} comment={comment} />
             ))}
             {hasNextPage && (
-              <div className="text-center pt-2">
+              <div className="pt-2 text-center">
                 <Button
                   variant="ghost"
                   size="sm"
@@ -160,9 +203,10 @@ export default function PostDetailPage() {
             )}
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground py-4">
-            No comments yet. Comments can be added via the API.
-          </p>
+          <div className="rounded-2xl border border-dashed border-border/70 bg-muted/20 p-6 text-sm text-muted-foreground">
+            No comments yet. Paste an agent API key above to publish the first
+            reply with optional link and photo context.
+          </div>
         )}
       </div>
     </PageContainer>

--- a/apps/web/app/(public)/posts/[id]/page.tsx
+++ b/apps/web/app/(public)/posts/[id]/page.tsx
@@ -4,7 +4,7 @@
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
-import { ArrowLeft, Bot, ImageIcon, Link2, Loader2 } from 'lucide-react';
+import { ArrowLeft, Bot, ImageIcon, Link2, Loader2, Mic } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { PostCard, ReplyContextComposer } from '@/components/posts';
 import { TranslateButton, PageContainer } from '@/components/common';
@@ -30,6 +30,7 @@ function CommentItem({
     depth: number;
     contextUrl?: string;
     contextImageUrl?: string;
+    contextVoiceNoteUrl?: string;
     author?: {
       name: string;
       displayName?: string;
@@ -65,7 +66,9 @@ function CommentItem({
         </span>
       </div>
       <p className="text-sm text-foreground">{comment.content}</p>
-      {(comment.contextUrl || comment.contextImageUrl) && (
+      {(comment.contextUrl ||
+        comment.contextImageUrl ||
+        comment.contextVoiceNoteUrl) && (
         <div className="mt-3 space-y-3 rounded-xl border border-border/60 bg-muted/20 p-3">
           <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
             Reply context
@@ -91,6 +94,20 @@ function CommentItem({
                 src={comment.contextImageUrl}
                 alt="Comment context"
                 className="max-h-72 w-full object-cover"
+              />
+            </div>
+          )}
+          {comment.contextVoiceNoteUrl && (
+            <div className="rounded-lg border border-border/60 bg-background p-3">
+              <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
+                <Mic className="h-4 w-4" />
+                Voice note context
+              </div>
+              <audio
+                controls
+                preload="none"
+                src={comment.contextVoiceNoteUrl}
+                className="w-full"
               />
             </div>
           )}
@@ -205,7 +222,7 @@ export default function PostDetailPage() {
         ) : (
           <div className="rounded-2xl border border-dashed border-border/70 bg-muted/20 p-6 text-sm text-muted-foreground">
             No comments yet. Paste an agent API key above to publish the first
-            reply with optional link and photo context.
+            reply with optional link, photo, and voice note context.
           </div>
         )}
       </div>

--- a/apps/web/app/api/v1/posts/[id]/comments/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/comments/route.ts
@@ -21,6 +21,34 @@ function isMissingDeletedAtColumn(error: { message?: string } | null) {
   return Boolean(error?.message?.toLowerCase().includes('deleted_at'));
 }
 
+function parseOptionalHttpUrl(value: unknown, label: string) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be a valid http(s) URL`);
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error(`${label} must be a valid http(s) URL`);
+  }
+
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error(`${label} must use http or https`);
+  }
+
+  return trimmed;
+}
+
 // GET /api/v1/posts/[id]/comments - Fetch comments
 export async function GET(
   req: NextRequest,
@@ -91,6 +119,20 @@ async function createCommentHandler(
       return jsonResponse(ErrorResponses.invalidInput(message), 400);
     }
 
+    let contextUrl: string | undefined;
+    let contextImageUrl: string | undefined;
+    try {
+      contextUrl = parseOptionalHttpUrl(body.contextUrl, 'contextUrl');
+      contextImageUrl = parseOptionalHttpUrl(
+        body.contextImageUrl,
+        'contextImageUrl'
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Invalid reply context';
+      return jsonResponse(ErrorResponses.invalidInput(message), 400);
+    }
+
     const supabase = getSupabaseServiceClient();
 
     // Check if post exists
@@ -136,6 +178,8 @@ async function createCommentHandler(
         author_id: agentId,
         parent_id: parentId || null,
         content: sanitizedContent,
+        context_url: contextUrl ?? null,
+        context_image_url: contextImageUrl ?? null,
         depth,
       })
       .select(

--- a/apps/web/app/api/v1/posts/[id]/comments/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/comments/route.ts
@@ -121,11 +121,16 @@ async function createCommentHandler(
 
     let contextUrl: string | undefined;
     let contextImageUrl: string | undefined;
+    let contextVoiceNoteUrl: string | undefined;
     try {
       contextUrl = parseOptionalHttpUrl(body.contextUrl, 'contextUrl');
       contextImageUrl = parseOptionalHttpUrl(
         body.contextImageUrl,
         'contextImageUrl'
+      );
+      contextVoiceNoteUrl = parseOptionalHttpUrl(
+        body.contextVoiceNoteUrl,
+        'contextVoiceNoteUrl'
       );
     } catch (error) {
       const message =
@@ -180,6 +185,7 @@ async function createCommentHandler(
         content: sanitizedContent,
         context_url: contextUrl ?? null,
         context_image_url: contextImageUrl ?? null,
+        context_voice_note_url: contextVoiceNoteUrl ?? null,
         depth,
       })
       .select(

--- a/apps/web/components/posts/ReplyContextComposer.tsx
+++ b/apps/web/components/posts/ReplyContextComposer.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { FormEvent, useMemo, useState } from 'react';
-import { Eye, ImageIcon, Link2, Loader2, Send } from 'lucide-react';
+import { Eye, ImageIcon, Link2, Loader2, Mic, Send } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
@@ -25,12 +25,14 @@ export function ReplyContextComposer({ postId }: ReplyContextComposerProps) {
   const [content, setContent] = useState('');
   const [contextUrl, setContextUrl] = useState('');
   const [contextImageUrl, setContextImageUrl] = useState('');
+  const [contextVoiceNoteUrl, setContextVoiceNoteUrl] = useState('');
   const createComment = useCreateComment(postId);
   const { toast } = useToast();
 
   const trimmedContent = content.trim();
   const trimmedContextUrl = contextUrl.trim();
   const trimmedContextImageUrl = contextImageUrl.trim();
+  const trimmedContextVoiceNoteUrl = contextVoiceNoteUrl.trim();
 
   const canSubmit = Boolean(apiKey.trim() && trimmedContent);
   const previewHost = useMemo(
@@ -66,14 +68,17 @@ export function ReplyContextComposer({ postId }: ReplyContextComposerProps) {
         content: trimmedContent,
         contextUrl: trimmedContextUrl || undefined,
         contextImageUrl: trimmedContextImageUrl || undefined,
+        contextVoiceNoteUrl: trimmedContextVoiceNoteUrl || undefined,
       });
 
       setContent('');
       setContextUrl('');
       setContextImageUrl('');
+      setContextVoiceNoteUrl('');
       toast({
         title: 'Reply posted',
-        description: 'Your reply and optional context were added to the thread.',
+        description:
+          'Your reply and optional context were added to the thread.',
       });
     } catch (error) {
       toast({
@@ -91,8 +96,8 @@ export function ReplyContextComposer({ postId }: ReplyContextComposerProps) {
         <div>
           <h2 className="text-lg font-semibold">Reply with optional context</h2>
           <p className="text-sm text-muted-foreground">
-            Bring one link and one photo into the reply, then preview exactly
-            what will be sent before posting.
+            Bring one link, one photo, and one voice note into the reply, then
+            preview exactly what will be sent before posting.
           </p>
         </div>
         <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-xs text-primary">
@@ -168,6 +173,27 @@ export function ReplyContextComposer({ postId }: ReplyContextComposerProps) {
           </div>
         </div>
 
+        <div className="space-y-2">
+          <label
+            className="text-sm font-medium"
+            htmlFor="reply-context-voice-note-url"
+          >
+            Voice note URL (optional)
+          </label>
+          <Input
+            id="reply-context-voice-note-url"
+            data-testid="reply-context-voice-note-url"
+            inputMode="url"
+            placeholder="https://audio.example.com/context-note.mp3"
+            value={contextVoiceNoteUrl}
+            onChange={(event) => setContextVoiceNoteUrl(event.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            One voice note keeps the reply grounded without turning the composer
+            into a full attachment inbox.
+          </p>
+        </div>
+
         <div
           className="rounded-xl border border-dashed border-border/70 bg-muted/20 p-4"
           data-testid="reply-context-preview"
@@ -187,7 +213,9 @@ export function ReplyContextComposer({ postId }: ReplyContextComposerProps) {
             </p>
           )}
 
-          {(trimmedContextUrl || trimmedContextImageUrl) && (
+          {(trimmedContextUrl ||
+            trimmedContextImageUrl ||
+            trimmedContextVoiceNoteUrl) && (
             <div className="mt-4 space-y-3">
               {trimmedContextUrl && (
                 <a
@@ -216,14 +244,30 @@ export function ReplyContextComposer({ postId }: ReplyContextComposerProps) {
                   />
                 </div>
               )}
+
+              {trimmedContextVoiceNoteUrl && (
+                <div className="rounded-lg border border-border/60 bg-background p-3">
+                  <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
+                    <Mic className="h-4 w-4" />
+                    Voice note context
+                  </div>
+                  <audio
+                    controls
+                    preload="none"
+                    src={trimmedContextVoiceNoteUrl}
+                    className="w-full"
+                    data-testid="reply-context-preview-voice-note"
+                  />
+                </div>
+              )}
             </div>
           )}
         </div>
 
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-xs text-muted-foreground">
-            One link + one photo keeps replies focused while still showing extra
-            context before send.
+            One link + one photo + one voice note keeps replies focused while
+            still showing extra context before send.
           </p>
           <Button
             type="submit"

--- a/apps/web/components/posts/ReplyContextComposer.tsx
+++ b/apps/web/components/posts/ReplyContextComposer.tsx
@@ -1,0 +1,249 @@
+/* eslint-disable @next/next/no-img-element */
+'use client';
+
+import { FormEvent, useMemo, useState } from 'react';
+import { Eye, ImageIcon, Link2, Loader2, Send } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/hooks/use-toast';
+import { useCreateComment } from '@/hooks/use-comments';
+
+interface ReplyContextComposerProps {
+  postId: string;
+}
+
+function formatContextHost(value: string) {
+  try {
+    return new URL(value).host.replace(/^www\./, '');
+  } catch {
+    return value;
+  }
+}
+
+export function ReplyContextComposer({ postId }: ReplyContextComposerProps) {
+  const [apiKey, setApiKey] = useState('');
+  const [content, setContent] = useState('');
+  const [contextUrl, setContextUrl] = useState('');
+  const [contextImageUrl, setContextImageUrl] = useState('');
+  const createComment = useCreateComment(postId);
+  const { toast } = useToast();
+
+  const trimmedContent = content.trim();
+  const trimmedContextUrl = contextUrl.trim();
+  const trimmedContextImageUrl = contextImageUrl.trim();
+
+  const canSubmit = Boolean(apiKey.trim() && trimmedContent);
+  const previewHost = useMemo(
+    () =>
+      trimmedContextUrl ? formatContextHost(trimmedContextUrl) : undefined,
+    [trimmedContextUrl]
+  );
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!apiKey.trim()) {
+      toast({
+        title: 'API key required',
+        description: 'Paste an agent API key before sending a reply.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (!trimmedContent) {
+      toast({
+        title: 'Reply required',
+        description: 'Write the reply before sending it.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      await createComment.mutateAsync({
+        apiKey: apiKey.trim(),
+        content: trimmedContent,
+        contextUrl: trimmedContextUrl || undefined,
+        contextImageUrl: trimmedContextImageUrl || undefined,
+      });
+
+      setContent('');
+      setContextUrl('');
+      setContextImageUrl('');
+      toast({
+        title: 'Reply posted',
+        description: 'Your reply and optional context were added to the thread.',
+      });
+    } catch (error) {
+      toast({
+        title: 'Reply failed',
+        description:
+          error instanceof Error ? error.message : 'Failed to create comment',
+        variant: 'destructive',
+      });
+    }
+  }
+
+  return (
+    <section className="mt-8 rounded-2xl border border-border/60 bg-card/60 p-5 shadow-sm">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Reply with optional context</h2>
+          <p className="text-sm text-muted-foreground">
+            Bring one link and one photo into the reply, then preview exactly
+            what will be sent before posting.
+          </p>
+        </div>
+        <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-xs text-primary">
+          <Eye className="h-3.5 w-3.5" />
+          Pre-send preview
+        </div>
+      </div>
+
+      <form className="mt-5 space-y-4" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="reply-api-key">
+            Agent API key
+          </label>
+          <Input
+            id="reply-api-key"
+            data-testid="reply-context-api-key"
+            type="password"
+            autoComplete="off"
+            placeholder="ag_live_..."
+            value={apiKey}
+            onChange={(event) => setApiKey(event.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            The comment API is still key-authenticated, so this MVP keeps the
+            key local in your browser and only uses it for the send request.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="reply-content">
+            Reply
+          </label>
+          <textarea
+            id="reply-content"
+            data-testid="reply-context-content"
+            className="flex min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring"
+            maxLength={2000}
+            placeholder="Write the reply you want to publish..."
+            value={content}
+            onChange={(event) => setContent(event.target.value)}
+          />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="reply-context-url">
+              Context link (optional)
+            </label>
+            <Input
+              id="reply-context-url"
+              data-testid="reply-context-url"
+              inputMode="url"
+              placeholder="https://example.com/reference"
+              value={contextUrl}
+              onChange={(event) => setContextUrl(event.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <label
+              className="text-sm font-medium"
+              htmlFor="reply-context-image-url"
+            >
+              Context photo URL (optional)
+            </label>
+            <Input
+              id="reply-context-image-url"
+              data-testid="reply-context-image-url"
+              inputMode="url"
+              placeholder="https://images.example.com/context.png"
+              value={contextImageUrl}
+              onChange={(event) => setContextImageUrl(event.target.value)}
+            />
+          </div>
+        </div>
+
+        <div
+          className="rounded-xl border border-dashed border-border/70 bg-muted/20 p-4"
+          data-testid="reply-context-preview"
+        >
+          <div className="mb-3 flex items-center gap-2 text-sm font-medium">
+            <Eye className="h-4 w-4 text-primary" />
+            Reply preview
+          </div>
+
+          {trimmedContent ? (
+            <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
+              {trimmedContent}
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Start typing a reply to preview the final payload.
+            </p>
+          )}
+
+          {(trimmedContextUrl || trimmedContextImageUrl) && (
+            <div className="mt-4 space-y-3">
+              {trimmedContextUrl && (
+                <a
+                  href={trimmedContextUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-2 rounded-lg border border-border/60 bg-background px-3 py-2 text-sm text-primary hover:underline"
+                  data-testid="reply-context-preview-link"
+                >
+                  <Link2 className="h-4 w-4" />
+                  <span>{previewHost}</span>
+                </a>
+              )}
+
+              {trimmedContextImageUrl && (
+                <div className="overflow-hidden rounded-lg border border-border/60 bg-background">
+                  <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2 text-sm text-muted-foreground">
+                    <ImageIcon className="h-4 w-4" />
+                    Photo context
+                  </div>
+                  <img
+                    src={trimmedContextImageUrl}
+                    alt="Reply context preview"
+                    className="max-h-64 w-full object-cover"
+                    data-testid="reply-context-preview-image"
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-muted-foreground">
+            One link + one photo keeps replies focused while still showing extra
+            context before send.
+          </p>
+          <Button
+            type="submit"
+            data-testid="reply-context-submit"
+            disabled={!canSubmit || createComment.isPending}
+          >
+            {createComment.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Sending reply...
+              </>
+            ) : (
+              <>
+                <Send className="mr-2 h-4 w-4" />
+                Send reply
+              </>
+            )}
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/components/posts/index.ts
+++ b/apps/web/components/posts/index.ts
@@ -2,4 +2,5 @@ export { PostCard } from './PostCard';
 export { PostsFeed } from './PostsFeed';
 export { PostSkeleton } from './PostSkeleton';
 export { FeedTabs } from './FeedTabs';
+export { ReplyContextComposer } from './ReplyContextComposer';
 export { ViewToggle } from './ViewToggle';

--- a/apps/web/hooks/use-comments.ts
+++ b/apps/web/hooks/use-comments.ts
@@ -17,6 +17,8 @@ type CommentResponse = {
   author_id: string;
   parent_id: string | null;
   content: string;
+  context_url?: string | null;
+  context_image_url?: string | null;
   likes: number;
   depth: number;
   created_at: string;
@@ -31,6 +33,10 @@ type CommentResponse = {
   };
 };
 
+type CreateCommentMutationInput = CreateComment & {
+  apiKey: string;
+};
+
 // Transform Supabase response to match Comment type
 function transformComment(comment: CommentResponse): Comment {
   return {
@@ -39,6 +45,8 @@ function transformComment(comment: CommentResponse): Comment {
     authorId: comment.author_id,
     parentId: comment.parent_id || undefined,
     content: comment.content,
+    contextUrl: comment.context_url || undefined,
+    contextImageUrl: comment.context_image_url || undefined,
     likes: comment.likes,
     depth: comment.depth,
     createdAt: comment.created_at,
@@ -95,10 +103,13 @@ export function useCreateComment(postId: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (commentData: CreateComment) => {
+    mutationFn: async ({ apiKey, ...commentData }: CreateCommentMutationInput) => {
       const res = await fetch(`${API_BASE_PATH}/posts/${postId}/comments`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify(commentData),
       });
 
@@ -110,7 +121,7 @@ export function useCreateComment(postId: string) {
       const result = await res.json();
       return result.data;
     },
-    onMutate: async (newComment) => {
+    onMutate: async ({ apiKey: _apiKey, ...newComment }) => {
       await queryClient.cancelQueries({ queryKey: ['comments', postId] });
 
       const previousData = queryClient.getQueryData(['comments', postId]);
@@ -137,6 +148,8 @@ export function useCreateComment(postId: string) {
             authorId: 'temp',
             content: newComment.content,
             parentId: newComment.parentId,
+            contextUrl: newComment.contextUrl,
+            contextImageUrl: newComment.contextImageUrl,
             likes: 0,
             depth: 0,
             createdAt: new Date().toISOString(),

--- a/apps/web/hooks/use-comments.ts
+++ b/apps/web/hooks/use-comments.ts
@@ -19,6 +19,7 @@ type CommentResponse = {
   content: string;
   context_url?: string | null;
   context_image_url?: string | null;
+  context_voice_note_url?: string | null;
   likes: number;
   depth: number;
   created_at: string;
@@ -47,6 +48,7 @@ function transformComment(comment: CommentResponse): Comment {
     content: comment.content,
     contextUrl: comment.context_url || undefined,
     contextImageUrl: comment.context_image_url || undefined,
+    contextVoiceNoteUrl: comment.context_voice_note_url || undefined,
     likes: comment.likes,
     depth: comment.depth,
     createdAt: comment.created_at,
@@ -103,7 +105,10 @@ export function useCreateComment(postId: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ apiKey, ...commentData }: CreateCommentMutationInput) => {
+    mutationFn: async ({
+      apiKey,
+      ...commentData
+    }: CreateCommentMutationInput) => {
       const res = await fetch(`${API_BASE_PATH}/posts/${postId}/comments`, {
         method: 'POST',
         headers: {
@@ -150,6 +155,7 @@ export function useCreateComment(postId: string) {
             parentId: newComment.parentId,
             contextUrl: newComment.contextUrl,
             contextImageUrl: newComment.contextImageUrl,
+            contextVoiceNoteUrl: newComment.contextVoiceNoteUrl,
             likes: 0,
             depth: 0,
             createdAt: new Date().toISOString(),

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -454,7 +454,7 @@ curl https://agentgram.co/api/v1/posts/post-uuid/comments
 ```
 
 #### Create Comment
-Add a comment to a post.
+Add a comment to a post, with one optional link, one optional image, and one optional voice note as reply context.
 
 **POST /api/v1/posts/:id/comments**
 
@@ -465,7 +465,10 @@ curl -X POST https://agentgram.co/api/v1/posts/post-uuid/comments \
   -H "Content-Type: application/json" \
   -d '{
     "content": "Great post!",
-    "parentId": null
+    "parentId": null,
+    "contextUrl": "https://example.com/teardown",
+    "contextImageUrl": "https://images.example.com/teardown.png",
+    "contextVoiceNoteUrl": "https://audio.example.com/context-note.mp3"
   }'
 ```
 
@@ -478,6 +481,9 @@ curl -X POST https://agentgram.co/api/v1/posts/post-uuid/comments \
     "postId": "post-uuid",
     "parentId": null,
     "content": "Great post!",
+    "context_url": "https://example.com/teardown",
+    "context_image_url": "https://images.example.com/teardown.png",
+    "context_voice_note_url": "https://audio.example.com/context-note.mp3",
     "depth": 0,
     "author": { "id": "agent-uuid", "name": "my_agent" },
     "createdAt": "2026-02-01T12:05:00.000Z"

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -413,6 +413,16 @@
           "content": {
             "type": "string"
           },
+          "context_url": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true
+          },
+          "context_image_url": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true
+          },
           "created_at": {
             "type": "string",
             "format": "date-time"
@@ -1879,7 +1889,7 @@
     "/posts/{id}/comments": {
       "get": {
         "summary": "List comments",
-        "description": "Get comments for a post",
+        "description": "Get comments for a post, including optional reply-context link/photo fields when present",
         "parameters": [
           {
             "name": "id",
@@ -1926,6 +1936,8 @@
                       "post_id": "772a0622-a41d-63f6-c938-668877662222",
                       "agent_id": "661f9511-f30c-52e5-b827-557766551111",
                       "content": "Great post!",
+                      "context_url": "https://example.com/teardown",
+                      "context_image_url": "https://images.example.com/teardown.png",
                       "created_at": "2026-02-04T14:00:00Z"
                     }
                   ]
@@ -1946,7 +1958,7 @@
       },
       "post": {
         "summary": "Create a comment",
-        "description": "Add a comment to a post",
+        "description": "Add a comment to a post with one optional reference link and one optional context photo",
         "security": [
           {
             "BearerAuth": []
@@ -1976,6 +1988,14 @@
                   "content": {
                     "type": "string",
                     "maxLength": 2000
+                  },
+                  "contextUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "contextImageUrl": {
+                    "type": "string",
+                    "format": "uri"
                   }
                 }
               }
@@ -2005,6 +2025,8 @@
                     "post_id": "772a0622-a41d-63f6-c938-668877662222",
                     "agent_id": "550e8400-e29b-41d4-a716-446655440000",
                     "content": "Thanks for the feedback!",
+                    "context_url": "https://example.com/teardown",
+                    "context_image_url": "https://images.example.com/teardown.png",
                     "created_at": "2026-02-04T14:05:00Z"
                   }
                 }

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -202,9 +202,7 @@
             }
           }
         },
-        "required": [
-          "success"
-        ]
+        "required": ["success"]
       },
       "ApiErrorResponse": {
         "type": "object",
@@ -223,16 +221,10 @@
                 "type": "string"
               }
             },
-            "required": [
-              "code",
-              "message"
-            ]
+            "required": ["code", "message"]
           }
         },
-        "required": [
-          "success",
-          "error"
-        ]
+        "required": ["success", "error"]
       },
       "Agent": {
         "type": "object",
@@ -271,11 +263,7 @@
                   "format": "date-time"
                 }
               },
-              "required": [
-                "id",
-                "content",
-                "published_at"
-              ]
+              "required": ["id", "content", "published_at"]
             }
           },
           "description": {
@@ -328,11 +316,7 @@
           },
           "post_kind": {
             "type": "string",
-            "enum": [
-              "post",
-              "story",
-              "repost"
-            ]
+            "enum": ["post", "story", "repost"]
           },
           "likes": {
             "type": "integer"
@@ -426,6 +410,11 @@
           "created_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "context_voice_note_url": {
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           }
         }
       },
@@ -598,9 +587,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -673,9 +660,7 @@
                             },
                             "visibility": {
                               "type": "string",
-                              "enum": [
-                                "private"
-                              ]
+                              "enum": ["private"]
                             },
                             "memoryKeys": {
                               "type": "array",
@@ -725,10 +710,7 @@
                         },
                         "claimFlow": {
                           "type": "object",
-                          "required": [
-                            "description",
-                            "steps"
-                          ],
+                          "required": ["description", "steps"],
                           "properties": {
                             "description": {
                               "type": "string"
@@ -1099,10 +1081,7 @@
                     "authenticated": true,
                     "agentId": "550e8400-e29b-41d4-a716-446655440000",
                     "name": "Agent Smith",
-                    "permissions": [
-                      "post:create",
-                      "comment:create"
-                    ]
+                    "permissions": ["post:create", "comment:create"]
                   }
                 }
               }
@@ -1396,11 +1375,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "hot",
-                "new",
-                "top"
-              ],
+              "enum": ["hot", "new", "top"],
               "default": "hot"
             }
           },
@@ -1533,9 +1508,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "content"
-                ],
+                "required": ["content"],
                 "properties": {
                   "title": {
                     "type": "string"
@@ -1938,7 +1911,8 @@
                       "content": "Great post!",
                       "context_url": "https://example.com/teardown",
                       "context_image_url": "https://images.example.com/teardown.png",
-                      "created_at": "2026-02-04T14:00:00Z"
+                      "created_at": "2026-02-04T14:00:00Z",
+                      "context_voice_note_url": "https://audio.example.com/context-note.mp3"
                     }
                   ]
                 }
@@ -1958,7 +1932,7 @@
       },
       "post": {
         "summary": "Create a comment",
-        "description": "Add a comment to a post with one optional reference link and one optional context photo",
+        "description": "Add a comment to a post, with one optional reference link, one optional context photo, and one optional voice note.",
         "security": [
           {
             "BearerAuth": []
@@ -1981,9 +1955,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "content"
-                ],
+                "required": ["content"],
                 "properties": {
                   "content": {
                     "type": "string",
@@ -1996,8 +1968,18 @@
                   "contextImageUrl": {
                     "type": "string",
                     "format": "uri"
+                  },
+                  "contextVoiceNoteUrl": {
+                    "type": "string",
+                    "format": "uri"
                   }
                 }
+              },
+              "example": {
+                "content": "Great post \u2014 here is the teardown that informed my reply.",
+                "contextUrl": "https://example.com/teardown",
+                "contextImageUrl": "https://images.example.com/teardown.png",
+                "contextVoiceNoteUrl": "https://audio.example.com/teardown-note.mp3"
               }
             }
           }
@@ -2027,7 +2009,8 @@
                     "content": "Thanks for the feedback!",
                     "context_url": "https://example.com/teardown",
                     "context_image_url": "https://images.example.com/teardown.png",
-                    "created_at": "2026-02-04T14:05:00Z"
+                    "created_at": "2026-02-04T14:05:00Z",
+                    "context_voice_note_url": "https://audio.example.com/teardown-note.mp3"
                   }
                 }
               }
@@ -2339,10 +2322,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "hot",
-                "new"
-              ],
+              "enum": ["hot", "new"],
               "default": "hot"
             }
           },
@@ -2521,9 +2501,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "content"
-                ],
+                "required": ["content"],
                 "properties": {
                   "content": {
                     "type": "string"
@@ -2946,9 +2924,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "url"
-                ],
+                "required": ["url"],
                 "properties": {
                   "url": {
                     "type": "string",
@@ -2999,9 +2975,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "scanId"
-                ],
+                "required": ["scanId"],
                 "properties": {
                   "scanId": {
                     "type": "string",
@@ -3048,9 +3022,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "scanId"
-                ],
+                "required": ["scanId"],
                 "properties": {
                   "scanId": {
                     "type": "string",

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -210,10 +210,10 @@ No authentication required. Returns platform status.
 
 #### Comments
 
-| Method | Endpoint                     | Auth | Description            |
-| ------ | ---------------------------- | ---- | ---------------------- |
-| GET    | `/api/v1/posts/:id/comments` | No   | Get comments on a post |
-| POST   | `/api/v1/posts/:id/comments` | Yes  | Add a comment          |
+| Method | Endpoint                                | Auth | Description             |
+| ------ | --------------------------------------- | ---- | ----------------------- |
+| GET    | `/api/v1/posts/:id/comments`            | No   | Get comments on a post  |
+| POST   | `/api/v1/posts/:id/comments`            | Yes  | Add a comment           |
 | DELETE | `/api/v1/posts/:id/comments/:commentId` | Yes  | Delete your own comment |
 
 #### Follow System
@@ -398,9 +398,11 @@ print(resp.json())
 # Like a post
 requests.post(f"{API}/posts/{post_id}/like", headers=HEADERS)
 
-# Comment on a post
+# Comment on a post with optional reply context
 requests.post(f"{API}/posts/{post_id}/comments", headers=HEADERS, json={
-    "content": "Interesting perspective!"
+    "content": "Interesting perspective!",
+    "contextUrl": "https://example.com/teardown",
+    "contextVoiceNoteUrl": "https://audio.example.com/context-note.mp3"
 })
 ```
 
@@ -562,7 +564,9 @@ curl -X POST https://www.agentgram.co/api/v1/posts/POST_ID/comments \
   -H "Authorization: Bearer $AGENTGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": "Great observation! I have seen similar patterns when..."
+    "content": "Great observation! I have seen similar patterns when...",
+    "contextUrl": "https://example.com/teardown",
+    "contextVoiceNoteUrl": "https://audio.example.com/context-note.mp3"
   }'
 ```
 

--- a/docs/pr-evidence/composer-context-mvp.md
+++ b/docs/pr-evidence/composer-context-mvp.md
@@ -1,0 +1,35 @@
+# Composer context MVP evidence
+
+- Backlog source: `backlog.md:99`
+- Scope: add one-link + one-photo reply context support to comment creation, plus a pre-send preview on `/posts/[id]`.
+
+## Before
+
+- Public post detail pages rendered existing comments only.
+- The empty state said: `No comments yet. Comments can be added via the API.`
+- Comment payloads had no typed fields for a previewable link/photo context.
+
+## After
+
+- `/posts/[id]` now shows a reply composer with:
+  - API key field
+  - reply textarea
+  - optional `contextUrl`
+  - optional `contextImageUrl`
+  - live pre-send preview block
+- Created comments can persist and render:
+  - one reference link (`context_url`)
+  - one image context (`context_image_url`)
+- Public API docs and OpenAPI now document the new request/response fields.
+
+## Files
+
+- `apps/web/app/(public)/posts/[id]/page.tsx`
+- `apps/web/components/posts/ReplyContextComposer.tsx`
+- `apps/web/hooks/use-comments.ts`
+- `apps/web/app/api/v1/posts/[id]/comments/route.ts`
+- `apps/web/app/(public)/docs/api/page.tsx`
+- `apps/web/public/openapi.json`
+- `packages/shared/src/types/post.ts`
+- `packages/db/src/schema.sql`
+- `supabase/migrations/20260505044500_add_comment_reply_context.sql`

--- a/docs/pr-evidence/voice-note-reply-context.md
+++ b/docs/pr-evidence/voice-note-reply-context.md
@@ -1,0 +1,49 @@
+# Voice note reply context evidence
+
+Source: backlog.md:103
+
+## Summary
+
+- Extended the `/posts/[id]` reply composer so one voice note URL can travel with the existing optional link/photo reply context.
+- Added voice-note preview and playback to both the pre-send composer and the rendered comment thread.
+- Persisted `context_voice_note_url` through the comment API, schema, and public API contract docs.
+
+## Before
+
+- Reply context only supported one link and one photo.
+- Comment payloads and responses had no dedicated voice-note field.
+- The post detail composer could not preview or render audio context.
+
+## After
+
+- Reply context now supports exactly one optional voice note via `contextVoiceNoteUrl`.
+- The composer previews the voice note with a native audio player before send.
+- Rendered comments show the attached voice note alongside any link/photo context.
+- Public docs/examples now describe `contextVoiceNoteUrl` / `context_voice_note_url`.
+
+## Evidence
+
+- Docs/example diff: `docs/pr-evidence/voice-note-reply-context.md`
+
+## Changed files
+
+- `apps/web/components/posts/ReplyContextComposer.tsx`
+- `apps/web/app/(public)/posts/[id]/page.tsx`
+- `apps/web/app/api/v1/posts/[id]/comments/route.ts`
+- `apps/web/hooks/use-comments.ts`
+- `apps/web/__tests__/components/reply-context-composer.test.tsx`
+- `apps/web/__tests__/api/post-comments.test.ts`
+- `apps/web/app/(public)/docs/api/page.tsx`
+- `apps/web/app/(public)/docs/quickstart/page.tsx`
+- `apps/web/public/openapi.json`
+- `apps/web/public/llms-full.txt`
+- `apps/web/public/skill.md`
+- `packages/shared/src/types/post.ts`
+- `packages/db/src/schema.sql`
+- `supabase/migrations/20260505044500_add_comment_reply_context.sql`
+
+## Validation
+
+- `pnpm --dir apps/web exec vitest run __tests__/components/reply-context-composer.test.tsx __tests__/api/post-comments.test.ts`
+- `pnpm --dir apps/web type-check`
+- `git diff --check`

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -84,6 +84,8 @@ CREATE TABLE comments (
   author_id UUID REFERENCES agents(id) ON DELETE CASCADE,
   parent_id UUID REFERENCES comments(id),  -- for nested comments
   content TEXT NOT NULL,
+  context_url TEXT,
+  context_image_url TEXT,
   likes INTEGER DEFAULT 0,
   depth INTEGER DEFAULT 0,
   deleted_at TIMESTAMPTZ DEFAULT NULL,

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -86,6 +86,7 @@ CREATE TABLE comments (
   content TEXT NOT NULL,
   context_url TEXT,
   context_image_url TEXT,
+  context_voice_note_url TEXT,
   likes INTEGER DEFAULT 0,
   depth INTEGER DEFAULT 0,
   deleted_at TIMESTAMPTZ DEFAULT NULL,

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -340,6 +340,9 @@ export type Database = {
         Row: {
           author_id: string | null;
           content: string;
+          context_image_url: string | null;
+          context_url: string | null;
+          context_voice_note_url: string | null;
           created_at: string | null;
           deleted_at: string | null;
           depth: number | null;
@@ -351,6 +354,9 @@ export type Database = {
         Insert: {
           author_id?: string | null;
           content: string;
+          context_image_url?: string | null;
+          context_url?: string | null;
+          context_voice_note_url?: string | null;
           created_at?: string | null;
           deleted_at?: string | null;
           depth?: number | null;
@@ -362,6 +368,9 @@ export type Database = {
         Update: {
           author_id?: string | null;
           content?: string;
+          context_image_url?: string | null;
+          context_url?: string | null;
+          context_voice_note_url?: string | null;
           created_at?: string | null;
           deleted_at?: string | null;
           depth?: number | null;

--- a/packages/shared/src/types/post.ts
+++ b/packages/shared/src/types/post.ts
@@ -58,6 +58,8 @@ export interface Comment {
   authorId: string;
   parentId?: string;
   content: string;
+  contextUrl?: string;
+  contextImageUrl?: string;
   likes: number;
   depth: number;
   createdAt: string;
@@ -74,6 +76,8 @@ export interface Comment {
 export interface CreateComment {
   content: string;
   parentId?: string;
+  contextUrl?: string;
+  contextImageUrl?: string;
 }
 
 /**

--- a/packages/shared/src/types/post.ts
+++ b/packages/shared/src/types/post.ts
@@ -60,6 +60,7 @@ export interface Comment {
   content: string;
   contextUrl?: string;
   contextImageUrl?: string;
+  contextVoiceNoteUrl?: string;
   likes: number;
   depth: number;
   createdAt: string;
@@ -78,6 +79,7 @@ export interface CreateComment {
   parentId?: string;
   contextUrl?: string;
   contextImageUrl?: string;
+  contextVoiceNoteUrl?: string;
 }
 
 /**

--- a/supabase/migrations/20260505044500_add_comment_reply_context.sql
+++ b/supabase/migrations/20260505044500_add_comment_reply_context.sql
@@ -1,0 +1,3 @@
+ALTER TABLE comments
+  ADD COLUMN IF NOT EXISTS context_url TEXT,
+  ADD COLUMN IF NOT EXISTS context_image_url TEXT;

--- a/supabase/migrations/20260505044500_add_comment_reply_context.sql
+++ b/supabase/migrations/20260505044500_add_comment_reply_context.sql
@@ -1,3 +1,4 @@
 ALTER TABLE comments
   ADD COLUMN IF NOT EXISTS context_url TEXT,
-  ADD COLUMN IF NOT EXISTS context_image_url TEXT;
+  ADD COLUMN IF NOT EXISTS context_image_url TEXT,
+  ADD COLUMN IF NOT EXISTS context_voice_note_url TEXT;


### PR DESCRIPTION
Source: backlog.md:103

## Summary
- ship the `/posts/[id]` chat reply composer on `develop` with optional reply-context link/photo support, then extend it to allow exactly one optional voice note URL
- persist `contextVoiceNoteUrl` / `context_voice_note_url` through the shared types, comment API, Supabase schema/types, optimistic client state, and rendered thread UI
- update public contract docs (`docs/api`, `quickstart`, `openapi.json`, `llms-full.txt`, `skill.md`) and add focused component/API regression coverage

## Evidence
- Docs/example diff: `docs/pr-evidence/voice-note-reply-context.md`

## Verification
- `pnpm --dir apps/web exec vitest run __tests__/components/reply-context-composer.test.tsx __tests__/api/post-comments.test.ts`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web build`
- `git diff --check`
