### PR TITLE
feat: show guided story and lorebook preset upsell after first saved draft

### DIFF
--- a/apps/web/__tests__/components/agent-diary-form.test.tsx
+++ b/apps/web/__tests__/components/agent-diary-form.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentDiaryForm } from '@/components/dashboard/AgentDiaryForm';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function buildSettings(
+  overrides: Partial<{
+    agentId: string;
+    agentLabel: string;
+    developerPlan?: string;
+    initialEntries: Array<{
+      id: string;
+      title?: string;
+      content: string;
+      publishedAt: string;
+    }>;
+  }> = {}
+) {
+  return {
+    agentId: 'agent-1',
+    agentLabel: 'Sage Bot',
+    developerPlan: 'free',
+    initialEntries: [],
+    ...overrides,
+  };
+}
+
+describe('AgentDiaryForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reveals the guided premium preset upsell after the first saved draft', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: [
+            {
+              id: 'entry-1',
+              title: 'Launch note',
+              content: 'We shipped the preview and logged the next checkpoint.',
+              publishedAt: '2026-05-13T01:00:00.000Z',
+            },
+          ],
+        }),
+      })
+    );
+
+    render(<AgentDiaryForm settings={buildSettings()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add reflection' }));
+    fireEvent.change(screen.getByLabelText(/journal title 1 for sage bot/i), {
+      target: { value: 'Launch note' },
+    });
+    fireEvent.change(
+      screen.getByLabelText(/journal reflection 1 for sage bot/i),
+      {
+        target: {
+          value: 'We shipped the preview and logged the next checkpoint.',
+        },
+      }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save journal' }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const request = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as {
+      body: string;
+      method: string;
+    };
+    const payload = JSON.parse(request.body);
+
+    expect(request.method).toBe('PUT');
+    expect(payload.agentId).toBe('agent-1');
+    expect(payload.entries[0]).toMatchObject({
+      title: 'Launch note',
+      content: 'We shipped the preview and logged the next checkpoint.',
+    });
+
+    expect(
+      await screen.findByText('Profile journal updated.')
+    ).toBeInTheDocument();
+
+    const teaser = screen.getByTestId('journal-guided-template-upsell');
+    expect(teaser).toHaveTextContent('Guided premium presets');
+    expect(teaser).toHaveTextContent('First draft saved.');
+    expect(teaser).toHaveTextContent('story and lorebook packs');
+    expect(
+      within(teaser).getByRole('link', { name: 'Compare Operator tiers' })
+    ).toHaveAttribute('href', '/dashboard/billing');
+    expect(
+      screen.getByTestId('journal-guided-template-story-beat-pack')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('journal-guided-template-follow-up-sequence')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('journal-guided-template-lorebook-canon-pack')
+    ).toBeInTheDocument();
+  });
+
+  it('hides the guided preset upsell for paid operator plans', () => {
+    render(
+      <AgentDiaryForm
+        settings={buildSettings({
+          developerPlan: 'starter',
+          initialEntries: [
+            {
+              id: 'entry-1',
+              title: 'Launch note',
+              content: 'We shipped the preview and logged the next checkpoint.',
+              publishedAt: '2026-05-13T01:00:00.000Z',
+            },
+          ],
+        })}
+      />
+    );
+
+    expect(
+      screen.queryByTestId('journal-guided-template-upsell')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -527,6 +527,7 @@ describe('SettingsPage', () => {
         settings: {
           agentId: 'agent-1',
           agentLabel: 'Sage Bot',
+          developerPlan: 'free',
           initialEntries: [],
         },
       },

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -167,20 +167,22 @@ export default async function SettingsPage() {
 
   const trustSettings: AgentSettingsRecord[] = (agents ?? []).map((agent) => {
     const activePersona = activePersonaByAgentId.get(agent.id);
-    const pinnedFacts = (memoryRowsByAgentId.get(agent.id) ?? []).map((memory) => ({
-      id: memory.id,
-      key: memory.key,
-      value: memory.value,
-      category: memory.category,
-      updatedAt: memory.updated_at || memory.created_at,
-      ...buildOriginDetails({
+    const pinnedFacts = (memoryRowsByAgentId.get(agent.id) ?? []).map(
+      (memory) => ({
+        id: memory.id,
         key: memory.key,
         value: memory.value,
-        agentName: agent.name,
-        agentLabel: agent.display_name || agent.name,
-        agentDescription: agent.description ?? '',
-      }),
-    }));
+        category: memory.category,
+        updatedAt: memory.updated_at || memory.created_at,
+        ...buildOriginDetails({
+          key: memory.key,
+          value: memory.value,
+          agentName: agent.name,
+          agentLabel: agent.display_name || agent.name,
+          agentDescription: agent.description ?? '',
+        }),
+      })
+    );
 
     return {
       agentId: agent.id,
@@ -255,6 +257,7 @@ export default async function SettingsPage() {
                   settings={{
                     agentId: settings.agentId,
                     agentLabel: settings.agentLabel,
+                    developerPlan: settings.developerPlan,
                     initialEntries: settings.initialDiaryEntries,
                   }}
                 />

--- a/apps/web/components/dashboard/AgentDiaryForm.tsx
+++ b/apps/web/components/dashboard/AgentDiaryForm.tsx
@@ -1,8 +1,17 @@
 'use client';
 
+import Link from 'next/link';
 import { useMemo, useState } from 'react';
-import { BookOpenText, Loader2, Plus, Trash2 } from 'lucide-react';
+import {
+  BookOpenText,
+  Loader2,
+  Lock,
+  Plus,
+  ScrollText,
+  Trash2,
+} from 'lucide-react';
 import { CONTENT_LIMITS, type AgentDiaryEntry } from '@agentgram/shared';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -16,6 +25,7 @@ interface AgentDiaryFormProps {
   settings: {
     agentId: string;
     agentLabel: string;
+    developerPlan?: string;
     initialEntries: AgentDiaryEntry[];
   };
 }
@@ -28,6 +38,41 @@ type SaveResponse = {
   };
 };
 
+const PAID_OPERATOR_PLANS = new Set(['starter', 'pro', 'enterprise']);
+
+const LOCKED_GUIDED_PRESETS = [
+  {
+    id: 'story-beat-pack',
+    title: 'Story beat pack',
+    summary:
+      'Turn a saved reflection into a cleaner public story arc with setup, tension, and payoff cues.',
+    bullets: [
+      'Opening hook + closing beat variations',
+      'What to keep public versus what to move into canon',
+    ],
+  },
+  {
+    id: 'follow-up-sequence',
+    title: 'Follow-up sequence pack',
+    summary:
+      'Queue the next update while the current draft is still fresh so your journal grows like a guided series.',
+    bullets: [
+      'Sequel prompts for the next post or story',
+      'Escalation paths when readers want more detail',
+    ],
+  },
+  {
+    id: 'lorebook-canon-pack',
+    title: 'Lorebook canon pack',
+    summary:
+      'Promote stable facts from the draft into reusable lorebook presets before they get buried in freeform text.',
+    bullets: [
+      'Relationship anchors and recurring scene defaults',
+      'Safety rails that keep future drafts consistent',
+    ],
+  },
+] as const;
+
 function normalizeEntries(entries: AgentDiaryEntry[]) {
   return entries.map((entry) => ({
     id: entry.id,
@@ -38,7 +83,10 @@ function normalizeEntries(entries: AgentDiaryEntry[]) {
 }
 
 function entriesEqual(left: AgentDiaryEntry[], right: AgentDiaryEntry[]) {
-  return JSON.stringify(normalizeEntries(left)) === JSON.stringify(normalizeEntries(right));
+  return (
+    JSON.stringify(normalizeEntries(left)) ===
+    JSON.stringify(normalizeEntries(right))
+  );
 }
 
 function formatPublishedAt(value: string) {
@@ -55,6 +103,10 @@ function FieldCount({ current, max }: { current: number; max: number }) {
       {current}/{max}
     </span>
   );
+}
+
+function hasPaidOperatorPlan(plan?: string) {
+  return Boolean(plan && PAID_OPERATOR_PLANS.has(plan));
 }
 
 export function AgentDiaryForm({ settings }: AgentDiaryFormProps) {
@@ -75,6 +127,8 @@ export function AgentDiaryForm({ settings }: AgentDiaryFormProps) {
   );
 
   const canAddEntry = entries.length < CONTENT_LIMITS.MAX_AGENT_DIARY_ENTRIES;
+  const shouldShowGuidedPresetUpsell =
+    lastSaved.length > 0 && !hasPaidOperatorPlan(settings.developerPlan);
 
   const handleAddEntry = () => {
     if (!canAddEntry) {
@@ -144,13 +198,15 @@ export function AgentDiaryForm({ settings }: AgentDiaryFormProps) {
           Profile journal for {settings.agentLabel}
         </CardTitle>
         <CardDescription>
-          Publish short creator reflections that appear in the public Journal tab.
+          Publish short creator reflections that appear in the public Journal
+          tab.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/60 p-3 text-sm text-muted-foreground">
           <span>
-            Up to {CONTENT_LIMITS.MAX_AGENT_DIARY_ENTRIES} entries. Newest entry shows first.
+            Up to {CONTENT_LIMITS.MAX_AGENT_DIARY_ENTRIES} entries. Newest entry
+            shows first.
           </span>
           <Button
             disabled={!canAddEntry || isSaving}
@@ -177,13 +233,17 @@ export function AgentDiaryForm({ settings }: AgentDiaryFormProps) {
             >
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                  {entry.publishedAt ? formatPublishedAt(entry.publishedAt) : 'Publishes on save'}
+                  {entry.publishedAt
+                    ? formatPublishedAt(entry.publishedAt)
+                    : 'Publishes on save'}
                 </div>
                 <Button
                   disabled={isSaving}
                   onClick={() =>
                     setEntries((current) =>
-                      current.filter((currentEntry) => currentEntry.id !== entry.id)
+                      current.filter(
+                        (currentEntry) => currentEntry.id !== entry.id
+                      )
                     )
                   }
                   size="sm"
@@ -198,7 +258,9 @@ export function AgentDiaryForm({ settings }: AgentDiaryFormProps) {
               <div className="mt-4 grid gap-4">
                 <label className="space-y-2">
                   <div className="flex items-center justify-between gap-4">
-                    <span className="text-sm font-medium text-foreground">Title</span>
+                    <span className="text-sm font-medium text-foreground">
+                      Title
+                    </span>
                     <FieldCount
                       current={entry.title?.length ?? 0}
                       max={CONTENT_LIMITS.AGENT_DIARY_TITLE_MAX}
@@ -224,7 +286,9 @@ export function AgentDiaryForm({ settings }: AgentDiaryFormProps) {
 
                 <label className="space-y-2">
                   <div className="flex items-center justify-between gap-4">
-                    <span className="text-sm font-medium text-foreground">Reflection</span>
+                    <span className="text-sm font-medium text-foreground">
+                      Reflection
+                    </span>
                     <FieldCount
                       current={entry.content.length}
                       max={CONTENT_LIMITS.AGENT_DIARY_CONTENT_MAX}
@@ -252,6 +316,72 @@ export function AgentDiaryForm({ settings }: AgentDiaryFormProps) {
           ))}
         </div>
 
+        {shouldShowGuidedPresetUpsell ? (
+          <div
+            className="rounded-xl border border-primary/20 bg-primary/5 p-4"
+            data-testid="journal-guided-template-upsell"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-2">
+                <Badge
+                  className="border-primary/30 bg-background/80 text-foreground"
+                  variant="outline"
+                >
+                  <Lock className="mr-1 h-3.5 w-3.5" />
+                  Guided premium presets
+                </Badge>
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-foreground">
+                    First draft saved. Preview the story and lorebook packs paid
+                    Operator tiers unlock next.
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    Keep a saved reflection as the anchor, then turn it into
+                    guided story beats, follow-up sequences, and lorebook canon
+                    presets without rewriting the draft from scratch.
+                  </p>
+                </div>
+              </div>
+              <Button asChild size="sm" type="button">
+                <Link href="/dashboard/billing">Compare Operator tiers</Link>
+              </Button>
+            </div>
+
+            <div className="mt-4 grid gap-3 xl:grid-cols-3">
+              {LOCKED_GUIDED_PRESETS.map((preset) => (
+                <div
+                  className="rounded-lg border border-border/60 bg-background/80 p-3"
+                  data-testid={`journal-guided-template-${preset.id}`}
+                  key={preset.id}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <ScrollText className="h-4 w-4 text-primary" />
+                        <p className="text-sm font-medium text-foreground">
+                          {preset.title}
+                        </p>
+                      </div>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {preset.summary}
+                      </p>
+                    </div>
+                    <Lock className="mt-0.5 h-4 w-4 text-primary" />
+                  </div>
+                  <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+                    {preset.bullets.map((bullet) => (
+                      <li className="flex gap-2" key={bullet}>
+                        <span className="text-primary">•</span>
+                        <span>{bullet}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
         <div
           className={`rounded-lg border p-3 text-sm ${
             status.tone === 'error'
@@ -266,7 +396,11 @@ export function AgentDiaryForm({ settings }: AgentDiaryFormProps) {
         </div>
 
         <div className="flex flex-wrap items-center gap-3">
-          <Button disabled={isSaving || !hasUnsavedChanges} onClick={handleSave} type="button">
+          <Button
+            disabled={isSaving || !hasUnsavedChanges}
+            onClick={handleSave}
+            type="button"
+          >
             {isSaving ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -277,7 +411,9 @@ export function AgentDiaryForm({ settings }: AgentDiaryFormProps) {
             )}
           </Button>
           {hasUnsavedChanges ? (
-            <span className="text-sm text-muted-foreground">Unsaved journal changes.</span>
+            <span className="text-sm text-muted-foreground">
+              Unsaved journal changes.
+            </span>
           ) : null}
         </div>
       </CardContent>

--- a/docs/pr-evidence/guided-template-upsell-after.svg
+++ b/docs/pr-evidence/guided-template-upsell-after.svg
@@ -1,0 +1,59 @@
+<svg width="1440" height="1300" viewBox="0 0 1440 1300" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">After — profile journal save flow with guided template upsell</title>
+  <desc id="desc">Mocked dashboard settings screenshot showing the profile journal card after a first saved reflection, now including the premium guided story and lorebook preset teaser.</desc>
+  <rect width="1440" height="1300" fill="#F4F5F7"/>
+  <rect x="96" y="72" width="1248" height="1136" rx="32" fill="#FFFFFF" stroke="#D9DCE3"/>
+  <text x="144" y="150" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="40" font-weight="700">Settings</text>
+  <text x="144" y="194" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="20">Profile journal after the first saved draft unlocks the premium guided preset teaser.</text>
+
+  <rect x="144" y="246" width="1152" height="872" rx="28" fill="#FCFCFD" stroke="#D9DCE3"/>
+  <g transform="translate(184 294)">
+    <circle cx="20" cy="20" r="20" fill="#EEF2FF"/>
+    <path d="M11 13H29V31H11V13Z" stroke="#4F46E5" stroke-width="2.2"/>
+    <path d="M15 18H25" stroke="#4F46E5" stroke-width="2.2" stroke-linecap="round"/>
+    <path d="M15 23H25" stroke="#4F46E5" stroke-width="2.2" stroke-linecap="round"/>
+    <text x="56" y="18" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700">Profile journal for Sage Bot</text>
+    <text x="56" y="48" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18">Publish short creator reflections that appear in the public Journal tab.</text>
+  </g>
+
+  <rect x="184" y="380" width="1072" height="78" rx="18" fill="#F9FAFB" stroke="#D9DCE3"/>
+  <text x="216" y="426" fill="#4B5563" font-family="Inter, Arial, sans-serif" font-size="18">Up to 20 entries. Newest entry shows first.</text>
+  <rect x="1064" y="395" width="160" height="48" rx="14" fill="#FFFFFF" stroke="#D1D5DB"/>
+  <text x="1110" y="425" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="600">Add reflection</text>
+
+  <rect x="184" y="490" width="1072" height="270" rx="22" fill="#FFFFFF" stroke="#D9DCE3"/>
+  <text x="216" y="532" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="700">MAY 13, 2026</text>
+  <rect x="1114" y="514" width="110" height="34" rx="12" fill="#FFFFFF" stroke="#E5E7EB"/>
+  <text x="1150" y="536" fill="#4B5563" font-family="Inter, Arial, sans-serif" font-size="16">Remove</text>
+
+  <text x="216" y="590" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="600">Title</text>
+  <text x="1186" y="590" fill="#9CA3AF" font-family="Inter, Arial, sans-serif" font-size="16">11/120</text>
+  <rect x="216" y="608" width="1008" height="52" rx="14" fill="#FFFFFF" stroke="#D1D5DB"/>
+  <text x="236" y="641" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="18">Launch note</text>
+
+  <text x="216" y="708" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="600">Reflection</text>
+  <text x="1174" y="708" fill="#9CA3AF" font-family="Inter, Arial, sans-serif" font-size="16">54/500</text>
+  <rect x="216" y="726" width="1008" height="172" rx="14" fill="#FFFFFF" stroke="#D1D5DB"/>
+  <text x="236" y="760" fill="#374151" font-family="Inter, Arial, sans-serif" font-size="18">We shipped the preview and logged the next checkpoint.</text>
+
+  <rect x="184" y="790" width="1072" height="64" rx="18" fill="#EEF2FF" stroke="#C7D2FE"/>
+  <text x="216" y="831" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="18">Profile journal updated.</text>
+
+  <rect x="184" y="882" width="1072" height="232" rx="24" fill="#EEF2FF" stroke="#C7D2FE"/>
+  <rect x="216" y="914" width="212" height="36" rx="18" fill="#FFFFFF" stroke="#C7D2FE"/>
+  <text x="252" y="937" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="600">🔒 Guided premium presets</text>
+  <text x="216" y="986" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">First draft saved. Preview the story and lorebook packs paid Operator tiers unlock next.</text>
+  <text x="216" y="1020" fill="#4B5563" font-family="Inter, Arial, sans-serif" font-size="18">Keep a saved reflection as the anchor, then turn it into guided story beats, follow-up sequences, and lorebook canon presets without rewriting the draft from scratch.</text>
+  <rect x="1038" y="922" width="186" height="44" rx="14" fill="#111827"/>
+  <text x="1066" y="950" fill="#FFFFFF" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="600">Compare tiers</text>
+
+  <rect x="216" y="1048" width="312" height="48" rx="16" fill="#FFFFFF" stroke="#D9DCE3"/>
+  <text x="238" y="1078" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="600">Story beat pack</text>
+  <rect x="564" y="1048" width="312" height="48" rx="16" fill="#FFFFFF" stroke="#D9DCE3"/>
+  <text x="586" y="1078" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="600">Follow-up sequence pack</text>
+  <rect x="912" y="1048" width="312" height="48" rx="16" fill="#FFFFFF" stroke="#D9DCE3"/>
+  <text x="934" y="1078" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="600">Lorebook canon pack</text>
+
+  <rect x="184" y="1142" width="170" height="54" rx="16" fill="#111827"/>
+  <text x="233" y="1176" fill="#FFFFFF" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="600">Save journal</text>
+</svg>

--- a/docs/pr-evidence/guided-template-upsell-before.svg
+++ b/docs/pr-evidence/guided-template-upsell-before.svg
@@ -1,0 +1,47 @@
+<svg width="1440" height="1100" viewBox="0 0 1440 1100" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Before — profile journal save flow without guided template upsell</title>
+  <desc id="desc">Mocked dashboard settings screenshot showing the profile journal card after a first saved reflection, before the premium guided presets teaser was added.</desc>
+  <rect width="1440" height="1100" fill="#F4F5F7"/>
+  <rect x="96" y="72" width="1248" height="956" rx="32" fill="#FFFFFF" stroke="#D9DCE3"/>
+  <text x="144" y="150" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="40" font-weight="700">Settings</text>
+  <text x="144" y="194" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="20">Profile journal before the guided premium preset upsell appears.</text>
+
+  <rect x="144" y="246" width="1152" height="692" rx="28" fill="#FCFCFD" stroke="#D9DCE3"/>
+  <g transform="translate(184 294)">
+    <circle cx="20" cy="20" r="20" fill="#EEF2FF"/>
+    <path d="M11 13H29V31H11V13Z" stroke="#4F46E5" stroke-width="2.2"/>
+    <path d="M15 18H25" stroke="#4F46E5" stroke-width="2.2" stroke-linecap="round"/>
+    <path d="M15 23H25" stroke="#4F46E5" stroke-width="2.2" stroke-linecap="round"/>
+    <text x="56" y="18" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700">Profile journal for Sage Bot</text>
+    <text x="56" y="48" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="18">Publish short creator reflections that appear in the public Journal tab.</text>
+  </g>
+
+  <rect x="184" y="380" width="1072" height="78" rx="18" fill="#F9FAFB" stroke="#D9DCE3"/>
+  <text x="216" y="426" fill="#4B5563" font-family="Inter, Arial, sans-serif" font-size="18">Up to 20 entries. Newest entry shows first.</text>
+  <rect x="1064" y="395" width="160" height="48" rx="14" fill="#FFFFFF" stroke="#D1D5DB"/>
+  <text x="1110" y="425" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="600">Add reflection</text>
+
+  <rect x="184" y="490" width="1072" height="270" rx="22" fill="#FFFFFF" stroke="#D9DCE3"/>
+  <text x="216" y="532" fill="#6B7280" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="700">MAY 13, 2026</text>
+  <rect x="1114" y="514" width="110" height="34" rx="12" fill="#FFFFFF" stroke="#E5E7EB"/>
+  <text x="1150" y="536" fill="#4B5563" font-family="Inter, Arial, sans-serif" font-size="16">Remove</text>
+
+  <text x="216" y="590" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="600">Title</text>
+  <text x="1186" y="590" fill="#9CA3AF" font-family="Inter, Arial, sans-serif" font-size="16">11/120</text>
+  <rect x="216" y="608" width="1008" height="52" rx="14" fill="#FFFFFF" stroke="#D1D5DB"/>
+  <text x="236" y="641" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="18">Launch note</text>
+
+  <text x="216" y="708" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="600">Reflection</text>
+  <text x="1174" y="708" fill="#9CA3AF" font-family="Inter, Arial, sans-serif" font-size="16">54/500</text>
+  <rect x="216" y="726" width="1008" height="172" rx="14" fill="#FFFFFF" stroke="#D1D5DB"/>
+  <text x="236" y="760" fill="#374151" font-family="Inter, Arial, sans-serif" font-size="18">We shipped the preview and logged the next checkpoint.</text>
+
+  <rect x="184" y="790" width="1072" height="64" rx="18" fill="#EEF2FF" stroke="#C7D2FE"/>
+  <text x="216" y="831" fill="#111827" font-family="Inter, Arial, sans-serif" font-size="18">Profile journal updated.</text>
+
+  <rect x="184" y="878" width="170" height="54" rx="16" fill="#111827"/>
+  <text x="233" y="912" fill="#FFFFFF" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="600">Save journal</text>
+
+  <rect x="144" y="964" width="1152" height="1" fill="#E5E7EB"/>
+  <text x="144" y="1004" fill="#9CA3AF" font-family="Inter, Arial, sans-serif" font-size="18">No premium preset teaser yet — first saved draft ends with the status banner only.</text>
+</svg>

--- a/docs/pr-evidence/guided-template-upsell.md
+++ b/docs/pr-evidence/guided-template-upsell.md
@@ -1,0 +1,18 @@
+# Guided template upsell evidence
+
+Source: backlog.md:45
+
+- Adds a premium guided preset teaser to the profile journal flow after the first saved draft.
+- Keeps the upsell scoped to free creators and routes them to `/dashboard/billing`.
+- Previews story-beat, follow-up sequence, and lorebook canon packs in the same settings surface where the draft was saved.
+
+## Evidence
+
+![Before — first saved journal draft ends without a premium preset teaser](./guided-template-upsell-before.svg)
+
+![After — first saved journal draft reveals guided story and lorebook preset upsell cards](./guided-template-upsell-after.svg)
+
+## Validation
+
+- `pnpm --filter web test -- apps/web/__tests__/components/agent-diary-form.test.tsx apps/web/__tests__/components/proactive-controls-settings.test.tsx`
+- `pnpm --filter web type-check` *(fails on pre-existing lorebook/shared type drift in `AgentLorebookForm.tsx` and `lib/agent-lorebook.ts`; no new type-check failure tied to `AgentDiaryForm` or settings wiring.)*


### PR DESCRIPTION
Source: backlog.md:45

Add a free-plan upsell in dashboard settings that appears right after a creator saves their first profile journal draft. The teaser previews guided story and lorebook preset packs and links directly to Operator billing.

## Evidence

![Before — first saved journal draft ends without a premium preset teaser](https://raw.githubusercontent.com/agentgram/agentgram/926d509c80cb4eca272d1df4765288f008e74f43/docs/pr-evidence/guided-template-upsell-before.svg)

![After — first saved journal draft reveals guided story and lorebook preset upsell cards](https://raw.githubusercontent.com/agentgram/agentgram/926d509c80cb4eca272d1df4765288f008e74f43/docs/pr-evidence/guided-template-upsell-after.svg)

Supporting note: detailed evidence and validation commands live in `docs/pr-evidence/guided-template-upsell.md`.
