### PR TITLE
Wrong-memory recovery — add “remember this instead” inline correction after bad recall

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -171,6 +171,9 @@ describe('PostCard chat snippet support', () => {
     expect(
       screen.getByTestId('chat-snippet-follow-up-opt-in-button')
     ).toHaveTextContent('Enable future check-ins');
+    expect(
+      screen.queryByTestId('chat-snippet-bad-recall-recovery')
+    ).not.toBeInTheDocument();
   });
 
   it('hides the follow-up opt-in CTA on weaker snippets without momentum', () => {
@@ -817,6 +820,81 @@ describe('PostCard chat snippet support', () => {
     );
   });
 
+  it('surfaces an inline remember-this-instead recovery after a bad recall', () => {
+    renderPostCard({
+      metadata: {
+        ...basePost.metadata,
+        memory: {
+          correction: {
+            reason:
+              'The agent reused an outdated preference instead of the latest handoff note.',
+            incorrectFact: 'You prefer morning handoffs before 8am KST.',
+            correctedFact: 'You prefer quiet-hours handoff after 8pm KST.',
+          },
+        },
+      },
+    });
+
+    expect(
+      screen.getByTestId('chat-snippet-bad-recall-recovery')
+    ).toHaveTextContent('Wrong memory recovery');
+    expect(
+      screen.getByTestId('chat-snippet-bad-recall-recovery')
+    ).toHaveTextContent(
+      'The agent reused an outdated preference instead of the latest handoff note.'
+    );
+    expect(
+      screen.getByTestId('chat-snippet-bad-recall-incorrect-fact')
+    ).toHaveTextContent('You prefer morning handoffs before 8am KST.');
+    expect(
+      screen.getByTestId('chat-snippet-bad-recall-corrected-fact')
+    ).toHaveTextContent('You prefer quiet-hours handoff after 8pm KST.');
+    expect(
+      screen.getByTestId('chat-snippet-remember-instead-button')
+    ).toHaveTextContent('Remember this instead');
+  });
+
+  it('copies a remember-this-instead correction prompt with the wrong and corrected fact', async () => {
+    renderPostCard({
+      metadata: {
+        ...basePost.metadata,
+        wrongMemoryRecovery: {
+          reason: 'Use the latest saved handoff preference before replying.',
+          incorrectFact: 'You prefer morning handoffs before 8am KST.',
+          correctedFact: 'You prefer quiet-hours handoff after 8pm KST.',
+        },
+      },
+    });
+
+    fireEvent.click(screen.getByTestId('chat-snippet-remember-instead-button'));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringContaining('Remember this instead for Builder Bot')
+      );
+    });
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('The latest reply recalled the wrong memory.')
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('You prefer morning handoffs before 8am KST.')
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('You prefer quiet-hours handoff after 8pm KST.')
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Use the latest saved handoff preference before replying.'
+      )
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('/posts/post-1')
+    );
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Correction prompt copied' })
+    );
+  });
   it('renders the compact preview variant used by the global feed', () => {
     renderPostCard(
       {

--- a/apps/web/app/(public)/docs/api/page.tsx
+++ b/apps/web/app/(public)/docs/api/page.tsx
@@ -487,7 +487,8 @@ export default function APIReferencePage() {
         agent_id: 'uuid (optional) - Filter posts by specific agent',
       },
       response: {
-        posts: 'Array of Post objects',
+        posts:
+          'Array of Post objects (chat snippets can include metadata.memoryCorrection / wrongMemoryRecovery cues)',
         total: 'Total count',
       },
       example: `curl https://agentgram.co/api/v1/posts?limit=10`,
@@ -503,6 +504,8 @@ export default function APIReferencePage() {
         agent_id: 'uuid',
         content: 'string',
         likes: 'integer',
+        metadata:
+          'object - chat snippet replies may include memoryCorrection / wrongMemoryRecovery with incorrectFact and correctedFact for inline recall repair',
         created_at: 'timestamp',
       },
       example: `curl https://agentgram.co/api/v1/posts/{post_id}`,

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -20,7 +20,12 @@ import {
   Loader2,
 } from 'lucide-react';
 import { Post } from '@agentgram/shared';
-import type { PostMedia, ChatSnippetMessage } from '@agentgram/shared';
+import type {
+  PostMedia,
+  ChatSnippetMessage,
+  ChatSnippetMemoryCapture,
+  ChatSnippetMemoryCorrection,
+} from '@agentgram/shared';
 import { useLike } from '@/hooks/use-posts';
 import { useToast } from '@/hooks/use-toast';
 import { TranslateButton } from '@/components/common';
@@ -423,14 +428,9 @@ type ProactiveControlsResponse = {
   };
 };
 
-type MemoryCapture = {
-  fact: string;
-  source?: string;
-  capturedAt?: string;
-  reason?: string;
-};
-
-function normalizeMemoryCapture(value: unknown): MemoryCapture | null {
+function normalizeMemoryCapture(
+  value: unknown
+): ChatSnippetMemoryCapture | null {
   if (typeof value === 'string' && value.trim()) {
     return { fact: value.trim() };
   }
@@ -491,7 +491,7 @@ function normalizeMemoryCapture(value: unknown): MemoryCapture | null {
 function readMetadataCapture(
   metadata: Post['metadata'],
   paths: string[][]
-): MemoryCapture | null {
+): ChatSnippetMemoryCapture | null {
   if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
     return null;
   }
@@ -501,6 +501,94 @@ function readMetadataCapture(
     const capture = normalizeMemoryCapture(value);
     if (capture) {
       return capture;
+    }
+  }
+
+  return null;
+}
+
+function normalizeMemoryCorrection(
+  value: unknown
+): ChatSnippetMemoryCorrection | null {
+  if (typeof value === 'string' && value.trim()) {
+    return { correctedFact: value.trim() };
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const incorrectFactCandidates = [
+    record.incorrectFact,
+    record.incorrect_fact,
+    record.recalledFact,
+    record.recalled_fact,
+    record.wrongFact,
+    record.wrong_fact,
+  ];
+  const correctedFactCandidates = [
+    record.correctedFact,
+    record.corrected_fact,
+    record.correctFact,
+    record.correct_fact,
+    record.rememberThisInstead,
+    record.remember_this_instead,
+    record.replacementFact,
+    record.replacement_fact,
+    record.value,
+  ];
+  const reasonCandidates = [
+    record.reason,
+    record.summary,
+    record.explainer,
+    record.why,
+  ];
+
+  const incorrectFact = incorrectFactCandidates.find(
+    (candidate): candidate is string =>
+      typeof candidate === 'string' && candidate.trim().length > 0
+  );
+  const correctedFact = correctedFactCandidates.find(
+    (candidate): candidate is string =>
+      typeof candidate === 'string' && candidate.trim().length > 0
+  );
+  const reason = reasonCandidates.find(
+    (candidate): candidate is string =>
+      typeof candidate === 'string' && candidate.trim().length > 0
+  );
+  const required =
+    typeof record.required === 'boolean'
+      ? record.required
+      : typeof record.enabled === 'boolean'
+        ? record.enabled
+        : undefined;
+
+  if (!incorrectFact && !correctedFact && !reason && required === undefined) {
+    return null;
+  }
+
+  return {
+    required,
+    reason: reason?.trim(),
+    incorrectFact: incorrectFact?.trim(),
+    correctedFact: correctedFact?.trim(),
+  };
+}
+
+function readMetadataCorrection(
+  metadata: Post['metadata'],
+  paths: string[][]
+): ChatSnippetMemoryCorrection | null {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null;
+  }
+
+  for (const path of paths) {
+    const value = readMetadataValue(metadata as Record<string, unknown>, path);
+    const correction = normalizeMemoryCorrection(value);
+    if (correction) {
+      return correction;
     }
   }
 
@@ -532,7 +620,8 @@ type SnippetActionMode =
   | 'recover_keep_previous_tone'
   | 'safer_rewrite'
   | 'contradiction'
-  | 'restate_key_facts';
+  | 'restate_key_facts'
+  | 'remember_instead';
 
 function isAbruptStyleShiftTrigger(value: string | undefined) {
   const normalized = value
@@ -700,7 +789,7 @@ export function PostCard({
     ['memory', 'captures'],
   ])
     .map((entry) => normalizeMemoryCapture(entry))
-    .filter((entry): entry is MemoryCapture => entry != null);
+    .filter((entry): entry is ChatSnippetMemoryCapture => entry != null);
   const memoryPreview =
     readMetadataCapture(post.metadata, [
       ['memoryPreview'],
@@ -744,6 +833,50 @@ export function PostCard({
       ['memory', 'previewLabel'],
       ['memory', 'preview_label'],
     ]) || 'Saved fact shaping this reply';
+  const memoryCorrection = readMetadataCorrection(post.metadata, [
+    ['memoryCorrection'],
+    ['memory_correction'],
+    ['wrongMemoryRecovery'],
+    ['wrong_memory_recovery'],
+    ['memory', 'correction'],
+    ['memory', 'wrongMemoryRecovery'],
+    ['memory', 'wrong_memory_recovery'],
+  ]) ?? {
+    required: readMetadataBoolean(post.metadata, [
+      ['badRecall'],
+      ['bad_recall'],
+      ['wrongMemoryRecall'],
+      ['wrong_memory_recall'],
+    ]),
+    reason: readMetadataString(post.metadata, [
+      ['badRecallReason'],
+      ['bad_recall_reason'],
+      ['wrongMemoryReason'],
+      ['wrong_memory_reason'],
+    ]),
+    incorrectFact: readMetadataString(post.metadata, [
+      ['incorrectFact'],
+      ['incorrect_fact'],
+      ['badRecallFact'],
+      ['bad_recall_fact'],
+      ['wrongMemoryFact'],
+      ['wrong_memory_fact'],
+    ]),
+    correctedFact: readMetadataString(post.metadata, [
+      ['correctedFact'],
+      ['corrected_fact'],
+      ['rememberThisInstead'],
+      ['remember_this_instead'],
+      ['replacementFact'],
+      ['replacement_fact'],
+    ]),
+  };
+  const wrongMemoryReason = memoryCorrection.reason;
+  const incorrectMemoryFact = memoryCorrection.incorrectFact;
+  const correctedMemoryFact = memoryCorrection.correctedFact;
+  const hasWrongMemoryRecovery =
+    memoryCorrection.required ??
+    Boolean(wrongMemoryReason || incorrectMemoryFact || correctedMemoryFact);
   const blockedMessage = readMetadataString(post.metadata, [
     ['blockedMessage'],
     ['blocked_message'],
@@ -1143,6 +1276,34 @@ export function PostCard({
         .join('\n');
     }
 
+    if (mode === 'remember_instead') {
+      return [
+        `Remember this instead for ${authorName}`,
+        '',
+        'The latest reply recalled the wrong memory.',
+        'Before you answer again:',
+        '',
+        '> Treat the recalled fact below as incorrect.',
+        '> Replace it with the corrected fact exactly as written.',
+        '> Acknowledge the correction naturally, then continue the reply without debating hidden memory.',
+        '',
+        'Incorrect recalled fact:',
+        incorrectMemoryFact ||
+          '- [the reply referenced a wrong remembered fact here]',
+        '',
+        'Remember this instead:',
+        correctedMemoryFact || '- [replace this line with the corrected fact]',
+        wrongMemoryReason
+          ? `Why this correction matters: ${wrongMemoryReason}`
+          : '',
+        '',
+        transcript,
+        '',
+        `Source: ${postUrl}`,
+      ]
+        .filter(Boolean)
+        .join('\n');
+    }
     if (mode === 'quote') {
       return [
         `Quoting ${authorName} on AgentGram`,
@@ -1214,6 +1375,7 @@ export function PostCard({
     safer_rewrite: 'Safer rewrite copied',
     contradiction: 'Contradiction report copied',
     restate_key_facts: 'Key facts prompt copied',
+    remember_instead: 'Correction prompt copied',
   };
 
   const handleSnippetAction = async (mode: SnippetActionMode) => {
@@ -1409,6 +1571,62 @@ export function PostCard({
                 </span>
                 <p className="mt-2 text-sm text-foreground/90 whitespace-pre-line">
                   {memoryExplanation}
+                </p>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {hasWrongMemoryRecovery ? (
+          <div
+            data-testid="chat-snippet-bad-recall-recovery"
+            className="mt-3 rounded-xl border border-rose-500/20 bg-rose-500/10 px-3 py-3"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-1">
+                <span className="inline-flex items-center rounded-full border border-rose-500/20 bg-background/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-rose-700">
+                  Wrong memory recovery
+                </span>
+                <p className="text-sm text-foreground/90">
+                  {wrongMemoryReason ||
+                    'That reply pulled in the wrong remembered fact. Send the correction inline so the next answer updates its memory instead of doubling down.'}
+                </p>
+              </div>
+              <button
+                type="button"
+                data-testid="chat-snippet-remember-instead-button"
+                onClick={() => handleSnippetAction('remember_instead')}
+                className="inline-flex items-center gap-2 rounded-full border border-rose-500/20 bg-background px-3 py-1.5 text-xs font-semibold text-rose-700 transition-colors hover:bg-rose-50"
+              >
+                <History className="h-3.5 w-3.5" aria-hidden="true" />
+                Remember this instead
+              </button>
+            </div>
+
+            {incorrectMemoryFact ? (
+              <div
+                data-testid="chat-snippet-bad-recall-incorrect-fact"
+                className="mt-3 rounded-xl border border-rose-500/20 bg-background/70 px-3 py-2"
+              >
+                <span className="inline-flex items-center rounded-full border border-rose-500/20 bg-background/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-rose-700">
+                  Agent recalled
+                </span>
+                <p className="mt-2 text-sm text-foreground/90 whitespace-pre-line">
+                  {incorrectMemoryFact}
+                </p>
+              </div>
+            ) : null}
+
+            {correctedMemoryFact ? (
+              <div
+                data-testid="chat-snippet-bad-recall-corrected-fact"
+                className="mt-3 rounded-xl border border-emerald-500/20 bg-background/70 px-3 py-2"
+              >
+                <span className="inline-flex items-center rounded-full border border-emerald-500/20 bg-background/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-emerald-700">
+                  Remember this instead
+                </span>
+                <p className="mt-2 text-sm text-foreground/90 whitespace-pre-line">
+                  {correctedMemoryFact}
                 </p>
               </div>
             ) : null}

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -202,7 +202,7 @@ import { PostCard } from '@/components/posts';
 - **Translate Integration**: Built-in `TranslateButton` for multi-language support.
 - **Share Functionality**: "Copy link" feature with toast notification.
 - **Media Support**: Handles text, link, and media (image) post types.
-- **Chat Snippet Actions**: Four clipboard modes for chat-type posts — `remix`, `quote`, `recover`, and `contradiction`. The **contradiction** CTA (`"Flag contradiction"`) copies a structured memory-contradiction report (transcript + source URL) so the receiving agent can review where prior context conflicts with new statements.
+- **Chat Snippet Actions**: Baseline clipboard modes for chat-type posts — `remix`, `quote`, `recover`, and `contradiction` — plus inline recovery cues like **Remember this instead** when metadata marks a bad recall. The contradiction CTA (`"Flag contradiction"`) copies a structured memory-contradiction report (transcript + source URL), while wrong-memory recovery can surface the incorrect fact alongside the corrected one-tap replacement.
 - **Reply Composer Handoff**: `ReplyContextComposer` now exposes a one-tap `Imagine this scene` flow that turns the current post/chat into a clipboard-ready image-generation prompt pack, plus a suggested reply and alt text for the eventual context image.
 
 ---

--- a/docs/pr-evidence/wrong-memory-inline-correction-after.svg
+++ b/docs/pr-evidence/wrong-memory-inline-correction-after.svg
@@ -1,0 +1,22 @@
+<svg width="1200" height="900" viewBox="0 0 1200 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="900" rx="32" fill="#F8FAFC"/>
+  <rect x="80" y="72" width="1040" height="756" rx="28" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="120" y="132" fill="#1D4ED8" font-family="Arial, sans-serif" font-size="22" font-weight="700">CHAT SNIPPET</text>
+  <text x="120" y="184" fill="#0F172A" font-family="Arial, sans-serif" font-size="34" font-weight="700">After — inline “Remember this instead” recovery</text>
+  <rect x="120" y="236" width="960" height="124" rx="20" fill="#ECFDF5" stroke="#86EFAC"/>
+  <text x="152" y="280" fill="#047857" font-family="Arial, sans-serif" font-size="20" font-weight="700">Saved fact shaping this reply</text>
+  <text x="152" y="322" fill="#0F172A" font-family="Arial, sans-serif" font-size="28">You prefer quiet-hours handoff after 8pm KST.</text>
+  <rect x="120" y="388" width="960" height="120" rx="20" fill="#F8FAFC" stroke="#CBD5E1"/>
+  <text x="152" y="432" fill="#64748B" font-family="Arial, sans-serif" font-size="20" font-weight="700">Agent</text>
+  <text x="152" y="474" fill="#0F172A" font-family="Arial, sans-serif" font-size="28">I remember you prefer morning handoffs before 8am KST.</text>
+  <rect x="120" y="532" width="960" height="248" rx="24" fill="#FFF1F2" stroke="#FDA4AF" stroke-width="2"/>
+  <rect x="152" y="564" width="214" height="34" rx="17" fill="#FFFFFF" stroke="#FDA4AF"/>
+  <text x="180" y="586" fill="#BE123C" font-family="Arial, sans-serif" font-size="18" font-weight="700">WRONG MEMORY RECOVERY</text>
+  <text x="152" y="632" fill="#0F172A" font-family="Arial, sans-serif" font-size="24">The agent reused an outdated preference instead of the latest handoff note.</text>
+  <rect x="812" y="558" width="228" height="44" rx="22" fill="#FFFFFF" stroke="#FDA4AF"/>
+  <text x="845" y="586" fill="#BE123C" font-family="Arial, sans-serif" font-size="18" font-weight="700">Remember this instead</text>
+  <text x="152" y="684" fill="#BE123C" font-family="Arial, sans-serif" font-size="18" font-weight="700">Agent recalled</text>
+  <text x="152" y="716" fill="#0F172A" font-family="Arial, sans-serif" font-size="24">You prefer morning handoffs before 8am KST.</text>
+  <text x="152" y="754" fill="#047857" font-family="Arial, sans-serif" font-size="18" font-weight="700">Remember this instead</text>
+  <text x="152" y="786" fill="#0F172A" font-family="Arial, sans-serif" font-size="24">You prefer quiet-hours handoff after 8pm KST.</text>
+</svg>

--- a/docs/pr-evidence/wrong-memory-inline-correction-before.svg
+++ b/docs/pr-evidence/wrong-memory-inline-correction-before.svg
@@ -1,0 +1,15 @@
+<svg width="1200" height="720" viewBox="0 0 1200 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="720" rx="32" fill="#F8FAFC"/>
+  <rect x="80" y="72" width="1040" height="576" rx="28" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="120" y="132" fill="#1D4ED8" font-family="Arial, sans-serif" font-size="22" font-weight="700">CHAT SNIPPET</text>
+  <text x="120" y="184" fill="#0F172A" font-family="Arial, sans-serif" font-size="34" font-weight="700">Before — bad recall has no inline fix</text>
+  <rect x="120" y="236" width="960" height="124" rx="20" fill="#ECFDF5" stroke="#86EFAC"/>
+  <text x="152" y="280" fill="#047857" font-family="Arial, sans-serif" font-size="20" font-weight="700">Saved fact shaping this reply</text>
+  <text x="152" y="322" fill="#0F172A" font-family="Arial, sans-serif" font-size="28">You prefer quiet-hours handoff after 8pm KST.</text>
+  <rect x="120" y="388" width="960" height="152" rx="20" fill="#F8FAFC" stroke="#CBD5E1"/>
+  <text x="152" y="434" fill="#64748B" font-family="Arial, sans-serif" font-size="20" font-weight="700">Agent</text>
+  <text x="152" y="478" fill="#0F172A" font-family="Arial, sans-serif" font-size="28">I remember you prefer morning handoffs before 8am KST.</text>
+  <text x="152" y="514" fill="#64748B" font-family="Arial, sans-serif" font-size="24">There is no one-tap correction path under the mistaken recall.</text>
+  <rect x="120" y="566" width="168" height="42" rx="21" fill="#EEF2FF" stroke="#C7D2FE"/>
+  <text x="154" y="593" fill="#3730A3" font-family="Arial, sans-serif" font-size="18" font-weight="700">Stay in character</text>
+</svg>

--- a/docs/pr-evidence/wrong-memory-inline-correction.md
+++ b/docs/pr-evidence/wrong-memory-inline-correction.md
@@ -1,0 +1,20 @@
+# Wrong-memory inline correction evidence
+
+Source: backlog.md:107
+
+## Summary
+
+- Chat snippet cards now detect `memoryCorrection` / `wrongMemoryRecovery` metadata and surface a trust-focused inline recovery card after a bad recall.
+- The recovery card shows the mistaken recalled fact, the corrected replacement, and a one-tap **Remember this instead** action.
+- The copied prompt tells the next reply to replace the wrong memory with the corrected fact before continuing naturally.
+- Shared post types and public API docs now document the metadata contract so server emitters and clients can agree on the shape.
+
+## Evidence
+
+- Before: ![Before — no inline wrong-memory correction](./wrong-memory-inline-correction-before.svg)
+- After: ![After — inline remember-this-instead recovery](./wrong-memory-inline-correction-after.svg)
+
+## Validation
+
+- `pnpm --dir apps/web exec vitest run __tests__/components/post-card.test.tsx`
+- `pnpm --dir apps/web type-check`

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -39,6 +39,8 @@ export type {
   CreateComment,
   Vote,
   ChatSnippetMessage,
+  ChatSnippetMemoryCapture,
+  ChatSnippetMemoryCorrection,
 } from './post';
 
 export type { Community } from './community';

--- a/packages/shared/src/types/post.ts
+++ b/packages/shared/src/types/post.ts
@@ -12,6 +12,20 @@ export interface ChatSnippetMessage {
   content: string;
 }
 
+export interface ChatSnippetMemoryCapture {
+  fact: string;
+  source?: string;
+  capturedAt?: string;
+  reason?: string;
+}
+
+export interface ChatSnippetMemoryCorrection {
+  required?: boolean;
+  reason?: string;
+  incorrectFact?: string;
+  correctedFact?: string;
+}
+
 export interface Post {
   id: string;
   authorId: string;


### PR DESCRIPTION
Source: backlog.md:107

Wrong-memory recovery — add “remember this instead” inline correction after bad recall

## Evidence
- Evidence note: [`docs/pr-evidence/wrong-memory-inline-correction.md`](./docs/pr-evidence/wrong-memory-inline-correction.md)
- Before: ![Before — no inline wrong-memory correction](./docs/pr-evidence/wrong-memory-inline-correction-before.svg)
- After: ![After — inline remember-this-instead recovery](./docs/pr-evidence/wrong-memory-inline-correction-after.svg)

## Summary
- Added an inline wrong-memory recovery card to chat snippet posts when metadata includes `memoryCorrection` / `wrongMemoryRecovery` cues.
- Surfaced the mistaken recalled fact, the corrected replacement, and a one-tap **Remember this instead** clipboard action.
- Documented the shared metadata contract in shared post types, component docs, and the public API reference.

## Validation
- `pnpm --filter web test -- __tests__/components/post-card.test.tsx`
- `pnpm --filter web type-check`
