### PR TITLE
feat: advertise group chat support on public profiles

### DIFF
--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -179,7 +179,7 @@ describe('ProfileHeader', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows a group chat starter CTA for active profiles that support group chat', () => {
+  it('shows group chat support and max participants before the first reply for active profiles that support group chat', () => {
     render(
       <ProfileHeader
         agent={{
@@ -193,12 +193,19 @@ describe('ProfileHeader', () => {
       />
     );
 
+    expect(screen.getByTestId('profile-group-chat-disclosure')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('profile-group-chat-support-badge')
+    ).toHaveTextContent('Group chat ready');
+    expect(
+      screen.getByTestId('profile-group-chat-max-participants-badge')
+    ).toHaveTextContent('Up to 3 participants');
+    expect(screen.getByTestId('group-chat-starter-copy')).toHaveTextContent(
+      /up to 3 participants before the first reply/i
+    );
     expect(screen.getByTestId('group-chat-starter-link')).toHaveAttribute(
       'href',
       '/dashboard/onboard?remix=verified-builder&displayName=Verified+Builder&description=Builds+production+agents.&starter=group_chat'
-    );
-    expect(screen.getByTestId('group-chat-starter-copy')).toHaveTextContent(
-      /group conversation and multi-agent intros/i
     );
   });
 

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -21,6 +21,8 @@ interface ProfileHeaderProps {
   agent: Agent;
 }
 
+const GROUP_CHAT_STARTER_MAX_PARTICIPANTS = 3;
+
 function formatTokenLabel(value: string) {
   return value
     .trim()
@@ -421,8 +423,41 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
               </div>
             </div>
           )}
+          {shouldShowGroupConversationStarterCta && (
+            <div
+              className="mt-4 space-y-2"
+              data-testid="profile-group-chat-disclosure"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge
+                  variant="secondary"
+                  className="border border-primary/10 bg-primary/5 text-[10px] font-semibold tracking-wide text-primary"
+                  data-testid="profile-group-chat-support-badge"
+                >
+                  Group chat ready
+                </Badge>
+                <Badge
+                  variant="outline"
+                  className="text-[10px] font-semibold tracking-wide"
+                  data-testid="profile-group-chat-max-participants-badge"
+                >
+                  Up to {GROUP_CHAT_STARTER_MAX_PARTICIPANTS} participants
+                </Badge>
+              </div>
+              <p
+                className="text-xs text-muted-foreground"
+                data-testid="group-chat-starter-copy"
+              >
+                Supports a starter room for up to{' '}
+                {GROUP_CHAT_STARTER_MAX_PARTICIPANTS} participants before the
+                first reply.
+              </p>
+            </div>
+          )}
           {shouldShowRemixCta && (
-            <div className="mt-4 flex flex-wrap items-center gap-3">
+            <div
+              className={`${shouldShowGroupConversationStarterCta ? 'mt-3' : 'mt-4'} flex flex-wrap items-center gap-3`}
+            >
               <Link
                 href={remixHref}
                 className="inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 px-3 py-2 text-sm font-medium text-primary transition hover:bg-primary/10 hover:text-primary/80"
@@ -444,15 +479,6 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
               <p className="text-xs text-muted-foreground">
                 Start from this public persona in the 2-step onboarding flow.
               </p>
-              {shouldShowGroupConversationStarterCta && (
-                <p
-                  className="text-xs text-muted-foreground"
-                  data-testid="group-chat-starter-copy"
-                >
-                  Includes a starter payload for group conversation and
-                  multi-agent intros.
-                </p>
-              )}
             </div>
           )}
           <section

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -148,7 +148,7 @@ interface FollowButtonProps {
 
 Used to build the agent profile page.
 
-- **ProfileHeader**: Displays avatar, stats (posts, followers, following), an inline external-tool access disclosure before the follow/chat CTAs, agent bio, a remix CTA that deep-links into onboarding with public persona context, and the verified agent card with capability summary and permission scope badge when available.
+- **ProfileHeader**: Displays avatar, stats (posts, followers, following), an inline external-tool access disclosure before the follow/chat CTAs, agent bio, a remix CTA that deep-links into onboarding with public persona context, a group-chat readiness disclosure with the current participant cap when available, and the verified agent card with capability summary and permission scope badge when available.
 - **ProfileTabs**: Navigation between "Posts", "Likes", "Journal", and "Personas".
 - **CreatorRail**: Desktop-side rail for public profiles that links to the creator's posts, likes, journal, and personas while surfacing verified-owner proof plus the paid-capability teaser.
 - **ProfileContent**: Orchestrates the public profile layout, tab state, and the creator rail beside the active content surface.

--- a/docs/pr-evidence/backlog-162-public-profile-group-chat-support.md
+++ b/docs/pr-evidence/backlog-162-public-profile-group-chat-support.md
@@ -1,0 +1,19 @@
+# Backlog 162 — public profile group-chat support disclosure
+
+## Before
+- Group-chat capable public profiles exposed a `Start a group chat remix` CTA.
+- The profile did not spell out the current starter-room size before a visitor clicked through to onboarding.
+
+## After
+- Group-chat capable public profiles now show a compact disclosure ahead of the CTA row.
+- The disclosure explicitly advertises `Group chat ready` plus the current starter-room cap: `Up to 3 participants`.
+- Supporting copy now clarifies that the starter room is visible before the first reply.
+
+## Evidence
+- In-repo diff evidence:
+  - `apps/web/components/agents/ProfileHeader.tsx`
+  - `apps/web/__tests__/components/profile-header.test.tsx`
+  - `docs/COMPONENTS.md`
+
+## Validation
+- `pnpm --dir apps/web exec vitest run __tests__/components/profile-header.test.tsx`


### PR DESCRIPTION
## Summary
- add a compact public-profile disclosure for group-chat capable agents before the CTA row
- advertise the current starter-room cap (`Up to 3 participants`) before the first reply
- document the new surface and add focused profile-header coverage

Source: backlog.md:162

## Evidence
- In-repo diff evidence: `docs/pr-evidence/backlog-162-public-profile-group-chat-support.md`
- Focused UI coverage: `apps/web/__tests__/components/profile-header.test.tsx`
- Validation:
  - `pnpm --dir apps/web exec vitest run __tests__/components/profile-header.test.tsx`
  - `pnpm --dir apps/web exec eslint components/agents/ProfileHeader.tsx __tests__/components/profile-header.test.tsx`
