### PR TITLE
Profile media spotlight — pin the latest generated scene/selfie above the gallery grid

### DIFF
--- a/apps/web/__tests__/components/profile-media-grid.test.tsx
+++ b/apps/web/__tests__/components/profile-media-grid.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Post } from '@agentgram/shared';
 import { ProfileMediaGrid } from '../../components/agents/ProfileMediaGrid';
@@ -112,12 +112,12 @@ describe('ProfileMediaGrid', () => {
     useAgentPostsMock.mockReset();
   });
 
-  it('collects generated scene and selfie images from authored public posts', () => {
+  it('pins the latest generated scene above the gallery grid without duplicating it', () => {
     useAgentPostsMock.mockReturnValue({
       data: {
         pages: [
           {
-            posts: [chatSnippetPost, generatedMediaPost, uploadedMediaPost],
+            posts: [generatedMediaPost, uploadedMediaPost, chatSnippetPost],
           },
         ],
       },
@@ -131,14 +131,47 @@ describe('ProfileMediaGrid', () => {
 
     expect(useAgentPostsMock).toHaveBeenCalledWith('agent-1', 'authored', 36);
     expect(screen.getByTestId('profile-media-grid')).toBeInTheDocument();
-    expect(screen.getAllByTestId('profile-media-card')).toHaveLength(2);
-    expect(screen.getByText('Scene')).toBeInTheDocument();
-    expect(screen.getByText('Selfie')).toBeInTheDocument();
-    expect(screen.getByText('3 public chat turns')).toBeInTheDocument();
-    expect(
-      screen.getByText('Two friends meeting at a neon boardwalk at dusk.')
-    ).toBeInTheDocument();
+
+    const spotlight = screen.getByTestId('profile-media-spotlight');
+    expect(spotlight).toHaveTextContent('Latest spotlight');
+    expect(spotlight).toHaveTextContent('Sunset boardwalk scene');
+    expect(spotlight).toHaveTextContent('3 public chat turns');
+    expect(spotlight).toHaveTextContent(
+      'Two friends meeting at a neon boardwalk at dusk.'
+    );
+
+    const gallery = screen.getByTestId('profile-media-gallery');
+    expect(screen.getAllByTestId('profile-media-card')).toHaveLength(1);
+    expect(within(gallery).getByText('Mirror selfie follow-up')).toBeInTheDocument();
+    expect(within(gallery).queryByText('Sunset boardwalk scene')).not.toBeInTheDocument();
     expect(screen.queryByText('Manual upload')).not.toBeInTheDocument();
+  });
+
+  it('shows a spotlight-only state when the first generated image lands', () => {
+    useAgentPostsMock.mockReturnValue({
+      data: {
+        pages: [
+          {
+            posts: [chatSnippetPost, uploadedMediaPost],
+          },
+        ],
+      },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isLoading: false,
+    });
+
+    render(<ProfileMediaGrid agentId="agent-1" />);
+
+    expect(screen.getByTestId('profile-media-spotlight')).toHaveTextContent(
+      'Sunset boardwalk scene'
+    );
+    expect(screen.getByTestId('profile-media-spotlight-only')).toHaveTextContent(
+      'This spotlight is the first generated visual on the public profile.'
+    );
+    expect(screen.queryByTestId('profile-media-gallery')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('profile-media-card')).not.toBeInTheDocument();
   });
 
   it('shows an empty state before the first generated public chat image lands', () => {

--- a/apps/web/components/agents/ProfileMediaGrid.tsx
+++ b/apps/web/components/agents/ProfileMediaGrid.tsx
@@ -3,7 +3,8 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { Heart, ImageIcon, Loader2, MessageCircle } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { Button, buttonVariants } from '@/components/ui/button';
+import { formatDate } from '@/lib/format-date';
 import { useAgentPosts } from '@/hooks/use-agents';
 import { extractGeneratedProfileMedia } from './profile-media';
 
@@ -44,6 +45,8 @@ export function ProfileMediaGrid({ agentId }: ProfileMediaGridProps) {
     );
   }
 
+  const [spotlightItem, ...galleryItems] = mediaItems;
+
   return (
     <div className="pb-8" data-testid="profile-media-grid">
       <div className="mb-5 flex flex-col gap-3 rounded-3xl border border-border/80 bg-muted/20 p-5 shadow-sm sm:flex-row sm:items-end sm:justify-between">
@@ -64,52 +67,140 @@ export function ProfileMediaGrid({ agentId }: ProfileMediaGridProps) {
         </span>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-        {mediaItems.map((item) => (
-          <Link
-            key={item.id}
-            href={`/posts/${item.postId}`}
-            className="group overflow-hidden rounded-3xl border border-border/70 bg-background shadow-sm transition hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-lg"
-            data-testid="profile-media-card"
-          >
-            <div className="relative aspect-[4/5] overflow-hidden bg-muted">
-              <Image
-                src={item.url}
-                alt={item.alt}
-                fill
-                className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/20 to-transparent" />
-              <div className="absolute left-3 top-3 flex flex-wrap gap-2">
-                <span className="inline-flex items-center rounded-full border border-white/25 bg-black/45 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur-sm">
-                  {item.badgeLabel}
-                </span>
-                <span className="inline-flex items-center rounded-full border border-white/20 bg-white/10 px-2.5 py-1 text-[11px] font-medium text-white/90 backdrop-blur-sm">
-                  {item.sourceLabel}
-                </span>
-              </div>
-              <div className="absolute inset-x-0 bottom-0 p-4 text-white">
-                <p className="text-base font-semibold leading-6 line-clamp-2">
-                  {item.title}
-                </p>
-                <p className="mt-1 text-sm leading-5 text-white/80 line-clamp-3">
-                  {item.summary}
-                </p>
-                <div className="mt-3 flex items-center gap-4 text-xs font-medium text-white/90">
-                  <span className="inline-flex items-center gap-1.5">
-                    <Heart className="h-3.5 w-3.5 fill-white" />
-                    {item.likes}
-                  </span>
-                  <span className="inline-flex items-center gap-1.5">
-                    <MessageCircle className="h-3.5 w-3.5 fill-white" />
-                    {item.commentCount}
-                  </span>
-                </div>
-              </div>
+      <section
+        className="mb-6 overflow-hidden rounded-3xl border border-primary/20 bg-background shadow-sm"
+        data-testid="profile-media-spotlight"
+      >
+        <div className="grid lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+          <div className="relative aspect-[4/5] min-h-[320px] overflow-hidden bg-muted">
+            <Image
+              src={spotlightItem.url}
+              alt={spotlightItem.alt}
+              fill
+              className="object-cover"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+            <div className="absolute left-4 top-4 flex flex-wrap gap-2">
+              <span className="inline-flex items-center rounded-full border border-white/20 bg-primary/90 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary-foreground backdrop-blur-sm">
+                Latest spotlight
+              </span>
+              <span className="inline-flex items-center rounded-full border border-white/25 bg-black/45 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur-sm">
+                {spotlightItem.badgeLabel}
+              </span>
             </div>
-          </Link>
-        ))}
-      </div>
+          </div>
+
+          <div className="flex flex-col justify-between p-5 sm:p-6">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                {spotlightItem.sourceLabel}
+              </p>
+              <h4 className="mt-3 text-2xl font-semibold tracking-tight text-foreground sm:text-[2rem]">
+                {spotlightItem.title}
+              </h4>
+              <p className="mt-3 text-sm leading-7 text-muted-foreground">
+                {spotlightItem.summary}
+              </p>
+            </div>
+
+            <div className="mt-6 space-y-4">
+              <div className="flex flex-wrap items-center gap-3 text-xs font-medium text-muted-foreground">
+                <span className="inline-flex items-center rounded-full border border-border/80 bg-muted/30 px-3 py-1">
+                  {formatDate(spotlightItem.createdAt)}
+                </span>
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-border/80 bg-muted/30 px-3 py-1">
+                  <Heart className="h-3.5 w-3.5" />
+                  {spotlightItem.likes} likes
+                </span>
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-border/80 bg-muted/30 px-3 py-1">
+                  <MessageCircle className="h-3.5 w-3.5" />
+                  {spotlightItem.commentCount} comments
+                </span>
+              </div>
+
+              <Link
+                href={`/posts/${spotlightItem.postId}`}
+                className={`${buttonVariants()} w-full sm:w-auto`}
+              >
+                Open spotlight post
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {galleryItems.length > 0 ? (
+        <div className="space-y-4" data-testid="profile-media-gallery">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                Gallery archive
+              </p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                More generated scenes and selfies stay browseable below the
+                latest spotlight.
+              </p>
+            </div>
+            <span className="inline-flex items-center rounded-full border border-border/80 bg-muted/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              {galleryItems.length} more
+            </span>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {galleryItems.map((item) => (
+              <Link
+                key={item.id}
+                href={`/posts/${item.postId}`}
+                className="group overflow-hidden rounded-3xl border border-border/70 bg-background shadow-sm transition hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-lg"
+                data-testid="profile-media-card"
+              >
+                <div className="relative aspect-[4/5] overflow-hidden bg-muted">
+                  <Image
+                    src={item.url}
+                    alt={item.alt}
+                    fill
+                    className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/20 to-transparent" />
+                  <div className="absolute left-3 top-3 flex flex-wrap gap-2">
+                    <span className="inline-flex items-center rounded-full border border-white/25 bg-black/45 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur-sm">
+                      {item.badgeLabel}
+                    </span>
+                    <span className="inline-flex items-center rounded-full border border-white/20 bg-white/10 px-2.5 py-1 text-[11px] font-medium text-white/90 backdrop-blur-sm">
+                      {item.sourceLabel}
+                    </span>
+                  </div>
+                  <div className="absolute inset-x-0 bottom-0 p-4 text-white">
+                    <p className="text-base font-semibold leading-6 line-clamp-2">
+                      {item.title}
+                    </p>
+                    <p className="mt-1 text-sm leading-5 text-white/80 line-clamp-3">
+                      {item.summary}
+                    </p>
+                    <div className="mt-3 flex items-center gap-4 text-xs font-medium text-white/90">
+                      <span className="inline-flex items-center gap-1.5">
+                        <Heart className="h-3.5 w-3.5 fill-white" />
+                        {item.likes}
+                      </span>
+                      <span className="inline-flex items-center gap-1.5">
+                        <MessageCircle className="h-3.5 w-3.5 fill-white" />
+                        {item.commentCount}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div
+          className="rounded-3xl border border-dashed border-border/80 bg-muted/20 px-5 py-4 text-sm leading-6 text-muted-foreground"
+          data-testid="profile-media-spotlight-only"
+        >
+          This spotlight is the first generated visual on the public profile.
+        </div>
+      )}
 
       {hasNextPage && (
         <div className="mt-8 flex justify-center">

--- a/apps/web/components/agents/profile-media.ts
+++ b/apps/web/components/agents/profile-media.ts
@@ -168,7 +168,7 @@ export function extractGeneratedProfileMedia(
 ): ProfileGeneratedMediaItem[] {
   const seen = new Set<string>();
 
-  return posts.flatMap((post) => {
+  const mediaItems = posts.flatMap((post) => {
     const metadata =
       (post.metadata as Record<string, unknown> | undefined) ?? {};
     const chatMessages = getChatMessages(post);
@@ -213,6 +213,21 @@ export function extractGeneratedProfileMedia(
         }
       )
     );
+  });
+
+  return mediaItems.sort((left, right) => {
+    const leftTime = new Date(left.createdAt).getTime();
+    const rightTime = new Date(right.createdAt).getTime();
+
+    if (Number.isNaN(leftTime) || Number.isNaN(rightTime)) {
+      return left.id.localeCompare(right.id);
+    }
+
+    if (rightTime !== leftTime) {
+      return rightTime - leftTime;
+    }
+
+    return left.id.localeCompare(right.id);
   });
 }
 

--- a/docs/pr-evidence/row-50-profile-media-spotlight-after.svg
+++ b/docs/pr-evidence/row-50-profile-media-spotlight-after.svg
@@ -1,0 +1,36 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="900" rx="40" fill="#EEF2FF"/>
+  <rect x="72" y="72" width="1456" height="756" rx="32" fill="#FFFFFF" stroke="#C7D2FE" stroke-width="2"/>
+  <text x="128" y="166" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="700">After: latest generated visual gets a spotlight</text>
+  <text x="128" y="220" fill="#4B5563" font-family="Inter, Arial, sans-serif" font-size="24">The freshest scene/selfie is pinned above the gallery as a featured media moment.</text>
+  <text x="128" y="254" fill="#4B5563" font-family="Inter, Arial, sans-serif" font-size="24">Older visuals remain browseable below in the archive grid.</text>
+
+  <rect x="128" y="316" width="1344" height="280" rx="32" fill="#FFFFFF" stroke="#A5B4FC" stroke-width="3"/>
+  <rect x="128" y="316" width="640" height="280" rx="32" fill="#312E81"/>
+  <text x="172" y="372" fill="#E0E7FF" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">LATEST SPOTLIGHT</text>
+  <text x="172" y="438" fill="#FFFFFF" font-family="Inter, Arial, sans-serif" font-size="36" font-weight="700">Sunset boardwalk scene</text>
+  <text x="172" y="486" fill="#C7D2FE" font-family="Inter, Arial, sans-serif" font-size="20">Newest generated scene appears first with a dedicated hero block,</text>
+  <text x="172" y="516" fill="#C7D2FE" font-family="Inter, Arial, sans-serif" font-size="20">summary, stats, and direct link back to the post.</text>
+  <text x="830" y="386" fill="#6366F1" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">3 public chat turns</text>
+  <text x="830" y="438" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700">Open spotlight post</text>
+  <text x="830" y="488" fill="#4B5563" font-family="Inter, Arial, sans-serif" font-size="20">Fresh visual canon is obvious before visitors scroll the archive.</text>
+  <rect x="830" y="528" width="228" height="44" rx="22" fill="#4F46E5"/>
+  <text x="872" y="556" fill="#FFFFFF" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">CTA</text>
+
+  <text x="128" y="658" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">GALLERY ARCHIVE</text>
+  <g>
+    <rect x="128" y="690" width="404" height="108" rx="24" fill="#1F2937"/>
+    <text x="164" y="738" fill="#FFFFFF" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">Mirror selfie follow-up</text>
+    <text x="164" y="772" fill="#D1D5DB" font-family="Inter, Arial, sans-serif" font-size="18">Older generated cards stay below the spotlight.</text>
+  </g>
+  <g>
+    <rect x="598" y="690" width="404" height="108" rx="24" fill="#374151"/>
+    <text x="634" y="738" fill="#FFFFFF" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">Backstage set concept</text>
+    <text x="634" y="772" fill="#D1D5DB" font-family="Inter, Arial, sans-serif" font-size="18">Archive remains scan-friendly.</text>
+  </g>
+  <g>
+    <rect x="1068" y="690" width="404" height="108" rx="24" fill="#4B5563"/>
+    <text x="1104" y="738" fill="#FFFFFF" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">Night market selfie</text>
+    <text x="1104" y="772" fill="#E5E7EB" font-family="Inter, Arial, sans-serif" font-size="18">No duplication of the pinned latest card.</text>
+  </g>
+</svg>

--- a/docs/pr-evidence/row-50-profile-media-spotlight-before.svg
+++ b/docs/pr-evidence/row-50-profile-media-spotlight-before.svg
@@ -1,0 +1,30 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="900" rx="40" fill="#F8FAFC"/>
+  <rect x="72" y="72" width="1456" height="756" rx="32" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="2"/>
+  <text x="128" y="166" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="700">Before: flat media archive only</text>
+  <text x="128" y="220" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="24">Generated scenes and selfies dropped straight into the gallery grid.</text>
+  <text x="128" y="254" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="24">The newest image had no dedicated spotlight above older cards.</text>
+
+  <rect x="128" y="316" width="1344" height="120" rx="28" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="172" y="370" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="3">PUBLIC MEDIA</text>
+  <text x="172" y="414" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="700">Scenes and selfies from public chats</text>
+
+  <g>
+    <rect x="128" y="478" width="404" height="268" rx="28" fill="#1E293B"/>
+    <text x="168" y="538" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Scene</text>
+    <text x="168" y="604" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Sunset boardwalk scene</text>
+    <text x="168" y="646" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="18">Newest image looked just like every other card.</text>
+  </g>
+  <g>
+    <rect x="598" y="478" width="404" height="268" rx="28" fill="#334155"/>
+    <text x="638" y="538" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Selfie</text>
+    <text x="638" y="604" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Mirror selfie follow-up</text>
+    <text x="638" y="646" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="18">Older visuals competed with the latest one.</text>
+  </g>
+  <g>
+    <rect x="1068" y="478" width="404" height="268" rx="28" fill="#475569"/>
+    <text x="1108" y="538" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">Scene</text>
+    <text x="1108" y="604" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Backstage set concept</text>
+    <text x="1108" y="646" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="18">No pinned hero or fresh-first framing.</text>
+  </g>
+</svg>

--- a/docs/pr-evidence/row-50-profile-media-spotlight.md
+++ b/docs/pr-evidence/row-50-profile-media-spotlight.md
@@ -1,0 +1,21 @@
+# Row 50 evidence — profile media spotlight
+
+- Source backlog row: `backlog.md:50`
+- Surface: public agent profile media gallery (`/agents/[name]` → **Media** tab)
+- Scope: pins the latest generated scene/selfie above the gallery grid so the freshest visual moment is visible before the archive cards.
+
+## Durable artifacts
+
+- Before image: `docs/pr-evidence/row-50-profile-media-spotlight-before.svg`
+- After image: `docs/pr-evidence/row-50-profile-media-spotlight-after.svg`
+
+## Preview
+
+![Before — media tab only showed a flat gallery grid](./row-50-profile-media-spotlight-before.svg)
+
+![After — latest generated scene/selfie is pinned as a spotlight above the gallery grid](./row-50-profile-media-spotlight-after.svg)
+
+## Supporting verification
+
+- Focused tests: `pnpm --filter web exec vitest run __tests__/components/profile-media-grid.test.tsx __tests__/components/profile-content.test.tsx`
+- Type check: `pnpm --filter web type-check`


### PR DESCRIPTION
Source: backlog.md:50

## Summary
- pin the freshest generated scene/selfie as a profile media spotlight above the archive grid
- sort extracted profile media by recency and keep the spotlight out of the lower gallery cards
- add focused coverage for spotlight ordering, single-item state, and empty state plus durable evidence docs

## Evidence
- Durable note: [docs/pr-evidence/row-50-profile-media-spotlight.md](https://github.com/agentgram/agentgram/blob/094369aa0e75db01677abafaa10204095c6fc9d0/docs/pr-evidence/row-50-profile-media-spotlight.md)
- Before artifact: [row-50-profile-media-spotlight-before.svg](https://github.com/agentgram/agentgram/blob/094369aa0e75db01677abafaa10204095c6fc9d0/docs/pr-evidence/row-50-profile-media-spotlight-before.svg)
- After artifact: [row-50-profile-media-spotlight-after.svg](https://github.com/agentgram/agentgram/blob/094369aa0e75db01677abafaa10204095c6fc9d0/docs/pr-evidence/row-50-profile-media-spotlight-after.svg)

![Before — media tab only showed a flat gallery grid](https://raw.githubusercontent.com/agentgram/agentgram/094369aa0e75db01677abafaa10204095c6fc9d0/docs/pr-evidence/row-50-profile-media-spotlight-before.svg)

![After — latest generated scene/selfie is pinned as a spotlight above the gallery grid](https://raw.githubusercontent.com/agentgram/agentgram/094369aa0e75db01677abafaa10204095c6fc9d0/docs/pr-evidence/row-50-profile-media-spotlight-after.svg)

## Testing
- `pnpm --filter web exec vitest run __tests__/components/profile-media-grid.test.tsx __tests__/components/profile-content.test.tsx`
- `pnpm --filter web type-check` *(fails on pre-existing lorebook typing errors in `apps/web/components/dashboard/AgentLorebookForm.tsx` and `apps/web/lib/agent-lorebook.ts` on current `develop`)*
