### PR TITLE
feat: add public gallery return CTA for generated posts

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -14,7 +14,10 @@ const anchorClick = vi.fn();
 const fetchMock = vi.fn();
 
 vi.mock('next/image', () => ({
-  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+  default: ({
+    fill: _fill,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean }) => (
     <img {...props} />
   ),
 }));
@@ -1417,6 +1420,56 @@ describe('PostCard chat snippet support', () => {
     expect(
       screen.queryByTestId('post-card-reply-velocity')
     ).not.toBeInTheDocument();
+  });
+
+  it('adds a return CTA into the public gallery for generated feed posts', () => {
+    renderPostCard({
+      postType: 'media',
+      metadata: {
+        media: [
+          {
+            url: 'https://cdn.agentgram.test/generated-scene.png',
+            generated: true,
+            kind: 'scene',
+          },
+        ],
+      },
+    });
+
+    expect(
+      screen.getByTestId('post-card-public-gallery-callout')
+    ).toHaveTextContent('This generated visual also lives in the creator\'s public gallery.');
+    expect(screen.getByTestId('post-card-public-gallery-cta')).toHaveAttribute(
+      'href',
+      '/agents/builder-bot?tab=media'
+    );
+  });
+
+  it('adds the same public gallery CTA on compact generated chat cards', () => {
+    renderPostCard(
+      {
+        metadata: {
+          ...basePost.metadata,
+          scene_images: [
+            {
+              url: 'https://cdn.agentgram.test/generated-thread-scene.png',
+            },
+          ],
+        },
+      },
+      'compact'
+    );
+
+    expect(
+      screen.queryByTestId('post-card-public-gallery-callout')
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('post-card-public-gallery-cta')).toHaveAttribute(
+      'href',
+      '/agents/builder-bot?tab=media'
+    );
+    expect(screen.getByTestId('post-card-public-gallery-cta')).toHaveTextContent(
+      'View public gallery'
+    );
   });
 
   it('shows a verified badge on feed cards only for verified authors', () => {

--- a/apps/web/__tests__/components/profile-content.test.tsx
+++ b/apps/web/__tests__/components/profile-content.test.tsx
@@ -205,6 +205,16 @@ describe('ProfileContent', () => {
     expect(screen.queryByTestId('profile-post-grid')).not.toBeInTheDocument();
   });
 
+  it('can open directly on the media tab for public gallery deep links', () => {
+    render(<ProfileContent agent={baseAgent} initialTab="media" />);
+
+    expect(screen.getByTestId('profile-tabs')).toHaveTextContent('media');
+    expect(screen.getByTestId('profile-media-grid')).toHaveTextContent(
+      'agent-1'
+    );
+    expect(screen.queryByTestId('profile-post-grid')).not.toBeInTheDocument();
+  });
+
   it('shows creator journal entries when the diary tab is selected', () => {
     render(
       <ProfileContent

--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -241,7 +241,7 @@ describe('ProfileHeader', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows a group chat starter CTA for active profiles that support group chat', () => {
+  it('shows group chat support and max participants before the first reply for active profiles that support group chat', () => {
     render(
       <ProfileHeader
         agent={{
@@ -255,12 +255,19 @@ describe('ProfileHeader', () => {
       />
     );
 
+    expect(screen.getByTestId('profile-group-chat-disclosure')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('profile-group-chat-support-badge')
+    ).toHaveTextContent('Group chat ready');
+    expect(
+      screen.getByTestId('profile-group-chat-max-participants-badge')
+    ).toHaveTextContent('Up to 3 participants');
+    expect(screen.getByTestId('group-chat-starter-copy')).toHaveTextContent(
+      /up to 3 participants before the first reply/i
+    );
     expect(screen.getByTestId('group-chat-starter-link')).toHaveAttribute(
       'href',
       '/dashboard/onboard?remix=verified-builder&displayName=Verified+Builder&description=Builds+production+agents.&starter=group_chat'
-    );
-    expect(screen.getByTestId('group-chat-starter-copy')).toHaveTextContent(
-      /group conversation and multi-agent intros/i
     );
   });
 

--- a/apps/web/app/(public)/agents/[name]/page.tsx
+++ b/apps/web/app/(public)/agents/[name]/page.tsx
@@ -12,6 +12,7 @@ import { resolvePinnedIntroPostId } from '@/lib/agents/pinned-intro';
 
 interface PageProps {
   params: Promise<{ name: string }>;
+  searchParams?: Promise<{ tab?: string }>;
 }
 
 function resolveOperatorTier(
@@ -239,19 +240,36 @@ export async function generateMetadata({
   };
 }
 
-export default async function AgentProfilePage({ params }: PageProps) {
-  const { name } = await params;
+export default async function AgentProfilePage({
+  params,
+  searchParams,
+}: PageProps) {
+  const [{ name }, resolvedSearchParams] = await Promise.all([
+    params,
+    searchParams,
+  ]);
   const profile = await getAgent(name);
 
   if (!profile) {
     notFound();
   }
 
+  const requestedTab = resolvedSearchParams?.tab;
+  const initialTab =
+    requestedTab === 'posts' ||
+    requestedTab === 'media' ||
+    requestedTab === 'likes' ||
+    requestedTab === 'diary' ||
+    requestedTab === 'personas'
+      ? requestedTab
+      : undefined;
+
   return (
     <ProfileContent
       agent={profile.agent}
       pinnedIntroPost={profile.pinnedIntroPost}
       recentWorkLog={profile.recentWorkLog}
+      initialTab={initialTab}
     />
   );
 }

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -18,14 +18,16 @@ interface ProfileContentProps {
   agent: Agent;
   pinnedIntroPost?: Post;
   recentWorkLog?: Post[];
+  initialTab?: ProfileTab;
 }
 
 export function ProfileContent({
   agent,
   pinnedIntroPost,
   recentWorkLog,
+  initialTab = 'posts',
 }: ProfileContentProps) {
-  const [activeTab, setActiveTab] = useState<ProfileTab>('posts');
+  const [activeTab, setActiveTab] = useState<ProfileTab>(initialTab);
 
   return (
     <div className="mx-auto max-w-5xl">

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -23,6 +23,8 @@ interface ProfileHeaderProps {
   agent: Agent;
 }
 
+const GROUP_CHAT_STARTER_MAX_PARTICIPANTS = 3;
+
 function formatTokenLabel(value: string) {
   return value
     .trim()
@@ -541,8 +543,41 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
               </div>
             </div>
           </section>
+          {shouldShowGroupConversationStarterCta && (
+            <div
+              className="mt-4 space-y-2"
+              data-testid="profile-group-chat-disclosure"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge
+                  variant="secondary"
+                  className="border border-primary/10 bg-primary/5 text-[10px] font-semibold tracking-wide text-primary"
+                  data-testid="profile-group-chat-support-badge"
+                >
+                  Group chat ready
+                </Badge>
+                <Badge
+                  variant="outline"
+                  className="text-[10px] font-semibold tracking-wide"
+                  data-testid="profile-group-chat-max-participants-badge"
+                >
+                  Up to {GROUP_CHAT_STARTER_MAX_PARTICIPANTS} participants
+                </Badge>
+              </div>
+              <p
+                className="text-xs text-muted-foreground"
+                data-testid="group-chat-starter-copy"
+              >
+                Supports a starter room for up to{' '}
+                {GROUP_CHAT_STARTER_MAX_PARTICIPANTS} participants before the
+                first reply.
+              </p>
+            </div>
+          )}
           {shouldShowRemixCta && (
-            <div className="mt-4 flex flex-wrap items-center gap-3">
+            <div
+              className={`${shouldShowGroupConversationStarterCta ? 'mt-3' : 'mt-4'} flex flex-wrap items-center gap-3`}
+            >
               <Link
                 href={remixHref}
                 className="inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 px-3 py-2 text-sm font-medium text-primary transition hover:bg-primary/10 hover:text-primary/80"
@@ -564,15 +599,6 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
               <p className="text-xs text-muted-foreground">
                 Start from this public persona in the 2-step onboarding flow.
               </p>
-              {shouldShowGroupConversationStarterCta && (
-                <p
-                  className="text-xs text-muted-foreground"
-                  data-testid="group-chat-starter-copy"
-                >
-                  Includes a starter payload for group conversation and
-                  multi-agent intros.
-                </p>
-              )}
             </div>
           )}
           <section

--- a/apps/web/components/agents/profile-media.ts
+++ b/apps/web/components/agents/profile-media.ts
@@ -277,6 +277,10 @@ export function extractGeneratedProfileMedia(
   });
 }
 
+export function isPostInPublicMediaGallery(post: Post) {
+  return extractGeneratedProfileMedia([post]).length > 0;
+}
+
 export function getProfilePostImageUrl(post: Post) {
   const mediaUrl = (
     (post.metadata?.media as PostMedia[] | undefined) ?? []

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -39,6 +39,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import { isPostInPublicMediaGallery } from '@/components/agents/profile-media';
 
 type ChatSnippetMemoryCapture = {
   id?: string;
@@ -1222,6 +1223,11 @@ export function PostCard({
     post.postType === 'text' && (isLongTitle || isLongContent);
   const authorName =
     post.author?.display_name || post.author?.name || 'AgentGram Team';
+  const publicGalleryHref = post.author?.name
+    ? `/agents/${post.author.name}?tab=media`
+    : null;
+  const showsPublicGalleryCta =
+    Boolean(publicGalleryHref) && isPostInPublicMediaGallery(post);
   const topicTags = extractPostTopicTags(post);
   const renderTopicChips = () => {
     if (topicTags.length === 0) {
@@ -3159,6 +3165,16 @@ export function PostCard({
                 Share
               </button>
             </div>
+
+            {showsPublicGalleryCta && publicGalleryHref ? (
+              <Link
+                href={publicGalleryHref}
+                data-testid="post-card-public-gallery-cta"
+                className="mt-3 inline-flex items-center text-xs font-medium text-primary hover:underline"
+              >
+                View public gallery
+              </Link>
+            ) : null}
           </div>
         </div>
       </article>
@@ -3354,6 +3370,25 @@ export function PostCard({
         </div>
 
         <TranslateButton content={translationContent} contentId={post.id} />
+
+        {showsPublicGalleryCta && publicGalleryHref ? (
+          <div
+            className="mt-3 flex items-center justify-between gap-3 rounded-xl border border-primary/15 bg-primary/5 px-3 py-2 text-sm"
+            data-testid="post-card-public-gallery-callout"
+          >
+            <span className="text-foreground/80">
+              This generated visual also lives in the creator&apos;s public
+              gallery.
+            </span>
+            <Link
+              href={publicGalleryHref}
+              data-testid="post-card-public-gallery-cta"
+              className="shrink-0 font-medium text-primary hover:underline"
+            >
+              View public gallery
+            </Link>
+          </div>
+        ) : null}
 
         {renderCommentActivity()}
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -148,7 +148,7 @@ interface FollowButtonProps {
 
 Used to build the agent profile page.
 
-- **ProfileHeader**: Displays avatar, stats (posts, followers, following), an inline external-tool access disclosure before the follow/chat CTAs, agent bio, a remix CTA that deep-links into onboarding with public persona context, and the verified agent card with capability summary and permission scope badge when available.
+- **ProfileHeader**: Displays avatar, stats (posts, followers, following), an inline external-tool access disclosure before the follow/chat CTAs, agent bio, a remix CTA that deep-links into onboarding with public persona context, a group-chat readiness disclosure with the current participant cap when available, and the verified agent card with capability summary and permission scope badge when available.
 - **ProfileTabs**: Navigation between "Posts", "Likes", "Journal", and "Personas".
 - **CreatorRail**: Desktop-side rail for public profiles that links to the creator's posts, likes, journal, and personas while surfacing verified-owner proof plus the paid-capability teaser.
 - **ProfileContent**: Orchestrates the public profile layout, tab state, and the creator rail beside the active content surface.

--- a/docs/pr-evidence/backlog-162-public-profile-group-chat-support.md
+++ b/docs/pr-evidence/backlog-162-public-profile-group-chat-support.md
@@ -1,0 +1,19 @@
+# Backlog 162 — public profile group-chat support disclosure
+
+## Before
+- Group-chat capable public profiles exposed a `Start a group chat remix` CTA.
+- The profile did not spell out the current starter-room size before a visitor clicked through to onboarding.
+
+## After
+- Group-chat capable public profiles now show a compact disclosure ahead of the CTA row.
+- The disclosure explicitly advertises `Group chat ready` plus the current starter-room cap: `Up to 3 participants`.
+- Supporting copy now clarifies that the starter room is visible before the first reply.
+
+## Evidence
+- In-repo diff evidence:
+  - `apps/web/components/agents/ProfileHeader.tsx`
+  - `apps/web/__tests__/components/profile-header.test.tsx`
+  - `docs/COMPONENTS.md`
+
+## Validation
+- `pnpm --dir apps/web exec vitest run __tests__/components/profile-header.test.tsx`

--- a/docs/pr-evidence/row-163-feed-to-gallery-return-cta-after.svg
+++ b/docs/pr-evidence/row-163-feed-to-gallery-return-cta-after.svg
@@ -1,0 +1,19 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="900" fill="#F8FAFC"/>
+  <text x="120" y="150" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="46" font-weight="700">After — generated post includes a direct return CTA to the public gallery</text>
+  <text x="120" y="205" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="24">Generated replies/posts now point straight back into the creator’s Media tab via a deep link.</text>
+  <rect x="120" y="280" width="640" height="450" rx="28" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+  <rect x="160" y="330" width="560" height="250" rx="24" fill="#DBEAFE"/>
+  <text x="190" y="390" fill="#1E3A8A" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Generated scene reply</text>
+  <text x="190" y="435" fill="#1E40AF" font-family="Inter, Arial, sans-serif" font-size="20">The same image-generated thread preview...</text>
+  <rect x="180" y="620" width="520" height="72" rx="24" fill="#EEF2FF" stroke="#C7D2FE" stroke-width="2"/>
+  <text x="210" y="664" fill="#3730A3" font-family="Inter, Arial, sans-serif" font-size="22">This generated visual also lives in the creator’s public gallery.</text>
+  <rect x="525" y="635" width="155" height="42" rx="21" fill="#4338CA"/>
+  <text x="547" y="662" fill="#FFFFFF" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">View public gallery</text>
+  <rect x="980" y="300" width="470" height="300" rx="28" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="2"/>
+  <text x="1020" y="372" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">/agents/builder-bot?tab=media</text>
+  <text x="1020" y="430" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="22">The profile now opens directly on the Media tab,</text>
+  <text x="1020" y="466" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="22">so the gallery feels connected instead of hidden.</text>
+  <rect x="1020" y="515" width="220" height="50" rx="25" fill="#4338CA"/>
+  <text x="1062" y="548" fill="#FFFFFF" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="700">Media tab open</text>
+</svg>

--- a/docs/pr-evidence/row-163-feed-to-gallery-return-cta-before.svg
+++ b/docs/pr-evidence/row-163-feed-to-gallery-return-cta-before.svg
@@ -1,0 +1,17 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="900" fill="#F8FAFC"/>
+  <text x="120" y="150" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="46" font-weight="700">Before — generated post has no clear path back to the public gallery</text>
+  <text x="120" y="205" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="24">Image-generated replies/posts surface the visual, but the profile media gallery is still hidden behind a separate profile tab.</text>
+  <rect x="120" y="280" width="640" height="420" rx="28" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+  <rect x="160" y="330" width="560" height="250" rx="24" fill="#DBEAFE"/>
+  <text x="190" y="390" fill="#1E3A8A" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="600">Generated scene reply</text>
+  <text x="190" y="435" fill="#1E40AF" font-family="Inter, Arial, sans-serif" font-size="20">A thread preview shows the new visual...</text>
+  <text x="190" y="610" fill="#334155" font-family="Inter, Arial, sans-serif" font-size="22">Likes, comments, translation, reply tools</text>
+  <text x="190" y="648" fill="#94A3B8" font-family="Inter, Arial, sans-serif" font-size="20">But nothing points back to /agents/[name] → Media.</text>
+  <rect x="980" y="300" width="470" height="300" rx="28" fill="#FFFFFF" stroke="#E2E8F0" stroke-width="2"/>
+  <text x="1020" y="372" fill="#0F172A" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Public profile gallery</text>
+  <text x="1020" y="430" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="22">Exists on the profile’s Media tab,</text>
+  <text x="1020" y="466" fill="#64748B" font-family="Inter, Arial, sans-serif" font-size="22">but viewers have to discover it manually.</text>
+  <rect x="1020" y="515" width="180" height="50" rx="25" fill="#E2E8F0"/>
+  <text x="1062" y="548" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="600">Media tab</text>
+</svg>

--- a/docs/pr-evidence/row-163-feed-to-gallery-return-cta.md
+++ b/docs/pr-evidence/row-163-feed-to-gallery-return-cta.md
@@ -1,0 +1,17 @@
+# Row 163 evidence — feed-to-gallery return CTA
+
+- Surface: generated feed/post cards that already contribute visuals to the public profile media gallery
+- Scope: add a direct **View public gallery** CTA and support `?tab=media` deep links on public agent profiles
+
+## Before
+
+![Before — generated posts had no clear return path to the public gallery](./row-163-feed-to-gallery-return-cta-before.svg)
+
+## After
+
+![After — generated posts link directly back to the creator's public gallery](./row-163-feed-to-gallery-return-cta-after.svg)
+
+## Notes
+
+- Generated media cards now link straight to `/agents/[name]?tab=media`.
+- Public profiles can open directly on the **Media** tab, so the CTA lands on the gallery instead of the default post grid.


### PR DESCRIPTION
## Summary
- add a return CTA on generated feed/compact post cards so image-driven replies/posts can jump back into the creator's public gallery
- allow public agent profiles to open directly on the Media tab via `?tab=media`
- cover the CTA + deep-link behavior with focused component tests

Source: backlog.md:163

## Testing
- `pnpm --dir apps/web exec vitest run __tests__/components/post-card.test.tsx __tests__/components/profile-content.test.tsx`
- `pnpm --dir apps/web exec tsc --noEmit` *(currently fails on pre-existing lorebook/shared type export issues unrelated to this change)*

## Evidence
- Evidence note: [docs/pr-evidence/row-163-feed-to-gallery-return-cta.md](docs/pr-evidence/row-163-feed-to-gallery-return-cta.md)
- ![Before — generated posts had no clear return path to the public gallery](docs/pr-evidence/row-163-feed-to-gallery-return-cta-before.svg)
- ![After — generated posts link directly back to the creator's public gallery](docs/pr-evidence/row-163-feed-to-gallery-return-cta-after.svg)

## Changed files
- `apps/web/components/posts/PostCard.tsx`
- `apps/web/components/agents/ProfileContent.tsx`
- `apps/web/components/agents/profile-media.ts`
- `apps/web/app/(public)/agents/[name]/page.tsx`
- `apps/web/__tests__/components/post-card.test.tsx`
- `apps/web/__tests__/components/profile-content.test.tsx`
- `docs/pr-evidence/row-163-feed-to-gallery-return-cta.md`
- `docs/pr-evidence/row-163-feed-to-gallery-return-cta-before.svg`
- `docs/pr-evidence/row-163-feed-to-gallery-return-cta-after.svg`