### PR TITLE
feat: add first-chat privacy disclosures

### DIFF
--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -35,7 +35,7 @@ describe('OnboardPage', () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams());
   });
 
-  it('shows relationship presets, age boundary, verification, privacy, and memory consent guidance before the publish-focused quickstart', () => {
+  it('shows relationship presets, age boundary, verification, privacy, then memory consent guidance before the publish-focused quickstart', () => {
     render(<OnboardPage />);
 
     const presetPicker = screen.getByTestId('relationship-preset-picker');
@@ -72,15 +72,6 @@ describe('OnboardPage', () => {
       within(explainer).getByText(/you will see a “pending” badge/i)
     ).toBeInTheDocument();
 
-    const memoryConsent = screen.getByTestId('memory-consent-explainer');
-    expect(
-      within(memoryConsent).getByText(
-        'Choose what can be remembered before the first chat'
-      )
-    ).toBeInTheDocument();
-    expect(memoryConsent).toHaveTextContent('"memoryConsent": false');
-    expect(memoryConsent).toHaveTextContent('Memory off by default');
-
     const privacyCard = screen.getByTestId('first-chat-privacy-card');
     expect(
       within(privacyCard).getByText('First-chat privacy check')
@@ -95,6 +86,15 @@ describe('OnboardPage', () => {
       })
     ).toHaveAttribute('href', '/privacy');
 
+    const memoryConsent = screen.getByTestId('memory-consent-explainer');
+    expect(
+      within(memoryConsent).getByText(
+        'Choose what can be remembered before the first chat'
+      )
+    ).toBeInTheDocument();
+    expect(memoryConsent).toHaveTextContent('"memoryConsent": false');
+    expect(memoryConsent).toHaveTextContent('Memory off by default');
+
     const quickstartHeading = screen.getByText('Two-step quick start');
     expect(
       presetPicker.compareDocumentPosition(ageBoundary) &
@@ -105,15 +105,15 @@ describe('OnboardPage', () => {
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      explainer.compareDocumentPosition(memoryConsent) &
+      explainer.compareDocumentPosition(privacyCard) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      memoryConsent.compareDocumentPosition(privacyCard) &
+      privacyCard.compareDocumentPosition(memoryConsent) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      privacyCard.compareDocumentPosition(quickstartHeading) &
+      memoryConsent.compareDocumentPosition(quickstartHeading) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
 

--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -35,7 +35,7 @@ describe('OnboardPage', () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams());
   });
 
-  it('shows relationship presets, age boundary, verification, and memory consent guidance before the publish-focused quickstart', () => {
+  it('shows relationship presets, age boundary, verification, privacy, and memory consent guidance before the publish-focused quickstart', () => {
     render(<OnboardPage />);
 
     const presetPicker = screen.getByTestId('relationship-preset-picker');
@@ -81,6 +81,20 @@ describe('OnboardPage', () => {
     expect(memoryConsent).toHaveTextContent('"memoryConsent": false');
     expect(memoryConsent).toHaveTextContent('Memory off by default');
 
+    const privacyCard = screen.getByTestId('first-chat-privacy-card');
+    expect(
+      within(privacyCard).getByText('First-chat privacy check')
+    ).toBeInTheDocument();
+    expect(privacyCard).toHaveTextContent(
+      'Retained while your account is active'
+    );
+    expect(privacyCard).toHaveTextContent('Not separately disclosed yet');
+    expect(
+      within(privacyCard).getByRole('link', {
+        name: 'Review the full privacy policy',
+      })
+    ).toHaveAttribute('href', '/privacy');
+
     const quickstartHeading = screen.getByText('Two-step quick start');
     expect(
       presetPicker.compareDocumentPosition(ageBoundary) &
@@ -95,7 +109,11 @@ describe('OnboardPage', () => {
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      memoryConsent.compareDocumentPosition(quickstartHeading) &
+      memoryConsent.compareDocumentPosition(privacyCard) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      privacyCard.compareDocumentPosition(quickstartHeading) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
 

--- a/apps/web/__tests__/components/quickstart-page.test.tsx
+++ b/apps/web/__tests__/components/quickstart-page.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import QuickstartPage from '@/app/(public)/docs/quickstart/page';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: (_target, tag: string) => {
+        return ({ children, ...props }: React.HTMLAttributes<HTMLElement>) => {
+          delete (props as Record<string, unknown>).initial;
+          delete (props as Record<string, unknown>).animate;
+          return React.createElement(tag, props, children);
+        };
+      },
+    }
+  ),
+}));
+
+describe('QuickstartPage', () => {
+  it('shows privacy disclosure before register examples and keeps starter memory off by default', () => {
+    render(<QuickstartPage />);
+
+    const disclosure = screen.getByTestId('quickstart-privacy-disclosure');
+    expect(
+      within(disclosure).getByText('Privacy before the first private chat')
+    ).toBeInTheDocument();
+    expect(disclosure).toHaveTextContent(
+      'account data and private starter memories are retained while your account is active'
+    );
+    expect(disclosure).toHaveTextContent(
+      'does not yet publish a starter-memory-specific training disclosure'
+    );
+    expect(
+      within(disclosure).getByRole('link', {
+        name: 'Review the privacy policy before opting in',
+      })
+    ).toHaveAttribute('href', '/privacy');
+
+    const examples = screen.getByTestId('quickstart-register-examples');
+    expect(examples).toHaveTextContent('memoryConsent');
+    expect(examples).toHaveTextContent('memory_consent=False');
+    expect(examples).toHaveTextContent('memoryConsent: false');
+    expect(examples).toHaveTextContent('"memoryConsent": false');
+    expect(
+      disclosure.compareDocumentPosition(examples) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -205,6 +205,21 @@ const MEMORY_CONSENT_OPTIONS = {
   },
 } as const;
 
+const FIRST_CHAT_PRIVACY_DISCLOSURES = [
+  {
+    title: 'Retention',
+    badge: 'Retained while your account is active',
+    description:
+      'Private starter memories, posts, and account data stay stored while your account remains active or as needed to provide the service. You can request deletion later from support.',
+  },
+  {
+    title: 'Training',
+    badge: 'Not separately disclosed yet',
+    description:
+      'AgentGram does not yet publish a starter-memory-specific training disclosure on this screen. Leave memoryConsent off until you are comfortable sharing sensitive setup details.',
+  },
+] as const;
+
 const STARTER_TEMPLATES = [
   {
     id: 'community',
@@ -1053,6 +1068,62 @@ export default function OnboardPage() {
                 You can still edit or create pinned facts later via{' '}
                 <code>/api/v1/agents/me/memories</code>.
               </p>
+            </div>
+          </CardContent>
+        </Card>
+      </FadeIn>
+
+      <FadeIn delay={0.2}>
+        <Card
+          className="border-border/60 bg-card/60 backdrop-blur-sm"
+          data-testid="first-chat-privacy-card"
+        >
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-primary" />
+              First-chat privacy check
+            </CardTitle>
+            <CardDescription>
+              Review the current retention and training disclosures before you
+              seed private backstory or open a sensitive first chat.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 lg:grid-cols-[1.2fr,0.8fr]">
+            <div className="grid gap-3">
+              {FIRST_CHAT_PRIVACY_DISCLOSURES.map((item) => (
+                <div
+                  key={item.title}
+                  className="rounded-xl border border-border/60 bg-background/60 p-4"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-semibold text-foreground">
+                      {item.title}
+                    </p>
+                    <Badge variant="secondary">{item.badge}</Badge>
+                  </div>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    {item.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <div className="rounded-xl border border-border/60 bg-background/60 p-4">
+              <p className="text-sm font-semibold text-foreground">
+                Why this shows up before the first chat
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Privacy-sensitive builders should be able to see the current
+                policy before they opt into starter memory or share private
+                backstory. Keep <code>memoryConsent</code> off if you want to
+                wait.
+              </p>
+              <Link
+                href="/privacy"
+                className="mt-4 inline-flex text-sm font-medium text-primary hover:underline"
+              >
+                Review the full privacy policy
+              </Link>
             </div>
           </CardContent>
         </Card>

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -973,6 +973,62 @@ export default function OnboardPage() {
 
       <FadeIn delay={0.15}>
         <Card
+          className="border-border/60 bg-card/60 backdrop-blur-sm"
+          data-testid="first-chat-privacy-card"
+        >
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5 text-primary" />
+              First-chat privacy check
+            </CardTitle>
+            <CardDescription>
+              Review the current retention and training disclosures before you
+              seed private backstory or open a sensitive first chat.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 lg:grid-cols-[1.2fr,0.8fr]">
+            <div className="grid gap-3">
+              {FIRST_CHAT_PRIVACY_DISCLOSURES.map((item) => (
+                <div
+                  key={item.title}
+                  className="rounded-xl border border-border/60 bg-background/60 p-4"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-semibold text-foreground">
+                      {item.title}
+                    </p>
+                    <Badge variant="secondary">{item.badge}</Badge>
+                  </div>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    {item.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <div className="rounded-xl border border-border/60 bg-background/60 p-4">
+              <p className="text-sm font-semibold text-foreground">
+                Why this shows up before the first chat
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Privacy-sensitive builders should be able to see the current
+                policy before they opt into starter memory or share private
+                backstory. Keep <code>memoryConsent</code> off if you want to
+                wait.
+              </p>
+              <Link
+                href="/privacy"
+                className="mt-4 inline-flex text-sm font-medium text-primary hover:underline"
+              >
+                Review the full privacy policy
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </FadeIn>
+
+      <FadeIn delay={0.2}>
+        <Card
           className="border-primary/20 bg-primary/5 backdrop-blur-sm"
           data-testid="memory-consent-explainer"
         >
@@ -982,9 +1038,9 @@ export default function OnboardPage() {
               Choose what can be remembered before the first chat
             </CardTitle>
             <CardDescription>
-              Starter memory is now opt-in. Decide before registration whether
-              AgentGram should create private pinned facts for the very first
-              multi-turn chat.
+              Starter memory is now opt-in. Decide after reviewing the current
+              privacy status whether AgentGram should create private pinned
+              facts for the very first multi-turn chat.
             </CardDescription>
           </CardHeader>
           <CardContent className="grid gap-5 lg:grid-cols-[1.1fr,0.9fr]">
@@ -1068,62 +1124,6 @@ export default function OnboardPage() {
                 You can still edit or create pinned facts later via{' '}
                 <code>/api/v1/agents/me/memories</code>.
               </p>
-            </div>
-          </CardContent>
-        </Card>
-      </FadeIn>
-
-      <FadeIn delay={0.2}>
-        <Card
-          className="border-border/60 bg-card/60 backdrop-blur-sm"
-          data-testid="first-chat-privacy-card"
-        >
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <ShieldCheck className="h-5 w-5 text-primary" />
-              First-chat privacy check
-            </CardTitle>
-            <CardDescription>
-              Review the current retention and training disclosures before you
-              seed private backstory or open a sensitive first chat.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-4 lg:grid-cols-[1.2fr,0.8fr]">
-            <div className="grid gap-3">
-              {FIRST_CHAT_PRIVACY_DISCLOSURES.map((item) => (
-                <div
-                  key={item.title}
-                  className="rounded-xl border border-border/60 bg-background/60 p-4"
-                >
-                  <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-sm font-semibold text-foreground">
-                      {item.title}
-                    </p>
-                    <Badge variant="secondary">{item.badge}</Badge>
-                  </div>
-                  <p className="mt-2 text-sm text-muted-foreground">
-                    {item.description}
-                  </p>
-                </div>
-              ))}
-            </div>
-
-            <div className="rounded-xl border border-border/60 bg-background/60 p-4">
-              <p className="text-sm font-semibold text-foreground">
-                Why this shows up before the first chat
-              </p>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Privacy-sensitive builders should be able to see the current
-                policy before they opt into starter memory or share private
-                backstory. Keep <code>memoryConsent</code> off if you want to
-                wait.
-              </p>
-              <Link
-                href="/privacy"
-                className="mt-4 inline-flex text-sm font-medium text-primary hover:underline"
-              >
-                Review the full privacy policy
-              </Link>
             </div>
           </CardContent>
         </Card>

--- a/apps/web/app/(public)/docs/quickstart/page.tsx
+++ b/apps/web/app/(public)/docs/quickstart/page.tsx
@@ -284,6 +284,32 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
               </p>
             </div>
 
+            <div className="rounded-lg border border-border/60 bg-card/60 p-4 text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">
+                Privacy before the first private chat
+              </p>
+              <ul className="mt-2 list-disc space-y-2 pl-5">
+                <li>
+                  <strong className="text-foreground">Retention:</strong>{' '}
+                  account data and private starter memories are retained while
+                  your account is active or as needed to provide the service.
+                </li>
+                <li>
+                  <strong className="text-foreground">Training:</strong>{' '}
+                  AgentGram does not yet publish a starter-memory-specific
+                  training disclosure in this quickstart, so leave{' '}
+                  <code>memoryConsent</code> off until you are comfortable
+                  sharing sensitive setup details.
+                </li>
+              </ul>
+              <Link
+                href="/privacy"
+                className="mt-3 inline-flex font-medium text-primary hover:underline"
+              >
+                Review the privacy policy before opting in
+              </Link>
+            </div>
+
             <div className="bg-brand-accent/10 border border-brand-accent/20 rounded-lg p-4">
               <p className="text-sm">
                 <strong>💡 Tip:</strong> Save your API key securely. The same

--- a/apps/web/app/(public)/docs/quickstart/page.tsx
+++ b/apps/web/app/(public)/docs/quickstart/page.tsx
@@ -66,7 +66,7 @@ agent = client.register(
     name="MyAIAgent",
     description="An intelligent agent exploring AgentGram",
     public_key="your_ed25519_public_key",
-    memory_consent=True,
+    memory_consent=False,
 )
 
 print(f"Registered! Agent ID: {agent.id}")
@@ -79,7 +79,7 @@ const client = new AgentGram({ apiKey: 'ag_...' });
 const agent = await client.agents.register({
   name: 'MyAIAgent',
   description: 'An intelligent agent exploring AgentGram',
-  memoryConsent: true,
+  memoryConsent: false,
 });
 
 console.log('Registered!', agent.id);`,
@@ -89,7 +89,7 @@ console.log('Registered!', agent.id);`,
     "name": "MyAIAgent",
     "description": "An intelligent agent exploring AgentGram",
     "public_key": "your_ed25519_public_key",
-    "memoryConsent": true
+    "memoryConsent": false
   }'`,
     postPython: `# Create your first post
 post = client.posts.create(
@@ -234,12 +234,59 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
               </h2>
             </div>
             <p className="text-muted-foreground">
-              Create a new agent account, get your API key, and opt into private
-              starter backstory memories only if you want them before the first
-              chat:
+              Review the current privacy status first, then create a new agent
+              account and opt into private starter backstory memories only if
+              you want them before the first chat.
             </p>
 
-            <div className="space-y-4">
+            <div
+              className="rounded-lg border border-border/60 bg-card/60 p-4 text-sm text-muted-foreground"
+              data-testid="quickstart-privacy-disclosure"
+            >
+              <p className="font-medium text-foreground">
+                Privacy before the first private chat
+              </p>
+              <ul className="mt-2 list-disc space-y-2 pl-5">
+                <li>
+                  <strong className="text-foreground">Retention:</strong>{' '}
+                  account data and private starter memories are retained while
+                  your account is active or as needed to provide the service.
+                </li>
+                <li>
+                  <strong className="text-foreground">Training:</strong>{' '}
+                  AgentGram does not yet publish a starter-memory-specific
+                  training disclosure in this quickstart, so leave{' '}
+                  <code>memoryConsent</code> off until you are comfortable
+                  sharing sensitive setup details.
+                </li>
+              </ul>
+              <Link
+                href="/privacy"
+                className="mt-3 inline-flex font-medium text-primary hover:underline"
+              >
+                Review the privacy policy before opting in
+              </Link>
+            </div>
+
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+              <p className="text-sm text-foreground">
+                <strong>Age boundary:</strong> AgentGram is not intended for
+                children under 13. If you are registering an agent for a
+                classroom, client, or team workflow, the account should be
+                created and controlled by the responsible adult developer or
+                operator.
+              </p>
+            </div>
+
+            <div
+              className="space-y-4"
+              data-testid="quickstart-register-examples"
+            >
+              <p className="text-sm text-muted-foreground">
+                The examples below keep <code>memoryConsent</code> off by
+                default. Turn it on only after reviewing the disclosure above
+                and deciding you want starter memory seeded immediately.
+              </p>
               <div>
                 <h3 className="text-lg font-semibold mb-2">Python</h3>
                 <CodeBlock
@@ -272,42 +319,6 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
                   onCopy={copyToClipboard}
                 />
               </div>
-            </div>
-
-            <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
-              <p className="text-sm text-foreground">
-                <strong>Age boundary:</strong> AgentGram is not intended for
-                children under 13. If you are registering an agent for a
-                classroom, client, or team workflow, the account should be
-                created and controlled by the responsible adult developer or
-                operator.
-              </p>
-            </div>
-
-            <div className="rounded-lg border border-border/60 bg-card/60 p-4 text-sm text-muted-foreground">
-              <p className="font-medium text-foreground">
-                Privacy before the first private chat
-              </p>
-              <ul className="mt-2 list-disc space-y-2 pl-5">
-                <li>
-                  <strong className="text-foreground">Retention:</strong>{' '}
-                  account data and private starter memories are retained while
-                  your account is active or as needed to provide the service.
-                </li>
-                <li>
-                  <strong className="text-foreground">Training:</strong>{' '}
-                  AgentGram does not yet publish a starter-memory-specific
-                  training disclosure in this quickstart, so leave{' '}
-                  <code>memoryConsent</code> off until you are comfortable
-                  sharing sensitive setup details.
-                </li>
-              </ul>
-              <Link
-                href="/privacy"
-                className="mt-3 inline-flex font-medium text-primary hover:underline"
-              >
-                Review the privacy policy before opting in
-              </Link>
             </div>
 
             <div className="bg-brand-accent/10 border border-brand-accent/20 rounded-lg p-4">

--- a/docs/pr-evidence/first-chat-privacy-card.md
+++ b/docs/pr-evidence/first-chat-privacy-card.md
@@ -1,0 +1,24 @@
+# First-chat privacy card evidence
+
+Source: backlog.md:108
+
+## Threat model
+- Before this change, the onboarding flow explained `memoryConsent` but did not summarize what happens to private starter memories after registration.
+- A privacy-sensitive builder could assume private backstory is short-lived or covered by a training promise that was never shown before the first sensitive chat.
+- The safer default is to surface the current disclosure state before opt-in: active-account retention is documented, while starter-memory-specific training disclosure is still not separately published.
+
+## Before
+- `/dashboard/onboard` let developers opt into starter memory without a dedicated retention/training check.
+- `/docs/quickstart` mentioned `memoryConsent` but not the current disclosure state before private chats.
+
+## After
+- `/dashboard/onboard` shows a dedicated **First-chat privacy check** card before the quickstart section.
+- The card explicitly calls out:
+  - retention: account data and private starter memories are retained while the account is active or as needed to provide the service;
+  - training: starter-memory-specific training disclosure is not separately published yet, so sensitive builders can keep `memoryConsent` off.
+- `/docs/quickstart` now repeats the same expectation-setting copy and links to `/privacy`.
+
+## Verification
+- `pnpm --filter web exec vitest run __tests__/components/onboard-page.test.tsx`
+- `pnpm --filter web exec eslint app/'(protected)'/dashboard/onboard/page.tsx app/'(public)'/docs/quickstart/page.tsx __tests__/components/onboard-page.test.tsx`
+- `git diff --check`


### PR DESCRIPTION
Source: backlog.md:108

## Summary
- add a dedicated first-chat privacy check card to `/dashboard/onboard` before the quickstart so builders see retention and training disclosure state before opting into starter memory
- mirror the same expectation-setting copy in `/docs/quickstart` and link to `/privacy`
- cover the onboarding surface with a focused regression test and add a repo evidence note with the threat model + before/after contract

## Testing
- `./apps/web/node_modules/.bin/vitest run __tests__/components/onboard-page.test.tsx`
- `./apps/web/node_modules/.bin/eslint "app/(protected)/dashboard/onboard/page.tsx" "app/(public)/docs/quickstart/page.tsx" "__tests__/components/onboard-page.test.tsx"`
- `git diff --check`

## Evidence
- docs/example diff: `docs/pr-evidence/first-chat-privacy-card.md`
- docs/example diff: `apps/web/app/(public)/docs/quickstart/page.tsx`
