### PR TITLE
[STRATEGY] Proactive trust preview — show quiet hours, next-send window, and mute CTA before opt-in

### DIFF
--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -329,14 +329,17 @@ describe('ProactiveControlsForm', () => {
     ).toHaveTextContent('2/day and 8/week caps');
   });
 
-  it('shows an opt-in gate banner before proactive outreach is enabled', () => {
+  it('shows quiet-hours and next-send previews before proactive outreach is enabled', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-26T20:15:00.000Z'));
+
     render(
       <ProactiveControlsForm
         initialSettings={{
           optIn: false,
           dailyLimit: 3,
           weeklyLimit: 9,
-          quietHoursEnabled: false,
+          quietHoursEnabled: true,
           quietHoursStart: '22:00',
           quietHoursEnd: '08:00',
           tonePreset: 'neutral',
@@ -344,6 +347,15 @@ describe('ProactiveControlsForm', () => {
       />
     );
 
+    expect(
+      screen.getByTestId('proactive-preview-quiet-hours')
+    ).toHaveTextContent('22:00 → 08:00 KST');
+    expect(
+      screen.getByTestId('proactive-preview-next-window')
+    ).toHaveTextContent('Apr 27, 2026, 8:00 AM KST');
+    expect(
+      screen.getByRole('button', { name: 'Keep muted' })
+    ).toBeInTheDocument();
     expect(
       screen.getByTestId('proactive-pre-send-banner-title')
     ).toHaveTextContent('Proactive send blocked until opt-in');
@@ -355,6 +367,46 @@ describe('ProactiveControlsForm', () => {
     expect(
       screen.getByTestId('proactive-pre-send-banner-body')
     ).toHaveTextContent('3/day and 9/week caps');
+  });
+
+  it('keeps proactive outreach muted with an explicit CTA before opt-in', async () => {
+    render(
+      <ProactiveControlsForm
+        initialSettings={{
+          optIn: false,
+          dailyLimit: 3,
+          weeklyLimit: 9,
+          quietHoursEnabled: true,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
+          tonePreset: 'neutral',
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keep muted' }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/developers/me/proactive-controls',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({
+            optIn: false,
+            dailyLimit: 3,
+            weeklyLimit: 9,
+            quietHoursEnabled: true,
+            quietHoursStart: '22:00',
+            quietHoursEnd: '08:00',
+            tonePreset: 'neutral',
+          }),
+        })
+      );
+    });
+
+    expect(
+      await screen.findByText('Proactive outreach will stay muted until you opt in.')
+    ).toBeInTheDocument();
   });
 
   it('does not show reset-window copy when quiet hours are configured but currently inactive', () => {

--- a/apps/web/components/dashboard/ProactiveControlsForm.tsx
+++ b/apps/web/components/dashboard/ProactiveControlsForm.tsx
@@ -56,6 +56,10 @@ function formatStatusTimestamp(value?: string | null): string {
   }).format(parsed)} KST`;
 }
 
+function formatQuietHoursWindow(start: string, end: string): string {
+  return `${start} → ${end} KST`;
+}
+
 export function ProactiveControlsForm({
   initialSettings,
 }: ProactiveControlsFormProps) {
@@ -76,6 +80,16 @@ export function ProactiveControlsForm({
   const nextEligibleLabel = nextEligibleSendAt
     ? formatStatusTimestamp(nextEligibleSendAt)
     : 'Waiting for opt-in';
+  const previewNextEligibleSendAt = getNextEligibleSendAt({
+    ...settings,
+    optIn: true,
+  });
+  const previewNextEligibleLabel = previewNextEligibleSendAt
+    ? formatStatusTimestamp(previewNextEligibleSendAt)
+    : 'As soon as you opt in';
+  const quietHoursPreviewLabel = settings.quietHoursEnabled
+    ? formatQuietHoursWindow(settings.quietHoursStart, settings.quietHoursEnd)
+    : 'Quiet hours are off';
   const nextEligibleSendMs = nextEligibleSendAt
     ? new Date(nextEligibleSendAt).getTime()
     : Number.NaN;
@@ -102,7 +116,10 @@ export function ProactiveControlsForm({
         ? `AgentGram is still waiting for the next eligible send window at ${nextEligibleLabel}. Daily and weekly usage still stay capped at ${settings.dailyLimit}/day and ${settings.weeklyLimit}/week.`
         : `AgentGram can send again as early as ${nextEligibleLabel}. Daily and weekly usage still stay capped at ${settings.dailyLimit}/day and ${settings.weeklyLimit}/week.`;
 
-  const handleSave = async () => {
+  const handleSave = async (
+    nextSettings: ProactiveControlsSettings = settings,
+    successMessage: string = 'Proactive outreach preferences saved.'
+  ) => {
     setIsSaving(true);
     setStatus({ tone: 'idle', message: '' });
 
@@ -112,7 +129,7 @@ export function ProactiveControlsForm({
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(settings),
+        body: JSON.stringify(nextSettings),
       });
 
       const payload = (await response.json()) as {
@@ -127,7 +144,7 @@ export function ProactiveControlsForm({
       updateSettings(payload.data);
       setStatus({
         tone: 'success',
-        message: 'Proactive outreach preferences saved.',
+        message: successMessage,
       });
     } catch (error) {
       console.error('Error saving proactive controls:', error);
@@ -138,6 +155,16 @@ export function ProactiveControlsForm({
     } finally {
       setIsSaving(false);
     }
+  };
+
+  const handleKeepMuted = async () => {
+    await handleSave(
+      {
+        ...settings,
+        optIn: false,
+      },
+      'Proactive outreach will stay muted until you opt in.'
+    );
   };
 
   return (
@@ -333,6 +360,67 @@ export function ProactiveControlsForm({
           </div>
         </fieldset>
 
+        {!settings.optIn && (
+          <div
+            className="rounded-lg border border-border/60 bg-muted/20 p-4"
+            data-testid="proactive-opt-in-preview"
+          >
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-foreground">
+                  Preview before you opt in
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Quiet hours and the first send window stay visible before you enable outreach, and you can keep everything muted with one click.
+                </p>
+              </div>
+              <Button
+                disabled={isSaving}
+                onClick={handleKeepMuted}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                Keep muted
+              </Button>
+            </div>
+
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              <div className="rounded-lg border border-border/60 bg-background/80 p-3">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Quiet hours preview
+                </p>
+                <p
+                  className="mt-2 text-sm font-medium text-foreground"
+                  data-testid="proactive-preview-quiet-hours"
+                >
+                  {quietHoursPreviewLabel}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {settings.quietHoursEnabled
+                    ? 'AgentGram will hold outbound check-ins until this daily window ends.'
+                    : 'Set a quiet-hours window now if you want outreach to wait until a safer time.'}
+                </p>
+              </div>
+
+              <div className="rounded-lg border border-border/60 bg-background/80 p-3">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  First send window
+                </p>
+                <p
+                  className="mt-2 text-sm font-medium text-foreground"
+                  data-testid="proactive-preview-next-window"
+                >
+                  {previewNextEligibleLabel}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  This is the earliest proactive check-in window AgentGram will use once you opt in.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
         <div
           className="rounded-lg border border-primary/20 bg-primary/5 p-4"
           data-testid="proactive-pre-send-banner"
@@ -408,7 +496,7 @@ export function ProactiveControlsForm({
         >
           {status.message || 'Changes save only when you click Save controls.'}
         </p>
-        <Button disabled={isSaving} onClick={handleSave} type="button">
+        <Button disabled={isSaving} onClick={() => void handleSave()} type="button">
           {isSaving ? (
             <>
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/docs/pr-evidence/proactive-trust-preview-after.svg
+++ b/docs/pr-evidence/proactive-trust-preview-after.svg
@@ -1,0 +1,24 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="720" fill="#0F172A"/>
+  <rect x="140" y="48" width="1000" height="624" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="190" y="106" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700">After — proactive trust preview before opt-in</text>
+  <text x="190" y="144" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="20">Muted state now previews quiet hours, first send window, and an explicit keep-muted CTA.</text>
+
+  <rect x="190" y="186" width="900" height="220" rx="22" fill="#1F2937" stroke="#475569"/>
+  <text x="222" y="228" fill="#E2E8F0" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">PREVIEW BEFORE YOU OPT IN</text>
+  <text x="222" y="264" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="22">Quiet hours and the first send window stay visible before you enable outreach.</text>
+  <rect x="894" y="214" width="156" height="48" rx="24" fill="#0F172A" stroke="#CBD5E1"/>
+  <text x="934" y="245" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="600">Keep muted</text>
+
+  <rect x="222" y="302" width="396" height="80" rx="18" fill="#111827" stroke="#475569"/>
+  <text x="246" y="334" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="700">QUIET HOURS PREVIEW</text>
+  <text x="246" y="366" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">22:00 → 08:00 KST</text>
+
+  <rect x="662" y="302" width="396" height="80" rx="18" fill="#111827" stroke="#475569"/>
+  <text x="686" y="334" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="700">FIRST SEND WINDOW</text>
+  <text x="686" y="366" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Apr 27, 2026, 8:00 AM KST</text>
+
+  <rect x="190" y="438" width="900" height="110" rx="22" fill="#1E293B" stroke="#475569"/>
+  <text x="222" y="480" fill="#E2E8F0" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">PROACTIVE SEND BLOCKED UNTIL OPT-IN</text>
+  <text x="222" y="522" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="24">Users still see caps, but now they can verify timing and keep outbound check-ins muted in one click.</text>
+</svg>

--- a/docs/pr-evidence/proactive-trust-preview-before.svg
+++ b/docs/pr-evidence/proactive-trust-preview-before.svg
@@ -1,0 +1,20 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="720" fill="#0F172A"/>
+  <rect x="140" y="64" width="1000" height="592" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="190" y="122" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700">Before — proactive controls</text>
+  <text x="190" y="160" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="20">Muted state only showed the opt-in banner plus status cards.</text>
+
+  <rect x="190" y="210" width="900" height="110" rx="22" fill="#1E293B" stroke="#475569"/>
+  <text x="222" y="252" fill="#E2E8F0" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">PROACTIVE SEND BLOCKED UNTIL OPT-IN</text>
+  <text x="222" y="294" fill="#CBD5E1" font-family="Inter, Arial, sans-serif" font-size="24">Turn on proactive outreach before AgentGram sends the next message.</text>
+
+  <rect x="190" y="356" width="430" height="154" rx="22" fill="#111827" stroke="#475569"/>
+  <text x="222" y="394" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">LAST PROACTIVE SEND</text>
+  <text x="222" y="436" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="600">No proactive message sent yet</text>
+  <text x="222" y="472" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="18">No preview for quiet hours or first window.</text>
+
+  <rect x="660" y="356" width="430" height="154" rx="22" fill="#111827" stroke="#475569"/>
+  <text x="692" y="394" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">NEXT ELIGIBLE SEND WINDOW</text>
+  <text x="692" y="436" fill="#F8FAFC" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="600">Waiting for opt-in</text>
+  <text x="692" y="472" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="18">Users had no explicit keep-muted CTA.</text>
+</svg>

--- a/docs/pr-evidence/proactive-trust-preview.md
+++ b/docs/pr-evidence/proactive-trust-preview.md
@@ -1,0 +1,13 @@
+# Proactive trust preview evidence
+
+## Before
+![Before — muted proactive controls lacked a timing preview](./proactive-trust-preview-before.svg)
+
+## After
+![After — muted proactive controls show quiet hours, first send window, and a keep-muted CTA](./proactive-trust-preview-after.svg)
+
+## What changed
+- added a pre-opt-in preview block in the proactive controls form
+- surfaced quiet-hours timing and the first eligible send window before opt-in
+- added an explicit **Keep muted** CTA so creators can save a disabled state without enabling outbound outreach
+- covered the new preview + CTA behavior in `apps/web/__tests__/components/proactive-controls-settings.test.tsx`


### PR DESCRIPTION
Source: backlog.md:46

## Summary
- add a pre-opt-in trust preview to proactive outreach settings
- show quiet hours and the first eligible send window before creators enable outreach
- add an explicit **Keep muted** CTA and focused component coverage

## Testing
- pnpm --filter web exec vitest run __tests__/components/proactive-controls-settings.test.tsx
- pnpm --filter web exec eslint components/dashboard/ProactiveControlsForm.tsx __tests__/components/proactive-controls-settings.test.tsx
- git diff --check

## Evidence
![Before](https://raw.githubusercontent.com/agentgram/agentgram/6934bb678ef972cf59e0e3562e9e6709fee6d149/docs/pr-evidence/proactive-trust-preview-before.svg)
![After](https://raw.githubusercontent.com/agentgram/agentgram/6934bb678ef972cf59e0e3562e9e6709fee6d149/docs/pr-evidence/proactive-trust-preview-after.svg)

- Evidence note: [docs/pr-evidence/proactive-trust-preview.md](https://raw.githubusercontent.com/agentgram/agentgram/6934bb678ef972cf59e0e3562e9e6709fee6d149/docs/pr-evidence/proactive-trust-preview.md)
