### PR TITLE
Add profile media tab for public chat images

### DIFF
--- a/apps/web/__tests__/components/creator-rail.test.tsx
+++ b/apps/web/__tests__/components/creator-rail.test.tsx
@@ -92,9 +92,15 @@ describe('CreatorRail', () => {
     expect(screen.getByTestId('creator-rail-tab-posts')).toHaveTextContent(
       'Recent posts'
     );
+    expect(screen.getByTestId('creator-rail-tab-media')).toHaveTextContent(
+      'Media gallery'
+    );
     expect(screen.getByTestId('creator-rail-tab-diary')).toHaveTextContent(
       'Creator journal'
     );
+
+    fireEvent.click(screen.getByTestId('creator-rail-tab-media'));
+    expect(onTabChange).toHaveBeenCalledWith('media');
 
     fireEvent.click(screen.getByTestId('creator-rail-tab-personas'));
     expect(onTabChange).toHaveBeenCalledWith('personas');
@@ -112,9 +118,9 @@ describe('CreatorRail', () => {
       />
     );
 
-    expect(screen.getByTestId('creator-rail-recent-work-log')).toHaveTextContent(
-      'Recent work log'
-    );
+    expect(
+      screen.getByTestId('creator-rail-recent-work-log')
+    ).toHaveTextContent('Recent work log');
     expect(
       screen.getByTestId('creator-rail-recent-work-link-post-1')
     ).toHaveAttribute('href', '/posts/post-1');
@@ -139,7 +145,9 @@ describe('CreatorRail', () => {
       />
     );
 
-    expect(screen.getByTestId('creator-rail-recent-work-empty')).toHaveTextContent(
+    expect(
+      screen.getByTestId('creator-rail-recent-work-empty')
+    ).toHaveTextContent(
       'Once this creator ships public posts, the latest three entries will show up here.'
     );
   });

--- a/apps/web/__tests__/components/profile-content.test.tsx
+++ b/apps/web/__tests__/components/profile-content.test.tsx
@@ -29,6 +29,9 @@ vi.mock('../../components/agents/ProfileTabs', () => ({
       <button onClick={() => onTabChange('diary')} type="button">
         switch-diary
       </button>
+      <button onClick={() => onTabChange('media')} type="button">
+        switch-media
+      </button>
     </div>
   ),
 }));
@@ -36,6 +39,12 @@ vi.mock('../../components/agents/ProfileTabs', () => ({
 vi.mock('../../components/agents/ProfilePostGrid', () => ({
   ProfilePostGrid: ({ type }: { type: string }) => (
     <div data-testid="profile-post-grid">{type}</div>
+  ),
+}));
+
+vi.mock('../../components/agents/ProfileMediaGrid', () => ({
+  ProfileMediaGrid: ({ agentId }: { agentId: string }) => (
+    <div data-testid="profile-media-grid">{agentId}</div>
   ),
 }));
 
@@ -68,7 +77,8 @@ vi.mock('../../components/agents/CreatorRail', () => ({
     recentWorkLog?: Post[];
   }) => (
     <div data-testid="creator-rail">
-      {activeTab}::{recentWorkLog?.map((post) => post.title).join(' | ') || 'none'}
+      {activeTab}::
+      {recentWorkLog?.map((post) => post.title).join(' | ') || 'none'}
     </div>
   ),
 }));
@@ -106,7 +116,8 @@ const starterPrompts: Agent['starterPrompts'] = [
   {
     id: 'starter-2',
     title: 'Launch checklist',
-    prompt: 'Give me a launch checklist for shipping this agent publicly today.',
+    prompt:
+      'Give me a launch checklist for shipping this agent publicly today.',
   },
 ];
 
@@ -180,6 +191,18 @@ describe('ProfileContent', () => {
       screen.queryByTestId('profile-starter-scenarios')
     ).not.toBeInTheDocument();
     expect(screen.getByTestId('profile-diary')).toBeInTheDocument();
+  });
+
+  it('shows generated public chat media when the media tab is selected', () => {
+    render(<ProfileContent agent={baseAgent} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch-media' }));
+
+    expect(screen.getByTestId('profile-tabs')).toHaveTextContent('media');
+    expect(screen.getByTestId('profile-media-grid')).toHaveTextContent(
+      'agent-1'
+    );
+    expect(screen.queryByTestId('profile-post-grid')).not.toBeInTheDocument();
   });
 
   it('shows creator journal entries when the diary tab is selected', () => {

--- a/apps/web/__tests__/components/profile-media-grid.test.tsx
+++ b/apps/web/__tests__/components/profile-media-grid.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Post } from '@agentgram/shared';
+import { ProfileMediaGrid } from '../../components/agents/ProfileMediaGrid';
+
+const useAgentPostsMock = vi.fn();
+
+vi.mock('next/image', () => ({
+  default: ({
+    fill: _fill,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean }) => (
+    <img {...props} />
+  ),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/hooks/use-agents', () => ({
+  useAgentPosts: (...args: unknown[]) => useAgentPostsMock(...args),
+}));
+
+const chatSnippetPost: Post = {
+  id: 'post-chat',
+  authorId: 'agent-1',
+  title: 'Sunset boardwalk scene',
+  content:
+    'We planned a neon boardwalk meetup after the public roleplay thread.',
+  postType: 'chat_snippet',
+  likes: 18,
+  commentCount: 4,
+  score: 72,
+  metadata: {
+    messages: [
+      { role: 'user', content: 'Let’s stage a boardwalk reunion scene.' },
+      {
+        role: 'assistant',
+        content: 'I can frame it with warm neon reflections.',
+      },
+      { role: 'user', content: 'Perfect — publish the visual once it lands.' },
+    ],
+    sceneImages: [
+      {
+        url: 'https://cdn.agentgram.test/scene.png',
+        prompt: 'Two friends meeting at a neon boardwalk at dusk.',
+      },
+    ],
+  },
+  createdAt: '2026-05-10T04:00:00.000Z',
+  updatedAt: '2026-05-10T04:00:00.000Z',
+};
+
+const generatedMediaPost: Post = {
+  id: 'post-selfie',
+  authorId: 'agent-1',
+  title: 'Mirror selfie follow-up',
+  postType: 'media',
+  likes: 7,
+  commentCount: 1,
+  score: 25,
+  metadata: {
+    media: [
+      {
+        url: 'https://cdn.agentgram.test/selfie.png',
+        type: 'image',
+        generated: true,
+        kind: 'selfie',
+        prompt: 'Polaroid-style mirror selfie with a soft flash bounce.',
+      },
+    ],
+  },
+  createdAt: '2026-05-09T22:00:00.000Z',
+  updatedAt: '2026-05-09T22:00:00.000Z',
+};
+
+const uploadedMediaPost: Post = {
+  id: 'post-upload',
+  authorId: 'agent-1',
+  title: 'Manual upload',
+  postType: 'media',
+  likes: 2,
+  commentCount: 0,
+  score: 9,
+  metadata: {
+    media: [
+      {
+        url: 'https://cdn.agentgram.test/upload.png',
+        type: 'image',
+      },
+    ],
+  },
+  createdAt: '2026-05-08T22:00:00.000Z',
+  updatedAt: '2026-05-08T22:00:00.000Z',
+};
+
+describe('ProfileMediaGrid', () => {
+  beforeEach(() => {
+    useAgentPostsMock.mockReset();
+  });
+
+  it('collects generated scene and selfie images from authored public posts', () => {
+    useAgentPostsMock.mockReturnValue({
+      data: {
+        pages: [
+          {
+            posts: [chatSnippetPost, generatedMediaPost, uploadedMediaPost],
+          },
+        ],
+      },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isLoading: false,
+    });
+
+    render(<ProfileMediaGrid agentId="agent-1" />);
+
+    expect(useAgentPostsMock).toHaveBeenCalledWith('agent-1', 'authored', 36);
+    expect(screen.getByTestId('profile-media-grid')).toBeInTheDocument();
+    expect(screen.getAllByTestId('profile-media-card')).toHaveLength(2);
+    expect(screen.getByText('Scene')).toBeInTheDocument();
+    expect(screen.getByText('Selfie')).toBeInTheDocument();
+    expect(screen.getByText('3 public chat turns')).toBeInTheDocument();
+    expect(
+      screen.getByText('Two friends meeting at a neon boardwalk at dusk.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Manual upload')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state before the first generated public chat image lands', () => {
+    useAgentPostsMock.mockReturnValue({
+      data: {
+        pages: [
+          {
+            posts: [uploadedMediaPost],
+          },
+        ],
+      },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isLoading: false,
+    });
+
+    render(<ProfileMediaGrid agentId="agent-1" />);
+
+    expect(screen.getByTestId('profile-media-empty')).toHaveTextContent(
+      'No public media yet'
+    );
+    expect(screen.queryByTestId('profile-media-card')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/agents/CreatorRail.tsx
+++ b/apps/web/components/agents/CreatorRail.tsx
@@ -67,8 +67,15 @@ export function CreatorRail({
     {
       id: 'posts',
       label: 'Recent posts',
-      description: 'Public launches, prompts, and work samples from this creator.',
+      description:
+        'Public launches, prompts, and work samples from this creator.',
       count: agent.postCount,
+    },
+    {
+      id: 'media',
+      label: 'Media gallery',
+      description:
+        'Generated scenes, selfies, and visual canon pulled from public chats.',
     },
     {
       id: 'likes',
@@ -78,13 +85,15 @@ export function CreatorRail({
     {
       id: 'diary',
       label: 'Creator journal',
-      description: 'Profile diary notes, changelogs, and public operating context.',
+      description:
+        'Profile diary notes, changelogs, and public operating context.',
       count: agent.diaryEntries?.length,
     },
     {
       id: 'personas',
       label: 'Personas',
-      description: 'Alternate public voices and role setups linked to this profile.',
+      description:
+        'Alternate public voices and role setups linked to this profile.',
     },
   ];
 
@@ -118,7 +127,8 @@ export function CreatorRail({
               More from this creator
             </p>
             <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              Jump between this profile&apos;s public work, journal, and persona surfaces.
+              Jump between this profile&apos;s posts, media, journal, and
+              persona surfaces.
             </p>
           </div>
           <Layers3 className="mt-0.5 h-4 w-4 text-primary" />
@@ -170,7 +180,8 @@ export function CreatorRail({
                 Recent work log
               </p>
               <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                Latest public posts, demos, and shipping notes from this profile.
+                Latest public posts, demos, and shipping notes from this
+                profile.
               </p>
             </div>
             <button
@@ -215,7 +226,8 @@ export function CreatorRail({
               className="mt-4 rounded-xl border border-dashed border-border/80 bg-muted/20 px-3 py-3 text-sm leading-6 text-muted-foreground"
               data-testid="creator-rail-recent-work-empty"
             >
-              Once this creator ships public posts, the latest three entries will show up here.
+              Once this creator ships public posts, the latest three entries
+              will show up here.
             </p>
           )}
         </section>
@@ -233,7 +245,8 @@ export function CreatorRail({
               {publicOwnerLabel}
             </p>
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              Public owner attribution is only shown after this creator clears AgentGram verification.
+              Public owner attribution is only shown after this creator clears
+              AgentGram verification.
             </p>
           </section>
         )}
@@ -265,7 +278,9 @@ export function CreatorRail({
             className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary transition hover:text-primary/80"
             data-testid="creator-rail-paid-capability-link"
           >
-            {hasPaidCapabilityLayer ? 'Compare Operator tiers' : 'See paid capabilities'}
+            {hasPaidCapabilityLayer
+              ? 'Compare Operator tiers'
+              : 'See paid capabilities'}
             <ArrowUpRight className="h-3.5 w-3.5" />
           </Link>
         </section>

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -6,6 +6,7 @@ import { ProfileHeader } from './ProfileHeader';
 import { ProfilePersona } from './ProfilePersona';
 import { ProfileTabs, type ProfileTab } from './ProfileTabs';
 import { ProfilePostGrid } from './ProfilePostGrid';
+import { ProfileMediaGrid } from './ProfileMediaGrid';
 import { PersonaList } from './PersonaList';
 import { ProfileDiary } from './ProfileDiary';
 import { ProfilePinnedIntroPost } from './ProfilePinnedIntroPost';
@@ -37,11 +38,16 @@ export function ProfileContent({
             <PersonaList agentId={agent.id} />
           ) : activeTab === 'diary' ? (
             <ProfileDiary entries={agent.diaryEntries ?? []} />
+          ) : activeTab === 'media' ? (
+            <ProfileMediaGrid agentId={agent.id} />
           ) : (
             <div className="space-y-6">
-              {activeTab === 'posts' && (agent.starterPrompts?.length ?? 0) > 0 && (
-                <ProfileStarterScenarios starters={agent.starterPrompts ?? []} />
-              )}
+              {activeTab === 'posts' &&
+                (agent.starterPrompts?.length ?? 0) > 0 && (
+                  <ProfileStarterScenarios
+                    starters={agent.starterPrompts ?? []}
+                  />
+                )}
               <ProfilePostGrid
                 agentId={agent.id}
                 type={activeTab === 'posts' ? 'authored' : 'liked'}

--- a/apps/web/components/agents/ProfileMediaGrid.tsx
+++ b/apps/web/components/agents/ProfileMediaGrid.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { Heart, ImageIcon, Loader2, MessageCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useAgentPosts } from '@/hooks/use-agents';
+import { extractGeneratedProfileMedia } from './profile-media';
+
+interface ProfileMediaGridProps {
+  agentId: string;
+}
+
+export function ProfileMediaGrid({ agentId }: ProfileMediaGridProps) {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+    useAgentPosts(agentId, 'authored', 36);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const posts = data?.pages.flatMap((page) => page.posts) || [];
+  const mediaItems = extractGeneratedProfileMedia(posts);
+
+  if (mediaItems.length === 0) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-border/80 bg-muted/20 px-6 py-14 text-center"
+        data-testid="profile-media-empty"
+      >
+        <div className="rounded-full bg-background p-4 shadow-sm">
+          <ImageIcon className="h-8 w-8 text-muted-foreground" />
+        </div>
+        <h3 className="mt-4 text-lg font-semibold">No public media yet</h3>
+        <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">
+          Generated scene and selfie images from this creator&apos;s public
+          chats will collect here once they share them.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pb-8" data-testid="profile-media-grid">
+      <div className="mb-5 flex flex-col gap-3 rounded-3xl border border-border/80 bg-muted/20 p-5 shadow-sm sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+            Public media
+          </p>
+          <h3 className="mt-2 text-xl font-semibold text-foreground">
+            Scenes and selfies from public chats
+          </h3>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+            Visitors can browse generated visual moments without digging through
+            every transcript first.
+          </p>
+        </div>
+        <span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+          {mediaItems.length} collected
+        </span>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {mediaItems.map((item) => (
+          <Link
+            key={item.id}
+            href={`/posts/${item.postId}`}
+            className="group overflow-hidden rounded-3xl border border-border/70 bg-background shadow-sm transition hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-lg"
+            data-testid="profile-media-card"
+          >
+            <div className="relative aspect-[4/5] overflow-hidden bg-muted">
+              <Image
+                src={item.url}
+                alt={item.alt}
+                fill
+                className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/20 to-transparent" />
+              <div className="absolute left-3 top-3 flex flex-wrap gap-2">
+                <span className="inline-flex items-center rounded-full border border-white/25 bg-black/45 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur-sm">
+                  {item.badgeLabel}
+                </span>
+                <span className="inline-flex items-center rounded-full border border-white/20 bg-white/10 px-2.5 py-1 text-[11px] font-medium text-white/90 backdrop-blur-sm">
+                  {item.sourceLabel}
+                </span>
+              </div>
+              <div className="absolute inset-x-0 bottom-0 p-4 text-white">
+                <p className="text-base font-semibold leading-6 line-clamp-2">
+                  {item.title}
+                </p>
+                <p className="mt-1 text-sm leading-5 text-white/80 line-clamp-3">
+                  {item.summary}
+                </p>
+                <div className="mt-3 flex items-center gap-4 text-xs font-medium text-white/90">
+                  <span className="inline-flex items-center gap-1.5">
+                    <Heart className="h-3.5 w-3.5 fill-white" />
+                    {item.likes}
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <MessageCircle className="h-3.5 w-3.5 fill-white" />
+                    {item.commentCount}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      {hasNextPage && (
+        <div className="mt-8 flex justify-center">
+          <Button
+            variant="outline"
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+          >
+            {isFetchingNextPage ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Loading...
+              </>
+            ) : (
+              'Load More Media'
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/agents/ProfilePostGrid.tsx
+++ b/apps/web/components/agents/ProfilePostGrid.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { Heart, MessageCircle, Copy } from 'lucide-react';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { getProfilePostImageUrl } from './profile-media';
 
 interface ProfilePostGridProps {
   agentId: string;
@@ -51,37 +52,43 @@ export function ProfilePostGrid({ agentId, type }: ProfilePostGridProps) {
   return (
     <div className="pb-8">
       <div className="grid grid-cols-3 gap-1 md:gap-4 mb-8">
-        {posts.map((post) => (
-          <Link
-            key={post.id}
-            href={`/posts/${post.id}`}
-            className="group relative aspect-square bg-muted overflow-hidden"
-          >
-            {post.postType === 'media' && post.url ? (
-              <Image
-                src={post.url}
-                alt={post.title}
-                fill
-                className="object-cover transition-transform group-hover:scale-105"
-              />
-            ) : (
-              <div className="flex h-full w-full flex-col items-center justify-center p-4 text-center bg-gradient-to-br from-background to-muted">
-                <p className="text-xs font-medium line-clamp-3">{post.title}</p>
-              </div>
-            )}
+        {posts.map((post) => {
+          const mediaUrl = getProfilePostImageUrl(post);
 
-            <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-4 text-white font-bold">
-              <div className="flex items-center gap-1">
-                <Heart className="h-5 w-5 fill-white" />
-                <span>{post.likes}</span>
+          return (
+            <Link
+              key={post.id}
+              href={`/posts/${post.id}`}
+              className="group relative aspect-square bg-muted overflow-hidden"
+            >
+              {post.postType === 'media' && mediaUrl ? (
+                <Image
+                  src={mediaUrl}
+                  alt={post.title || 'Post image'}
+                  fill
+                  className="object-cover transition-transform group-hover:scale-105"
+                />
+              ) : (
+                <div className="flex h-full w-full flex-col items-center justify-center p-4 text-center bg-gradient-to-br from-background to-muted">
+                  <p className="text-xs font-medium line-clamp-3">
+                    {post.title}
+                  </p>
+                </div>
+              )}
+
+              <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-4 text-white font-bold">
+                <div className="flex items-center gap-1">
+                  <Heart className="h-5 w-5 fill-white" />
+                  <span>{post.likes}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <MessageCircle className="h-5 w-5 fill-white" />
+                  <span>{post.commentCount}</span>
+                </div>
               </div>
-              <div className="flex items-center gap-1">
-                <MessageCircle className="h-5 w-5 fill-white" />
-                <span>{post.commentCount}</span>
-              </div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          );
+        })}
       </div>
 
       {hasNextPage && (

--- a/apps/web/components/agents/ProfileTabs.tsx
+++ b/apps/web/components/agents/ProfileTabs.tsx
@@ -1,9 +1,15 @@
 'use client';
 
-import { BookOpenText, Grid3x3, Heart, Sparkles } from 'lucide-react';
+import {
+  BookOpenText,
+  Grid3x3,
+  Heart,
+  ImageIcon,
+  Sparkles,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-export type ProfileTab = 'posts' | 'likes' | 'diary' | 'personas';
+export type ProfileTab = 'posts' | 'media' | 'likes' | 'diary' | 'personas';
 
 interface ProfileTabsProps {
   activeTab: ProfileTab;
@@ -12,6 +18,7 @@ interface ProfileTabsProps {
 
 const TABS: { id: ProfileTab; label: string; icon: typeof Grid3x3 }[] = [
   { id: 'posts', label: 'Posts', icon: Grid3x3 },
+  { id: 'media', label: 'Media', icon: ImageIcon },
   { id: 'likes', label: 'Likes', icon: Heart },
   { id: 'diary', label: 'Journal', icon: BookOpenText },
   { id: 'personas', label: 'Personas', icon: Sparkles },

--- a/apps/web/components/agents/profile-media.ts
+++ b/apps/web/components/agents/profile-media.ts
@@ -1,0 +1,227 @@
+import type { ChatSnippetMessage, Post, PostMedia } from '@agentgram/shared';
+
+export interface ProfileGeneratedMediaItem {
+  id: string;
+  postId: string;
+  url: string;
+  title: string;
+  alt: string;
+  badgeLabel: 'Scene' | 'Selfie' | 'Generated';
+  sourceLabel: string;
+  summary: string;
+  likes: number;
+  commentCount: number;
+  createdAt: string;
+}
+
+type MetadataCollection = {
+  path: string[];
+  fallbackBadge?: ProfileGeneratedMediaItem['badgeLabel'];
+  requireGeneratedFlag: boolean;
+};
+
+type MediaCandidate = Partial<PostMedia> & {
+  alt?: string;
+  generated?: boolean;
+  kind?: string;
+  label?: string;
+  prompt?: string;
+  source?: string;
+  title?: string;
+};
+
+const MEDIA_COLLECTIONS: readonly MetadataCollection[] = [
+  { path: ['media'], requireGeneratedFlag: true },
+  { path: ['generatedMedia'], requireGeneratedFlag: false },
+  { path: ['generated_media'], requireGeneratedFlag: false },
+  {
+    path: ['sceneImages'],
+    fallbackBadge: 'Scene',
+    requireGeneratedFlag: false,
+  },
+  {
+    path: ['scene_images'],
+    fallbackBadge: 'Scene',
+    requireGeneratedFlag: false,
+  },
+  {
+    path: ['selfieImages'],
+    fallbackBadge: 'Selfie',
+    requireGeneratedFlag: false,
+  },
+  {
+    path: ['selfie_images'],
+    fallbackBadge: 'Selfie',
+    requireGeneratedFlag: false,
+  },
+] as const;
+
+function getMetadataValue(metadata: Record<string, unknown>, path: string[]) {
+  let current: unknown = metadata;
+
+  for (const segment of path) {
+    if (!current || typeof current !== 'object' || !(segment in current)) {
+      return undefined;
+    }
+
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current;
+}
+
+function getChatMessages(post: Post) {
+  return (
+    (post.metadata?.messages as ChatSnippetMessage[] | undefined) ?? []
+  ).filter(
+    (message): message is ChatSnippetMessage =>
+      Boolean(message?.role?.trim()) && Boolean(message?.content?.trim())
+  );
+}
+
+function summarizePost(post: Post) {
+  const explicitSummary = [post.content, post.title].find((value) =>
+    value?.trim()
+  );
+
+  if (explicitSummary) {
+    return explicitSummary;
+  }
+
+  const chatMessages = getChatMessages(post)
+    .slice(0, 2)
+    .map((message) => `${message.role}: ${message.content}`);
+
+  return chatMessages.join(' · ') || 'Generated from a public chat moment.';
+}
+
+function normalizeBadgeLabel(
+  value: string | undefined,
+  fallbackBadge?: ProfileGeneratedMediaItem['badgeLabel']
+): ProfileGeneratedMediaItem['badgeLabel'] {
+  const normalized = value?.trim().toLowerCase();
+
+  if (normalized?.includes('selfie')) {
+    return 'Selfie';
+  }
+
+  if (normalized?.includes('scene')) {
+    return 'Scene';
+  }
+
+  return fallbackBadge ?? 'Generated';
+}
+
+function isGeneratedCandidate(
+  candidate: MediaCandidate,
+  requireGeneratedFlag: boolean,
+  fallbackBadge?: ProfileGeneratedMediaItem['badgeLabel']
+) {
+  if (candidate.generated === true) {
+    return true;
+  }
+
+  const source = candidate.source?.trim().toLowerCase();
+  if (source === 'generated' || source === 'ai' || source === 'public_chat') {
+    return true;
+  }
+
+  const kind = candidate.kind?.trim().toLowerCase();
+  const label = candidate.label?.trim().toLowerCase();
+  if (
+    kind === 'scene' ||
+    kind === 'selfie' ||
+    label?.includes('scene') ||
+    label?.includes('selfie')
+  ) {
+    return true;
+  }
+
+  return !requireGeneratedFlag && Boolean(fallbackBadge);
+}
+
+function extractCandidates(
+  post: Post,
+  metadata: Record<string, unknown>,
+  collection: MetadataCollection
+) {
+  const rawEntries = getMetadataValue(metadata, collection.path);
+  if (!Array.isArray(rawEntries)) {
+    return [];
+  }
+
+  return rawEntries
+    .map((entry) => entry as MediaCandidate)
+    .filter((entry) => typeof entry?.url === 'string' && entry.url.length > 0)
+    .filter((entry) =>
+      isGeneratedCandidate(
+        entry,
+        collection.requireGeneratedFlag,
+        collection.fallbackBadge
+      )
+    )
+    .map((entry, index) => ({ entry, index }));
+}
+
+export function extractGeneratedProfileMedia(
+  posts: Post[]
+): ProfileGeneratedMediaItem[] {
+  const seen = new Set<string>();
+
+  return posts.flatMap((post) => {
+    const metadata =
+      (post.metadata as Record<string, unknown> | undefined) ?? {};
+    const chatMessages = getChatMessages(post);
+    const sourceLabel =
+      post.postType === 'chat_snippet' && chatMessages.length > 0
+        ? `${chatMessages.length} public chat turns`
+        : 'Published image post';
+    const fallbackSummary = summarizePost(post);
+
+    return MEDIA_COLLECTIONS.flatMap((collection) =>
+      extractCandidates(post, metadata, collection).flatMap(
+        ({ entry, index }) => {
+          const dedupeKey = `${post.id}:${entry.url}`;
+          if (seen.has(dedupeKey)) {
+            return [];
+          }
+
+          seen.add(dedupeKey);
+
+          const badgeLabel = normalizeBadgeLabel(
+            entry.label || entry.kind,
+            collection.fallbackBadge
+          );
+
+          return [
+            {
+              id: `${post.id}-${index}-${badgeLabel.toLowerCase()}`,
+              postId: post.id,
+              url: entry.url as string,
+              title: entry.title?.trim() || post.title,
+              alt:
+                entry.alt?.trim() ||
+                `${post.title || 'Generated image'} — ${badgeLabel.toLowerCase()}`,
+              badgeLabel,
+              sourceLabel,
+              summary: entry.prompt?.trim() || fallbackSummary,
+              likes: post.likes,
+              commentCount: post.commentCount,
+              createdAt: post.createdAt,
+            },
+          ];
+        }
+      )
+    );
+  });
+}
+
+export function getProfilePostImageUrl(post: Post) {
+  const mediaUrl = (
+    (post.metadata?.media as PostMedia[] | undefined) ?? []
+  ).find(
+    (entry) => typeof entry?.url === 'string' && entry.url.length > 0
+  )?.url;
+
+  return mediaUrl || post.url;
+}

--- a/apps/web/hooks/use-agents.ts
+++ b/apps/web/hooks/use-agents.ts
@@ -136,7 +136,7 @@ export function useAgentPosts(
   limit = 12
 ) {
   return useInfiniteQuery({
-    queryKey: ['agents', agentId, 'posts', type],
+    queryKey: ['agents', agentId, 'posts', type, limit],
     queryFn: async ({ pageParam = 0 }) => {
       const supabase = getSupabaseBrowser();
       const from = pageParam * limit;

--- a/docs/pr-evidence/row-109-profile-media-tab-after.html
+++ b/docs/pr-evidence/row-109-profile-media-tab-after.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Row 109 after</title>
+    <style>
+      body {
+        font-family: Inter, system-ui, sans-serif;
+        margin: 0;
+        background: #f5f7fb;
+        color: #111827;
+      }
+      .frame {
+        width: 1280px;
+        margin: 0 auto;
+        padding: 56px 64px;
+      }
+      .card {
+        background: white;
+        border: 1px solid #e5e7eb;
+        border-radius: 24px;
+        box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+        padding: 32px;
+      }
+      .eyebrow {
+        font-size: 14px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #6b7280;
+        margin-bottom: 12px;
+      }
+      h1 {
+        font-size: 40px;
+        margin: 0 0 8px;
+      }
+      p {
+        margin: 0 0 24px;
+        color: #6b7280;
+        font-size: 20px;
+      }
+      .toolbar {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        margin-bottom: 28px;
+      }
+      .pill {
+        border: 1px solid #d1d5db;
+        background: #f9fafb;
+        color: #111827;
+        border-radius: 9999px;
+        padding: 12px 18px;
+        font-weight: 600;
+        font-size: 15px;
+      }
+      .pill.active {
+        background: #111827;
+        color: white;
+        border-color: #111827;
+      }
+      .summary {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        border: 1px solid #e5e7eb;
+        border-radius: 24px;
+        padding: 24px;
+        margin-bottom: 24px;
+        background: #f9fafb;
+      }
+      .badge {
+        padding: 8px 14px;
+        border-radius: 9999px;
+        background: #e0e7ff;
+        color: #4338ca;
+        font-size: 13px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .gallery {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+      }
+      .shot {
+        border-radius: 24px;
+        min-height: 280px;
+        padding: 18px;
+        color: white;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+      }
+      .shot-a {
+        background: linear-gradient(135deg, #312e81, #c026d3);
+      }
+      .shot-b {
+        background: linear-gradient(135deg, #065f46, #0ea5e9);
+      }
+      .shot-c {
+        background: linear-gradient(135deg, #7c2d12, #f59e0b);
+      }
+      .shot .meta {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .shot .meta span {
+        padding: 6px 10px;
+        border-radius: 9999px;
+        background: rgba(15, 23, 42, 0.35);
+        font-size: 12px;
+        font-weight: 700;
+      }
+      .rail {
+        margin-top: 24px;
+        border-top: 1px solid #e5e7eb;
+        padding-top: 24px;
+        color: #6b7280;
+        font-size: 18px;
+        line-height: 1.8;
+      }
+      .rail strong {
+        color: #4338ca;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="frame">
+      <div class="card">
+        <div class="eyebrow">After</div>
+        <h1>Profile media tab collects public chat visuals</h1>
+        <p>
+          A dedicated media tab and rail entry surface generated scenes/selfies
+          in one gallery.
+        </p>
+        <div class="toolbar">
+          <div class="pill">Posts</div>
+          <div class="pill active">Media</div>
+          <div class="pill">Likes</div>
+          <div class="pill">Journal</div>
+          <div class="pill">Personas</div>
+        </div>
+        <div class="summary">
+          <div>
+            <strong>Scenes and selfies from public chats</strong>
+            <div style="margin-top: 8px; color: #6b7280; font-size: 18px">
+              Visitors can browse generated visual moments without digging
+              through every transcript first.
+            </div>
+          </div>
+          <div class="badge">3 collected</div>
+        </div>
+        <div class="gallery">
+          <div class="shot shot-a">
+            <div class="meta">
+              <span>Scene</span><span>3 public chat turns</span>
+            </div>
+            <div>
+              <strong>Sunset boardwalk scene</strong>
+              <div style="margin-top: 10px; color: rgba(255, 255, 255, 0.82)">
+                Prompt and engagement stay attached to the visual card.
+              </div>
+            </div>
+          </div>
+          <div class="shot shot-b">
+            <div class="meta">
+              <span>Selfie</span><span>Published image post</span>
+            </div>
+            <div>
+              <strong>Mirror selfie follow-up</strong>
+              <div style="margin-top: 10px; color: rgba(255, 255, 255, 0.82)">
+                Generated selfie posts show up beside scene cards.
+              </div>
+            </div>
+          </div>
+          <div class="shot shot-c">
+            <div class="meta">
+              <span>Generated</span><span>Public profile gallery</span>
+            </div>
+            <div>
+              <strong>Visual canon stays grouped</strong>
+              <div style="margin-top: 10px; color: rgba(255, 255, 255, 0.82)">
+                The rail also adds a direct jump back into the media tab.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="rail">
+          Creator rail: Recent posts · <strong>Media gallery</strong> · Liked
+          posts · Creator journal · Personas
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/pr-evidence/row-109-profile-media-tab-after.svg
+++ b/docs/pr-evidence/row-109-profile-media-tab-after.svg
@@ -1,0 +1,59 @@
+<svg width="1280" height="900" viewBox="0 0 1280 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="cardA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#312E81"/>
+      <stop offset="100%" stop-color="#C026D3"/>
+    </linearGradient>
+    <linearGradient id="cardB" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#065F46"/>
+      <stop offset="100%" stop-color="#0EA5E9"/>
+    </linearGradient>
+    <linearGradient id="cardC" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7C2D12"/>
+      <stop offset="100%" stop-color="#F59E0B"/>
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="900" fill="#F5F7FB"/>
+  <rect x="96" y="72" width="1088" height="756" rx="32" fill="white" stroke="#E5E7EB" stroke-width="2"/>
+  <text x="152" y="152" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="4">AFTER</text>
+  <text x="152" y="208" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="700">Profile media tab collects public chat visuals</text>
+  <text x="152" y="252" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="22">A dedicated media tab and rail entry surface generated scenes/selfies in one gallery.</text>
+  <rect x="152" y="304" width="130" height="52" rx="26" fill="#F3F4F6" stroke="#D1D5DB"/>
+  <text x="194" y="338" fill="#374151" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Posts</text>
+  <rect x="298" y="304" width="142" height="52" rx="26" fill="#111827"/>
+  <text x="339" y="338" fill="white" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Media</text>
+  <rect x="456" y="304" width="128" height="52" rx="26" fill="#F3F4F6" stroke="#D1D5DB"/>
+  <text x="501" y="338" fill="#374151" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Likes</text>
+  <rect x="600" y="304" width="144" height="52" rx="26" fill="#F3F4F6" stroke="#D1D5DB"/>
+  <text x="639" y="338" fill="#374151" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Journal</text>
+  <rect x="760" y="304" width="162" height="52" rx="26" fill="#F3F4F6" stroke="#D1D5DB"/>
+  <text x="804" y="338" fill="#374151" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Personas</text>
+  <rect x="152" y="392" width="672" height="112" rx="28" fill="#F9FAFB" stroke="#E5E7EB"/>
+  <text x="196" y="444" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700">Scenes and selfies from public chats</text>
+  <text x="196" y="486" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="20">Visitors can browse generated visual moments without digging through every transcript first.</text>
+  <rect x="732" y="420" width="70" height="36" rx="18" fill="#E0E7FF"/>
+  <text x="749" y="443" fill="#4338CA" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="700">3 collected</text>
+  <rect x="152" y="528" width="206" height="256" rx="28" fill="url(#cardA)"/>
+  <rect x="384" y="528" width="206" height="256" rx="28" fill="url(#cardB)"/>
+  <rect x="616" y="528" width="206" height="256" rx="28" fill="url(#cardC)"/>
+  <rect x="172" y="548" width="70" height="28" rx="14" fill="rgba(17,24,39,0.45)"/>
+  <text x="191" y="567" fill="white" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700">Scene</text>
+  <rect x="252" y="548" width="112" height="28" rx="14" fill="rgba(255,255,255,0.18)"/>
+  <text x="269" y="567" fill="white" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="600">3 public chat turns</text>
+  <text x="176" y="716" fill="white" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700">Sunset boardwalk scene</text>
+  <text x="176" y="748" fill="#E5E7EB" font-family="Inter, Arial, sans-serif" font-size="15">Prompt and engagement stay attached to the visual card.</text>
+  <rect x="404" y="548" width="72" height="28" rx="14" fill="rgba(17,24,39,0.45)"/>
+  <text x="423" y="567" fill="white" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700">Selfie</text>
+  <rect x="486" y="548" width="108" height="28" rx="14" fill="rgba(255,255,255,0.18)"/>
+  <text x="506" y="567" fill="white" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="600">Published image post</text>
+  <text x="408" y="716" fill="white" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700">Mirror selfie follow-up</text>
+  <text x="408" y="748" fill="#E5E7EB" font-family="Inter, Arial, sans-serif" font-size="15">Generated selfie posts show up beside scene cards.</text>
+  <rect x="868" y="404" width="236" height="380" rx="28" fill="#F9FAFB" stroke="#E5E7EB"/>
+  <text x="912" y="456" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">Creator rail</text>
+  <text x="912" y="500" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18">Recent posts</text>
+  <rect x="900" y="520" width="172" height="48" rx="18" fill="#EEF2FF" stroke="#C7D2FE"/>
+  <text x="928" y="550" fill="#4338CA" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Media gallery</text>
+  <text x="912" y="612" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18">Liked posts</text>
+  <text x="912" y="648" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18">Creator journal</text>
+  <text x="912" y="684" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18">Personas</text>
+</svg>

--- a/docs/pr-evidence/row-109-profile-media-tab-before.html
+++ b/docs/pr-evidence/row-109-profile-media-tab-before.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Row 109 before</title>
+    <style>
+      body {
+        font-family: Inter, system-ui, sans-serif;
+        margin: 0;
+        background: #f5f7fb;
+        color: #111827;
+      }
+      .frame {
+        width: 1280px;
+        margin: 0 auto;
+        padding: 56px 64px;
+      }
+      .card {
+        background: white;
+        border: 1px solid #e5e7eb;
+        border-radius: 24px;
+        box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+        padding: 32px;
+      }
+      .eyebrow {
+        font-size: 14px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #6b7280;
+        margin-bottom: 12px;
+      }
+      h1 {
+        font-size: 40px;
+        margin: 0 0 8px;
+      }
+      p {
+        margin: 0 0 24px;
+        color: #6b7280;
+        font-size: 20px;
+      }
+      .toolbar {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        margin-bottom: 28px;
+      }
+      .pill {
+        border: 1px solid #d1d5db;
+        background: #f9fafb;
+        color: #111827;
+        border-radius: 9999px;
+        padding: 12px 18px;
+        font-weight: 600;
+        font-size: 15px;
+      }
+      .pill.active {
+        background: #111827;
+        color: white;
+        border-color: #111827;
+      }
+      .placeholder {
+        border: 2px dashed #d1d5db;
+        border-radius: 24px;
+        padding: 36px;
+        color: #6b7280;
+        font-size: 20px;
+        min-height: 220px;
+        display: flex;
+        align-items: center;
+      }
+      .rail {
+        margin-top: 24px;
+        border-top: 1px solid #e5e7eb;
+        padding-top: 24px;
+        color: #6b7280;
+        font-size: 18px;
+        line-height: 1.8;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="frame">
+      <div class="card">
+        <div class="eyebrow">Before</div>
+        <h1>Profile tabs before media collection</h1>
+        <p>
+          Generated scene/selfie visuals were still buried inside individual
+          posts.
+        </p>
+        <div class="toolbar">
+          <div class="pill active">Posts</div>
+          <div class="pill">Likes</div>
+          <div class="pill">Journal</div>
+          <div class="pill">Personas</div>
+        </div>
+        <div class="placeholder">
+          No dedicated visual gallery for public chat images.
+        </div>
+        <div class="rail">
+          Creator rail: Recent posts · Liked posts · Creator journal · Personas
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/pr-evidence/row-109-profile-media-tab-before.svg
+++ b/docs/pr-evidence/row-109-profile-media-tab-before.svg
@@ -1,0 +1,25 @@
+<svg width="1280" height="900" viewBox="0 0 1280 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="900" fill="#F5F7FB"/>
+  <rect x="96" y="72" width="1088" height="756" rx="32" fill="white" stroke="#E5E7EB" stroke-width="2"/>
+  <text x="152" y="152" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="4">BEFORE</text>
+  <text x="152" y="208" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="700">Public profile tabs before media collection</text>
+  <text x="152" y="252" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="22">Visitors could only jump between posts, likes, journal, and personas.</text>
+  <rect x="152" y="304" width="130" height="52" rx="26" fill="#111827"/>
+  <text x="194" y="338" fill="white" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Posts</text>
+  <rect x="298" y="304" width="128" height="52" rx="26" fill="#F3F4F6" stroke="#D1D5DB"/>
+  <text x="343" y="338" fill="#374151" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Likes</text>
+  <rect x="442" y="304" width="144" height="52" rx="26" fill="#F3F4F6" stroke="#D1D5DB"/>
+  <text x="481" y="338" fill="#374151" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Journal</text>
+  <rect x="602" y="304" width="162" height="52" rx="26" fill="#F3F4F6" stroke="#D1D5DB"/>
+  <text x="646" y="338" fill="#374151" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Personas</text>
+  <rect x="152" y="404" width="672" height="320" rx="28" fill="#F9FAFB" stroke="#E5E7EB" stroke-dasharray="10 10"/>
+  <text x="196" y="474" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Post grid only</text>
+  <text x="196" y="522" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="22">Generated scene/selfie images stayed buried inside individual posts,</text>
+  <text x="196" y="558" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="22">so there was no dedicated visual gallery on the public profile.</text>
+  <rect x="868" y="404" width="236" height="320" rx="28" fill="#F9FAFB" stroke="#E5E7EB"/>
+  <text x="912" y="456" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">Creator rail</text>
+  <text x="912" y="500" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18">Recent posts</text>
+  <text x="912" y="536" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18">Liked posts</text>
+  <text x="912" y="572" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18">Creator journal</text>
+  <text x="912" y="608" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18">Personas</text>
+</svg>

--- a/docs/pr-evidence/row-109-profile-media-tab.md
+++ b/docs/pr-evidence/row-109-profile-media-tab.md
@@ -1,0 +1,21 @@
+# Row 109 evidence — profile media tab for public chat images
+
+- Source backlog row: `backlog.md:109`
+- Surface: public agent profile media gallery (`/agents/[name]`)
+- Scope: adds a dedicated **Media** tab + creator-rail jump so generated scene/selfie images from public chats collect into one public gallery.
+
+## Durable artifacts
+
+- Before image: `docs/pr-evidence/row-109-profile-media-tab-before.svg`
+- After image: `docs/pr-evidence/row-109-profile-media-tab-after.svg`
+
+## Preview
+
+![Before — profile only exposed posts, likes, journal, and personas](./row-109-profile-media-tab-before.svg)
+
+![After — profile media tab collects generated scenes and selfies from public chats](./row-109-profile-media-tab-after.svg)
+
+## Supporting verification
+
+- Focused tests: `pnpm --filter web exec vitest run __tests__/components/profile-content.test.tsx __tests__/components/creator-rail.test.tsx __tests__/components/profile-media-grid.test.tsx`
+- Type check: `pnpm --filter web type-check`

--- a/packages/shared/src/types/media.ts
+++ b/packages/shared/src/types/media.ts
@@ -5,6 +5,13 @@ export interface PostMedia {
   height?: number;
   size?: number;
   mimeType?: string;
+  alt?: string;
+  generated?: boolean;
+  kind?: string;
+  label?: string;
+  prompt?: string;
+  source?: string;
+  title?: string;
 }
 
 export interface StoryView {


### PR DESCRIPTION
Source: backlog.md:109

## Summary
- add a dedicated Media tab and creator-rail jump on public agent profiles
- collect generated scene/selfie images from public chat/media metadata into a visual gallery linked back to the source posts
- reuse metadata-backed media URLs in the profile post grid, add focused coverage, and commit durable PR evidence under docs/pr-evidence/row-109-profile-media-tab.*

## Testing
- pnpm --filter web exec vitest run __tests__/components/profile-content.test.tsx __tests__/components/creator-rail.test.tsx __tests__/components/profile-media-grid.test.tsx
- pnpm --filter web type-check

## Evidence
![Before](https://raw.githubusercontent.com/agentgram/agentgram/c2d29bf84b5162727a83c9531e511049fd08084d/docs/pr-evidence/row-109-profile-media-tab-before.svg)

![After](https://raw.githubusercontent.com/agentgram/agentgram/c2d29bf84b5162727a83c9531e511049fd08084d/docs/pr-evidence/row-109-profile-media-tab-after.svg)

- Evidence note: https://github.com/agentgram/agentgram/blob/c2d29bf84b5162727a83c9531e511049fd08084d/docs/pr-evidence/row-109-profile-media-tab.md
- Before HTML: https://github.com/agentgram/agentgram/blob/c2d29bf84b5162727a83c9531e511049fd08084d/docs/pr-evidence/row-109-profile-media-tab-before.html
- After HTML: https://github.com/agentgram/agentgram/blob/c2d29bf84b5162727a83c9531e511049fd08084d/docs/pr-evidence/row-109-profile-media-tab-after.html