### PR TITLE
Fix verified active now directory recovery

### DIFF
--- a/apps/web/__tests__/api/agents.test.ts
+++ b/apps/web/__tests__/api/agents.test.ts
@@ -347,13 +347,8 @@ describe('GET /api/v1/agents', () => {
     );
   });
 
-  it('falls back to minimal directory columns when verification_state is unavailable on live agents rows', async () => {
+  it('falls back to compatibility directory columns when verification_state is unavailable on live agents rows', async () => {
     mockRange
-      .mockResolvedValueOnce({
-        data: null,
-        error: { message: 'column agents.verification_state does not exist' },
-        count: null,
-      })
       .mockResolvedValueOnce({
         data: null,
         error: { message: 'column agents.verification_state does not exist' },
@@ -366,6 +361,7 @@ describe('GET /api/v1/agents', () => {
             name: 'legacy-fallback-agent',
             display_name: 'Legacy Fallback Agent',
             description: 'Still renders when verification_state is missing',
+            email_verified: true,
             developer_id: 'dev-legacy',
             avatar_url: null,
             axp: 7,
@@ -375,6 +371,9 @@ describe('GET /api/v1/agents', () => {
             created_at: '2026-01-01T00:00:00Z',
             updated_at: '2026-01-02T00:00:00Z',
             last_active: '2026-01-03T00:00:00Z',
+            developer: {
+              display_name: 'Legacy Owner',
+            },
           },
         ],
         error: null,
@@ -389,6 +388,78 @@ describe('GET /api/v1/agents', () => {
     expect(response.status).toBe(200);
     expect(json.data[0]).toMatchObject({
       name: 'legacy-fallback-agent',
+      verificationState: 'verified',
+      publicOwnerLabel: 'Legacy Owner',
+      capabilities: {
+        voice: false,
+        group_chat: false,
+        roleplay: false,
+      },
+    });
+    expect(mockSelect).toHaveBeenCalledTimes(3);
+    expect(mockSelect.mock.calls[0][0]).toContain('verification_state');
+    expect(mockSelect.mock.calls[1][0]).not.toContain('verification_state');
+    expect(mockSelect.mock.calls[1][0]).toContain('email_verified');
+    expect(mockSelect.mock.calls[1][0]).toContain('developer:developers(display_name)');
+  });
+
+  it('falls back to minimal directory columns when compatibility directory columns still drift', async () => {
+    mockRange
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'column agents.verification_state does not exist' },
+        count: null,
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: {
+          message:
+            "Could not find a relationship between 'agents' and 'developers' in the schema cache",
+        },
+        count: null,
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 'agent-minimal-fallback',
+            name: 'minimal-fallback-agent',
+            display_name: 'Minimal Fallback Agent',
+            description: 'Still renders when compatibility owner joins drift',
+            developer_id: 'dev-minimal',
+            avatar_url: null,
+            axp: 7,
+            status: 'active',
+            trust_score: 0.1,
+            metadata: {},
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            last_active: '2026-01-03T00:00:00Z',
+          },
+        ],
+        error: null,
+        count: 1,
+      });
+
+    mockDeveloperIn.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'dev-minimal',
+          display_name: 'Minimal Owner',
+          plan: null,
+          subscription_status: null,
+        },
+      ],
+      error: null,
+    });
+
+    const { GET } = await import('../../app/api/v1/agents/route');
+    const request = new Request('http://localhost/api/v1/agents');
+    const response = await GET(request as unknown as Parameters<typeof GET>[0]);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data[0]).toMatchObject({
+      name: 'minimal-fallback-agent',
       verificationState: 'unverified',
       capabilities: {
         voice: false,
@@ -399,8 +470,8 @@ describe('GET /api/v1/agents', () => {
     expect(json.data[0]).not.toHaveProperty('publicOwnerLabel');
     expect(mockSelect).toHaveBeenCalledTimes(5);
     expect(mockSelect.mock.calls[0][0]).toContain('verification_state');
-    expect(mockSelect.mock.calls[1][0]).toContain('verification_state');
-    expect(mockSelect.mock.calls[1][0]).not.toContain('developer:developers(');
+    expect(mockSelect.mock.calls[1][0]).not.toContain('verification_state');
+    expect(mockSelect.mock.calls[1][0]).toContain('developer:developers(display_name)');
     expect(mockSelect.mock.calls[2][0]).not.toContain('verification_state');
     expect(mockSelect.mock.calls[2][0]).not.toContain('developer:developers(');
     expect(mockSelect.mock.calls[3][0]).toBe(
@@ -933,5 +1004,110 @@ describe('GET /api/v1/agents', () => {
       'verified-older',
       'network-ghost',
     ]);
+  });
+
+  it('keeps verified_active sorting working when verification_state is missing but owner labels still exist', async () => {
+    mockRange
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'column agents.verification_state does not exist' },
+        count: null,
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 'agent-compat-count',
+            name: 'compat-count',
+            display_name: 'Compat Count',
+            description: 'Count probe row',
+            email_verified: true,
+            avatar_url: null,
+            axp: 5,
+            status: 'active',
+            trust_score: 0.1,
+            metadata: {},
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            last_active: '2026-01-03T00:00:00Z',
+            developer: { display_name: 'Compat Owner' },
+          },
+        ],
+        error: null,
+        count: 3,
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 'agent-ghost',
+            name: 'network-ghost',
+            display_name: 'Network Ghost',
+            description: 'Unverified but recently active',
+            email_verified: false,
+            avatar_url: null,
+            axp: 900,
+            status: 'active',
+            trust_score: 0.2,
+            metadata: {},
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            last_active: '2026-01-05T00:00:00Z',
+            developer: { display_name: 'Ghost' },
+          },
+          {
+            id: 'agent-builder',
+            name: 'verified-builder',
+            display_name: 'Verified Builder',
+            description: 'Verified human-owned agent',
+            email_verified: true,
+            avatar_url: null,
+            axp: 120,
+            status: 'active',
+            trust_score: 0.6,
+            metadata: {},
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            last_active: '2026-01-04T00:00:00Z',
+            developer: { display_name: 'Ralph' },
+          },
+          {
+            id: 'agent-older',
+            name: 'verified-older',
+            display_name: 'Verified Older',
+            description: 'Verified but less recent',
+            email_verified: true,
+            avatar_url: null,
+            axp: 80,
+            status: 'active',
+            trust_score: 0.5,
+            metadata: {},
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            last_active: '2026-01-02T00:00:00Z',
+            developer: { display_name: 'Mina' },
+          },
+        ],
+        error: null,
+        count: 3,
+      });
+
+    const { GET } = await import('../../app/api/v1/agents/route');
+    const request = new Request(
+      'http://localhost/api/v1/agents?sort=verified_active&limit=10'
+    );
+    const response = await GET(request as unknown as Parameters<typeof GET>[0]);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data.map((agent: { name: string }) => agent.name)).toEqual([
+      'verified-builder',
+      'verified-older',
+      'network-ghost',
+    ]);
+    expect(json.data[0]).toMatchObject({
+      verificationState: 'verified',
+      publicOwnerLabel: 'Ralph',
+    });
+    expect(mockSelect.mock.calls[1][0]).toContain('developer:developers(display_name)');
+    expect(mockSelect.mock.calls[1][0]).not.toContain('verification_state');
   });
 });

--- a/apps/web/app/api/v1/agents/route.ts
+++ b/apps/web/app/api/v1/agents/route.ts
@@ -60,6 +60,12 @@ const AGENTS_DIRECTORY_FALLBACK_SELECT = `
   developer:developers(display_name)
 `;
 
+const AGENTS_DIRECTORY_COMPAT_SELECT = `
+  ${AGENTS_DIRECTORY_BASE_SELECT},
+  email_verified,
+  developer:developers(display_name)
+`;
+
 const AGENTS_DIRECTORY_LEGACY_SELECT = `
   ${AGENTS_DIRECTORY_BASE_SELECT},
   verification_state
@@ -115,8 +121,32 @@ function applySort<TQuery extends SortableQuery<TQuery>>(
   return query;
 }
 
+function hasPublicOwnerDisplayName(agent: AgentResponse) {
+  const developer = Array.isArray(agent.developer)
+    ? agent.developer[0]
+    : agent.developer;
+
+  return Boolean(developer?.display_name?.trim());
+}
+
+function normalizeLegacyVerificationState(
+  agent: DirectoryAgentResponse
+): DirectoryAgentResponse {
+  if (agent.verification_state) {
+    return agent;
+  }
+
+  return {
+    ...agent,
+    verification_state:
+      agent.email_verified && hasPublicOwnerDisplayName(agent)
+        ? 'verified'
+        : 'unverified',
+  };
+}
+
 function isVerifiedHumanOwned(agent: AgentResponse) {
-  const transformed = transformAgent(agent);
+  const transformed = transformAgent(normalizeLegacyVerificationState(agent));
   return (
     transformed.verificationState === 'verified' &&
     Boolean(transformed.publicOwnerLabel?.trim())
@@ -177,11 +207,14 @@ function shouldRetryWithoutDeveloperBilling(error: unknown) {
   return message.includes('plan') || message.includes('subscription_status');
 }
 
+function shouldRetryWithCompatibilityDirectorySelect(error: unknown) {
+  return getErrorMessage(error).includes('verification_state');
+}
+
 function shouldRetryWithLegacyDirectorySelect(error: unknown) {
   const message = getErrorMessage(error);
 
   if (
-    message.includes('verification_state') ||
     message.includes('capability_summary') ||
     message.includes('permission_scope') ||
     message.includes('public_key') ||
@@ -361,9 +394,11 @@ export async function GET(req: NextRequest) {
           return { error: allAgentsError };
         }
 
-        const allAgents = await hydrateDirectoryAgentsWithDevelopers(
-          coerceDirectoryAgentRows(fullFetchData)
-        );
+        const allAgents = (
+          await hydrateDirectoryAgentsWithDevelopers(
+            coerceDirectoryAgentRows(fullFetchData)
+          )
+        ).map(normalizeLegacyVerificationState);
         let filteredAgents = allAgents;
 
         if (sort === 'discussed') {
@@ -435,14 +470,49 @@ export async function GET(req: NextRequest) {
       }
 
       return {
-        agents: await hydrateDirectoryAgentsWithDevelopers(
-          coerceDirectoryAgentRows(result.data)
-        ),
+        agents: (
+          await hydrateDirectoryAgentsWithDevelopers(
+            coerceDirectoryAgentRows(result.data)
+          )
+        ).map(normalizeLegacyVerificationState),
         count: result.count || 0,
       };
     };
 
     let directoryResult = await fetchAgentsDirectoryPage(AGENTS_DIRECTORY_SELECT);
+
+    const retryWithMinimalDirectorySelect = async (message: string) => {
+      console.warn(message, directoryResult.error);
+      directoryResult = await fetchAgentsDirectoryPage(
+        AGENTS_DIRECTORY_MINIMAL_SELECT
+      );
+    };
+
+    const retryWithLegacyDirectorySelect = async (message: string) => {
+      console.warn(message, directoryResult.error);
+      directoryResult = await fetchAgentsDirectoryPage(
+        AGENTS_DIRECTORY_LEGACY_SELECT
+      );
+
+      if ('error' in directoryResult) {
+        await retryWithMinimalDirectorySelect(
+          'Agents query still failed after legacy retry; retrying with the minimal public directory columns.'
+        );
+      }
+    };
+
+    const retryWithCompatibilityDirectorySelect = async (message: string) => {
+      console.warn(message, directoryResult.error);
+      directoryResult = await fetchAgentsDirectoryPage(
+        AGENTS_DIRECTORY_COMPAT_SELECT
+      );
+
+      if ('error' in directoryResult) {
+        await retryWithMinimalDirectorySelect(
+          'Agents compatibility query still failed; retrying with the minimal public directory columns.'
+        );
+      }
+    };
 
     if ('error' in directoryResult) {
       if (shouldRetryWithoutDeveloperBilling(directoryResult.error)) {
@@ -454,46 +524,25 @@ export async function GET(req: NextRequest) {
           AGENTS_DIRECTORY_FALLBACK_SELECT
         );
 
-        if (
-          'error' in directoryResult &&
-          shouldRetryWithLegacyDirectorySelect(directoryResult.error)
-        ) {
-          console.warn(
-            'Agents query still failed after removing billing metadata; retrying with legacy directory columns.',
-            directoryResult.error
-          );
-          directoryResult = await fetchAgentsDirectoryPage(
-            AGENTS_DIRECTORY_LEGACY_SELECT
-          );
-
-          if ('error' in directoryResult) {
-            console.warn(
-              'Agents query still failed after legacy retry; retrying with the minimal public directory columns.',
-              directoryResult.error
+        if ('error' in directoryResult) {
+          if (shouldRetryWithCompatibilityDirectorySelect(directoryResult.error)) {
+            await retryWithCompatibilityDirectorySelect(
+              'Agents query still failed on verification_state after removing billing metadata; retrying with compatibility directory columns.'
             );
-            directoryResult = await fetchAgentsDirectoryPage(
-              AGENTS_DIRECTORY_MINIMAL_SELECT
+          } else if (shouldRetryWithLegacyDirectorySelect(directoryResult.error)) {
+            await retryWithLegacyDirectorySelect(
+              'Agents query still failed after removing billing metadata; retrying with legacy directory columns.'
             );
           }
         }
+      } else if (shouldRetryWithCompatibilityDirectorySelect(directoryResult.error)) {
+        await retryWithCompatibilityDirectorySelect(
+          'Agents query failed on verification_state; retrying with compatibility directory columns.'
+        );
       } else if (shouldRetryWithLegacyDirectorySelect(directoryResult.error)) {
-        console.warn(
-          'Agents query failed against newer public schema fields; retrying with legacy directory columns.',
-          directoryResult.error
+        await retryWithLegacyDirectorySelect(
+          'Agents query failed against newer public schema fields; retrying with legacy directory columns.'
         );
-        directoryResult = await fetchAgentsDirectoryPage(
-          AGENTS_DIRECTORY_LEGACY_SELECT
-        );
-
-        if ('error' in directoryResult) {
-          console.warn(
-            'Agents query still failed after legacy retry; retrying with the minimal public directory columns.',
-            directoryResult.error
-          );
-          directoryResult = await fetchAgentsDirectoryPage(
-            AGENTS_DIRECTORY_MINIMAL_SELECT
-          );
-        }
       }
     }
 


### PR DESCRIPTION
Source: backlog.md:108

## Summary
- recover `/api/v1/agents` from live `verification_state` schema drift by retrying into a compatibility select before dropping the developer join entirely
- preserve verified-owner proof on legacy rows by deriving `verificationState` from `email_verified + developer.display_name` when the explicit column is unavailable
- add focused regression coverage and durable evidence files for the row-108 / row-112 shared directory bug

## Testing
- `pnpm --filter web exec -- vitest run __tests__/api/agents.test.ts`
- `pnpm --filter web exec -- eslint app/api/v1/agents/route.ts __tests__/api/agents.test.ts`

## Evidence
![Before — verified active now sort](docs/pr-evidence/row-107-verified-active-now-sort-before.png)
![After — verified active now sort](docs/pr-evidence/row-107-verified-active-now-sort-after.png)

- [Row 108 recovery note](docs/pr-evidence/row-108-verified-active-now-recovery.md)
- [Production 500 probes](docs/pr-evidence/row-108-verified-active-now-production-before.txt)
- [Live schema drift probe](docs/pr-evidence/row-108-verified-active-now-schema-probe.txt)
- [Validation output](docs/pr-evidence/row-108-verified-active-now-recovery-validation.txt)

## Row 112 overlap
- Yes — this fixes the same `/api/v1/agents` schema-drift path row 112 was tracking, unless production still has a separate deploy/runtime issue after merge.
