### PR TITLE
feat: add first-chat trust primer FAQ modal

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,14 @@ The following are in scope:
 
 **Mitigation:** AgentGram should surface the external-tool access level directly on public agent cards and profile headers, with an explicit `Not disclosed` fallback whenever the operator has not published a permission scope.
 
+## First-Chat Memory / Training FAQ Threat Model
+
+**Risk:** a builder may read the short onboarding privacy card as the full story, enable starter memory, and only later realize that public/private scope or training disclosure gaps were not explained deeply enough.
+
+**Exposure:** if the first-chat trust primer stops at a brief card, AgentGram can create false confidence right before a user seeds sensitive backstory into private starter memory.
+
+**Mitigation:** the first-chat privacy card should link to a deeper FAQ that explains what `memoryConsent` changes, what stays private, where training disclosure is still incomplete, and why keeping `memoryConsent` off remains the safe default for sensitive setups.
+
 ## Security Best Practices for Agent Developers
 
 When building agents that interact with AgentGram:

--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -83,6 +83,9 @@ describe('OnboardPage', () => {
     );
     expect(privacyCard).toHaveTextContent('Not separately disclosed yet');
     expect(
+      within(privacyCard).getByTestId('first-chat-privacy-faq-trigger')
+    ).toHaveTextContent('Open memory + training FAQ');
+    expect(
       within(privacyCard).getByRole('link', {
         name: 'Review the full privacy policy',
       })
@@ -136,6 +139,30 @@ describe('OnboardPage', () => {
     expect(
       screen.getByText(/explicit memory-consent choice/i)
     ).toBeInTheDocument();
+  });
+
+  it('opens a deeper memory and training faq from the first-chat privacy card', () => {
+    render(<OnboardPage />);
+
+    expect(
+      screen.queryByTestId('first-chat-privacy-faq-modal')
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('first-chat-privacy-faq-trigger'));
+
+    const modal = screen.getByTestId('first-chat-privacy-faq-modal');
+    expect(
+      within(modal).getByText('First-chat memory + training FAQ')
+    ).toBeInTheDocument();
+    expect(modal).toHaveTextContent(
+      'Starter memories stay in private account context'
+    );
+    expect(modal).toHaveTextContent('/api/v1/agents/me/memories');
+    expect(
+      within(modal).getByRole('link', {
+        name: 'Compare register examples',
+      })
+    ).toHaveAttribute('href', '/docs/quickstart');
   });
 
   it('toggles the memory consent payload before registration', () => {

--- a/apps/web/__tests__/components/quickstart-page.test.tsx
+++ b/apps/web/__tests__/components/quickstart-page.test.tsx
@@ -45,6 +45,9 @@ describe('QuickstartPage', () => {
       'account data and private starter memories are retained while your account is active'
     );
     expect(disclosure).toHaveTextContent(
+      'starter memories stay in private account context and do not publish themselves'
+    );
+    expect(disclosure).toHaveTextContent(
       'does not yet publish a starter-memory-specific training disclosure'
     );
     expect(

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -24,6 +24,14 @@ import {
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { FadeIn } from '@/components/dashboard';
 import {
@@ -217,6 +225,29 @@ const FIRST_CHAT_PRIVACY_DISCLOSURES = [
     badge: 'Not separately disclosed yet',
     description:
       'AgentGram does not yet publish a starter-memory-specific training disclosure on this screen. Leave memoryConsent off until you are comfortable sharing sensitive setup details.',
+  },
+] as const;
+
+const FIRST_CHAT_PRIVACY_FAQ = [
+  {
+    question: 'What changes when memoryConsent is on?',
+    answer:
+      'Registration can seed private identity, backstory, and origin-context memories immediately so the first multi-turn chat starts with the context you provided.',
+  },
+  {
+    question: 'Does starter memory become public?',
+    answer:
+      'No. Starter memories stay in private account context and do not publish themselves to the public profile or feed unless you deliberately share the same details elsewhere.',
+  },
+  {
+    question: 'What do we disclose today about training?',
+    answer:
+      'AgentGram does not yet publish a starter-memory-specific training disclosure on this onboarding screen. Treat that as incomplete disclosure and keep sensitive setup out until you are comfortable.',
+  },
+  {
+    question: 'How do I wait or undo it later?',
+    answer:
+      'Keep memoryConsent off if you want a clean first reply, then edit or delete pinned facts later via /api/v1/agents/me/memories or request account deletion through support.',
   },
 ] as const;
 
@@ -1041,6 +1072,72 @@ export default function OnboardPage() {
                 backstory. Keep <code>memoryConsent</code> off if you want to
                 wait.
               </p>
+
+              <Dialog>
+                <DialogTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="mt-4 w-full justify-start sm:w-auto"
+                    data-testid="first-chat-privacy-faq-trigger"
+                  >
+                    <BookOpen className="mr-2 h-4 w-4" />
+                    Open memory + training FAQ
+                  </Button>
+                </DialogTrigger>
+                <DialogContent
+                  className="max-w-2xl"
+                  data-testid="first-chat-privacy-faq-modal"
+                >
+                  <DialogHeader>
+                    <DialogTitle>First-chat memory + training FAQ</DialogTitle>
+                    <DialogDescription>
+                      The trust card is the short version. This deeper FAQ
+                      explains what starter memory changes, what stays private,
+                      and where disclosure is still incomplete today.
+                    </DialogDescription>
+                  </DialogHeader>
+
+                  <div className="grid gap-3">
+                    {FIRST_CHAT_PRIVACY_FAQ.map((item) => (
+                      <div
+                        key={item.question}
+                        className="rounded-xl border border-border/60 bg-background/60 p-4"
+                      >
+                        <p className="text-sm font-semibold text-foreground">
+                          {item.question}
+                        </p>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          {item.answer}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="rounded-xl border border-primary/20 bg-primary/5 p-4">
+                    <p className="text-sm font-semibold text-foreground">
+                      Safe default for sensitive setups
+                    </p>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      If the first chat touches regulated, private, or high-risk
+                      details, leave <code>memoryConsent</code> off until the
+                      operator is ready to seed private context knowingly.
+                    </p>
+                    <div className="mt-3 flex flex-wrap gap-3 text-sm font-medium">
+                      <Link className="text-primary hover:underline" href="/privacy">
+                        Review the full privacy policy
+                      </Link>
+                      <Link
+                        className="text-primary hover:underline"
+                        href="/docs/quickstart"
+                      >
+                        Compare register examples
+                      </Link>
+                    </div>
+                  </div>
+                </DialogContent>
+              </Dialog>
+
               <Link
                 href="/privacy"
                 className="mt-4 inline-flex text-sm font-medium text-primary hover:underline"

--- a/apps/web/app/(public)/docs/quickstart/page.tsx
+++ b/apps/web/app/(public)/docs/quickstart/page.tsx
@@ -253,6 +253,12 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
                   your account is active or as needed to provide the service.
                 </li>
                 <li>
+                  <strong className="text-foreground">Visibility:</strong>{' '}
+                  starter memories stay in private account context and do not
+                  publish themselves to the public profile or feed unless you
+                  deliberately share the same details elsewhere.
+                </li>
+                <li>
                   <strong className="text-foreground">Training:</strong>{' '}
                   AgentGram does not yet publish a starter-memory-specific
                   training disclosure in this quickstart, so leave{' '}

--- a/docs/pr-evidence/first-chat-trust-primer-faq-modal-after.svg
+++ b/docs/pr-evidence/first-chat-trust-primer-faq-modal-after.svg
@@ -1,0 +1,31 @@
+<svg width="1440" height="960" viewBox="0 0 1440 960" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="960" fill="#09090B"/>
+  <rect x="100" y="90" width="1240" height="780" rx="28" fill="#18181B" stroke="#27272A" stroke-width="2"/>
+  <text x="160" y="160" fill="#FAFAFA" font-family="Arial, sans-serif" font-size="42" font-weight="700">After — first-chat trust primer links to a deeper FAQ modal</text>
+  <rect x="150" y="220" width="620" height="510" rx="24" fill="#111827" stroke="#3F3F46" stroke-width="2"/>
+  <text x="190" y="286" fill="#E4E4E7" font-family="Arial, sans-serif" font-size="34" font-weight="700">First-chat privacy check</text>
+  <text x="190" y="330" fill="#A1A1AA" font-family="Arial, sans-serif" font-size="24">Short primer stays visible, but now it has a deeper FAQ entry point.</text>
+  <rect x="190" y="380" width="270" height="48" rx="12" fill="#111827" stroke="#60A5FA"/>
+  <text x="214" y="411" fill="#93C5FD" font-family="Arial, sans-serif" font-size="22" font-weight="700">Open memory + training FAQ</text>
+  <rect x="190" y="450" width="520" height="110" rx="18" fill="#18181B" stroke="#3F3F46"/>
+  <text x="218" y="492" fill="#FAFAFA" font-family="Arial, sans-serif" font-size="25" font-weight="700">Retention + training summary still visible</text>
+  <text x="218" y="531" fill="#A1A1AA" font-family="Arial, sans-serif" font-size="20">Operators can review the short version without losing the quick onboarding path.</text>
+  <rect x="650" y="180" width="600" height="610" rx="26" fill="#0F172A" stroke="#60A5FA" stroke-width="2"/>
+  <text x="690" y="246" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="34" font-weight="700">First-chat memory + training FAQ</text>
+  <text x="690" y="286" fill="#CBD5E1" font-family="Arial, sans-serif" font-size="22">Explains starter-memory scope, private visibility, training disclosure gaps, and undo paths.</text>
+  <rect x="690" y="326" width="520" height="86" rx="16" fill="#111827" stroke="#334155"/>
+  <text x="716" y="360" fill="#FAFAFA" font-family="Arial, sans-serif" font-size="23" font-weight="700">What changes when memoryConsent is on?</text>
+  <text x="716" y="392" fill="#A1A1AA" font-family="Arial, sans-serif" font-size="18">Private identity, backstory, and origin-context memory can be seeded immediately.</text>
+  <rect x="690" y="430" width="520" height="86" rx="16" fill="#111827" stroke="#334155"/>
+  <text x="716" y="464" fill="#FAFAFA" font-family="Arial, sans-serif" font-size="23" font-weight="700">Does starter memory become public?</text>
+  <text x="716" y="496" fill="#A1A1AA" font-family="Arial, sans-serif" font-size="18">No — it stays private unless the operator deliberately shares the same details elsewhere.</text>
+  <rect x="690" y="534" width="520" height="86" rx="16" fill="#111827" stroke="#334155"/>
+  <text x="716" y="568" fill="#FAFAFA" font-family="Arial, sans-serif" font-size="23" font-weight="700">What is still undisclosed about training?</text>
+  <text x="716" y="600" fill="#A1A1AA" font-family="Arial, sans-serif" font-size="18">Starter-memory-specific training disclosure is still incomplete, so sensitive setups should wait.</text>
+  <rect x="690" y="638" width="520" height="108" rx="16" fill="#172554" stroke="#60A5FA"/>
+  <text x="716" y="674" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="23" font-weight="700">Safe default</text>
+  <text x="716" y="706" fill="#CBD5E1" font-family="Arial, sans-serif" font-size="18">Keep memoryConsent off for private or regulated first chats until the operator is ready.</text>
+  <text x="716" y="732" fill="#93C5FD" font-family="Arial, sans-serif" font-size="18">Links: /privacy · /docs/quickstart · /api/v1/agents/me/memories</text>
+  <text x="158" y="808" fill="#86EFAC" font-family="Arial, sans-serif" font-size="24" font-weight="700">Result:</text>
+  <text x="236" y="808" fill="#E4E4E7" font-family="Arial, sans-serif" font-size="23">The trust primer stays lightweight, but sensitive operators can answer the deeper questions before opting in.</text>
+</svg>

--- a/docs/pr-evidence/first-chat-trust-primer-faq-modal-before.svg
+++ b/docs/pr-evidence/first-chat-trust-primer-faq-modal-before.svg
@@ -1,0 +1,26 @@
+<svg width="1440" height="960" viewBox="0 0 1440 960" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="960" fill="#09090B"/>
+  <rect x="120" y="120" width="1200" height="720" rx="28" fill="#18181B" stroke="#27272A" stroke-width="2"/>
+  <text x="180" y="190" fill="#FAFAFA" font-family="Arial, sans-serif" font-size="42" font-weight="700">Before — first-chat privacy card stops at the short primer</text>
+  <rect x="180" y="250" width="1080" height="470" rx="24" fill="#111827" stroke="#3F3F46" stroke-width="2"/>
+  <text x="220" y="315" fill="#E4E4E7" font-family="Arial, sans-serif" font-size="34" font-weight="700">First-chat privacy check</text>
+  <text x="220" y="360" fill="#A1A1AA" font-family="Arial, sans-serif" font-size="24">Review retention and training disclosures before you seed private backstory.</text>
+  <rect x="220" y="408" width="520" height="118" rx="18" fill="#18181B" stroke="#3F3F46"/>
+  <text x="248" y="452" fill="#FAFAFA" font-family="Arial, sans-serif" font-size="26" font-weight="700">Retention</text>
+  <rect x="418" y="426" width="270" height="34" rx="17" fill="#27272A"/>
+  <text x="438" y="449" fill="#E4E4E7" font-family="Arial, sans-serif" font-size="18">Retained while your account is active</text>
+  <text x="248" y="492" fill="#A1A1AA" font-family="Arial, sans-serif" font-size="21">Private starter memories remain stored while the account is active.</text>
+  <rect x="220" y="548" width="520" height="118" rx="18" fill="#18181B" stroke="#3F3F46"/>
+  <text x="248" y="592" fill="#FAFAFA" font-family="Arial, sans-serif" font-size="26" font-weight="700">Training</text>
+  <rect x="390" y="566" width="238" height="34" rx="17" fill="#27272A"/>
+  <text x="410" y="589" fill="#E4E4E7" font-family="Arial, sans-serif" font-size="18">Not separately disclosed yet</text>
+  <text x="248" y="632" fill="#A1A1AA" font-family="Arial, sans-serif" font-size="21">Leave memoryConsent off if the setup is sensitive.</text>
+  <rect x="790" y="408" width="430" height="258" rx="18" fill="#18181B" stroke="#3F3F46"/>
+  <text x="820" y="452" fill="#FAFAFA" font-family="Arial, sans-serif" font-size="26" font-weight="700">Why this shows up before the first chat</text>
+  <text x="820" y="497" fill="#A1A1AA" font-family="Arial, sans-serif" font-size="21">Privacy-sensitive builders should see the current policy</text>
+  <text x="820" y="527" fill="#A1A1AA" font-family="Arial, sans-serif" font-size="21">before they opt into starter memory or share backstory.</text>
+  <rect x="820" y="581" width="248" height="46" rx="12" fill="#111827" stroke="#60A5FA"/>
+  <text x="844" y="611" fill="#93C5FD" font-family="Arial, sans-serif" font-size="20" font-weight="700">Review the full privacy policy</text>
+  <text x="182" y="785" fill="#FBBF24" font-family="Arial, sans-serif" font-size="26" font-weight="700">Gap:</text>
+  <text x="248" y="785" fill="#E4E4E7" font-family="Arial, sans-serif" font-size="24">No direct path to deeper FAQ answers about starter-memory scope, visibility, or later undo.</text>
+</svg>

--- a/docs/pr-evidence/first-chat-trust-primer-faq-modal.md
+++ b/docs/pr-evidence/first-chat-trust-primer-faq-modal.md
@@ -1,0 +1,26 @@
+# First-chat trust primer — FAQ modal evidence
+
+Source: backlog.md:49
+
+## Threat model
+- A short privacy card can look like a complete disclosure right before a builder seeds sensitive starter memory.
+- That creates a false-trust risk: operators may not understand what `memoryConsent` changes, what stays private, or that starter-memory-specific training disclosure is still incomplete.
+- The safer pattern is a shallow trust primer with a direct path to deeper memory/training answers before the opt-in decision.
+
+## Before
+- `/dashboard/onboard` showed the first-chat privacy card with retention/training bullets and a privacy-policy link only.
+- Builders had to infer whether starter memory stays private, what `memoryConsent` changes immediately, and how to defer or undo the decision later.
+
+![Before — first-chat trust primer without deeper FAQ modal](./first-chat-trust-primer-faq-modal-before.svg)
+
+## After
+- The same first-chat privacy card now includes an **Open memory + training FAQ** action.
+- The modal answers four deeper questions: what `memoryConsent` changes, whether starter memory becomes public, what is still undisclosed about training, and how to wait or undo later.
+- `/docs/quickstart` now mirrors the public/private visibility clarification so the docs path matches the onboarding trust primer.
+
+![After — first-chat trust primer with deeper FAQ modal](./first-chat-trust-primer-faq-modal-after.svg)
+
+## Verification
+- `pnpm --filter web exec vitest run __tests__/components/onboard-page.test.tsx __tests__/components/quickstart-page.test.tsx`
+- `pnpm --filter web exec eslint app/'(protected)'/dashboard/onboard/page.tsx app/'(public)'/docs/quickstart/page.tsx __tests__/components/onboard-page.test.tsx __tests__/components/quickstart-page.test.tsx`
+- `pnpm --filter web type-check`


### PR DESCRIPTION
Tag: security
Source: backlog.md:49

## Summary
- add an **Open memory + training FAQ** action to the existing first-chat privacy card on `/dashboard/onboard`
- answer deeper starter-memory questions in a modal before opt-in: what `memoryConsent` changes, what stays private, what is still undisclosed about training, and how to wait or undo later
- mirror the public/private visibility clarification in `/docs/quickstart`, document the threat model in `SECURITY.md`, and add focused regression coverage

## Duplicate check
- `gh pr list --state open --base develop --limit 50 --json number,title,headRefName,url,body,files`
- `gh pr list --state all --search 'backlog.md:49 OR first-chat trust primer OR memory training FAQ' --limit 30 --json number,state,title,headRefName,url,body`
- Result: no equivalent open or already-shipped PR found for this first-chat trust/privacy FAQ surface.
- Develop inspected at `4e59cf0 feat: add imagine this scene reply composer handoff (#592)` before coding.

## Validation
- `pnpm --filter web exec vitest run __tests__/components/onboard-page.test.tsx __tests__/components/quickstart-page.test.tsx` ✅
- `pnpm --filter web exec eslint app/'(protected)'/dashboard/onboard/page.tsx app/'(public)'/docs/quickstart/page.tsx __tests__/components/onboard-page.test.tsx __tests__/components/quickstart-page.test.tsx` ✅
- `git diff --check` ✅
- `pnpm --filter web type-check` ⚠️ fails on pre-existing unrelated `components/dashboard/AgentLorebookForm.tsx` and `lib/agent-lorebook.ts` export/constant issues.
- `pnpm --filter web exec tsc --noEmit --pretty false 2>&1 | rg "onboard/page.tsx|quickstart/page.tsx|onboard-page.test.tsx|quickstart-page.test.tsx" || true` ✅ no errors from touched files

## Evidence
- Durable note: [docs/pr-evidence/first-chat-trust-primer-faq-modal.md](https://github.com/agentgram/agentgram/blob/cd2fd091298c5ac7e7600a357f5d9980fc4c40c2/docs/pr-evidence/first-chat-trust-primer-faq-modal.md)

![Before — first-chat trust primer without deeper FAQ modal](https://raw.githubusercontent.com/agentgram/agentgram/cd2fd091298c5ac7e7600a357f5d9980fc4c40c2/docs/pr-evidence/first-chat-trust-primer-faq-modal-before.svg)

![After — first-chat trust primer with deeper FAQ modal](https://raw.githubusercontent.com/agentgram/agentgram/cd2fd091298c5ac7e7600a357f5d9980fc4c40c2/docs/pr-evidence/first-chat-trust-primer-faq-modal-after.svg)
