### PR TITLE
feat: surface reply modality badges on agent cards

### DIFF
--- a/apps/web/__tests__/api/agents.test.ts
+++ b/apps/web/__tests__/api/agents.test.ts
@@ -61,9 +61,7 @@ describe('GET /api/v1/agents', () => {
     mockContains.mockReturnThis();
     mockIn.mockReturnValue({ is: mockIs });
     mockIs.mockResolvedValue({
-      data: [
-        { author_id: 'agent-1', comment_count: 2 },
-      ],
+      data: [{ author_id: 'agent-1', comment_count: 2 }],
       error: null,
     });
     mockRange.mockResolvedValue({
@@ -117,6 +115,9 @@ describe('GET /api/v1/agents', () => {
               voice: 'true',
               group_chat: true,
               roleplay: 1,
+              video: true,
+              image_reply: true,
+              web_aware: true,
             },
           },
           created_at: '2026-01-01T00:00:00Z',
@@ -144,9 +145,7 @@ describe('GET /api/v1/agents', () => {
   });
 
   it('should return paginated agents', async () => {
-    const { GET } = await import(
-      '../../app/api/v1/agents/route'
-    );
+    const { GET } = await import('../../app/api/v1/agents/route');
 
     const request = new Request('http://localhost/api/v1/agents');
     const response = await GET(request as unknown as Parameters<typeof GET>[0]);
@@ -165,6 +164,9 @@ describe('GET /api/v1/agents', () => {
         voice: false,
         group_chat: true,
         roleplay: false,
+        video: true,
+        image: true,
+        web: true,
       },
       memoryPolicy: 'ephemeral_only',
       workProofUrl: 'https://example.com/proof',
@@ -320,9 +322,7 @@ describe('GET /api/v1/agents', () => {
   });
 
   it('should escape SQL wildcards in search parameter', async () => {
-    const { GET } = await import(
-      '../../app/api/v1/agents/route'
-    );
+    const { GET } = await import('../../app/api/v1/agents/route');
 
     const request = new Request(
       'http://localhost/api/v1/agents?search=test%25injection'
@@ -338,9 +338,7 @@ describe('GET /api/v1/agents', () => {
   });
 
   it('should filter by enabled capability params', async () => {
-    const { GET } = await import(
-      '../../app/api/v1/agents/route'
-    );
+    const { GET } = await import('../../app/api/v1/agents/route');
 
     const request = new Request(
       'http://localhost/api/v1/agents?voice=true&group_chat=1'
@@ -357,9 +355,7 @@ describe('GET /api/v1/agents', () => {
   });
 
   it('should clamp page parameter to valid range', async () => {
-    const { GET } = await import(
-      '../../app/api/v1/agents/route'
-    );
+    const { GET } = await import('../../app/api/v1/agents/route');
 
     const request = new Request(
       'http://localhost/api/v1/agents?page=999999999'
@@ -373,13 +369,9 @@ describe('GET /api/v1/agents', () => {
   });
 
   it('should clamp limit parameter to MAX_LIMIT', async () => {
-    const { GET } = await import(
-      '../../app/api/v1/agents/route'
-    );
+    const { GET } = await import('../../app/api/v1/agents/route');
 
-    const request = new Request(
-      'http://localhost/api/v1/agents?limit=999'
-    );
+    const request = new Request('http://localhost/api/v1/agents?limit=999');
     const response = await GET(request as unknown as Parameters<typeof GET>[0]);
     const json = await response.json();
 
@@ -389,9 +381,7 @@ describe('GET /api/v1/agents', () => {
   });
 
   it('should apply capability filters from metadata.capabilities', async () => {
-    const { GET } = await import(
-      '../../app/api/v1/agents/route'
-    );
+    const { GET } = await import('../../app/api/v1/agents/route');
 
     const request = new Request(
       'http://localhost/api/v1/agents?voice=true&group_chat=1'
@@ -450,7 +440,7 @@ describe('GET /api/v1/agents', () => {
     expect(json.success).toBe(false);
   });
 
-  it('should support discussed sort using total comments received on each agent\'s posts', async () => {
+  it("should support discussed sort using total comments received on each agent's posts", async () => {
     mockRange
       .mockResolvedValueOnce({
         data: [
@@ -529,9 +519,7 @@ describe('GET /api/v1/agents', () => {
       error: null,
     });
     mockRemixIlike.mockResolvedValueOnce({
-      data: [
-        { description: 'Inspired by @chatty-agent: first remix' },
-      ],
+      data: [{ description: 'Inspired by @chatty-agent: first remix' }],
       error: null,
     });
 

--- a/apps/web/__tests__/components/agent-card.test.tsx
+++ b/apps/web/__tests__/components/agent-card.test.tsx
@@ -74,7 +74,7 @@ describe('AgentCard', () => {
     );
   });
 
-  it('renders capability badges and the relationship mode badge when present', () => {
+  it('shows reply modality badges before the remaining capability chips', () => {
     render(
       <AgentCard
         agent={{
@@ -84,6 +84,9 @@ describe('AgentCard', () => {
           relationshipPreset: 'mentor',
           capabilities: {
             voice: true,
+            video: true,
+            image: true,
+            web: true,
             group_chat: true,
             roleplay: false,
           },
@@ -91,15 +94,34 @@ describe('AgentCard', () => {
       />
     );
 
+    const modalityStrip = screen.getByTestId('agent-card-modality-badges');
+
     expect(screen.getByTestId('agent-relationship-badge')).toHaveTextContent(
       'Mentor mode'
     );
     expect(
-      screen.getByTestId('agent-capability-badge-voice')
+      screen.getByTestId('agent-card-modality-badge-voice')
     ).toHaveTextContent('Voice');
+    expect(
+      screen.getByTestId('agent-card-modality-badge-video')
+    ).toHaveTextContent('Video');
+    expect(
+      screen.getByTestId('agent-card-modality-badge-image')
+    ).toHaveTextContent('Image');
+    expect(
+      screen.getByTestId('agent-card-modality-badge-web')
+    ).toHaveTextContent('Web-aware');
+    expect(
+      screen.queryByTestId('agent-capability-badge-voice')
+    ).not.toBeInTheDocument();
     expect(
       screen.getByTestId('agent-capability-badge-group_chat')
     ).toHaveTextContent('Group chat');
+    expect(
+      modalityStrip.compareDocumentPosition(
+        screen.getByTestId('agent-capability-badge-group_chat')
+      ) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
     expect(
       screen.queryByTestId('agent-capability-badge-roleplay')
     ).not.toBeInTheDocument();

--- a/apps/web/app/api/v1/agents/route.ts
+++ b/apps/web/app/api/v1/agents/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseClient } from '@agentgram/db';
 import {
-  AGENT_CAPABILITY_KEYS,
+  AGENT_DIRECTORY_FILTER_CAPABILITY_KEYS,
   ErrorResponses,
   jsonResponse,
   createSuccessResponse,
@@ -37,15 +37,18 @@ export async function GET(req: NextRequest) {
       Math.min(parseInt(searchParams.get('page') || '1', 10) || 1, 10000)
     );
     const limit = Math.min(
-      Math.max(1, parseInt(
-        searchParams.get('limit') || String(PAGINATION.AGENTS_PER_PAGE),
-        10
-      ) || PAGINATION.AGENTS_PER_PAGE),
+      Math.max(
+        1,
+        parseInt(
+          searchParams.get('limit') || String(PAGINATION.AGENTS_PER_PAGE),
+          10
+        ) || PAGINATION.AGENTS_PER_PAGE
+      ),
       PAGINATION.MAX_LIMIT
     );
     const search = searchParams.get('search') || undefined;
-    const enabledCapabilities = AGENT_CAPABILITY_KEYS.filter((key) =>
-      isCapabilityFilterEnabled(searchParams.get(key))
+    const enabledCapabilities = AGENT_DIRECTORY_FILTER_CAPABILITY_KEYS.filter(
+      (key) => isCapabilityFilterEnabled(searchParams.get(key))
     );
 
     const supabase = getSupabaseClient();
@@ -100,8 +103,8 @@ export async function GET(req: NextRequest) {
     let count;
 
     if (sort === 'discussed') {
-      const { error: countError, count: totalCount } = await buildAgentsQuery()
-        .range(0, 0);
+      const { error: countError, count: totalCount } =
+        await buildAgentsQuery().range(0, 0);
 
       if (countError) {
         console.error('Agents query error:', countError);
@@ -153,7 +156,8 @@ export async function GET(req: NextRequest) {
 
           discussionCounts.set(
             row.author_id,
-            (discussionCounts.get(row.author_id) || 0) + (row.comment_count || 0)
+            (discussionCounts.get(row.author_id) || 0) +
+              (row.comment_count || 0)
           );
         }
       }
@@ -161,7 +165,8 @@ export async function GET(req: NextRequest) {
       agents = [...allAgents]
         .sort((a, b) => {
           const discussionDelta =
-            (discussionCounts.get(b.id) || 0) - (discussionCounts.get(a.id) || 0);
+            (discussionCounts.get(b.id) || 0) -
+            (discussionCounts.get(a.id) || 0);
           if (discussionDelta !== 0) return discussionDelta;
 
           const lastActiveDelta =

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -1,13 +1,26 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import type { PlanType, RelationshipPreset } from '@agentgram/shared';
-import { Award, Bot, Lock, ShieldAlert, Sparkles } from 'lucide-react';
+import {
+  Award,
+  Bot,
+  Globe,
+  Image as ImageIcon,
+  Lock,
+  Mic,
+  ShieldAlert,
+  Sparkles,
+  Video,
+} from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { getRelationshipModeLabel } from '@/lib/agents/relationship-mode';
 import { cn } from '@/lib/utils';
 import {
+  AGENT_MODALITY_KEYS,
+  AGENT_MODALITY_LABELS,
   DIRECTORY_CAPABILITY_KEYS,
   DIRECTORY_CAPABILITY_LABELS,
+  type AgentModalityKey,
   type DirectoryCapabilities,
 } from '@/lib/agents/capabilities';
 
@@ -95,6 +108,13 @@ function getActivityFreshness(lastActive?: string | null) {
   };
 }
 
+const MODALITY_BADGE_ICONS: Record<AgentModalityKey, typeof Mic> = {
+  voice: Mic,
+  video: Video,
+  image: ImageIcon,
+  web: Globe,
+};
+
 interface AgentCardProps {
   agent: AgentCardAgent;
   showNewBadge?: boolean;
@@ -123,6 +143,12 @@ export function AgentCard({
     Boolean(publicOwnerLabel || formattedMemoryPolicy || activityFreshness);
   const shouldShowPremiumTrustStrip = Boolean(
     paidTierLabel || agent.matureContent
+  );
+  const enabledReplyModalities = AGENT_MODALITY_KEYS.filter(
+    (key) => agent.capabilities?.[key] === true
+  );
+  const enabledDiscoveryCapabilities = DIRECTORY_CAPABILITY_KEYS.filter(
+    (key) => key !== 'voice' && agent.capabilities?.[key] === true
   );
 
   const isNew =
@@ -226,6 +252,32 @@ export function AgentCard({
         </div>
       )}
 
+      {enabledReplyModalities.length > 0 && (
+        <div
+          className="mt-3 flex flex-wrap items-center gap-2"
+          data-testid="agent-card-modality-badges"
+        >
+          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Replies with
+          </span>
+          {enabledReplyModalities.map((key) => {
+            const Icon = MODALITY_BADGE_ICONS[key];
+
+            return (
+              <Badge
+                key={key}
+                variant="secondary"
+                className="gap-1.5 border border-primary/15 bg-primary/5 text-[10px] font-semibold uppercase tracking-wide text-foreground/85"
+                data-testid={`agent-card-modality-badge-${key}`}
+              >
+                <Icon className="h-3 w-3 text-primary" />
+                {AGENT_MODALITY_LABELS[key]}
+              </Badge>
+            );
+          })}
+        </div>
+      )}
+
       <div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
         <div className="flex items-center gap-2">
           <Award className="h-3.5 w-3.5" />
@@ -293,11 +345,9 @@ export function AgentCard({
         </div>
       )}
 
-      {agent.capabilities && (
+      {enabledDiscoveryCapabilities.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-2">
-          {DIRECTORY_CAPABILITY_KEYS.filter(
-            (key) => agent.capabilities?.[key]
-          ).map((key) => (
+          {enabledDiscoveryCapabilities.map((key) => (
             <Badge
               key={key}
               variant="outline"

--- a/apps/web/lib/agents/capabilities.ts
+++ b/apps/web/lib/agents/capabilities.ts
@@ -4,10 +4,21 @@ export const DIRECTORY_CAPABILITY_KEYS = [
   'roleplay',
 ] as const;
 
-export type DirectoryCapabilityKey =
-  (typeof DIRECTORY_CAPABILITY_KEYS)[number];
+export const AGENT_MODALITY_KEYS = ['voice', 'video', 'image', 'web'] as const;
 
-export type DirectoryCapabilities = Record<DirectoryCapabilityKey, boolean>;
+export const AGENT_CAPABILITY_KEYS = [
+  'voice',
+  'group_chat',
+  'roleplay',
+  'video',
+  'image',
+  'web',
+] as const;
+
+export type DirectoryCapabilityKey = (typeof DIRECTORY_CAPABILITY_KEYS)[number];
+export type AgentModalityKey = (typeof AGENT_MODALITY_KEYS)[number];
+export type AgentCapabilityKey = (typeof AGENT_CAPABILITY_KEYS)[number];
+export type DirectoryCapabilities = Record<AgentCapabilityKey, boolean>;
 
 export const DIRECTORY_CAPABILITY_LABELS: Record<
   DirectoryCapabilityKey,
@@ -18,49 +29,112 @@ export const DIRECTORY_CAPABILITY_LABELS: Record<
   roleplay: 'Roleplay',
 };
 
+export const AGENT_MODALITY_LABELS: Record<AgentModalityKey, string> = {
+  voice: 'Voice',
+  video: 'Video',
+  image: 'Image',
+  web: 'Web-aware',
+};
+
+const CAPABILITY_METADATA_PATHS: Record<
+  AgentCapabilityKey,
+  ReadonlyArray<readonly string[]>
+> = {
+  voice: [
+    ['capabilities', 'voice'],
+    ['capabilities', 'voice_reply'],
+    ['capabilities', 'voiceReply'],
+    ['replyModalities', 'voice'],
+    ['reply_modalities', 'voice'],
+  ],
+  group_chat: [
+    ['capabilities', 'group_chat'],
+    ['capabilities', 'groupChat'],
+  ],
+  roleplay: [['capabilities', 'roleplay']],
+  video: [
+    ['capabilities', 'video'],
+    ['capabilities', 'video_reply'],
+    ['capabilities', 'videoReply'],
+    ['replyModalities', 'video'],
+    ['reply_modalities', 'video'],
+  ],
+  image: [
+    ['capabilities', 'image'],
+    ['capabilities', 'image_reply'],
+    ['capabilities', 'imageReply'],
+    ['replyModalities', 'image'],
+    ['reply_modalities', 'image'],
+  ],
+  web: [
+    ['capabilities', 'web'],
+    ['capabilities', 'web_aware'],
+    ['capabilities', 'webAware'],
+    ['capabilities', 'web_aware_replies'],
+    ['capabilities', 'webAwareReplies'],
+    ['replyModalities', 'web'],
+    ['replyModalities', 'webAware'],
+    ['reply_modalities', 'web'],
+    ['reply_modalities', 'web_aware'],
+  ],
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function readBooleanLike(value: unknown): boolean {
-  if (typeof value === 'boolean') {
-    return value;
+function readMetadataValue(
+  metadata: Record<string, unknown>,
+  path: readonly string[]
+): unknown {
+  let current: unknown = metadata;
+
+  for (const segment of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+
+    current = current[segment];
   }
 
-  if (typeof value === 'string') {
-    return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
-  }
+  return current;
+}
 
-  if (typeof value === 'number') {
-    return value === 1;
+function readCapabilityFlag(
+  metadata: Record<string, unknown>,
+  key: AgentCapabilityKey
+): boolean {
+  for (const path of CAPABILITY_METADATA_PATHS[key]) {
+    const value = readMetadataValue(metadata, path);
+    if (typeof value === 'boolean') {
+      return value;
+    }
   }
 
   return false;
 }
 
-export function getAgentCapabilities(
-  metadata: unknown
-): DirectoryCapabilities {
+export function getAgentCapabilities(metadata: unknown): DirectoryCapabilities {
   const emptyCapabilities: DirectoryCapabilities = {
     voice: false,
     group_chat: false,
     roleplay: false,
+    video: false,
+    image: false,
+    web: false,
   };
 
   if (!isRecord(metadata)) {
     return emptyCapabilities;
   }
 
-  const capabilities = metadata.capabilities;
-  if (!isRecord(capabilities)) {
-    return emptyCapabilities;
-  }
-
-  return {
-    voice: readBooleanLike(capabilities.voice),
-    group_chat: readBooleanLike(capabilities.group_chat),
-    roleplay: readBooleanLike(capabilities.roleplay),
-  };
+  return AGENT_CAPABILITY_KEYS.reduce(
+    (acc, key) => {
+      acc[key] = readCapabilityFlag(metadata, key);
+      return acc;
+    },
+    { ...emptyCapabilities }
+  );
 }
 
 export function isCapabilityFilterEnabled(value: string | null): boolean {

--- a/docs/pr-evidence/modality-badges-before-chat.md
+++ b/docs/pr-evidence/modality-badges-before-chat.md
@@ -1,0 +1,30 @@
+# Row 103 evidence — modality badges before chat
+
+Source: backlog.md:103
+
+## Before
+
+- Agent cards only exposed the generic capability chip row.
+- Voice could appear there, but video reply, image reply, and web-aware reply support were invisible on the directory card.
+- Buyers had to click through before seeing those reply modalities.
+
+## After
+
+- Agent cards now render a dedicated `Replies with` strip ahead of the remaining capability chips.
+- The strip shows `Voice`, `Video`, `Image`, and `Web-aware` badges when the public capability metadata enables them.
+- Voice is no longer duplicated in the lower generic chip row; that row now stays focused on discovery capabilities like `Group chat` and `Roleplay`.
+
+## Durable implementation evidence
+
+- `apps/web/components/agents/AgentCard.tsx`
+- `apps/web/lib/agents/capabilities.ts`
+- `packages/shared/src/types/agent.ts`
+- `packages/shared/src/transforms/agent.ts`
+- `apps/web/__tests__/components/agent-card.test.tsx`
+- `apps/web/__tests__/api/agents.test.ts`
+
+## Validation
+
+- `pnpm --filter web test -- __tests__/components/agent-card.test.tsx __tests__/api/agents.test.ts`
+- `pnpm --filter web type-check`
+- `pnpm --filter @agentgram/shared type-check`

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -4,14 +4,68 @@ import {
   RELATIONSHIP_PRESETS,
   type Agent,
   type AgentCapabilities,
+  type AgentCapabilityKey,
   type AgentDiaryEntry,
   type RelationshipPreset,
 } from '../types';
 import { deriveAgentMemoryProfile } from './agent-memory';
 import { metadataBoolean, metadataString, metadataValue } from './metadata';
 
-function readCapabilityEnabled(value: unknown): boolean {
-  return value === true;
+const CAPABILITY_METADATA_PATHS: Record<
+  AgentCapabilityKey,
+  ReadonlyArray<readonly string[]>
+> = {
+  voice: [
+    ['capabilities', 'voice'],
+    ['capabilities', 'voice_reply'],
+    ['capabilities', 'voiceReply'],
+    ['replyModalities', 'voice'],
+    ['reply_modalities', 'voice'],
+  ],
+  group_chat: [
+    ['capabilities', 'group_chat'],
+    ['capabilities', 'groupChat'],
+  ],
+  roleplay: [['capabilities', 'roleplay']],
+  video: [
+    ['capabilities', 'video'],
+    ['capabilities', 'video_reply'],
+    ['capabilities', 'videoReply'],
+    ['replyModalities', 'video'],
+    ['reply_modalities', 'video'],
+  ],
+  image: [
+    ['capabilities', 'image'],
+    ['capabilities', 'image_reply'],
+    ['capabilities', 'imageReply'],
+    ['replyModalities', 'image'],
+    ['reply_modalities', 'image'],
+  ],
+  web: [
+    ['capabilities', 'web'],
+    ['capabilities', 'web_aware'],
+    ['capabilities', 'webAware'],
+    ['capabilities', 'web_aware_replies'],
+    ['capabilities', 'webAwareReplies'],
+    ['replyModalities', 'web'],
+    ['replyModalities', 'webAware'],
+    ['reply_modalities', 'web'],
+    ['reply_modalities', 'web_aware'],
+  ],
+};
+
+function readCapabilityEnabled(
+  meta: Record<string, unknown>,
+  key: AgentCapabilityKey
+): boolean {
+  for (const path of CAPABILITY_METADATA_PATHS[key]) {
+    const value = metadataValue(meta, path);
+    if (typeof value === 'boolean') {
+      return value;
+    }
+  }
+
+  return false;
 }
 
 function deriveCapabilities(meta: Record<string, unknown>): AgentCapabilities {
@@ -19,22 +73,14 @@ function deriveCapabilities(meta: Record<string, unknown>): AgentCapabilities {
     voice: false,
     group_chat: false,
     roleplay: false,
+    video: false,
+    image: false,
+    web: false,
   };
-
-  const capabilities = metadataValue(meta, ['capabilities']);
-  if (
-    !capabilities ||
-    typeof capabilities !== 'object' ||
-    Array.isArray(capabilities)
-  ) {
-    return emptyCapabilities;
-  }
-
-  const capabilityRecord = capabilities as Record<string, unknown>;
 
   return AGENT_CAPABILITY_KEYS.reduce(
     (acc, key) => {
-      acc[key] = readCapabilityEnabled(capabilityRecord[key]);
+      acc[key] = readCapabilityEnabled(meta, key);
       return acc;
     },
     { ...emptyCapabilities }
@@ -55,9 +101,7 @@ function deriveRelationshipPreset(
     return undefined;
   }
 
-  return RELATIONSHIP_PRESETS.includes(
-    relationshipPreset as RelationshipPreset
-  )
+  return RELATIONSHIP_PRESETS.includes(relationshipPreset as RelationshipPreset)
     ? (relationshipPreset as RelationshipPreset)
     : undefined;
 }
@@ -118,12 +162,12 @@ export function deriveAgentDiaryEntries(
   return rawEntries
     .map((entry, index) => normalizeDiaryEntry(entry, index))
     .filter((entry): entry is AgentDiaryEntry => Boolean(entry))
-    .sort((left, right) =>
-      right.publishedAt.localeCompare(left.publishedAt)
-    );
+    .sort((left, right) => right.publishedAt.localeCompare(left.publishedAt));
 }
 
-function deriveMatureContent(meta: Record<string, unknown>): boolean | undefined {
+function deriveMatureContent(
+  meta: Record<string, unknown>
+): boolean | undefined {
   const matureFlag = metadataBoolean(meta, [
     ['matureContent'],
     ['mature_content'],

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -2,14 +2,33 @@ import type { PlanType } from './billing';
 import type { AgentMemoryProfile } from './agent-memory';
 import type { Persona } from './persona';
 
-export const AGENT_CAPABILITY_KEYS = [
+export const AGENT_DIRECTORY_FILTER_CAPABILITY_KEYS = [
   'voice',
   'group_chat',
   'roleplay',
 ] as const;
 
+export const AGENT_REPLY_MODALITY_KEYS = [
+  'voice',
+  'video',
+  'image',
+  'web',
+] as const;
+
+export const AGENT_CAPABILITY_KEYS = [
+  'voice',
+  'group_chat',
+  'roleplay',
+  'video',
+  'image',
+  'web',
+] as const;
+
 export const RELATIONSHIP_PRESETS = ['friend', 'mentor', 'partner'] as const;
 
+export type AgentDirectoryFilterCapabilityKey =
+  (typeof AGENT_DIRECTORY_FILTER_CAPABILITY_KEYS)[number];
+export type AgentReplyModalityKey = (typeof AGENT_REPLY_MODALITY_KEYS)[number];
 export type AgentCapabilityKey = (typeof AGENT_CAPABILITY_KEYS)[number];
 export type AgentCapabilities = Record<AgentCapabilityKey, boolean>;
 export type RelationshipPreset = (typeof RELATIONSHIP_PRESETS)[number];

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,14 +1,18 @@
 export {
   AGENT_CAPABILITY_KEYS,
+  AGENT_DIRECTORY_FILTER_CAPABILITY_KEYS,
   AGENT_PUBLIC_DIARY_METADATA_PATH,
+  AGENT_REPLY_MODALITY_KEYS,
   RELATIONSHIP_PRESETS,
 } from './agent';
 export type {
   Agent,
-  AgentDiaryEntry,
-  AgentRegistration,
   AgentCapabilityKey,
   AgentCapabilities,
+  AgentDiaryEntry,
+  AgentDirectoryFilterCapabilityKey,
+  AgentRegistration,
+  AgentReplyModalityKey,
   RelationshipPreset,
 } from './agent';
 export type { AgentMemoryProfile } from './agent-memory';


### PR DESCRIPTION
## Summary
- add a dedicated `Replies with` strip on agent directory cards for voice, video, image, and web-aware replies
- keep directory filter chips scoped to discovery filters while extending shared/public capability parsing for reply modalities
- cover the UI and API contract with focused tests

## Validation
- `pnpm exec vitest run __tests__/components/agent-card.test.tsx __tests__/api/agents.test.ts`
- `pnpm --filter web type-check && pnpm --filter @agentgram/shared type-check`
- `pnpm exec prettier --check apps/web/app/api/v1/agents/route.ts apps/web/components/agents/AgentCard.tsx apps/web/lib/agents/capabilities.ts apps/web/__tests__/components/agent-card.test.tsx apps/web/__tests__/api/agents.test.ts packages/shared/src/types/agent.ts packages/shared/src/types/index.ts packages/shared/src/transforms/agent.ts docs/pr-evidence/modality-badges-before-chat.md`

## Evidence
- Durable artifact: [docs/pr-evidence/modality-badges-before-chat.md](https://github.com/agentgram/agentgram/blob/feat/modality-badges-before-chat/docs/pr-evidence/modality-badges-before-chat.md)
- Screenshots were not feasible in this subagent worktree, so the committed evidence note captures the before/after contract and touched files.

Source: backlog.md:103
