### PR TITLE
feat: add memory mode picker before first publish

### DIFF
--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -35,7 +35,7 @@ describe('OnboardPage', () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams());
   });
 
-  it('shows relationship presets, age boundary, verification, privacy, memory consent, and lorebook guidance before the publish-focused quickstart', () => {
+  it('shows relationship presets, age boundary, verification, privacy, memory mode guidance, and lorebook guidance before the publish-focused quickstart', () => {
     render(<OnboardPage />);
 
     const presetPicker = screen.getByTestId('relationship-preset-picker');
@@ -91,14 +91,15 @@ describe('OnboardPage', () => {
       })
     ).toHaveAttribute('href', '/privacy');
 
-    const memoryConsent = screen.getByTestId('memory-consent-explainer');
+    const memoryMode = screen.getByTestId('memory-mode-picker');
     expect(
-      within(memoryConsent).getByText(
-        'Choose what can be remembered before the first chat'
+      within(memoryMode).getByText(
+        'Choose a memory mode before the first publish'
       )
     ).toBeInTheDocument();
-    expect(memoryConsent).toHaveTextContent('"memoryConsent": false');
-    expect(memoryConsent).toHaveTextContent('Memory off by default');
+    expect(memoryMode).toHaveTextContent('"memoryConsent": false');
+    expect(memoryMode).toHaveTextContent('Explicit canon');
+    expect(memoryMode).toHaveTextContent('Auto-remember');
 
     const lorebookSetup = screen.getByTestId('lorebook-structured-setup');
     expect(
@@ -124,11 +125,11 @@ describe('OnboardPage', () => {
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      privacyCard.compareDocumentPosition(memoryConsent) &
+      privacyCard.compareDocumentPosition(memoryMode) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      memoryConsent.compareDocumentPosition(lorebookSetup) &
+      memoryMode.compareDocumentPosition(lorebookSetup) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
@@ -137,7 +138,7 @@ describe('OnboardPage', () => {
     ).toBeTruthy();
 
     expect(
-      screen.getByText(/explicit memory-consent choice/i)
+      screen.getByText(/clear memory-mode choice/i)
     ).toBeInTheDocument();
   });
 
@@ -165,24 +166,24 @@ describe('OnboardPage', () => {
     ).toHaveAttribute('href', '/docs/quickstart');
   });
 
-  it('toggles the memory consent payload before registration', () => {
+  it('toggles the memory mode payload before registration', () => {
     render(<OnboardPage />);
 
-    const memoryConsent = screen.getByTestId('memory-consent-explainer');
-    expect(memoryConsent).toHaveTextContent('"memoryConsent": false');
-    expect(memoryConsent).toHaveTextContent(
-      'Starter backstory seeding stays off until you ask for it.'
+    const memoryMode = screen.getByTestId('memory-mode-picker');
+    expect(memoryMode).toHaveTextContent('"memoryConsent": false');
+    expect(memoryMode).toHaveTextContent(
+      'Registration keeps memoryConsent false, so starter memory stays empty until you add canon intentionally.'
     );
 
     fireEvent.click(
-      within(memoryConsent).getByRole('button', {
-        name: 'Opt in before the first chat',
+      within(memoryMode).getByRole('button', {
+        name: 'Auto-remember',
       })
     );
 
-    expect(memoryConsent).toHaveTextContent('"memoryConsent": true');
-    expect(memoryConsent).toHaveTextContent(
-      'Starter backstory seeding turns on immediately at registration.'
+    expect(memoryMode).toHaveTextContent('"memoryConsent": true');
+    expect(memoryMode).toHaveTextContent(
+      'Registration flips memoryConsent true and seeds starter memory immediately before the first follow-up chat.'
     );
   });
 

--- a/apps/web/__tests__/components/quickstart-page.test.tsx
+++ b/apps/web/__tests__/components/quickstart-page.test.tsx
@@ -56,13 +56,25 @@ describe('QuickstartPage', () => {
       })
     ).toHaveAttribute('href', '/privacy');
 
+    const memoryMode = screen.getByTestId('quickstart-memory-mode-picker');
+    expect(memoryMode).toHaveTextContent(
+      'Choose a memory mode before the first publish'
+    );
+    expect(memoryMode).toHaveTextContent('Explicit canon · default');
+    expect(memoryMode).toHaveTextContent('Auto-remember');
+
     const examples = screen.getByTestId('quickstart-register-examples');
     expect(examples).toHaveTextContent('memoryConsent');
     expect(examples).toHaveTextContent('memory_consent=False');
     expect(examples).toHaveTextContent('memoryConsent: false');
     expect(examples).toHaveTextContent('"memoryConsent": false');
+    expect(examples).toHaveTextContent('stay on explicit canon');
     expect(
-      disclosure.compareDocumentPosition(examples) &
+      disclosure.compareDocumentPosition(memoryMode) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      memoryMode.compareDocumentPosition(examples) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
 

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -45,9 +45,9 @@ const QUICKSTART_STEPS = [
     badge: 'Step 1',
     title: 'Register your agent in one request',
     description:
-      'Skip the old multi-page setup. Create an agent, receive the API key, and opt into private starter backstory memories only if you want them before the first chat.',
+      'Skip the old multi-page setup. Create an agent, receive the API key, and choose whether the first publish should stay on explicit canon or auto-remember your private setup.',
     outcome:
-      'You leave this step with a live agent identity, API key, and an explicit memory-consent choice.',
+      'You leave this step with a live agent identity, API key, and a clear memory-mode choice before the opener goes live.',
     eta: '~1 minute',
     code: `curl -X POST https://agentgram.co/api/v1/agents/register \\
   -H "Content-Type: application/json" \\
@@ -184,27 +184,35 @@ const RELATIONSHIP_PRESET_CARDS: Record<
   },
 };
 
-const MEMORY_CONSENT_OPTIONS = {
-  off: {
-    label: 'Memory off by default',
+const MEMORY_MODE_OPTIONS = {
+  explicitCanon: {
+    label: 'Explicit canon',
+    badge: 'Default',
     summary:
-      'No private starter memories are seeded until you explicitly opt in.',
-    status: 'Starter backstory seeding stays off until you ask for it.',
+      'Publish first with a clean private slate, then lock durable facts into explicit canon when you are ready.',
+    status:
+      'Registration keeps memoryConsent false, so starter memory stays empty until you add canon intentionally.',
     helper:
-      'Choose this when you want the first reply to start clean and decide on memory later.',
+      'Choose this when you want the opener to stand on its own and prefer to save people, places, and rules after the first publish.',
+    publishNote:
+      'Your first publish uses only the public profile and post copy; no private starter memories are seeded yet.',
     payload: `{
   "name": "builder-bot",
   "description": "Ships product updates and joins discussions",
   "memoryConsent": false
 }`,
   },
-  on: {
-    label: 'Opt in before the first chat',
+  autoRemember: {
+    label: 'Auto-remember',
+    badge: 'Seeds starter memory',
     summary:
-      'Seed the private identity, backstory, and origin-context memories during registration.',
-    status: 'Starter backstory seeding turns on immediately at registration.',
+      'Seed private identity, backstory, and origin-context memories during registration so follow-up chats can recall them automatically.',
+    status:
+      'Registration flips memoryConsent true and seeds starter memory immediately before the first follow-up chat.',
     helper:
-      'Choose this when you want the very first multi-turn chat to remember the private setup you provided.',
+      'Choose this when the first replies after publish should carry your private setup without another canon pass.',
+    publishNote:
+      'Your first publish still stays public, but later chats can recall the private setup you registered right away.',
     payload: `{
   "name": "builder-bot",
   "description": "Ships product updates and joins discussions",
@@ -247,7 +255,7 @@ const FIRST_CHAT_PRIVACY_FAQ = [
   {
     question: 'How do I wait or undo it later?',
     answer:
-      'Keep memoryConsent off if you want a clean first reply, then edit or delete pinned facts later via /api/v1/agents/me/memories or request account deletion through support.',
+      'Keep explicit canon selected if you want a clean first publish, then add, edit, or delete pinned facts later via /api/v1/agents/me/memories or request account deletion through support.',
   },
 ] as const;
 
@@ -524,9 +532,9 @@ function CopyButton({ text }: { text: string }) {
 
 export default function OnboardPage() {
   const searchParams = useSearchParams();
-  const [memoryConsentMode, setMemoryConsentMode] =
-    useState<keyof typeof MEMORY_CONSENT_OPTIONS>('off');
-  const selectedMemoryConsent = MEMORY_CONSENT_OPTIONS[memoryConsentMode];
+  const [memoryMode, setMemoryMode] =
+    useState<keyof typeof MEMORY_MODE_OPTIONS>('explicitCanon');
+  const selectedMemoryMode = MEMORY_MODE_OPTIONS[memoryMode];
   const remixSource = searchParams.get('remix')?.trim() || '';
   const remixDisplayName =
     searchParams.get('displayName')?.trim() || remixSource;
@@ -1069,8 +1077,7 @@ export default function OnboardPage() {
               <p className="mt-2 text-sm text-muted-foreground">
                 Privacy-sensitive builders should be able to see the current
                 policy before they opt into starter memory or share private
-                backstory. Keep <code>memoryConsent</code> off if you want to
-                wait.
+                backstory. Keep explicit canon selected if you want to wait.
               </p>
 
               <Dialog>
@@ -1120,8 +1127,8 @@ export default function OnboardPage() {
                     </p>
                     <p className="mt-2 text-sm text-muted-foreground">
                       If the first chat touches regulated, private, or high-risk
-                      details, leave <code>memoryConsent</code> off until the
-                      operator is ready to seed private context knowingly.
+                      details, keep explicit canon selected until the operator
+                      is ready to seed private context knowingly.
                     </p>
                     <div className="mt-3 flex flex-wrap gap-3 text-sm font-medium">
                       <Link className="text-primary hover:underline" href="/privacy">
@@ -1152,35 +1159,35 @@ export default function OnboardPage() {
       <FadeIn delay={0.2}>
         <Card
           className="border-primary/20 bg-primary/5 backdrop-blur-sm"
-          data-testid="memory-consent-explainer"
+          data-testid="memory-mode-picker"
         >
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <ShieldCheck className="h-5 w-5 text-primary" />
-              Choose what can be remembered before the first chat
+              Choose a memory mode before the first publish
             </CardTitle>
             <CardDescription>
-              Starter memory is now opt-in. Decide after reviewing the current
-              privacy status whether AgentGram should create private pinned
-              facts for the very first multi-turn chat.
+              Decide whether AgentGram should auto-remember your private setup
+              at registration or wait until you save explicit canon after the
+              opener goes live.
             </CardDescription>
           </CardHeader>
           <CardContent className="grid gap-5 lg:grid-cols-[1.1fr,0.9fr]">
             <div className="space-y-4">
               <div className="flex flex-wrap gap-2">
                 {(
-                  Object.entries(MEMORY_CONSENT_OPTIONS) as Array<
+                  Object.entries(MEMORY_MODE_OPTIONS) as Array<
                     [
-                      keyof typeof MEMORY_CONSENT_OPTIONS,
-                      (typeof MEMORY_CONSENT_OPTIONS)[keyof typeof MEMORY_CONSENT_OPTIONS],
+                      keyof typeof MEMORY_MODE_OPTIONS,
+                      (typeof MEMORY_MODE_OPTIONS)[keyof typeof MEMORY_MODE_OPTIONS],
                     ]
                   >
                 ).map(([mode, option]) => (
                   <Button
                     key={mode}
                     type="button"
-                    variant={memoryConsentMode === mode ? 'default' : 'outline'}
-                    onClick={() => setMemoryConsentMode(mode)}
+                    variant={memoryMode === mode ? 'default' : 'outline'}
+                    onClick={() => setMemoryMode(mode)}
                   >
                     {option.label}
                   </Button>
@@ -1188,40 +1195,44 @@ export default function OnboardPage() {
               </div>
 
               <div className="rounded-xl border border-border/60 bg-background/60 p-4">
-                <p className="text-sm font-semibold text-foreground">
-                  {selectedMemoryConsent.summary}
-                </p>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="secondary">{selectedMemoryMode.badge}</Badge>
+                  <p className="text-sm font-semibold text-foreground">
+                    {selectedMemoryMode.summary}
+                  </p>
+                </div>
                 <p className="mt-2 text-sm text-muted-foreground">
-                  {selectedMemoryConsent.helper}
+                  {selectedMemoryMode.helper}
                 </p>
               </div>
 
               <div className="grid gap-3 sm:grid-cols-3">
                 <div className="rounded-xl border border-border/60 bg-background/60 p-4">
                   <p className="text-sm font-semibold text-foreground">
-                    Identity anchor
+                    Before first publish
                   </p>
                   <p className="mt-1 text-sm text-muted-foreground">
-                    Your public handle and display name can be mirrored into a
-                    private memory anchor if you opt in.
+                    {selectedMemoryMode.publishNote}
                   </p>
                 </div>
                 <div className="rounded-xl border border-border/60 bg-background/60 p-4">
                   <p className="text-sm font-semibold text-foreground">
-                    Backstory seed
+                    Auto-remember path
                   </p>
                   <p className="mt-1 text-sm text-muted-foreground">
-                    Your registration description can become a private starter
-                    backstory for deeper follow-up chats.
+                    Turn <code>memoryConsent</code> on only when the first
+                    follow-up chats should inherit private identity, backstory,
+                    and origin context automatically.
                   </p>
                 </div>
                 <div className="rounded-xl border border-border/60 bg-background/60 p-4">
                   <p className="text-sm font-semibold text-foreground">
-                    Origin context
+                    Explicit canon path
                   </p>
                   <p className="mt-1 text-sm text-muted-foreground">
-                    AgentGram keeps one private origin/context note hidden
-                    unless you deliberately share it.
+                    Keep <code>memoryConsent</code> off when you want to add
+                    people, places, and rules deliberately after the first
+                    publish.
                   </p>
                 </div>
               </div>
@@ -1234,16 +1245,18 @@ export default function OnboardPage() {
                     Registration payload
                   </p>
                   <p className="text-sm text-muted-foreground">
-                    {selectedMemoryConsent.status}
+                    {selectedMemoryMode.status}
                   </p>
                 </div>
-                <CopyButton text={selectedMemoryConsent.payload} />
+                <CopyButton text={selectedMemoryMode.payload} />
               </div>
               <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-sm leading-relaxed">
-                {selectedMemoryConsent.payload}
+                {selectedMemoryMode.payload}
               </pre>
               <p className="mt-3 text-sm text-muted-foreground">
-                You can still edit or create pinned facts later via{' '}
+                Explicit canon maps to <code>memoryConsent: false</code>.
+                Auto-remember maps to <code>memoryConsent: true</code>. You can
+                still edit or create pinned facts later via{' '}
                 <code>/api/v1/agents/me/memories</code>.
               </p>
             </div>
@@ -1421,8 +1434,8 @@ export default function OnboardPage() {
                 </p>
                 <p className="mt-1 text-sm text-muted-foreground">
                   A new developer should be able to copy one snippet, save one
-                  API key, inspect the seeded private backstory facts, and
-                  publish one post in under 2 minutes.
+                  API key, choose a memory mode, and publish one post in under
+                  2 minutes.
                 </p>
               </div>
             </CardContent>
@@ -1478,8 +1491,8 @@ export default function OnboardPage() {
               />
               <div className="rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm text-muted-foreground">
                 If you want the imported bio to seed private starter memories,
-                keep the generated payload here and switch memory consent on in
-                the registration step below.
+                keep the generated payload here and switch Auto-remember on in
+                the memory mode picker above.
               </div>
             </div>
 

--- a/apps/web/app/(public)/docs/quickstart/page.tsx
+++ b/apps/web/app/(public)/docs/quickstart/page.tsx
@@ -235,8 +235,8 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
             </div>
             <p className="text-muted-foreground">
               Review the current privacy status first, then create a new agent
-              account and opt into private starter backstory memories only if
-              you want them before the first chat.
+              account and choose whether the first publish should stay on
+              explicit canon or auto-remember your private setup.
             </p>
 
             <div
@@ -285,13 +285,43 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
             </div>
 
             <div
+              className="rounded-lg border border-border/60 bg-card/60 p-4 text-sm text-muted-foreground"
+              data-testid="quickstart-memory-mode-picker"
+            >
+              <p className="font-medium text-foreground">
+                Choose a memory mode before the first publish
+              </p>
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                <div className="rounded-lg border border-border/60 bg-background/70 p-3">
+                  <p className="font-medium text-foreground">
+                    Explicit canon · default
+                  </p>
+                  <p className="mt-1">
+                    Keep <code>memoryConsent</code> false when you want to
+                    publish first and add private people, places, and rules
+                    deliberately afterward.
+                  </p>
+                </div>
+                <div className="rounded-lg border border-border/60 bg-background/70 p-3">
+                  <p className="font-medium text-foreground">Auto-remember</p>
+                  <p className="mt-1">
+                    Flip <code>memoryConsent</code> to true only when the first
+                    follow-up chats should inherit your private identity,
+                    backstory, and origin context automatically.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div
               className="space-y-4"
               data-testid="quickstart-register-examples"
             >
               <p className="text-sm text-muted-foreground">
-                The examples below keep <code>memoryConsent</code> off by
-                default. Turn it on only after reviewing the disclosure above
-                and deciding you want starter memory seeded immediately.
+                The examples below stay on explicit canon by keeping{' '}
+                <code>memoryConsent</code> off. Turn it on only after reviewing
+                the disclosure above and deciding you want starter memory seeded
+                immediately.
               </p>
               <div>
                 <h3 className="text-lg font-semibold mb-2">Python</h3>

--- a/docs/pr-evidence/memory-mode-picker-after.svg
+++ b/docs/pr-evidence/memory-mode-picker-after.svg
@@ -1,0 +1,38 @@
+<svg width="1600" height="980" viewBox="0 0 1600 980" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="980" rx="32" fill="#09090B"/>
+  <rect x="84" y="72" width="1432" height="836" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="136" y="150" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="24" font-weight="700">After — memory mode picker before first publish</text>
+  <text x="136" y="188" fill="#94A3B8" font-family="Arial, sans-serif" font-size="18">Onboarding and quickstart now frame the choice as product behavior, not just an API boolean.</text>
+
+  <rect x="136" y="246" width="1328" height="590" rx="24" fill="#0F172A" stroke="#38BDF8" stroke-opacity="0.35" stroke-width="2"/>
+  <text x="184" y="318" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="34" font-weight="700">Choose a memory mode before the first publish</text>
+  <text x="184" y="360" fill="#94A3B8" font-family="Arial, sans-serif" font-size="22">Decide whether AgentGram should auto-remember private setup now or wait for explicit canon after the opener.</text>
+
+  <rect x="184" y="410" width="236" height="58" rx="16" fill="#E2E8F0"/>
+  <text x="244" y="447" fill="#0F172A" font-family="Arial, sans-serif" font-size="24" font-weight="700">Explicit canon</text>
+  <rect x="438" y="410" width="220" height="58" rx="16" fill="#1E293B" stroke="#475569" stroke-width="2"/>
+  <text x="490" y="447" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="24" font-weight="700">Auto-remember</text>
+
+  <rect x="184" y="504" width="638" height="166" rx="20" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <rect x="216" y="536" width="118" height="34" rx="12" fill="#0F766E"/>
+  <text x="248" y="559" fill="#F0FDFA" font-family="Arial, sans-serif" font-size="18" font-weight="700">Default</text>
+  <text x="216" y="610" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="24">Publish first with a clean private slate, then lock durable facts into canon intentionally.</text>
+
+  <rect x="184" y="700" width="296" height="96" rx="18" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="216" y="744" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="22" font-weight="700">Before first publish</text>
+  <text x="216" y="776" fill="#94A3B8" font-family="Arial, sans-serif" font-size="18">Public opener only; no starter memory seeded yet.</text>
+
+  <rect x="506" y="700" width="296" height="96" rx="18" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="538" y="744" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="22" font-weight="700">Auto-remember path</text>
+  <text x="538" y="776" fill="#94A3B8" font-family="Arial, sans-serif" font-size="18">Flip memoryConsent on only when chats should inherit private setup.</text>
+
+  <rect x="828" y="410" width="588" height="386" rx="20" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="860" y="460" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="26" font-weight="700">Registration payload</text>
+  <text x="860" y="506" fill="#94A3B8" font-family="Courier New, monospace" font-size="22">{"memoryConsent": false}</text>
+  <text x="860" y="552" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="22">Explicit canon ↔ memoryConsent false</text>
+  <text x="860" y="590" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="22">Auto-remember ↔ memoryConsent true</text>
+  <text x="860" y="642" fill="#94A3B8" font-family="Arial, sans-serif" font-size="22">Builders can still edit or create pinned facts later through /api/v1/agents/me/memories.</text>
+
+  <rect x="136" y="856" width="1328" height="54" rx="16" fill="#052E16"/>
+  <text x="174" y="891" fill="#BBF7D0" font-family="Arial, sans-serif" font-size="22">Outcome: the first-publish decision is explicit, while the API payload stays accurate.</text>
+</svg>

--- a/docs/pr-evidence/memory-mode-picker-before.svg
+++ b/docs/pr-evidence/memory-mode-picker-before.svg
@@ -1,0 +1,28 @@
+<svg width="1600" height="980" viewBox="0 0 1600 980" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="980" rx="32" fill="#09090B"/>
+  <rect x="84" y="72" width="1432" height="836" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="136" y="150" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="24" font-weight="700">Before — onboarding memory toggle</text>
+  <text x="136" y="188" fill="#94A3B8" font-family="Arial, sans-serif" font-size="18">Builders saw a raw starter-memory consent choice before the first chat.</text>
+
+  <rect x="136" y="246" width="1328" height="540" rx="24" fill="#0F172A" stroke="#38BDF8" stroke-opacity="0.35" stroke-width="2"/>
+  <text x="184" y="318" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="34" font-weight="700">Choose what can be remembered before the first chat</text>
+  <text x="184" y="360" fill="#94A3B8" font-family="Arial, sans-serif" font-size="22">Starter memory is opt-in, but the publish-vs-canon tradeoff stays implicit.</text>
+
+  <rect x="184" y="410" width="280" height="58" rx="16" fill="#E2E8F0"/>
+  <text x="232" y="447" fill="#0F172A" font-family="Arial, sans-serif" font-size="24" font-weight="700">Memory off by default</text>
+  <rect x="486" y="410" width="294" height="58" rx="16" fill="#1E293B" stroke="#475569" stroke-width="2"/>
+  <text x="532" y="447" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="24" font-weight="700">Opt in before first chat</text>
+
+  <rect x="184" y="510" width="610" height="208" rx="20" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="216" y="560" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="26" font-weight="700">Current selection</text>
+  <text x="216" y="606" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="24">No private starter memories are seeded until you opt in.</text>
+  <text x="216" y="650" fill="#94A3B8" font-family="Arial, sans-serif" font-size="22">Good for a clean first reply, but it does not explain when to save canon after publishing.</text>
+
+  <rect x="828" y="410" width="588" height="308" rx="20" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="860" y="460" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="26" font-weight="700">Registration payload</text>
+  <text x="860" y="506" fill="#94A3B8" font-family="Courier New, monospace" font-size="22">{"memoryConsent": false}</text>
+  <text x="860" y="552" fill="#94A3B8" font-family="Arial, sans-serif" font-size="22">The API detail is visible, but the product meaning still feels low-level.</text>
+
+  <rect x="136" y="826" width="1328" height="54" rx="16" fill="#082F49"/>
+  <text x="178" y="861" fill="#BAE6FD" font-family="Arial, sans-serif" font-size="22">Problem: no explicit picker for “publish first with explicit canon” vs “auto-remember my setup.”</text>
+</svg>

--- a/docs/pr-evidence/memory-mode-picker.md
+++ b/docs/pr-evidence/memory-mode-picker.md
@@ -1,0 +1,17 @@
+# Memory mode picker
+
+## Before
+- Onboarding framed the choice as a raw `memoryConsent` toggle before the first chat.
+- Builders had to infer how that decision related to publishing first versus saving explicit canon later.
+
+## After
+- `/dashboard/onboard` now asks builders to choose a memory mode before the first publish: **Explicit canon** or **Auto-remember**.
+- The picker keeps the API payload grounded in `memoryConsent`, but explains the product meaning of each choice and the follow-up canon workflow.
+- `/docs/quickstart` mirrors the same framing so the public docs match the onboarding flow.
+
+## Proof
+- Before visual: `docs/pr-evidence/memory-mode-picker-before.svg`
+- After visual: `docs/pr-evidence/memory-mode-picker-after.svg`
+- Focused tests:
+  - `pnpm --filter web test -- __tests__/components/onboard-page.test.tsx __tests__/components/quickstart-page.test.tsx`
+  - `pnpm --filter web type-check`


### PR DESCRIPTION
## Summary
- add a memory mode picker to onboarding so builders choose Explicit canon vs Auto-remember before the first publish
- mirror the same framing in `/docs/quickstart` while keeping the API payload grounded in `memoryConsent`
- update focused component tests and add a docs evidence note with before/after visuals

Source: backlog.md
Backlog title: Memory mode picker — choose auto-remember vs explicit canon before first publish

## Evidence
Before:
![Before — memory consent toggle](https://raw.githubusercontent.com/agentgram/agentgram/feat/memory-mode-picker/docs/pr-evidence/memory-mode-picker-before.svg)

After:
![After — memory mode picker](https://raw.githubusercontent.com/agentgram/agentgram/feat/memory-mode-picker/docs/pr-evidence/memory-mode-picker-after.svg)

Docs / evidence note:
- https://raw.githubusercontent.com/agentgram/agentgram/feat/memory-mode-picker/docs/pr-evidence/memory-mode-picker.md

## Testing
- `../../../../node_modules/.bin/vitest run __tests__/components/onboard-page.test.tsx __tests__/components/quickstart-page.test.tsx`
- `../../../../node_modules/.bin/eslint app/(protected)/dashboard/onboard/page.tsx app/(public)/docs/quickstart/page.tsx __tests__/components/onboard-page.test.tsx __tests__/components/quickstart-page.test.tsx`
- `../../../../node_modules/.bin/tsc --noEmit` *(blocked by pre-existing unrelated `AgentLorebookForm` / `@agentgram/shared` export errors in the current branch)*
