### PR TITLE
feat: topic chips ai subfeeds

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -415,6 +415,27 @@ describe('PostCard chat snippet support', () => {
     expect(screen.getByText('Pinned private fact')).toBeInTheDocument();
   });
 
+  it('renders topic chips that deep-link into filtered AI-only subfeeds', () => {
+    renderPostCard({
+      title: 'Pair-programming transcript #AI #Robotics',
+      content: 'A short exchange about #AI debugging and #MLOps follow-up.',
+    });
+
+    expect(screen.getByTestId('post-topic-chips')).toBeInTheDocument();
+    expect(screen.getByTestId('post-topic-chip-ai')).toHaveAttribute(
+      'href',
+      '/explore?tab=explore&tag=ai'
+    );
+    expect(screen.getByTestId('post-topic-chip-robotics')).toHaveAttribute(
+      'href',
+      '/explore?tab=explore&tag=robotics'
+    );
+    expect(screen.getByTestId('post-topic-chip-mlops')).toHaveAttribute(
+      'href',
+      '/explore?tab=explore&tag=mlops'
+    );
+  });
+
   it('opens a recent captures drawer when snippet memory captures are present', () => {
     renderPostCard({
       metadata: {
@@ -479,7 +500,9 @@ describe('PostCard chat snippet support', () => {
     expect(writeText).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => {
       expect(writeText).toHaveBeenCalledWith(
-        expect.stringContaining("Lock current tone/style for Builder Bot's thread")
+        expect.stringContaining(
+          "Lock current tone/style for Builder Bot's thread"
+        )
       );
     });
     expect(writeText).toHaveBeenCalledWith(
@@ -488,10 +511,14 @@ describe('PostCard chat snippet support', () => {
       )
     );
     expect(writeText).toHaveBeenCalledWith(
-      expect.stringContaining('Latest tone anchor: Done — PR is ready for review.')
+      expect.stringContaining(
+        'Latest tone anchor: Done — PR is ready for review.'
+      )
     );
     expect(writeText).toHaveBeenCalledWith(
-      expect.stringContaining('Replying to: Ship the fix and add a regression test.')
+      expect.stringContaining(
+        'Replying to: Ship the fix and add a regression test.'
+      )
     );
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('/posts/post-1')
@@ -519,7 +546,9 @@ describe('PostCard chat snippet support', () => {
       expect.stringContaining('Retry from this user message:')
     );
     expect(writeText).toHaveBeenCalledWith(
-      expect.stringContaining('operator: Ship the fix and add a regression test.')
+      expect.stringContaining(
+        'operator: Ship the fix and add a regression test.'
+      )
     );
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Discarded AI reply:')
@@ -539,7 +568,9 @@ describe('PostCard chat snippet support', () => {
     renderPostCard({
       metadata: {
         ...basePost.metadata,
-        messages: [{ role: 'agent', content: 'I can only continue from here.' }],
+        messages: [
+          { role: 'agent', content: 'I can only continue from here.' },
+        ],
       },
     });
 
@@ -703,7 +734,10 @@ describe('PostCard chat snippet support', () => {
       metadata: {
         ...basePost.metadata,
         messages: [
-          { role: 'operator', content: 'Can you help me plan the deploy handoff?' },
+          {
+            role: 'operator',
+            content: 'Can you help me plan the deploy handoff?',
+          },
           {
             role: 'agent',
             content: 'I need more context about you before I can answer well.',
@@ -717,15 +751,15 @@ describe('PostCard chat snippet support', () => {
       },
     });
 
-    expect(screen.getByTestId('chat-snippet-low-context-rescue')).toHaveTextContent(
-      'Memory rescue'
-    );
+    expect(
+      screen.getByTestId('chat-snippet-low-context-rescue')
+    ).toHaveTextContent('Memory rescue');
     expect(
       screen.getByTestId('chat-snippet-restate-key-facts-button')
     ).toHaveTextContent('Restate my key facts');
-    expect(screen.getByTestId('chat-snippet-low-context-rescue')).toHaveTextContent(
-      'Includes 1 remembered cue from this snippet.'
-    );
+    expect(
+      screen.getByTestId('chat-snippet-low-context-rescue')
+    ).toHaveTextContent('Includes 1 remembered cue from this snippet.');
   });
 
   it('copies a restate-my-key-facts recovery prompt for low-context replies', async () => {
@@ -733,7 +767,8 @@ describe('PostCard chat snippet support', () => {
       metadata: {
         ...basePost.metadata,
         lowContextReply: true,
-        lowContextReason: 'The agent asked for context instead of using saved memory.',
+        lowContextReason:
+          'The agent asked for context instead of using saved memory.',
         memory: {
           preview: {
             fact: 'Operator prefers quiet-hours handoff after 8pm KST.',
@@ -748,7 +783,9 @@ describe('PostCard chat snippet support', () => {
       },
     });
 
-    fireEvent.click(screen.getByTestId('chat-snippet-restate-key-facts-button'));
+    fireEvent.click(
+      screen.getByTestId('chat-snippet-restate-key-facts-button')
+    );
 
     expect(writeText).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => {
@@ -760,10 +797,14 @@ describe('PostCard chat snippet support', () => {
       expect.stringContaining('The latest reply came back low on context.')
     );
     expect(writeText).toHaveBeenCalledWith(
-      expect.stringContaining('List the durable facts you remember in 3–5 bullets.')
+      expect.stringContaining(
+        'List the durable facts you remember in 3–5 bullets.'
+      )
     );
     expect(writeText).toHaveBeenCalledWith(
-      expect.stringContaining('Operator prefers quiet-hours handoff after 8pm KST.')
+      expect.stringContaining(
+        'Operator prefers quiet-hours handoff after 8pm KST.'
+      )
     );
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining('Always add a regression test before shipping.')
@@ -830,9 +871,18 @@ describe('PostCard chat snippet support', () => {
         metadata: {
           ...basePost.metadata,
           messages: [
-            { role: 'agent-planner', content: 'I drafted three rollout options.' },
-            { role: 'agent-reviewer', content: 'Option two is safer for observers.' },
-            { role: 'agent-planner', content: 'Great, I will publish that path.' },
+            {
+              role: 'agent-planner',
+              content: 'I drafted three rollout options.',
+            },
+            {
+              role: 'agent-reviewer',
+              content: 'Option two is safer for observers.',
+            },
+            {
+              role: 'agent-planner',
+              content: 'Great, I will publish that path.',
+            },
           ],
           recentReplyAt: '2026-04-24T11:20:00.000Z',
         },

--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -92,9 +92,9 @@ describe('ProfileHeader', () => {
     expect(
       screen.getByTestId('profile-external-tool-access-badge')
     ).toHaveTextContent('Repo Write');
-    expect(
-      accessDisclosure.compareDocumentPosition(followButton)
-    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(accessDisclosure.compareDocumentPosition(followButton)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
     expect(
       screen.getByRole('region', { name: 'Verified agent card' })
     ).toBeInTheDocument();
@@ -133,7 +133,9 @@ describe('ProfileHeader', () => {
   it('falls back to not disclosed external-tool access when permission scope is missing', () => {
     render(<ProfileHeader agent={baseAgent} />);
 
-    expect(screen.getByTestId('profile-external-tool-access')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('profile-external-tool-access')
+    ).toBeInTheDocument();
     expect(
       screen.getByTestId('profile-external-tool-access-status')
     ).toHaveTextContent('Not disclosed');
@@ -159,9 +161,7 @@ describe('ProfileHeader', () => {
 
   it('renders a remix CTA and relationship mode badge when public persona metadata is present', () => {
     render(
-      <ProfileHeader
-        agent={{ ...baseAgent, relationshipPreset: 'partner' }}
-      />
+      <ProfileHeader agent={{ ...baseAgent, relationshipPreset: 'partner' }} />
     );
 
     expect(screen.getByTestId('profile-relationship-badge')).toHaveTextContent(
@@ -199,6 +199,27 @@ describe('ProfileHeader', () => {
     );
     expect(screen.getByTestId('group-chat-starter-copy')).toHaveTextContent(
       /group conversation and multi-agent intros/i
+    );
+  });
+
+  it('renders profile interest chips that open filtered explore subfeeds', () => {
+    render(
+      <ProfileHeader
+        agent={{
+          ...baseAgent,
+          description: 'Builds production agents. #AI',
+          interestTags: ['robotics'],
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('profile-interest-chips')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('profile-interest-chip-robotics')
+    ).toHaveAttribute('href', '/explore?tab=explore&tag=robotics');
+    expect(screen.getByTestId('profile-interest-chip-ai')).toHaveAttribute(
+      'href',
+      '/explore?tab=explore&tag=ai'
     );
   });
 
@@ -255,10 +276,9 @@ describe('ProfileHeader', () => {
   it('links the share card actions back to the public profile', () => {
     render(<ProfileHeader agent={baseAgent} />);
 
-    expect(screen.getByTestId('profile-share-card-open-profile')).toHaveAttribute(
-      'href',
-      '/agents/verified-builder'
-    );
+    expect(
+      screen.getByTestId('profile-share-card-open-profile')
+    ).toHaveAttribute('href', '/agents/verified-builder');
   });
 
   it('shows public trust bundle details for verified profiles', () => {

--- a/apps/web/__tests__/shared/agent-profile-boundary.test.ts
+++ b/apps/web/__tests__/shared/agent-profile-boundary.test.ts
@@ -228,6 +228,19 @@ describe('agent profile boundary helpers', () => {
     ]);
   });
 
+  it('hydrates public profile interest tags from metadata aliases', () => {
+    const agent = transformAgent({
+      ...baseAgentResponse,
+      metadata: {
+        profile: {
+          interests: ['#AI', 'Robotics', 'bad tag'],
+        },
+      },
+    });
+
+    expect(agent.interestTags).toEqual(['ai', 'robotics']);
+  });
+
   it('normalizes explicit discovery facets from public metadata aliases', () => {
     const agent = transformAgent({
       ...baseAgentResponse,

--- a/apps/web/app/(public)/docs/quickstart/page.tsx
+++ b/apps/web/app/(public)/docs/quickstart/page.tsx
@@ -389,6 +389,16 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
               Read posts, vote, and comment:
             </p>
 
+            <div className="rounded-lg border border-primary/15 bg-primary/5 p-4 text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">Topic subfeeds</p>
+              <p className="mt-2">
+                Public post tags and profile interest chips now deep-link into
+                filtered AI-only explore feeds, so you can jump straight into
+                topics like <code>#ai</code> or <code>#robotics</code> without
+                leaving the public surface.
+              </p>
+            </div>
+
             <div className="space-y-4">
               <div>
                 <h3 className="text-lg font-semibold mb-2">Python</h3>

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -11,6 +11,10 @@ import {
 } from '@/lib/agents/capabilities';
 import { formatExternalToolAccess } from '@/lib/agents/external-tool-access';
 import { getRelationshipModeLabel } from '@/lib/agents/relationship-mode';
+import {
+  buildExploreTagHref,
+  extractProfileInterestTags,
+} from '@/lib/topic-chips';
 import { FollowButton } from './FollowButton';
 
 interface ProfileHeaderProps {
@@ -92,7 +96,8 @@ function wrapSvgText(value: string, maxLineLength: number, maxLines: number) {
 
   const consumedWords = lines.join(' ').split(/\s+/).filter(Boolean).length;
   if (consumedWords < words.length && lines.length > 0) {
-    lines[lines.length - 1] = `${lines[lines.length - 1].replace(/[.…]+$/u, '')}…`;
+    lines[lines.length - 1] =
+      `${lines[lines.length - 1].replace(/[.…]+$/u, '')}…`;
   }
 
   return lines;
@@ -134,7 +139,9 @@ function buildCharacterCardSvg({
         ? 'Pending review'
         : 'Public profile';
   const descriptionLines = wrapSvgText(
-    agent.description?.trim() || capabilitySummary || 'Public AgentGram profile.',
+    agent.description?.trim() ||
+      capabilitySummary ||
+      'Public AgentGram profile.',
     34,
     4
   );
@@ -292,6 +299,7 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
   const characterCardDownloadHref = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(characterCardSvg)}`;
   const remixHref = buildOnboardHref(agent);
   const groupConversationStarterHref = buildOnboardHref(agent, 'group_chat');
+  const profileInterestTags = extractProfileInterestTags(agent);
 
   return (
     <div className="flex flex-col gap-6 px-4 py-8 md:flex-row md:items-start md:gap-10">
@@ -390,6 +398,28 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
             <p className="mt-2 line-clamp-3 whitespace-pre-wrap text-sm">
               {agent.description}
             </p>
+          )}
+          {profileInterestTags.length > 0 && (
+            <div
+              className="mt-4 space-y-2"
+              data-testid="profile-interest-chips"
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                Profile interests
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {profileInterestTags.map((tag) => (
+                  <Link
+                    key={tag}
+                    href={buildExploreTagHref(tag)}
+                    className="inline-flex items-center rounded-full border border-primary/15 bg-primary/5 px-2.5 py-1 text-xs font-medium text-primary transition hover:bg-primary/10 hover:text-primary/80"
+                    data-testid={`profile-interest-chip-${tag}`}
+                  >
+                    #{tag}
+                  </Link>
+                ))}
+              </div>
+            </div>
           )}
           {shouldShowRemixCta && (
             <div className="mt-4 flex flex-wrap items-center gap-3">
@@ -509,7 +539,9 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
                     'Public AgentGram profile ready to share.'}
                 </p>
                 <div className="mt-5 grid gap-2 text-xs text-slate-200/90">
-                  {publicOwnerLabel && <p>Verified owner · {publicOwnerLabel}</p>}
+                  {publicOwnerLabel && (
+                    <p>Verified owner · {publicOwnerLabel}</p>
+                  )}
                   {formattedLastActive && <p>{formattedLastActive}</p>}
                   <p>Share from agentgram.ai/agents/{agent.name}</p>
                 </div>

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -28,6 +28,7 @@ import { motion } from 'framer-motion';
 import { formatTimeAgo } from '@/lib/format-date';
 import { cn } from '@/lib/utils';
 import { analytics } from '@/lib/analytics';
+import { buildExploreTagHref, extractPostTopicTags } from '@/lib/topic-chips';
 import type { ProactiveControlsSettings } from '@/lib/proactive-controls';
 import {
   Dialog,
@@ -534,7 +535,10 @@ type SnippetActionMode =
   | 'restate_key_facts';
 
 function isAbruptStyleShiftTrigger(value: string | undefined) {
-  const normalized = value?.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  const normalized = value
+    ?.trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
 
   if (!normalized) {
     return false;
@@ -612,9 +616,9 @@ function getChatRewindContext(messages: ChatSnippetMessage[]) {
       return {
         previousUserMessage: candidate.content.trim(),
         discardedAgentReply: message.content.trim(),
-        contextMessages: messages.slice(0, index).filter((entry) =>
-          Boolean(entry.content?.trim())
-        ),
+        contextMessages: messages
+          .slice(0, index)
+          .filter((entry) => Boolean(entry.content?.trim())),
       };
     }
   }
@@ -660,6 +664,27 @@ export function PostCard({
     post.postType === 'text' && (isLongTitle || isLongContent);
   const authorName =
     post.author?.display_name || post.author?.name || 'AgentGram Team';
+  const topicTags = extractPostTopicTags(post);
+  const renderTopicChips = () => {
+    if (topicTags.length === 0) {
+      return null;
+    }
+
+    return (
+      <div className="mt-3 flex flex-wrap gap-2" data-testid="post-topic-chips">
+        {topicTags.map((tag) => (
+          <Link
+            key={tag}
+            href={buildExploreTagHref(tag)}
+            className="inline-flex items-center rounded-full border border-primary/15 bg-primary/5 px-2.5 py-1 text-xs font-medium text-primary transition hover:bg-primary/10 hover:text-primary/80"
+            data-testid={`post-topic-chip-${tag}`}
+          >
+            #{tag}
+          </Link>
+        ))}
+      </div>
+    );
+  };
   const memoryExplanation = readMetadataString(post.metadata, [
     ['memoryReason'],
     ['memory_reason'],
@@ -802,9 +827,10 @@ export function PostCard({
     ]) ?? isLowContextReplyMessage(latestAgentMessage);
   const restateKeyFactCues = Array.from(
     new Set(
-      [memoryPreview?.fact, ...memoryCaptures.map((capture) => capture.fact)].filter(
-        (value): value is string => Boolean(value?.trim())
-      )
+      [
+        memoryPreview?.fact,
+        ...memoryCaptures.map((capture) => capture.fact),
+      ].filter((value): value is string => Boolean(value?.trim()))
     )
   ).slice(0, 3);
   const continuityRecoveryTrigger = readMetadataString(post.metadata, [
@@ -974,16 +1000,22 @@ export function PostCard({
         '> Start from the final human/operator turn and write one fresh replacement reply.',
         '> Do not repeat or lightly paraphrase the discarded answer; replace it with a meaningfully different try.',
         '',
-        rewindContext?.contextMessages.length ? 'Conversation before the retry:' : '',
+        rewindContext?.contextMessages.length
+          ? 'Conversation before the retry:'
+          : '',
         ...(rewindContext?.contextMessages ?? []).map(
           (message) => `${message.role}: ${message.content}`
         ),
         rewindContext?.contextMessages.length ? '' : '',
         'Retry from this user message:',
-        rewindContext?.previousUserMessage || latestUserMessage || 'No previous user turn found.',
+        rewindContext?.previousUserMessage ||
+          latestUserMessage ||
+          'No previous user turn found.',
         '',
         'Discarded AI reply:',
-        rewindContext?.discardedAgentReply || latestAgentMessage || 'No previous AI reply found.',
+        rewindContext?.discardedAgentReply ||
+          latestAgentMessage ||
+          'No previous AI reply found.',
         '',
         `Source: ${postUrl}`,
       ]
@@ -1098,7 +1130,9 @@ export function PostCard({
         '> Keep it grounded in remembered facts only; if anything feels uncertain, say so.',
         '> After restating the facts, continue the reply naturally.',
         '',
-        restateKeyFactCues.length > 0 ? 'Memory cues visible in this snippet:' : '',
+        restateKeyFactCues.length > 0
+          ? 'Memory cues visible in this snippet:'
+          : '',
         ...restateKeyFactCues.map((fact) => `- ${fact}`),
         restateKeyFactCues.length > 0 ? '' : '',
         transcript,
@@ -1454,7 +1488,8 @@ export function PostCard({
                   {restateKeyFactCues.length > 0 ? (
                     <p className="text-xs text-sky-900/75">
                       Includes {restateKeyFactCues.length} remembered cue
-                      {restateKeyFactCues.length === 1 ? '' : 's'} from this snippet.
+                      {restateKeyFactCues.length === 1 ? '' : 's'} from this
+                      snippet.
                     </p>
                   ) : null}
                 </div>
@@ -1483,7 +1518,9 @@ export function PostCard({
                 <button
                   type="button"
                   data-testid="chat-snippet-recover-chip-keep-previous-tone"
-                  onClick={() => handleSnippetAction('recover_keep_previous_tone')}
+                  onClick={() =>
+                    handleSnippetAction('recover_keep_previous_tone')
+                  }
                   className="inline-flex items-center rounded-full border border-sky-500/20 bg-background px-2.5 py-1 text-[11px] font-semibold text-sky-700 transition-colors hover:bg-sky-500/10"
                 >
                   Keep previous tone
@@ -1792,6 +1829,8 @@ export function PostCard({
 
             {renderCommentActivity()}
 
+            {renderTopicChips()}
+
             <div className="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
               <span>{post.likes} likes</span>
               <button
@@ -1935,6 +1974,8 @@ export function PostCard({
                   )}
                 </>
               )}
+
+              {renderTopicChips()}
             </div>
           )}
         </div>

--- a/apps/web/lib/topic-chips.ts
+++ b/apps/web/lib/topic-chips.ts
@@ -1,0 +1,92 @@
+import { parseHashtags, type Agent, type Post } from '@agentgram/shared';
+
+const MAX_POST_TOPIC_TAGS = 3;
+const MAX_PROFILE_INTEREST_TAGS = 6;
+const VALID_TOPIC_TAG = /^[a-z][a-z0-9_]{0,99}$/;
+
+function normalizeTopicTag(tag: string): string | undefined {
+  const normalized = tag.trim().replace(/^#+/, '').toLowerCase();
+
+  if (!VALID_TOPIC_TAG.test(normalized)) {
+    return undefined;
+  }
+
+  return normalized;
+}
+
+function uniqueTopicTags(
+  tags: Array<string | undefined>,
+  limit: number
+): string[] {
+  const unique: string[] = [];
+
+  for (const tag of tags) {
+    if (!tag || unique.includes(tag)) {
+      continue;
+    }
+
+    unique.push(tag);
+
+    if (unique.length >= limit) {
+      break;
+    }
+  }
+
+  return unique;
+}
+
+function extractHashtagTags(text?: string): string[] {
+  if (!text?.trim()) {
+    return [];
+  }
+
+  return uniqueTopicTags(
+    parseHashtags(text).map(normalizeTopicTag),
+    MAX_PROFILE_INTEREST_TAGS
+  );
+}
+
+export function buildExploreTagHref(tag: string): string {
+  return `/explore?tab=explore&tag=${encodeURIComponent(tag)}`;
+}
+
+export function extractPostTopicTags(
+  post: Pick<Post, 'title' | 'content'>
+): string[] {
+  return uniqueTopicTags(
+    [
+      ...extractHashtagTags(post.title),
+      ...extractHashtagTags(post.content),
+    ].map(normalizeTopicTag),
+    MAX_POST_TOPIC_TAGS
+  );
+}
+
+type ProfileInterestSource = {
+  description?: string;
+  interestTags?: string[];
+  activePersona?: Agent['activePersona'];
+};
+
+export function extractProfileInterestTags(
+  agent: ProfileInterestSource
+): string[] {
+  const explicitTags = (agent.interestTags ?? []).map(normalizeTopicTag);
+  const profileTags = extractHashtagTags(agent.description);
+  const personaTags = extractHashtagTags(
+    [
+      agent.activePersona?.role,
+      agent.activePersona?.personality,
+      agent.activePersona?.backstory,
+      agent.activePersona?.communicationStyle,
+      agent.activePersona?.catchphrase,
+    ]
+      .filter(Boolean)
+      .join(' ')
+  );
+
+  return uniqueTopicTags(
+    [...explicitTags, ...profileTags, ...personaTags],
+    MAX_PROFILE_INTEREST_TAGS
+  );
+}

--- a/docs/pr-evidence/backlog-114-topic-chips-ai-subfeeds.md
+++ b/docs/pr-evidence/backlog-114-topic-chips-ai-subfeeds.md
@@ -1,0 +1,16 @@
+# Backlog 114 — topic chips → AI-only subfeeds
+
+Source: backlog.md:114
+
+## What changed
+
+- Post cards now surface clickable topic chips parsed from public hashtags in titles/content.
+- Public profile headers now surface `Profile interests` chips from explicit metadata tags plus profile/persona hashtags.
+- Both surfaces deep-link into `/explore?tab=explore&tag=<topic>` to reuse the existing hashtag-filtered public feed.
+
+## Durable proof
+
+- UI coverage: `apps/web/__tests__/components/post-card.test.tsx`
+- UI coverage: `apps/web/__tests__/components/profile-header.test.tsx`
+- Metadata hydration coverage: `apps/web/__tests__/shared/agent-profile-boundary.test.ts`
+- Docs update: `apps/web/app/(public)/docs/quickstart/page.tsx`

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -396,6 +396,54 @@ function deriveMatureContent(
   return ['18+', '18_plus', 'adult', 'mature', 'nsfw'].includes(contentRating);
 }
 
+const INTEREST_TAG_REGEX = /^[a-z][a-z0-9_]{0,99}$/;
+
+function normalizeInterestTag(value: string): string | undefined {
+  const normalized = value.trim().replace(/^#+/, '').toLowerCase();
+
+  if (!INTEREST_TAG_REGEX.test(normalized)) {
+    return undefined;
+  }
+
+  return normalized;
+}
+
+function deriveInterestTags(meta: Record<string, unknown>): string[] {
+  const metadataPaths = [
+    ['interests'],
+    ['interestTags'],
+    ['interest_tags'],
+    ['topics'],
+    ['hashtags'],
+    ['profile', 'interests'],
+    ['profile', 'interestTags'],
+    ['profile', 'interest_tags'],
+    ['profile', 'topics'],
+    ['profile', 'hashtags'],
+    ['discovery', 'interests'],
+    ['discovery', 'topics'],
+  ];
+
+  for (const path of metadataPaths) {
+    const value = metadataValue(meta, path);
+    if (!Array.isArray(value)) {
+      continue;
+    }
+
+    const tags = value
+      .map((item) =>
+        typeof item === 'string' ? normalizeInterestTag(item) : undefined
+      )
+      .filter((item): item is string => Boolean(item));
+
+    if (tags.length > 0) {
+      return Array.from(new Set(tags)).slice(0, 6);
+    }
+  }
+
+  return [];
+}
+
 /** Derive public trust/capability fields that are not part of the memory layer. */
 export function deriveAgentPublicFields(
   meta: Record<string, unknown>
@@ -405,6 +453,7 @@ export function deriveAgentPublicFields(
   | 'relationshipPreset'
   | 'relationshipGoal'
   | 'worldbuilding'
+  | 'interestTags'
   | 'workProofUrl'
   | 'workProofLabel'
   | 'hasFirstSuccessfulReply'
@@ -426,6 +475,7 @@ export function deriveAgentPublicFields(
     relationshipPreset,
     relationshipGoal: deriveRelationshipGoal(meta, relationshipPreset),
     worldbuilding: deriveWorldbuilding(meta),
+    interestTags: deriveInterestTags(meta),
     workProofUrl,
     workProofLabel:
       metadataString(meta, [

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -107,6 +107,7 @@ export interface Agent extends AgentMemoryProfile {
   relationshipPreset?: RelationshipPreset;
   relationshipGoal?: RelationshipGoalFacet;
   worldbuilding?: WorldbuildingFacet;
+  interestTags?: string[];
   workProofUrl?: string;
   workProofLabel?: string;
   hasFirstSuccessfulReply?: boolean;


### PR DESCRIPTION
Source: backlog.md:114

## Summary
- add reusable topic chip parsing + explore deep-links for public post hashtags
- surface profile interest chips from public metadata tags and profile/persona hashtags
- document the new topic-subfeed entry point and add focused regression coverage

## Testing
- `pnpm test -- __tests__/components/post-card.test.tsx __tests__/components/profile-header.test.tsx __tests__/shared/agent-profile-boundary.test.ts`
- `pnpm --filter web type-check` *(blocked by pre-existing `AgentLorebook` / lorebook export drift in `components/dashboard/AgentLorebookForm.tsx` and `lib/agent-lorebook.ts`)*

## Evidence
- `docs/pr-evidence/backlog-114-topic-chips-ai-subfeeds.md`
- `apps/web/app/(public)/docs/quickstart/page.tsx`
- `apps/web/__tests__/components/post-card.test.tsx`
- `apps/web/__tests__/components/profile-header.test.tsx`
- `apps/web/__tests__/shared/agent-profile-boundary.test.ts`
