### PR TITLE
[STRATEGY] Lorebook upgrade teaser — preview locked canon templates after first structured save

### DIFF
--- a/apps/web/__tests__/components/agent-lorebook-form.test.tsx
+++ b/apps/web/__tests__/components/agent-lorebook-form.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CONTENT_LIMITS } from '@agentgram/shared';
 import {
@@ -132,6 +138,22 @@ describe('AgentLorebookForm', () => {
     expect(
       screen.getByText(/3 structured lorebook entries/i)
     ).toBeInTheDocument();
+
+    const teaser = screen.getByTestId('lorebook-upgrade-teaser');
+    expect(teaser).toHaveTextContent('Locked canon templates');
+    expect(teaser).toHaveTextContent('First structured save complete.');
+    expect(
+      within(teaser).getByRole('link', { name: 'Compare Operator tiers' })
+    ).toHaveAttribute('href', '/dashboard/billing');
+    expect(
+      screen.getByTestId('lorebook-upgrade-template-relationship-anchor')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('lorebook-upgrade-template-scene-starter')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('lorebook-upgrade-template-safety-rail')
+    ).toBeInTheDocument();
   });
 
   it('caps each lorebook section at the shared entry limit', () => {
@@ -158,6 +180,31 @@ describe('AgentLorebookForm', () => {
     expect(addPersonButton).toBeDisabled();
     expect(addPlaceButton).toBeDisabled();
     expect(addRuleButton).toBeDisabled();
+  });
+
+  it('hides the upgrade teaser for paid operator plans', () => {
+    render(
+      <AgentLorebookForm
+        settings={buildSettings({
+          developerPlan: 'starter',
+          initialLorebook: {
+            updatedAt: '2026-05-09T03:00:00.000Z',
+            people: [
+              {
+                id: 'person-1',
+                name: 'Mina Park',
+                role: 'Launch producer',
+                details: 'Keeps launch comms calm and timestamped.',
+              },
+            ],
+            places: [],
+            rules: [],
+          },
+        })}
+      />
+    );
+
+    expect(screen.queryByTestId('lorebook-upgrade-teaser')).not.toBeInTheDocument();
   });
 
   it('skips the network call when nothing changed', async () => {

--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -70,6 +70,7 @@ function createSettingsPageClient() {
             eq: vi.fn().mockReturnValue({
               single: vi.fn().mockResolvedValue({
                 data: {
+                  plan: 'free',
                   metadata: {
                     proactiveControls: {
                       optIn: false,
@@ -496,6 +497,7 @@ describe('SettingsPage', () => {
           agentName: 'sage-bot',
           agentLabel: 'Sage Bot',
           personaName: 'Release Sage',
+          developerPlan: 'free',
           initialLorebook: {
             updatedAt: '2026-05-09T03:00:00.000Z',
             people: [

--- a/apps/web/__tests__/components/quickstart-page.test.tsx
+++ b/apps/web/__tests__/components/quickstart-page.test.tsx
@@ -62,5 +62,16 @@ describe('QuickstartPage', () => {
       disclosure.compareDocumentPosition(examples) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
+
+    const lorebookNote = screen.getByTestId('quickstart-lorebook-upgrade-note');
+    expect(lorebookNote).toHaveTextContent(
+      'After your first structured lorebook save in /dashboard/settings'
+    );
+    expect(lorebookNote).toHaveTextContent('previews locked canon templates');
+    expect(
+      within(lorebookNote).getByRole('link', {
+        name: 'Compare Operator tiers from the dashboard',
+      })
+    ).toHaveAttribute('href', '/dashboard/billing');
   });
 });

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -28,6 +28,7 @@ type AgentSettingsRecord = {
   agentName: string;
   agentLabel: string;
   personaName?: string;
+  developerPlan: string;
   initialSnapshot: {
     displayName: string;
     description: string;
@@ -124,7 +125,7 @@ export default async function SettingsPage() {
   const { developer_id } = member as { developer_id: string };
   const { data: developer } = await supabase
     .from('developers')
-    .select('metadata')
+    .select('metadata, plan')
     .eq('id', developer_id)
     .single();
 
@@ -186,6 +187,8 @@ export default async function SettingsPage() {
       agentName: agent.name,
       agentLabel: agent.display_name || agent.name,
       personaName: activePersona?.name ?? undefined,
+      developerPlan:
+        typeof developer?.plan === 'string' ? developer.plan : 'free',
       initialSnapshot: {
         displayName: agent.display_name ?? '',
         description: agent.description ?? '',
@@ -244,6 +247,7 @@ export default async function SettingsPage() {
                     agentName: settings.agentName,
                     agentLabel: settings.agentLabel,
                     personaName: settings.personaName,
+                    developerPlan: settings.developerPlan,
                     initialLorebook: settings.initialLorebook,
                   }}
                 />

--- a/apps/web/app/(public)/docs/quickstart/page.tsx
+++ b/apps/web/app/(public)/docs/quickstart/page.tsx
@@ -321,6 +321,25 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
               </div>
             </div>
 
+            <div
+              className="rounded-lg border border-primary/20 bg-primary/5 p-4 text-sm text-muted-foreground"
+              data-testid="quickstart-lorebook-upgrade-note"
+            >
+              After your first structured lorebook save in{' '}
+              <code>/dashboard/settings</code>, AgentGram previews locked canon
+              templates for recurring relationships, scene defaults, and safety
+              rails. Free creators land on Operator billing from that teaser so
+              they can compare tiers before unlocking the full packs.
+              <div className="mt-3">
+                <Link
+                  href="/dashboard/billing"
+                  className="font-medium text-primary hover:underline"
+                >
+                  Compare Operator tiers from the dashboard
+                </Link>
+              </div>
+            </div>
+
             <div className="bg-brand-accent/10 border border-brand-accent/20 rounded-lg p-4">
               <p className="text-sm">
                 <strong>💡 Tip:</strong> Save your API key securely. The same

--- a/apps/web/components/dashboard/AgentLorebookForm.tsx
+++ b/apps/web/components/dashboard/AgentLorebookForm.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import {
   BookOpen,
   Loader2,
+  Lock,
   MapPin,
   Plus,
   ScrollText,
@@ -17,6 +19,7 @@ import {
   type LorebookPlaceEntry,
   type LorebookRuleEntry,
 } from '@agentgram/shared';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -39,6 +42,7 @@ export interface AgentLorebookSettings {
   agentName: string;
   agentLabel: string;
   personaName?: string;
+  developerPlan?: string;
   initialLorebook: AgentLorebook;
 }
 
@@ -113,6 +117,45 @@ function FieldCount({ current, max }: { current: number; max: number }) {
   );
 }
 
+const PAID_OPERATOR_PLANS = new Set(['starter', 'pro', 'enterprise']);
+
+const LOCKED_CANON_TEMPLATES = [
+  {
+    id: 'relationship-anchor',
+    title: 'Relationship anchor pack',
+    summary:
+      'Freeze recurring dynamics, trust boundaries, and callback beats for one important person.',
+    bullets: [
+      'Power dynamic + emotional baseline',
+      'Allowed escalation and de-escalation cues',
+    ],
+  },
+  {
+    id: 'scene-starter',
+    title: 'Scene starter pack',
+    summary:
+      'Bundle place defaults, sensory cues, and scene constraints into a reusable canon card.',
+    bullets: [
+      'Setting mood + default props',
+      'What never changes when a scene resets',
+    ],
+  },
+  {
+    id: 'safety-rail',
+    title: 'Safety rail pack',
+    summary:
+      'Lock behavior rules that keep tone, consent, and off-limit topics stable across edits.',
+    bullets: [
+      'Boundary reminders before risky turns',
+      'Recovery phrasing when canon gets shaky',
+    ],
+  },
+] as const;
+
+function hasPaidOperatorPlan(plan?: string) {
+  return Boolean(plan && PAID_OPERATOR_PLANS.has(plan));
+}
+
 export function AgentLorebookForm({ settings }: AgentLorebookFormProps) {
   const [form, setForm] = useState(() =>
     cloneLorebook(settings.initialLorebook)
@@ -138,10 +181,14 @@ export function AgentLorebookForm({ settings }: AgentLorebookFormProps) {
     CONTENT_LIMITS.MAX_LOREBOOK_ENTRIES_PER_SECTION;
   const totalEntries =
     form.people.length + form.places.length + form.rules.length;
+  const savedEntryCount =
+    lastSaved.people.length + lastSaved.places.length + lastSaved.rules.length;
   const lastSavedLabel = formatSavedAt(lastSaved.updatedAt);
   const canAddPeople = form.people.length < maxEntriesPerSection;
   const canAddPlaces = form.places.length < maxEntriesPerSection;
   const canAddRules = form.rules.length < maxEntriesPerSection;
+  const shouldShowUpgradeTeaser =
+    savedEntryCount > 0 && !hasPaidOperatorPlan(settings.developerPlan);
 
   function updatePeople(nextPeople: LorebookPersonEntry[]) {
     setForm((current) => ({
@@ -652,6 +699,69 @@ export function AgentLorebookForm({ settings }: AgentLorebookFormProps) {
             ) : null}
           </div>
         </div>
+
+        {shouldShowUpgradeTeaser ? (
+          <div
+            className="rounded-xl border border-primary/20 bg-primary/5 p-4"
+            data-testid="lorebook-upgrade-teaser"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-2">
+                <Badge
+                  className="border-primary/30 bg-background/80 text-foreground"
+                  variant="outline"
+                >
+                  <Lock className="mr-1 h-3.5 w-3.5" />
+                  Locked canon templates
+                </Badge>
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-foreground">
+                    First structured save complete. Preview the canon packs paid
+                    Operator tiers unlock next.
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    Keep people, places, and rules structured now, then unlock
+                    reusable relationship anchors, scene starters, and safety
+                    rails without rebuilding canon from scratch.
+                  </p>
+                </div>
+              </div>
+              <Button asChild size="sm" type="button">
+                <Link href="/dashboard/billing">Compare Operator tiers</Link>
+              </Button>
+            </div>
+
+            <div className="mt-4 grid gap-3 xl:grid-cols-3">
+              {LOCKED_CANON_TEMPLATES.map((template) => (
+                <div
+                  className="rounded-lg border border-border/60 bg-background/80 p-3"
+                  data-testid={`lorebook-upgrade-template-${template.id}`}
+                  key={template.id}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">
+                        {template.title}
+                      </p>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {template.summary}
+                      </p>
+                    </div>
+                    <Lock className="mt-0.5 h-4 w-4 text-primary" />
+                  </div>
+                  <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+                    {template.bullets.map((bullet) => (
+                      <li className="flex gap-2" key={bullet}>
+                        <span className="text-primary">•</span>
+                        <span>{bullet}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
 
         <div
           className={`rounded-lg border p-3 text-sm ${

--- a/docs/pr-evidence/lorebook-upgrade-teaser.md
+++ b/docs/pr-evidence/lorebook-upgrade-teaser.md
@@ -1,0 +1,24 @@
+# Lorebook upgrade teaser evidence
+
+## Summary
+- Adds a locked canon template teaser to the dashboard lorebook form after the first structured save.
+- Shows an Operator-tier CTA for free creators directly from the teaser.
+- Updates the public quickstart doc so creators know where the teaser appears and where the upgrade link goes.
+
+## Durable paths
+- UI surface: `apps/web/components/dashboard/AgentLorebookForm.tsx`
+- Settings wiring: `apps/web/app/(protected)/dashboard/settings/page.tsx`
+- Public docs note: `apps/web/app/(public)/docs/quickstart/page.tsx`
+- Focused tests: `apps/web/__tests__/components/agent-lorebook-form.test.tsx`, `apps/web/__tests__/components/proactive-controls-settings.test.tsx`, `apps/web/__tests__/components/quickstart-page.test.tsx`
+
+## Example diff
+```diff
++ After a first structured lorebook save, the dashboard shows a "Locked canon templates" teaser.
++ The teaser previews relationship anchor, scene starter, and safety rail canon packs.
++ Free-plan creators get a "Compare Operator tiers" CTA to /dashboard/billing.
++ Quickstart now documents that /dashboard/settings is where the teaser appears after the first save.
+```
+
+## Validation
+- `pnpm --filter web test -- apps/web/__tests__/components/agent-lorebook-form.test.tsx apps/web/__tests__/components/proactive-controls-settings.test.tsx apps/web/__tests__/components/quickstart-page.test.tsx`
+- `pnpm --filter web type-check`


### PR DESCRIPTION
Source: backlog.md:45

## Summary
- show a locked canon-template teaser in the lorebook form after the first structured save
- wire the current developer plan into settings so free creators get the upgrade CTA and paid plans skip the teaser
- document the teaser path in quickstart and cover the new behavior with focused component tests

## Testing
- `pnpm exec vitest run __tests__/components/agent-lorebook-form.test.tsx __tests__/components/proactive-controls-settings.test.tsx __tests__/components/quickstart-page.test.tsx`
- `pnpm --filter web type-check`

## Evidence
- UI + logic: `apps/web/components/dashboard/AgentLorebookForm.tsx`
- Settings wiring: `apps/web/app/(protected)/dashboard/settings/page.tsx`
- Quickstart doc update: `apps/web/app/(public)/docs/quickstart/page.tsx`
- Durable evidence note: `docs/pr-evidence/lorebook-upgrade-teaser.md`
