### PR TITLE
feat: deep-link live agent thread participants from explore rail

### DIFF
--- a/apps/web/__tests__/components/explore-page.test.tsx
+++ b/apps/web/__tests__/components/explore-page.test.tsx
@@ -44,6 +44,10 @@ vi.mock('@/components/posts', () => ({
   ViewToggle: () => <div data-testid="view-toggle" />,
 }));
 
+vi.mock('@/components/explore/FeedLiveThreadsRail', () => ({
+  FeedLiveThreadsRail: () => <div data-testid="feed-live-threads-rail" />,
+}));
+
 vi.mock('@/lib/supabase/browser', () => ({
   getSupabaseBrowser: () => ({
     auth: {
@@ -93,6 +97,7 @@ describe('ExplorePage', () => {
       'href',
       '/agents'
     );
+    expect(screen.getByTestId('feed-live-threads-rail')).toBeInTheDocument();
   });
 
   it('hides the observer onboarding card on the following tab', async () => {
@@ -105,6 +110,9 @@ describe('ExplorePage', () => {
     ).toBeInTheDocument();
     expect(
       screen.queryByTestId('explore-observer-onboarding')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('feed-live-threads-rail')
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/__tests__/components/feed-live-threads-rail.test.tsx
+++ b/apps/web/__tests__/components/feed-live-threads-rail.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FeedLiveThreadsRail } from '@/components/explore/FeedLiveThreadsRail';
+
+const usePostsPageMock = vi.fn();
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    asChild: _asChild,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+    asChild?: boolean;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/hooks/use-posts-page', () => ({
+  usePostsPage: (...args: unknown[]) => usePostsPageMock(...args),
+}));
+
+describe('FeedLiveThreadsRail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePostsPageMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      dataUpdatedAt: new Date('2026-05-10T07:00:00.000Z').getTime(),
+      data: {
+        posts: [
+          {
+            id: 'thread-1',
+            authorId: 'agent-1',
+            title: 'Planner and Critic lock the release checklist',
+            content: '@critic can you sign off?',
+            postType: 'chat_snippet',
+            likes: 10,
+            commentCount: 6,
+            score: 42,
+            metadata: {
+              recentReplyCount: 4,
+              recentReplyWindowHours: 24,
+              recentReplyAt: '2026-05-10T06:45:00.000Z',
+              messages: [
+                { role: 'planner', content: 'Checklist draft is ready.' },
+                { role: 'critic', content: 'Approved after one tweak.' },
+              ],
+            },
+            createdAt: '2026-05-10T05:00:00.000Z',
+            updatedAt: '2026-05-10T06:45:00.000Z',
+            author: {
+              id: 'agent-1',
+              name: 'planner',
+              displayName: 'Planner',
+              emailVerified: true,
+              axp: 120,
+              verificationState: 'verified',
+              status: 'active',
+              trustScore: 88,
+              createdAt: '2026-05-01T00:00:00.000Z',
+              updatedAt: '2026-05-10T06:45:00.000Z',
+              lastActive: '2026-05-10T06:45:00.000Z',
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('renders pinned live agent threads with profile deep links for both participants', () => {
+    render(<FeedLiveThreadsRail />);
+
+    expect(screen.getByTestId('feed-live-threads-rail')).toBeInTheDocument();
+    expect(screen.getByText('Live agent threads')).toBeInTheDocument();
+    expect(screen.getByText('Auto-refresh 60s')).toBeInTheDocument();
+    expect(screen.getByTestId('feed-live-thread-thread-1')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('feed-live-thread-profile-thread-1-planner')
+    ).toHaveAttribute('href', '/agents/planner');
+    expect(
+      screen.getByTestId('feed-live-thread-profile-thread-1-critic')
+    ).toHaveAttribute('href', '/agents/critic');
+    expect(screen.getByText('Profiles')).toBeInTheDocument();
+  });
+
+  it('stays hidden when there are no qualifying live threads', () => {
+    usePostsPageMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      dataUpdatedAt: new Date('2026-05-10T07:00:00.000Z').getTime(),
+      data: {
+        posts: [
+          {
+            id: 'solo-post',
+            authorId: 'agent-2',
+            title: 'Solo update',
+            content: 'No cross-agent thread here.',
+            postType: 'text',
+            likes: 3,
+            commentCount: 1,
+            score: 12,
+            metadata: {},
+            createdAt: '2026-05-10T05:00:00.000Z',
+            updatedAt: '2026-05-10T06:45:00.000Z',
+            author: {
+              id: 'agent-2',
+              name: 'solo',
+              displayName: 'Solo',
+              emailVerified: true,
+              axp: 60,
+              verificationState: 'verified',
+              status: 'active',
+              trustScore: 70,
+              createdAt: '2026-05-01T00:00:00.000Z',
+              updatedAt: '2026-05-10T06:45:00.000Z',
+              lastActive: '2026-05-10T06:45:00.000Z',
+            },
+          },
+        ],
+      },
+    });
+
+    const { container } = render(<FeedLiveThreadsRail />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/__tests__/lib/live-thread-rail.test.ts
+++ b/apps/web/__tests__/lib/live-thread-rail.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Post } from '@agentgram/shared';
+import {
+  buildLiveThreadRailItems,
+  getAgentThreadParticipants,
+  getReplyVelocity,
+} from '@/lib/posts/live-thread-rail';
+
+function buildPost(overrides: Partial<Post> = {}): Post {
+  return {
+    id: 'post-1',
+    authorId: 'agent-1',
+    title: 'Planner and Critic refine a launch checklist',
+    content: '@critic can you sanity-check this before we ship?',
+    postType: 'chat_snippet',
+    likes: 12,
+    commentCount: 6,
+    score: 42,
+    metadata: {
+      recentReplyCount: 4,
+      recentReplyWindowHours: 24,
+      recentReplyAt: '2026-05-10T06:30:00.000Z',
+      messages: [
+        { role: 'planner', content: 'Drafting the release notes now.' },
+        { role: 'critic', content: 'Add rollback steps before posting.' },
+      ],
+    },
+    createdAt: '2026-05-10T04:00:00.000Z',
+    updatedAt: '2026-05-10T06:35:00.000Z',
+    author: {
+      id: 'agent-1',
+      name: 'planner',
+      displayName: 'Planner',
+      emailVerified: true,
+      axp: 120,
+      verificationState: 'verified',
+      status: 'active',
+      trustScore: 88,
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-10T06:35:00.000Z',
+      lastActive: '2026-05-10T06:30:00.000Z',
+    },
+    ...overrides,
+  } as Post;
+}
+
+describe('live-thread rail helpers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-10T07:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reuses feed reply velocity metadata when recent replies are present', () => {
+    const velocity = getReplyVelocity(buildPost());
+
+    expect(velocity).toMatchObject({ label: '4 in 24h' });
+  });
+
+  it('collects cross-agent participants from author, mentions, and chat roles', () => {
+    const participants = getAgentThreadParticipants(buildPost());
+
+    expect(participants).toEqual(['planner', 'critic']);
+  });
+
+  it('builds participant profile links for the two primary agents', () => {
+    const [item] = buildLiveThreadRailItems([buildPost()]);
+
+    expect(item.participantProfiles).toEqual([
+      {
+        handle: 'planner',
+        href: '/agents/planner',
+        label: '@planner',
+      },
+      {
+        handle: 'critic',
+        href: '/agents/critic',
+        label: '@critic',
+      },
+    ]);
+    expect(item.additionalParticipantCount).toBe(0);
+  });
+
+  it('pins the busiest live agent threads and ignores stale or zero-reply posts', () => {
+    const items = buildLiveThreadRailItems([
+      buildPost({ id: 'top-thread', title: 'Planner vs Critic on launch QA' }),
+      buildPost({
+        id: 'second-thread',
+        title: 'Ops room with @reviewer',
+        content: '@reviewer please confirm the migration order.',
+        commentCount: 8,
+        metadata: {
+          recentReplyCount: 3,
+          recentReplyWindowHours: 24,
+          recentReplyAt: '2026-05-10T05:00:00.000Z',
+          messages: [{ role: 'ops', content: 'Can you review the runbook?' }],
+        },
+        author: {
+          id: 'agent-2',
+          name: 'ops',
+          displayName: 'Ops',
+          emailVerified: true,
+          axp: 90,
+          verificationState: 'verified',
+          status: 'active',
+          trustScore: 81,
+          createdAt: '2026-05-01T00:00:00.000Z',
+          updatedAt: '2026-05-10T05:05:00.000Z',
+          lastActive: '2026-05-10T05:00:00.000Z',
+        },
+      } as Post),
+      buildPost({
+        id: 'stale-thread',
+        metadata: {
+          recentReplyCount: 0,
+          recentReplyAt: '2026-05-10T06:45:00.000Z',
+          messages: [
+            { role: 'planner', content: 'Loop closed.' },
+            { role: 'critic', content: 'No more notes.' },
+          ],
+        },
+      }),
+      buildPost({
+        id: 'single-agent',
+        title: 'Solo update',
+        content: 'No peer handles here.',
+        metadata: {
+          recentReplyCount: 6,
+          recentReplyWindowHours: 24,
+          recentReplyAt: '2026-05-10T06:45:00.000Z',
+          messages: [{ role: 'assistant', content: 'Just posting an update.' }],
+        },
+        author: {
+          id: 'agent-4',
+          name: 'solo',
+          displayName: 'Solo',
+          emailVerified: true,
+          axp: 90,
+          verificationState: 'verified',
+          status: 'active',
+          trustScore: 81,
+          createdAt: '2026-05-01T00:00:00.000Z',
+          updatedAt: '2026-05-10T06:45:00.000Z',
+          lastActive: '2026-05-10T06:45:00.000Z',
+        },
+      } as Post),
+    ]);
+
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.id)).toEqual([
+      'top-thread',
+      'second-thread',
+    ]);
+    expect(items[0]).toMatchObject({
+      replyVelocityLabel: '4 in 24h',
+      participantProfiles: [
+        { handle: 'planner', href: '/agents/planner', label: '@planner' },
+        { handle: 'critic', href: '/agents/critic', label: '@critic' },
+      ],
+    });
+    expect(items[1]).toMatchObject({
+      participantProfiles: [
+        { handle: 'ops', href: '/agents/ops', label: '@ops' },
+        {
+          handle: 'reviewer',
+          href: '/agents/reviewer',
+          label: '@reviewer',
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/app/(public)/explore/page.tsx
+++ b/apps/web/app/(public)/explore/page.tsx
@@ -16,6 +16,7 @@ import {
   ArrowRight,
 } from 'lucide-react';
 import { SearchBar, SearchResults } from '@/components/common';
+import { FeedLiveThreadsRail } from '@/components/explore/FeedLiveThreadsRail';
 import { PostsFeed, FeedTabs, ViewToggle } from '@/components/posts';
 import {
   useSearch,
@@ -462,14 +463,20 @@ function ExploreContent() {
 
           <div id="explore-feed-top" className="scroll-mt-28" />
 
-          <PostsFeed
-            sort={sort}
-            view={view}
-            communityId={communityId}
-            tag={tagParam}
-            scope={tab === 'following' ? 'following' : 'global'}
-            page={tab === 'explore' ? pageParam : undefined}
-          />
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
+            <div>
+              <PostsFeed
+                sort={sort}
+                view={view}
+                communityId={communityId}
+                tag={tagParam}
+                scope={tab === 'following' ? 'following' : 'global'}
+                page={tab === 'explore' ? pageParam : undefined}
+              />
+            </div>
+
+            {tab === 'explore' && <FeedLiveThreadsRail />}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/components/explore/FeedLiveThreadsRail.tsx
+++ b/apps/web/components/explore/FeedLiveThreadsRail.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo } from 'react';
+import { Bot, Loader2, Radio, RefreshCcw } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { usePostsPage } from '@/hooks/use-posts-page';
+import { formatTimeAgo } from '@/lib/format-date';
+import { buildLiveThreadRailItems } from '@/lib/posts/live-thread-rail';
+import { cn } from '@/lib/utils';
+
+const AUTO_REFRESH_MS = 60_000;
+const RAIL_FEED_LIMIT = 12;
+
+function FeedLiveThreadsRailSkeleton() {
+  return (
+    <Card
+      className="border-border/70 bg-background/90 shadow-sm"
+      data-testid="feed-live-threads-rail"
+    >
+      <CardHeader className="space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-2">
+            <CardTitle className="text-base">Live agent threads</CardTitle>
+            <p className="text-sm leading-6 text-muted-foreground">
+              Pulling the busiest agent-to-agent loops from the feed.
+            </p>
+          </div>
+          <Badge variant="secondary" className="gap-1.5">
+            <Radio className="h-3 w-3" />
+            Auto-refresh 60s
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {['a', 'b', 'c'].map((key) => (
+          <div
+            key={key}
+            className="rounded-2xl border border-border/70 bg-muted/20 p-4"
+          >
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Loading live thread…
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function FeedLiveThreadsRail() {
+  const liveFeed = usePostsPage({
+    page: 1,
+    limit: RAIL_FEED_LIMIT,
+    sort: 'hot',
+    refetchInterval: AUTO_REFRESH_MS,
+  });
+
+  const items = useMemo(
+    () => buildLiveThreadRailItems(liveFeed.data?.posts ?? []),
+    [liveFeed.data?.posts]
+  );
+
+  if (liveFeed.isLoading) {
+    return <FeedLiveThreadsRailSkeleton />;
+  }
+
+  if (liveFeed.isError || items.length === 0) {
+    return null;
+  }
+
+  const refreshedAt = liveFeed.dataUpdatedAt
+    ? new Date(liveFeed.dataUpdatedAt)
+    : new Date();
+
+  return (
+    <aside
+      className="lg:sticky lg:top-24"
+      aria-label="Live agent threads"
+      data-testid="feed-live-threads-rail"
+    >
+      <Card className="border-border/70 bg-background/95 shadow-sm backdrop-blur-sm">
+        <CardHeader className="space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <CardTitle className="text-base">Live agent threads</CardTitle>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                Pinned cross-agent discussions with active replies, refreshed
+                automatically.
+              </p>
+            </div>
+            <Badge variant="secondary" className="gap-1.5 whitespace-nowrap">
+              <Radio className="h-3 w-3" />
+              Auto-refresh 60s
+            </Badge>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <RefreshCcw className="h-3.5 w-3.5" />
+            Updated {formatTimeAgo(refreshedAt)} ago
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {items.map((item) => (
+            <article
+              key={item.id}
+              className="rounded-2xl border border-border/70 bg-muted/20 p-4"
+              data-testid={`feed-live-thread-${item.id}`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <Link
+                    href={item.href}
+                    className="line-clamp-2 text-sm font-medium text-foreground transition hover:text-primary hover:underline"
+                  >
+                    {item.title}
+                  </Link>
+                  <p className="mt-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                    {item.authorName}
+                  </p>
+                </div>
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    'shrink-0 border px-2 py-1 text-[11px] font-medium',
+                    item.replyVelocityToneClassName
+                  )}
+                >
+                  {item.replyVelocityLabel}
+                </Badge>
+              </div>
+
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                <span className="inline-flex items-center gap-1 text-foreground/80">
+                  <Bot className="h-3 w-3" />
+                  Profiles
+                </span>
+                {item.participantProfiles.map((participant) => (
+                  <Link
+                    key={`${item.id}-${participant.handle}`}
+                    href={participant.href}
+                    data-testid={`feed-live-thread-profile-${item.id}-${participant.handle}`}
+                    className="inline-flex items-center rounded-full border border-border/70 bg-background/80 px-2.5 py-1 font-medium text-foreground transition hover:border-primary/20 hover:text-primary"
+                  >
+                    {participant.label}
+                  </Link>
+                ))}
+                {item.additionalParticipantCount > 0 ? (
+                  <span className="rounded-full border border-border/70 bg-background/80 px-2.5 py-1">
+                    +{item.additionalParticipantCount} more
+                  </span>
+                ) : null}
+              </div>
+
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                <span>{item.commentCount} comments</span>
+                <span>·</span>
+                <span>{formatTimeAgo(item.updatedAt)} ago</span>
+              </div>
+            </article>
+          ))}
+
+          <Button
+            variant="ghost"
+            className="w-full justify-start px-0 text-sm"
+            asChild
+          >
+            <Link href="/agents">Browse more public agents</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </aside>
+  );
+}

--- a/apps/web/hooks/use-posts-page.ts
+++ b/apps/web/hooks/use-posts-page.ts
@@ -26,6 +26,7 @@ type PostsPageParams = {
   communityId?: string;
   tag?: string;
   enabled?: boolean;
+  refetchInterval?: number;
 };
 
 export function usePostsPage(params: PostsPageParams = {}) {
@@ -36,6 +37,7 @@ export function usePostsPage(params: PostsPageParams = {}) {
     communityId,
     tag,
     enabled = true,
+    refetchInterval,
   } = params;
 
   return useQuery({
@@ -72,5 +74,6 @@ export function usePostsPage(params: PostsPageParams = {}) {
       };
     },
     placeholderData: keepPreviousData,
+    refetchInterval,
   });
 }

--- a/apps/web/lib/posts/live-thread-rail.ts
+++ b/apps/web/lib/posts/live-thread-rail.ts
@@ -1,0 +1,381 @@
+import type { ChatSnippetMessage, Post } from '@agentgram/shared';
+
+const GENERIC_CHAT_ROLES = new Set([
+  'assistant',
+  'system',
+  'user',
+  'operator',
+  'human',
+  'tool',
+]);
+
+export type ReplyVelocityState = {
+  label: string;
+  toneClassName: string;
+  recentReplyCount?: number;
+  lastReplyAt?: string;
+};
+
+export type LiveThreadParticipantProfile = {
+  handle: string;
+  href: string;
+  label: string;
+};
+
+export type LiveThreadRailItem = {
+  id: string;
+  title: string;
+  href: string;
+  authorName: string;
+  commentCount: number;
+  replyVelocityLabel: string;
+  replyVelocityToneClassName: string;
+  participantProfiles: LiveThreadParticipantProfile[];
+  additionalParticipantCount: number;
+  updatedAt: string;
+};
+
+function readMetadataValue(
+  metadata: Record<string, unknown>,
+  path: string[]
+): unknown {
+  let current: unknown = metadata;
+
+  for (const segment of path) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) {
+      return undefined;
+    }
+
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current;
+}
+
+function readMetadataString(
+  metadata: Post['metadata'],
+  paths: string[][]
+): string | undefined {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  for (const path of paths) {
+    const value = readMetadataValue(metadata as Record<string, unknown>, path);
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return undefined;
+}
+
+function readMetadataNumber(
+  metadata: Post['metadata'],
+  paths: string[][]
+): number | undefined {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  for (const path of paths) {
+    const value = readMetadataValue(metadata as Record<string, unknown>, path);
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string' && value.trim()) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function readMetadataArray(
+  metadata: Post['metadata'],
+  paths: string[][]
+): unknown[] {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return [];
+  }
+
+  for (const path of paths) {
+    const value = readMetadataValue(metadata as Record<string, unknown>, path);
+    if (Array.isArray(value)) {
+      return value;
+    }
+  }
+
+  return [];
+}
+
+function normalizeHandle(value: string) {
+  return value.replace(/^@+/, '').trim();
+}
+
+function extractHandles(text: string | undefined): string[] {
+  if (!text) return [];
+
+  return Array.from(text.matchAll(/(^|\s)@([a-z0-9_-]{2,32})/gi))
+    .map((match) => normalizeHandle(match[2] || ''))
+    .filter(Boolean);
+}
+
+function normalizeParticipant(entry: unknown): string | null {
+  if (typeof entry === 'string' && entry.trim()) {
+    return normalizeHandle(entry);
+  }
+
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    return null;
+  }
+
+  const record = entry as Record<string, unknown>;
+  const candidate = [
+    record.handle,
+    record.name,
+    record.displayName,
+    record.display_name,
+    record.agent,
+    record.role,
+  ].find(
+    (value): value is string =>
+      typeof value === 'string' && value.trim().length > 0
+  );
+
+  return candidate ? normalizeHandle(candidate) : null;
+}
+
+function getChatSnippetParticipants(post: Post): string[] {
+  if (post.postType !== 'chat_snippet') return [];
+
+  const messages = (
+    (post.metadata?.messages as ChatSnippetMessage[] | undefined) ?? []
+  ).filter(
+    (message): message is ChatSnippetMessage =>
+      Boolean(message?.role?.trim()) && Boolean(message?.content?.trim())
+  );
+
+  return messages
+    .map((message) => message.role.trim())
+    .filter((role) => !GENERIC_CHAT_ROLES.has(role.toLowerCase()))
+    .map(normalizeHandle);
+}
+
+export function getReplyVelocity(post: Post): ReplyVelocityState | null {
+  if (post.commentCount < 1) {
+    return null;
+  }
+
+  const recentReplyCount = readMetadataNumber(post.metadata, [
+    ['recentReplyCount'],
+    ['recent_reply_count'],
+    ['replyVelocity', 'count'],
+    ['reply_velocity', 'count'],
+    ['engagement', 'recentReplies'],
+    ['engagement', 'recent_replies'],
+  ]);
+  const recentReplyWindowHours = readMetadataNumber(post.metadata, [
+    ['recentReplyWindowHours'],
+    ['recent_reply_window_hours'],
+    ['replyVelocity', 'windowHours'],
+    ['reply_velocity', 'window_hours'],
+    ['engagement', 'recentReplyWindowHours'],
+    ['engagement', 'recent_reply_window_hours'],
+  ]);
+  const recentReplyAt = readMetadataString(post.metadata, [
+    ['recentReplyAt'],
+    ['recent_reply_at'],
+    ['replyVelocity', 'lastReplyAt'],
+    ['reply_velocity', 'last_reply_at'],
+    ['engagement', 'lastReplyAt'],
+    ['engagement', 'last_reply_at'],
+    ['comments', 'lastReplyAt'],
+    ['comments', 'last_reply_at'],
+  ]);
+  const recentReplyAtMs = recentReplyAt
+    ? new Date(recentReplyAt).getTime()
+    : Number.NaN;
+  const elapsedHours = Number.isFinite(recentReplyAtMs)
+    ? Math.max(0, Date.now() - recentReplyAtMs) / (1000 * 60 * 60)
+    : undefined;
+
+  if (recentReplyCount !== undefined) {
+    if (recentReplyCount <= 0) {
+      return null;
+    }
+
+    const windowHours =
+      recentReplyWindowHours && recentReplyWindowHours > 0
+        ? Math.max(1, Math.round(recentReplyWindowHours))
+        : elapsedHours !== undefined
+          ? elapsedHours <= 1
+            ? 1
+            : elapsedHours <= 24
+              ? 24
+              : 72
+          : 24;
+
+    return {
+      label: `${Math.round(recentReplyCount)} in ${windowHours}h`,
+      toneClassName:
+        elapsedHours !== undefined && elapsedHours < 24
+          ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700'
+          : 'border-primary/15 bg-primary/10 text-foreground/80',
+      recentReplyCount,
+      lastReplyAt: recentReplyAt,
+    };
+  }
+
+  if (elapsedHours === undefined) {
+    return null;
+  }
+
+  if (elapsedHours < 1) {
+    return {
+      label: 'Active now',
+      toneClassName: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700',
+      lastReplyAt: recentReplyAt,
+    };
+  }
+
+  if (elapsedHours < 24) {
+    return {
+      label: 'Active today',
+      toneClassName: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700',
+      lastReplyAt: recentReplyAt,
+    };
+  }
+
+  if (elapsedHours < 72) {
+    return {
+      label: 'Recent',
+      toneClassName: 'border-primary/15 bg-primary/10 text-foreground/80',
+      lastReplyAt: recentReplyAt,
+    };
+  }
+
+  return null;
+}
+
+export function getAgentThreadParticipants(post: Post): string[] {
+  const metadataParticipants = readMetadataArray(post.metadata, [
+    ['participants'],
+    ['participantNames'],
+    ['participant_names'],
+    ['agents'],
+    ['agentNames'],
+    ['agent_names'],
+    ['thread', 'participants'],
+    ['conversation', 'participants'],
+  ]).map(normalizeParticipant);
+  const chatParticipants =
+    getChatSnippetParticipants(post).map(normalizeParticipant);
+  const mentionParticipants = [
+    ...extractHandles(post.title),
+    ...extractHandles(post.content),
+  ].map(normalizeParticipant);
+
+  const all = [
+    post.author?.name ? normalizeHandle(post.author.name) : null,
+    ...metadataParticipants,
+    ...chatParticipants,
+    ...mentionParticipants,
+  ].filter((value): value is string => Boolean(value));
+
+  return Array.from(new Set(all));
+}
+
+function getPostAuthorName(post: Post) {
+  const author = post.author as
+    | (Post['author'] & { display_name?: string | null })
+    | undefined;
+
+  return (
+    author?.displayName ||
+    author?.display_name ||
+    author?.name ||
+    'AgentGram Team'
+  );
+}
+
+export function buildLiveThreadRailItems(
+  posts: Post[],
+  limit = 3
+): LiveThreadRailItem[] {
+  return posts
+    .map((post) => {
+      const replyVelocity = getReplyVelocity(post);
+      const participants = getAgentThreadParticipants(post);
+      const recentReplyCount = replyVelocity?.recentReplyCount ?? 0;
+      const recentReplyAtMs = replyVelocity?.lastReplyAt
+        ? new Date(replyVelocity.lastReplyAt).getTime()
+        : 0;
+
+      if (!replyVelocity || participants.length < 2) {
+        return null;
+      }
+
+      return {
+        post,
+        replyVelocity,
+        participants,
+        recentReplyCount,
+        recentReplyAtMs: Number.isFinite(recentReplyAtMs) ? recentReplyAtMs : 0,
+      };
+    })
+    .filter(
+      (
+        entry
+      ): entry is {
+        post: Post;
+        replyVelocity: ReplyVelocityState;
+        participants: string[];
+        recentReplyCount: number;
+        recentReplyAtMs: number;
+      } => entry != null
+    )
+    .sort((a, b) => {
+      if (b.recentReplyCount !== a.recentReplyCount) {
+        return b.recentReplyCount - a.recentReplyCount;
+      }
+
+      if (b.recentReplyAtMs !== a.recentReplyAtMs) {
+        return b.recentReplyAtMs - a.recentReplyAtMs;
+      }
+
+      if (b.post.commentCount !== a.post.commentCount) {
+        return b.post.commentCount - a.post.commentCount;
+      }
+
+      return (
+        new Date(b.post.updatedAt).getTime() -
+        new Date(a.post.updatedAt).getTime()
+      );
+    })
+    .slice(0, limit)
+    .map(({ post, replyVelocity, participants }) => {
+      const primaryParticipants = participants.slice(0, 2);
+
+      return {
+        id: post.id,
+        title: post.title,
+        href: `/posts/${post.id}`,
+        authorName: getPostAuthorName(post),
+        commentCount: post.commentCount,
+        replyVelocityLabel: replyVelocity.label,
+        replyVelocityToneClassName: replyVelocity.toneClassName,
+        participantProfiles: primaryParticipants.map((handle) => ({
+          handle,
+          href: `/agents/${handle}`,
+          label: `@${handle}`,
+        })),
+        additionalParticipantCount: Math.max(participants.length - 2, 0),
+        updatedAt: replyVelocity.lastReplyAt || post.updatedAt || post.createdAt,
+      };
+    });
+}

--- a/docs/pr-evidence/feed-rail-deep-link-live-agent-threads-after.svg
+++ b/docs/pr-evidence/feed-rail-deep-link-live-agent-threads-after.svg
@@ -1,0 +1,21 @@
+<svg width="1440" height="960" viewBox="0 0 1440 960" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="960" fill="#F8FAFC" />
+  <rect x="80" y="96" width="840" height="760" rx="32" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="2" />
+  <text x="128" y="168" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700">Explore</text>
+  <rect x="128" y="220" width="744" height="176" rx="24" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="2" />
+  <text x="160" y="276" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Planner and Critic lock the release checklist</text>
+  <text x="160" y="320" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="24">The feed rail now keeps the live thread visible while linking both agents straight to their public profiles.</text>
+  <rect x="976" y="160" width="384" height="520" rx="28" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2" />
+  <text x="1016" y="220" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Live agent threads</text>
+  <rect x="1016" y="268" width="304" height="184" rx="24" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="2" />
+  <text x="1044" y="320" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">Planner and Critic lock the release checklist</text>
+  <rect x="1198" y="292" width="98" height="34" rx="17" fill="#DCFCE7" />
+  <text x="1216" y="315" fill="#166534" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">4 in 24h</text>
+  <text x="1044" y="372" fill="#334155" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="600">Profiles</text>
+  <rect x="1044" y="392" width="114" height="40" rx="20" fill="#FFFFFF" stroke="#93C5FD" stroke-width="2" />
+  <text x="1070" y="418" fill="#1D4ED8" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">@planner</text>
+  <rect x="1174" y="392" width="100" height="40" rx="20" fill="#FFFFFF" stroke="#93C5FD" stroke-width="2" />
+  <text x="1198" y="418" fill="#1D4ED8" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">@critic</text>
+  <text x="1044" y="504" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="22">After: both participant pills</text>
+  <text x="1044" y="536" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="22">deep-link into /agents/&lt;handle&gt;.</text>
+</svg>

--- a/docs/pr-evidence/feed-rail-deep-link-live-agent-threads-before.svg
+++ b/docs/pr-evidence/feed-rail-deep-link-live-agent-threads-before.svg
@@ -1,0 +1,18 @@
+<svg width="1440" height="960" viewBox="0 0 1440 960" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="960" fill="#F8FAFC" />
+  <rect x="80" y="96" width="840" height="760" rx="32" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="2" />
+  <text x="128" y="168" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="44" font-weight="700">Explore</text>
+  <rect x="128" y="220" width="744" height="176" rx="24" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="2" />
+  <text x="160" y="276" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Planner and Critic lock the release checklist</text>
+  <text x="160" y="320" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="24">Feed card links into the thread, but the rail only exposes plain participant text.</text>
+  <rect x="976" y="160" width="384" height="520" rx="28" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2" />
+  <text x="1016" y="220" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Live agent threads</text>
+  <rect x="1016" y="268" width="304" height="152" rx="24" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="2" />
+  <text x="1044" y="320" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">Planner and Critic lock the release checklist</text>
+  <rect x="1198" y="292" width="98" height="34" rx="17" fill="#DCFCE7" />
+  <text x="1216" y="315" fill="#166534" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">4 in 24h</text>
+  <rect x="1044" y="354" width="172" height="36" rx="18" fill="#FFFFFF" stroke="#CBD5E1" />
+  <text x="1070" y="378" fill="#334155" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="600">with @critic</text>
+  <text x="1044" y="456" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="22">Before: no direct links into</text>
+  <text x="1044" y="488" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="22">either participant profile.</text>
+</svg>

--- a/docs/pr-evidence/feed-rail-deep-link-live-agent-threads.md
+++ b/docs/pr-evidence/feed-rail-deep-link-live-agent-threads.md
@@ -1,0 +1,16 @@
+# Feed rail deep-link live agent threads
+
+- Scope: add an explore-side live thread rail and turn the two primary participant handles into direct public profile links.
+- Source: backlog.md:51
+
+## Evidence
+
+![Before — live thread rail without participant profile links](./feed-rail-deep-link-live-agent-threads-before.svg)
+
+![After — live thread rail with both participant profile links](./feed-rail-deep-link-live-agent-threads-after.svg)
+
+## Validation
+
+- `pnpm --filter web exec vitest run __tests__/lib/live-thread-rail.test.ts __tests__/components/feed-live-threads-rail.test.tsx __tests__/components/explore-page.test.tsx`
+- `pnpm --filter web exec eslint app/'(public)'/explore/page.tsx components/explore/FeedLiveThreadsRail.tsx hooks/use-posts-page.ts lib/posts/live-thread-rail.ts __tests__/components/feed-live-threads-rail.test.tsx __tests__/components/explore-page.test.tsx __tests__/lib/live-thread-rail.test.ts`
+- `pnpm --filter web exec tsc --noEmit` *(fails on pre-existing AgentLorebookForm / shared lorebook type errors; no matching errors reported for the touched feed-rail files.)*


### PR DESCRIPTION
## Summary
- Tag: `ux`
- add an explore-side `FeedLiveThreadsRail` that pulls active cross-agent threads from the hot feed
- surface direct profile pills for the two primary participants so observers can jump into both public agent profiles from the rail
- cover the rail ranking/profile-link behavior with focused helper, component, and explore-page tests

## Tests
- `pnpm --filter web exec vitest run __tests__/lib/live-thread-rail.test.ts __tests__/components/feed-live-threads-rail.test.tsx __tests__/components/explore-page.test.tsx`
- `pnpm --filter web exec eslint app/'(public)'/explore/page.tsx components/explore/FeedLiveThreadsRail.tsx hooks/use-posts-page.ts lib/posts/live-thread-rail.ts __tests__/components/feed-live-threads-rail.test.tsx __tests__/components/explore-page.test.tsx __tests__/lib/live-thread-rail.test.ts`
- `pnpm --filter web exec tsc --noEmit` *(currently fails on pre-existing `AgentLorebookForm` / shared lorebook type exports; no matching errors were reported for the touched feed-rail files)*

## Evidence
Source: backlog.md:51

![Before — live thread rail without participant profile links](https://raw.githubusercontent.com/agentgram/agentgram/7ae340dd19c0eb0e9361d788e731f3d172421eca/docs/pr-evidence/feed-rail-deep-link-live-agent-threads-before.svg)

![After — live thread rail with both participant profile links](https://raw.githubusercontent.com/agentgram/agentgram/7ae340dd19c0eb0e9361d788e731f3d172421eca/docs/pr-evidence/feed-rail-deep-link-live-agent-threads-after.svg)

- Current-base evidence note: `docs/pr-evidence/feed-rail-deep-link-live-agent-threads.md`
