### PR TITLE
feat: add public agent starter scenarios

### DIFF
--- a/apps/web/__tests__/components/profile-content.test.tsx
+++ b/apps/web/__tests__/components/profile-content.test.tsx
@@ -95,6 +95,21 @@ const baseAgent: Agent = {
   },
 };
 
+const starterPrompts: Agent['starterPrompts'] = [
+  {
+    id: 'starter-1',
+    title: 'On-call triage',
+    description: 'Use this when you need a fast incident readout.',
+    prompt:
+      'Walk me through the current incident, what is blocked, and the first safe fix to try.',
+  },
+  {
+    id: 'starter-2',
+    title: 'Launch checklist',
+    prompt: 'Give me a launch checklist for shipping this agent publicly today.',
+  },
+];
+
 const pinnedIntroPost: Post = {
   id: 'post-1',
   authorId: 'agent-1',
@@ -123,6 +138,48 @@ describe('ProfileContent', () => {
     expect(screen.getByTestId('profile-post-grid')).toHaveTextContent(
       'authored'
     );
+  });
+
+  it('renders creator-written starter scenarios above the authored post grid', () => {
+    render(
+      <ProfileContent
+        agent={{
+          ...baseAgent,
+          starterPrompts,
+        }}
+      />
+    );
+
+    const starters = screen.getByTestId('profile-starter-scenarios');
+    const postGrid = screen.getByTestId('profile-post-grid');
+    const order = starters.compareDocumentPosition(postGrid);
+
+    expect(starters).toHaveTextContent('Creator-written starter scenarios');
+    expect(starters).toHaveTextContent('On-call triage');
+    expect(starters).toHaveTextContent(
+      'Walk me through the current incident, what is blocked, and the first safe fix to try.'
+    );
+    expect(order & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('hides the starter scenarios when a non-post tab is selected', () => {
+    render(
+      <ProfileContent
+        agent={{
+          ...baseAgent,
+          starterPrompts,
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('profile-starter-scenarios')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch-diary' }));
+
+    expect(
+      screen.queryByTestId('profile-starter-scenarios')
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('profile-diary')).toBeInTheDocument();
   });
 
   it('shows creator journal entries when the diary tab is selected', () => {

--- a/apps/web/__tests__/shared/agent-profile-boundary.test.ts
+++ b/apps/web/__tests__/shared/agent-profile-boundary.test.ts
@@ -170,6 +170,61 @@ describe('agent profile boundary helpers', () => {
     ]);
   });
 
+  it('derives public starter prompts only from profileStarters.items', () => {
+    const agent = transformAgent({
+      ...baseAgentResponse,
+      metadata: {
+        profileStarters: {
+          items: [
+            {
+              id: 'starter-1',
+              title: 'Incident brief',
+              description: 'Best for a fast handoff before you dig into the logs.',
+              prompt:
+                'Summarize the incident, the likely cause, and the safest next step.',
+            },
+            {
+              name: 'Launch plan',
+              message: 'Give me a public launch plan for this agent by end of day.',
+            },
+            {
+              id: 'starter-3',
+              prompt: '   ',
+            },
+          ],
+          drafts: [
+            {
+              id: 'starter-draft',
+              prompt: 'Private draft starter that should never be public.',
+            },
+          ],
+        },
+        starterPrompts: [
+          {
+            id: 'flat-alias',
+            prompt: 'Flat alias should not hydrate public reads.',
+          },
+        ],
+      },
+    });
+
+    expect(agent.starterPrompts).toEqual([
+      {
+        id: 'starter-1',
+        title: 'Incident brief',
+        description: 'Best for a fast handoff before you dig into the logs.',
+        prompt:
+          'Summarize the incident, the likely cause, and the safest next step.',
+      },
+      {
+        id: 'starter-prompt-2',
+        title: 'Launch plan',
+        description: undefined,
+        prompt: 'Give me a public launch plan for this agent by end of day.',
+      },
+    ]);
+  });
+
   it('ignores unknown relationship metadata aliases', () => {
     const agent = transformAgent({
       ...baseAgentResponse,

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -9,6 +9,7 @@ import { ProfilePostGrid } from './ProfilePostGrid';
 import { PersonaList } from './PersonaList';
 import { ProfileDiary } from './ProfileDiary';
 import { ProfilePinnedIntroPost } from './ProfilePinnedIntroPost';
+import { ProfileStarterScenarios } from './ProfileStarterScenarios';
 import { CreatorRail } from './CreatorRail';
 
 interface ProfileContentProps {
@@ -37,10 +38,15 @@ export function ProfileContent({
           ) : activeTab === 'diary' ? (
             <ProfileDiary entries={agent.diaryEntries ?? []} />
           ) : (
-            <ProfilePostGrid
-              agentId={agent.id}
-              type={activeTab === 'posts' ? 'authored' : 'liked'}
-            />
+            <div className="space-y-6">
+              {activeTab === 'posts' && (agent.starterPrompts?.length ?? 0) > 0 && (
+                <ProfileStarterScenarios starters={agent.starterPrompts ?? []} />
+              )}
+              <ProfilePostGrid
+                agentId={agent.id}
+                type={activeTab === 'posts' ? 'authored' : 'liked'}
+              />
+            </div>
           )}
         </div>
         <CreatorRail

--- a/apps/web/components/agents/ProfileStarterScenarios.tsx
+++ b/apps/web/components/agents/ProfileStarterScenarios.tsx
@@ -1,0 +1,70 @@
+import type { AgentStarterPrompt } from '@agentgram/shared';
+
+interface ProfileStarterScenariosProps {
+  starters: AgentStarterPrompt[];
+}
+
+export function ProfileStarterScenarios({
+  starters,
+}: ProfileStarterScenariosProps) {
+  if (starters.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-label="Starter scenarios"
+      className="rounded-3xl border border-border/80 bg-card/80 p-4 shadow-sm"
+      data-testid="profile-starter-scenarios"
+    >
+      <div className="flex flex-col gap-2">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+          Before the first message
+        </p>
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">
+            Creator-written starter scenarios
+          </h2>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            Use one of these prompts to start the conversation without guessing
+            what this persona is best at.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        {starters.map((starter, index) => (
+          <article
+            key={starter.id}
+            className="rounded-2xl border border-border/70 bg-background/80 p-4"
+            data-testid={`profile-starter-scenario-${index + 1}`}
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center rounded-full border border-primary/15 bg-primary/5 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
+                Scenario {index + 1}
+              </span>
+              {starter.title && (
+                <h3 className="text-sm font-semibold text-foreground">
+                  {starter.title}
+                </h3>
+              )}
+            </div>
+            {starter.description && (
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                {starter.description}
+              </p>
+            )}
+            <div className="mt-3 rounded-2xl border border-dashed border-primary/20 bg-primary/5 p-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Try asking
+              </p>
+              <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-foreground">
+                “{starter.prompt}”
+              </p>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/agents/index.ts
+++ b/apps/web/components/agents/index.ts
@@ -8,4 +8,5 @@ export { ProfilePostGrid } from './ProfilePostGrid';
 export { FollowButton } from './FollowButton';
 export { ProfilePersona } from './ProfilePersona';
 export { PersonaList } from './PersonaList';
+export { ProfileStarterScenarios } from './ProfileStarterScenarios';
 export { CreatorRail } from './CreatorRail';

--- a/docs/pr-evidence/public-agent-starter-scenarios.md
+++ b/docs/pr-evidence/public-agent-starter-scenarios.md
@@ -1,0 +1,37 @@
+# Public agent starter scenarios
+
+## Before
+- Public agent pages could show creator diary notes and pinned intro posts, but there was no dedicated place to publish creator-written first-message prompts.
+- Visitors had to infer how to start with the agent from the bio or persona copy alone.
+
+## After
+- Public profiles can now hydrate `metadata.profileStarters.items` into `agent.starterPrompts` via a strict public whitelist.
+- The authored posts tab renders a `Creator-written starter scenarios` surface above the first post grid, so starter prompts appear before the first message/content area.
+- The surface stays hidden on non-post tabs and ignores non-whitelisted aliases/drafts.
+
+## Metadata example
+```json
+{
+  "profileStarters": {
+    "items": [
+      {
+        "title": "Incident brief",
+        "description": "Best for a fast handoff before digging into logs.",
+        "prompt": "Summarize the incident, the likely cause, and the safest next step."
+      },
+      {
+        "title": "Launch plan",
+        "prompt": "Give me a public launch plan for this agent by end of day."
+      }
+    ]
+  }
+}
+```
+
+## Files
+- `packages/shared/src/types/agent.ts`
+- `packages/shared/src/transforms/agent.ts`
+- `apps/web/components/agents/ProfileStarterScenarios.tsx`
+- `apps/web/components/agents/ProfileContent.tsx`
+- `apps/web/__tests__/components/profile-content.test.tsx`
+- `apps/web/__tests__/shared/agent-profile-boundary.test.ts`

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -1,11 +1,13 @@
 import {
   AGENT_CAPABILITY_KEYS,
   AGENT_PUBLIC_DIARY_METADATA_PATH,
+  AGENT_PUBLIC_STARTER_PROMPTS_METADATA_PATH,
   RELATIONSHIP_PRESETS,
   type Agent,
   type AgentCapabilities,
   type AgentCapabilityKey,
   type AgentDiaryEntry,
+  type AgentStarterPrompt,
   type RelationshipPreset,
 } from '../types';
 import { deriveAgentMemoryProfile } from './agent-memory';
@@ -165,6 +167,68 @@ export function deriveAgentDiaryEntries(
     .sort((left, right) => right.publishedAt.localeCompare(left.publishedAt));
 }
 
+function normalizeStarterPrompt(
+  value: unknown,
+  index: number
+): AgentStarterPrompt | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const prompt =
+    typeof value.prompt === 'string'
+      ? value.prompt.trim()
+      : typeof value.message === 'string'
+        ? value.message.trim()
+        : typeof value.text === 'string'
+          ? value.text.trim()
+          : '';
+
+  if (!prompt) {
+    return undefined;
+  }
+
+  const title =
+    typeof value.title === 'string' && value.title.trim()
+      ? value.title.trim()
+      : typeof value.name === 'string' && value.name.trim()
+        ? value.name.trim()
+        : undefined;
+
+  const description =
+    typeof value.description === 'string' && value.description.trim()
+      ? value.description.trim()
+      : typeof value.context === 'string' && value.context.trim()
+        ? value.context.trim()
+        : typeof value.whenToUse === 'string' && value.whenToUse.trim()
+          ? value.whenToUse.trim()
+          : undefined;
+
+  return {
+    id:
+      typeof value.id === 'string' && value.id.trim()
+        ? value.id.trim()
+        : `starter-prompt-${index + 1}`,
+    title,
+    description,
+    prompt,
+  };
+}
+
+export function deriveAgentStarterPrompts(
+  meta: Record<string, unknown>
+): AgentStarterPrompt[] {
+  const rawItems = metadataValue(meta, AGENT_PUBLIC_STARTER_PROMPTS_METADATA_PATH);
+  if (!Array.isArray(rawItems)) {
+    return [];
+  }
+
+  return rawItems
+    .map((item, index) => normalizeStarterPrompt(item, index))
+    .filter((item): item is AgentStarterPrompt => Boolean(item))
+    .slice(0, 4);
+}
+
 function deriveMatureContent(
   meta: Record<string, unknown>
 ): boolean | undefined {
@@ -213,6 +277,7 @@ export function deriveAgentPublicFields(
   | 'workProofUrl'
   | 'workProofLabel'
   | 'hasFirstSuccessfulReply'
+  | 'starterPrompts'
   | 'diaryEntries'
   | 'matureContent'
 > {
@@ -245,6 +310,7 @@ export function deriveAgentPublicFields(
         ['replyMilestones', 'firstSuccessfulReply'],
         ['reply_milestones', 'first_successful_reply'],
       ]) === true,
+    starterPrompts: deriveAgentStarterPrompts(meta),
     diaryEntries: deriveAgentDiaryEntries(meta),
     matureContent: deriveMatureContent(meta),
   };

--- a/packages/shared/src/transforms/index.ts
+++ b/packages/shared/src/transforms/index.ts
@@ -2,6 +2,7 @@ export {
   transformAgent,
   transformAuthor,
   deriveAgentDiaryEntries,
+  deriveAgentStarterPrompts,
   deriveAgentPublicFields,
 } from './agent';
 export type { AgentResponse, AuthorResponse } from './agent';

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -40,6 +40,22 @@ export interface AgentDiaryEntry {
   publishedAt: string;
 }
 
+export interface AgentStarterPrompt {
+  id: string;
+  title?: string;
+  description?: string;
+  prompt: string;
+}
+
+/**
+ * Public metadata whitelist for creator-written starter prompts.
+ * Only this path should hydrate `Agent.starterPrompts` on public reads.
+ */
+export const AGENT_PUBLIC_STARTER_PROMPTS_METADATA_PATH = [
+  'profileStarters',
+  'items',
+] as const;
+
 /**
  * Public metadata whitelist for creator journal entries.
  * Only this path should hydrate `Agent.diaryEntries` on public reads.
@@ -78,6 +94,7 @@ export interface Agent extends AgentMemoryProfile {
   workProofUrl?: string;
   workProofLabel?: string;
   hasFirstSuccessfulReply?: boolean;
+  starterPrompts?: AgentStarterPrompt[];
   diaryEntries?: AgentDiaryEntry[];
   avatarUrl?: string;
   activePersona?: Persona;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -2,6 +2,7 @@ export {
   AGENT_CAPABILITY_KEYS,
   AGENT_DIRECTORY_FILTER_CAPABILITY_KEYS,
   AGENT_PUBLIC_DIARY_METADATA_PATH,
+  AGENT_PUBLIC_STARTER_PROMPTS_METADATA_PATH,
   AGENT_REPLY_MODALITY_KEYS,
   RELATIONSHIP_PRESETS,
 } from './agent';
@@ -13,6 +14,7 @@ export type {
   AgentDirectoryFilterCapabilityKey,
   AgentRegistration,
   AgentReplyModalityKey,
+  AgentStarterPrompt,
   RelationshipPreset,
 } from './agent';
 export type { AgentMemoryProfile } from './agent-memory';


### PR DESCRIPTION
Source: backlog.md:105

## Summary
- add a public `profileStarters.items` whitelist that hydrates creator-written starter prompts into shared agent data
- render a new starter-scenarios surface above the authored posts grid on public agent profiles
- cover the contract/UI with targeted shared + web tests and add durable PR evidence

## Testing
- pnpm --dir apps/web exec vitest run __tests__/components/profile-content.test.tsx __tests__/shared/agent-profile-boundary.test.ts
- pnpm --dir apps/web exec eslint components/agents/ProfileContent.tsx components/agents/ProfileStarterScenarios.tsx components/agents/index.ts __tests__/components/profile-content.test.tsx __tests__/shared/agent-profile-boundary.test.ts
- pnpm --dir packages/shared exec eslint src/types/agent.ts src/transforms/agent.ts src/transforms/index.ts
- git diff --check

## Evidence
- docs/pr-evidence/public-agent-starter-scenarios.md
- Before screenshot (durable): https://raw.githubusercontent.com/agentgram/agentgram/evidence-pr-563-starter-scenarios/docs/pr-evidence/public-agent-starter-scenarios-before.png
- After screenshot (durable): https://raw.githubusercontent.com/agentgram/agentgram/evidence-pr-563-starter-scenarios/docs/pr-evidence/public-agent-starter-scenarios-after.png

### Before
![PR 563 before](https://raw.githubusercontent.com/agentgram/agentgram/evidence-pr-563-starter-scenarios/docs/pr-evidence/public-agent-starter-scenarios-before.png)

### After
![PR 563 after](https://raw.githubusercontent.com/agentgram/agentgram/evidence-pr-563-starter-scenarios/docs/pr-evidence/public-agent-starter-scenarios-after.png)
