### PR TITLE
refactor: fix PR artifact pack validation drift

### DIFF
--- a/scripts/__tests__/validate-pr-body.test.mjs
+++ b/scripts/__tests__/validate-pr-body.test.mjs
@@ -1,7 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 import { validatePrArtifactPack } from '../validate-pr-body.mjs';
+
+const prTemplateBody = readFileSync(
+  resolve(process.cwd(), '.github/PULL_REQUEST_TEMPLATE.md'),
+  'utf8'
+);
 
 const nonAuthBody = `## Source
 Source: backlog.md:97
@@ -41,12 +48,41 @@ test('fails when source does not cite a backlog row or issue', () => {
   );
 });
 
+test('fails when source still contains template placeholder text', () => {
+  const result = validatePrArtifactPack({
+    title: 'refactor: require verification artifact pack in PRs',
+    body: nonAuthBody.replace(
+      'Source: backlog.md:97',
+      'Source: backlog.md:97 or #ISSUE'
+    ),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(
+    result.errors.join('\n'),
+    /## Source must cite a backlog row or issue/
+  );
+});
+
 test('fails when evidence is placeholder-only', () => {
   const result = validatePrArtifactPack({
     title: 'refactor: require verification artifact pack in PRs',
     body: nonAuthBody.replace(
       '- Docs/example diff: docs/pr-evidence/row-97-verification-artifact-pack.md\n- Validation: `node --test scripts/__tests__/validate-pr-body.test.mjs`',
       '-'
+    ),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /## Evidence must be filled/);
+});
+
+test('fails when evidence only keeps the template scaffold labels', () => {
+  const result = validatePrArtifactPack({
+    title: 'refactor: require verification artifact pack in PRs',
+    body: nonAuthBody.replace(
+      '- Docs/example diff: docs/pr-evidence/row-97-verification-artifact-pack.md\n- Validation: `node --test scripts/__tests__/validate-pr-body.test.mjs`',
+      '- Docs/example diff:\n- Screenshot/live-proof:\n- Validation:'
     ),
   });
 
@@ -86,4 +122,20 @@ curl -H "Authorization: Bearer $SESSION_TOKEN" https://agentgram.local/api/priva
 
   assert.equal(result.ok, true);
   assert.equal(result.authGated, true);
+});
+
+test('passes a non-auth PR body derived from the template once source and evidence are filled', () => {
+  const result = validatePrArtifactPack({
+    title: 'refactor: unblock reviewable PRs',
+    labels: ['type: refactor'],
+    body: prTemplateBody
+      .replace('Source: backlog.md:ROW or #ISSUE', 'Source: backlog.md:97')
+      .replace(
+        '- Docs/example diff:\n- Screenshot/live-proof:\n- Validation:',
+        '- Docs/example diff: docs/pr-evidence/row-97-verification-artifact-pack.md\n- Validation: `node --test scripts/__tests__/validate-pr-body.test.mjs`'
+      ),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.authGated, false);
 });

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -16,8 +16,11 @@ const PLACEHOLDER_LINE_PATTERNS = [
 ];
 const SOURCE_REFERENCE_PATTERN =
   /(Source:\s*)?(backlog\.md:\d+|#\d+|https?:\/\/\S+)/i;
+const SOURCE_TEMPLATE_PLACEHOLDER_PATTERN = /backlog\.md:row|#issue/i;
 const EVIDENCE_SIGNAL_PATTERN =
   /(docs\/|\.png\b|\.jpe?g\b|\.gif\b|\.webp\b|\.html\b|\.md\b|screenshot|live[- ]proof|docs\/example diff|diff|validation|test)/i;
+const EMPTY_EVIDENCE_SCAFFOLD_PATTERN =
+  /^[-*]\s*(docs\/example diff|screenshot\/live-proof|validation):\s*$/i;
 const AUTH_SNIPPET_SIGNAL_PATTERN =
   /```[\s\S]+```|`[^`]+`|\bcurl\b|\bpnpm\b|\bvitest\b|\bplaywright\b|\bauthorization\b|\bbearer\b|\bcookie\b|\bsession\b|\btoken\b/i;
 const EXPLICIT_NA_PATTERN =
@@ -67,6 +70,16 @@ function isExplicitNa(text) {
   );
 }
 
+function normalizeEvidenceContent(text) {
+  return stripComments(text)
+    .replace(/\r/g, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !EMPTY_EVIDENCE_SCAFFOLD_PATTERN.test(line))
+    .join('\n')
+    .trim();
+}
+
 function parseSections(body) {
   const buckets = Object.fromEntries(
     REQUIRED_SECTION_TITLES.map((title) => [title, []])
@@ -97,7 +110,7 @@ function parseSections(body) {
 }
 
 function hasCheckedAuthArea(body) {
-  return /^- \[[xX]\].*`area: auth`/m.test(body);
+  return /^- \[[xX]\].*`area: auth`/m.test(stripComments(body));
 }
 
 function isAuthGated({
@@ -113,10 +126,11 @@ function isAuthGated({
   const normalizedLabels = labels.map((label) =>
     String(label).trim().toLowerCase()
   );
+  const bodyWithoutComments = stripComments(body);
   return (
     normalizedLabels.includes('area: auth') ||
-    hasCheckedAuthArea(body) ||
-    /\bauth[- ]gated\b/i.test(`${title}\n${body}`)
+    hasCheckedAuthArea(bodyWithoutComments) ||
+    /\bauth[- ]gated\b/i.test(`${title}\n${bodyWithoutComments}`)
   );
 }
 
@@ -151,10 +165,12 @@ export function validatePrArtifactPack({
   });
 
   const source = sections.Source;
+  const normalizedSource = normalizeSectionContent(source);
   if (
     !source ||
     isPlaceholderOnly(source) ||
-    !SOURCE_REFERENCE_PATTERN.test(source)
+    !SOURCE_REFERENCE_PATTERN.test(source) ||
+    SOURCE_TEMPLATE_PLACEHOLDER_PATTERN.test(normalizedSource)
   ) {
     errors.push(
       '## Source must cite a backlog row or issue (for example `Source: backlog.md:97` or `Source: #123`).'
@@ -162,11 +178,16 @@ export function validatePrArtifactPack({
   }
 
   const evidence = sections.Evidence;
-  if (!evidence || isPlaceholderOnly(evidence) || isExplicitNa(evidence)) {
+  const normalizedEvidence = normalizeEvidenceContent(evidence);
+  if (
+    !normalizedEvidence ||
+    isPlaceholderOnly(normalizedEvidence) ||
+    isExplicitNa(normalizedEvidence)
+  ) {
     errors.push(
       '## Evidence must be filled with screenshot/live-proof or docs/example diff details.'
     );
-  } else if (!EVIDENCE_SIGNAL_PATTERN.test(evidence)) {
+  } else if (!EVIDENCE_SIGNAL_PATTERN.test(normalizedEvidence)) {
     errors.push(
       '## Evidence must reference a concrete artifact such as a docs/example diff, screenshot, live-proof, or validation command.'
     );


### PR DESCRIPTION
## Description
- strip PR template comments before auth-gated detection so non-auth PRs can keep `N/A`
- reject source entries that still carry `backlog.md:ROW` / `#ISSUE` template placeholders
- ignore empty Evidence scaffold labels unless a concrete docs/example diff, screenshot, or validation artifact is present

## Source
Source: backlog.md:123

## Evidence
- Docs/example diff: `scripts/validate-pr-body.mjs`, `scripts/__tests__/validate-pr-body.test.mjs`
- Validation: `node --test scripts/__tests__/validate-pr-body.test.mjs`

## Auth-only Proof
N/A
