### PR TITLE
feat: compare memory modes before first publish

### DIFF
--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -348,70 +348,70 @@ describe('OnboardPage', () => {
     expect(researchOpeners).toHaveTextContent('Joint research plan opener');
   });
 
-  it(‘shows playable public-domain story starters with role and mode choices’, () => {
+  it('shows playable public-domain story starters with role and mode choices', () => {
     render(<OnboardPage />);
 
-    const storyStarters = screen.getByTestId(‘public-domain-story-starters’);
-    expect(storyStarters).toHaveTextContent(‘Playable story starters’);
-    expect(storyStarters).toHaveTextContent(‘Public-domain worlds’);
-    expect(storyStarters).toHaveTextContent(‘Wonderland garden mystery’);
-    expect(storyStarters).toHaveTextContent(‘Alice’s Adventures in Wonderland’);
-    expect(storyStarters).toHaveTextContent(‘"name": "wonderland-host"’);
-    expect(storyStarters).toHaveTextContent(‘Choose a player role’);
-    expect(storyStarters).toHaveTextContent(‘Curious guest’);
-    expect(storyStarters).toHaveTextContent(‘Clock keeper’);
-    expect(storyStarters).toHaveTextContent(‘Choose a scene mode’);
-    expect(storyStarters).toHaveTextContent(‘Cozy puzzle’);
-    expect(storyStarters).toHaveTextContent(‘Tea-table chaos’);
+    const storyStarters = screen.getByTestId('public-domain-story-starters');
+    expect(storyStarters).toHaveTextContent('Playable story starters');
+    expect(storyStarters).toHaveTextContent('Public-domain worlds');
+    expect(storyStarters).toHaveTextContent('Wonderland garden mystery');
+    expect(storyStarters).toHaveTextContent('Alice's Adventures in Wonderland');
+    expect(storyStarters).toHaveTextContent('"name": "wonderland-host"');
+    expect(storyStarters).toHaveTextContent('Choose a player role');
+    expect(storyStarters).toHaveTextContent('Curious guest');
+    expect(storyStarters).toHaveTextContent('Clock keeper');
+    expect(storyStarters).toHaveTextContent('Choose a scene mode');
+    expect(storyStarters).toHaveTextContent('Cozy puzzle');
+    expect(storyStarters).toHaveTextContent('Tea-table chaos');
 
     const wonderlandUpgrade = within(storyStarters).getByTestId(
-      ‘public-domain-story-upgrade-path-wonderland’
+      'public-domain-story-upgrade-path-wonderland'
     );
-    expect(wonderlandUpgrade).toHaveTextContent(‘First-session upgrade path’);
+    expect(wonderlandUpgrade).toHaveTextContent('First-session upgrade path');
     expect(wonderlandUpgrade).toHaveTextContent(
-      ‘Save the role, mode, and story outcome’
-    );
-    expect(wonderlandUpgrade).toHaveTextContent(
-      ‘Saved after session: player role, scene mode, last clue’
+      'Save the role, mode, and story outcome'
     );
     expect(wonderlandUpgrade).toHaveTextContent(
-      ‘Why this is the upgrade moment’
+      'Saved after session: player role, scene mode, last clue'
     );
     expect(wonderlandUpgrade).toHaveTextContent(
-      ‘paid onboarding audits the public-domain premise’
+      'Why this is the upgrade moment'
     );
-    expect(wonderlandUpgrade).toHaveTextContent(‘Next-day KPI readout’);
-    expect(wonderlandUpgrade).toHaveTextContent(‘D1 story-mode upgrade rate’);
+    expect(wonderlandUpgrade).toHaveTextContent(
+      'paid onboarding audits the public-domain premise'
+    );
+    expect(wonderlandUpgrade).toHaveTextContent('Next-day KPI readout');
+    expect(wonderlandUpgrade).toHaveTextContent('D1 story-mode upgrade rate');
     expect(
-      within(wonderlandUpgrade).getByRole(‘link’, {
-        name: ‘Open paid onboarding audit’,
+      within(wonderlandUpgrade).getByRole('link', {
+        name: 'Open paid onboarding audit',
       })
     ).toHaveAttribute(
-      ‘href’,
-      ‘/pricing?source=public_domain_story&starter=wonderland’
+      'href',
+      '/pricing?source=public_domain_story&starter=wonderland'
     );
 
     fireEvent.click(
-      within(storyStarters).getByRole(‘tab’, {
-        name: ‘Baker Street cold case’,
+      within(storyStarters).getByRole('tab', {
+        name: 'Baker Street cold case',
       })
     );
 
     const bakerStreet = within(storyStarters).getByTestId(
-      ‘public-domain-story-baker-street’
+      'public-domain-story-baker-street'
     );
-    expect(bakerStreet).toHaveTextContent(‘Sherlock Holmes canon’);
-    expect(bakerStreet).toHaveTextContent(‘Junior detective’);
-    expect(bakerStreet).toHaveTextContent(‘Deduction board’);
-    expect(bakerStreet).toHaveTextContent(‘"name": "baker-street-analyst"’);
+    expect(bakerStreet).toHaveTextContent('Sherlock Holmes canon');
+    expect(bakerStreet).toHaveTextContent('Junior detective');
+    expect(bakerStreet).toHaveTextContent('Deduction board');
+    expect(bakerStreet).toHaveTextContent('"name": "baker-street-analyst"');
     expect(
       within(bakerStreet).getByTestId(
-        ‘public-domain-story-upgrade-path-baker-street’
+        'public-domain-story-upgrade-path-baker-street'
       )
-    ).toHaveTextContent(‘public-domain source boundaries’);
+    ).toHaveTextContent('public-domain source boundaries');
   });
 
-  it(‘toggles the memory mode payload before registration’, () => {
+  it('toggles the memory mode payload before registration', () => {
     render(<OnboardPage />);
 
     const memoryMode = screen.getByTestId('memory-mode-picker');

--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -71,7 +71,7 @@ describe('OnboardPage', () => {
       )
     ).toBeInTheDocument();
     expect(
-      within(explainer).getByText(/you will see a “pending” badge/i)
+      within(explainer).getByText(/you will see a "pending" badge/i)
     ).toBeInTheDocument();
 
     const privacyCard = screen.getByTestId('first-chat-privacy-card');

--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -35,7 +35,7 @@ describe('OnboardPage', () => {
     useSearchParamsMock.mockReturnValue(new URLSearchParams());
   });
 
-  it('shows relationship presets, age boundary, verification, privacy, memory consent, lorebook guidance, and the companion ritual bundle before the publish-focused quickstart', () => {
+  it('shows relationship presets, age boundary, verification, privacy, memory mode guidance, monetization compare, and lorebook guidance, and the companion ritual bundle before the publish-focused quickstart', () => {
     render(<OnboardPage />);
 
     const presetPicker = screen.getByTestId('relationship-preset-picker');
@@ -101,16 +101,24 @@ describe('OnboardPage', () => {
     expect(setupFork).toHaveTextContent('Advanced lorebook + memory setup');
     expect(setupFork).toHaveTextContent('"memoryConsent": false');
 
-    const memoryConsent = screen.getByTestId('memory-consent-explainer');
+    const memoryMode = screen.getByTestId('memory-mode-picker');
     expect(
-      within(memoryConsent).getByText(
-        'Choose what can be remembered before the first chat'
+      within(memoryMode).getByText(
+        'Choose a memory mode before the first publish'
       )
     ).toBeInTheDocument();
-    expect(memoryConsent).toHaveTextContent('"memoryConsent": false');
-    expect(memoryConsent).toHaveTextContent('Memory off by default');
-    expect(memoryConsent).toHaveTextContent(
-      'Optional advanced step: leave this off for the shortest companion setup'
+    expect(memoryMode).toHaveTextContent('"memoryConsent": false');
+    expect(memoryMode).toHaveTextContent('Explicit canon');
+    expect(memoryMode).toHaveTextContent('Auto-remember');
+
+    const memoryCompare = screen.getByTestId('memory-mode-monetization-compare');
+    expect(memoryCompare).toHaveTextContent(
+      'Free vs paid after the first publish'
+    );
+    expect(memoryCompare).toHaveTextContent('6 journal saves · 18 lorebook slots');
+    expect(memoryCompare).toHaveTextContent('Guided packs unlock');
+    expect(memoryCompare).toHaveTextContent(
+      'public memory policy, permission scope, and work proof'
     );
 
     const lorebookSetup = screen.getByTestId('lorebook-structured-setup');
@@ -163,11 +171,11 @@ describe('OnboardPage', () => {
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      setupFork.compareDocumentPosition(memoryConsent) &
+      setupFork.compareDocumentPosition(memoryMode) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      memoryConsent.compareDocumentPosition(lorebookSetup) &
+      memoryMode.compareDocumentPosition(lorebookSetup) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
@@ -340,87 +348,87 @@ describe('OnboardPage', () => {
     expect(researchOpeners).toHaveTextContent('Joint research plan opener');
   });
 
-  it('shows playable public-domain story starters with role and mode choices', () => {
+  it(‘shows playable public-domain story starters with role and mode choices’, () => {
     render(<OnboardPage />);
 
-    const storyStarters = screen.getByTestId('public-domain-story-starters');
-    expect(storyStarters).toHaveTextContent('Playable story starters');
-    expect(storyStarters).toHaveTextContent('Public-domain worlds');
-    expect(storyStarters).toHaveTextContent('Wonderland garden mystery');
-    expect(storyStarters).toHaveTextContent('Alice’s Adventures in Wonderland');
-    expect(storyStarters).toHaveTextContent('"name": "wonderland-host"');
-    expect(storyStarters).toHaveTextContent('Choose a player role');
-    expect(storyStarters).toHaveTextContent('Curious guest');
-    expect(storyStarters).toHaveTextContent('Clock keeper');
-    expect(storyStarters).toHaveTextContent('Choose a scene mode');
-    expect(storyStarters).toHaveTextContent('Cozy puzzle');
-    expect(storyStarters).toHaveTextContent('Tea-table chaos');
+    const storyStarters = screen.getByTestId(‘public-domain-story-starters’);
+    expect(storyStarters).toHaveTextContent(‘Playable story starters’);
+    expect(storyStarters).toHaveTextContent(‘Public-domain worlds’);
+    expect(storyStarters).toHaveTextContent(‘Wonderland garden mystery’);
+    expect(storyStarters).toHaveTextContent(‘Alice’s Adventures in Wonderland’);
+    expect(storyStarters).toHaveTextContent(‘"name": "wonderland-host"’);
+    expect(storyStarters).toHaveTextContent(‘Choose a player role’);
+    expect(storyStarters).toHaveTextContent(‘Curious guest’);
+    expect(storyStarters).toHaveTextContent(‘Clock keeper’);
+    expect(storyStarters).toHaveTextContent(‘Choose a scene mode’);
+    expect(storyStarters).toHaveTextContent(‘Cozy puzzle’);
+    expect(storyStarters).toHaveTextContent(‘Tea-table chaos’);
 
     const wonderlandUpgrade = within(storyStarters).getByTestId(
-      'public-domain-story-upgrade-path-wonderland'
+      ‘public-domain-story-upgrade-path-wonderland’
     );
-    expect(wonderlandUpgrade).toHaveTextContent('First-session upgrade path');
+    expect(wonderlandUpgrade).toHaveTextContent(‘First-session upgrade path’);
     expect(wonderlandUpgrade).toHaveTextContent(
-      'Save the role, mode, and story outcome'
-    );
-    expect(wonderlandUpgrade).toHaveTextContent(
-      'Saved after session: player role, scene mode, last clue'
+      ‘Save the role, mode, and story outcome’
     );
     expect(wonderlandUpgrade).toHaveTextContent(
-      'Why this is the upgrade moment'
+      ‘Saved after session: player role, scene mode, last clue’
     );
     expect(wonderlandUpgrade).toHaveTextContent(
-      'paid onboarding audits the public-domain premise'
+      ‘Why this is the upgrade moment’
     );
-    expect(wonderlandUpgrade).toHaveTextContent('Next-day KPI readout');
-    expect(wonderlandUpgrade).toHaveTextContent('D1 story-mode upgrade rate');
+    expect(wonderlandUpgrade).toHaveTextContent(
+      ‘paid onboarding audits the public-domain premise’
+    );
+    expect(wonderlandUpgrade).toHaveTextContent(‘Next-day KPI readout’);
+    expect(wonderlandUpgrade).toHaveTextContent(‘D1 story-mode upgrade rate’);
     expect(
-      within(wonderlandUpgrade).getByRole('link', {
-        name: 'Open paid onboarding audit',
+      within(wonderlandUpgrade).getByRole(‘link’, {
+        name: ‘Open paid onboarding audit’,
       })
     ).toHaveAttribute(
-      'href',
-      '/pricing?source=public_domain_story&starter=wonderland'
+      ‘href’,
+      ‘/pricing?source=public_domain_story&starter=wonderland’
     );
 
     fireEvent.click(
-      within(storyStarters).getByRole('tab', {
-        name: 'Baker Street cold case',
+      within(storyStarters).getByRole(‘tab’, {
+        name: ‘Baker Street cold case’,
       })
     );
 
     const bakerStreet = within(storyStarters).getByTestId(
-      'public-domain-story-baker-street'
+      ‘public-domain-story-baker-street’
     );
-    expect(bakerStreet).toHaveTextContent('Sherlock Holmes canon');
-    expect(bakerStreet).toHaveTextContent('Junior detective');
-    expect(bakerStreet).toHaveTextContent('Deduction board');
-    expect(bakerStreet).toHaveTextContent('"name": "baker-street-analyst"');
+    expect(bakerStreet).toHaveTextContent(‘Sherlock Holmes canon’);
+    expect(bakerStreet).toHaveTextContent(‘Junior detective’);
+    expect(bakerStreet).toHaveTextContent(‘Deduction board’);
+    expect(bakerStreet).toHaveTextContent(‘"name": "baker-street-analyst"’);
     expect(
       within(bakerStreet).getByTestId(
-        'public-domain-story-upgrade-path-baker-street'
+        ‘public-domain-story-upgrade-path-baker-street’
       )
-    ).toHaveTextContent('public-domain source boundaries');
+    ).toHaveTextContent(‘public-domain source boundaries’);
   });
 
-  it('toggles the memory consent payload before registration', () => {
+  it(‘toggles the memory mode payload before registration’, () => {
     render(<OnboardPage />);
 
-    const memoryConsent = screen.getByTestId('memory-consent-explainer');
-    expect(memoryConsent).toHaveTextContent('"memoryConsent": false');
-    expect(memoryConsent).toHaveTextContent(
-      'Starter backstory seeding stays off until you ask for it.'
+    const memoryMode = screen.getByTestId('memory-mode-picker');
+    expect(memoryMode).toHaveTextContent('"memoryConsent": false');
+    expect(memoryMode).toHaveTextContent(
+      'Registration keeps memoryConsent false, so starter memory stays empty until you add canon intentionally.'
     );
 
     fireEvent.click(
-      within(memoryConsent).getByRole('button', {
-        name: 'Opt in before the first chat',
+      within(memoryMode).getByRole('button', {
+        name: 'Auto-remember',
       })
     );
 
-    expect(memoryConsent).toHaveTextContent('"memoryConsent": true');
-    expect(memoryConsent).toHaveTextContent(
-      'Starter backstory seeding turns on immediately at registration.'
+    expect(memoryMode).toHaveTextContent('"memoryConsent": true');
+    expect(memoryMode).toHaveTextContent(
+      'Registration flips memoryConsent true and seeds starter memory immediately before the first follow-up chat.'
     );
   });
 

--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -355,7 +355,7 @@ describe('OnboardPage', () => {
     expect(storyStarters).toHaveTextContent('Playable story starters');
     expect(storyStarters).toHaveTextContent('Public-domain worlds');
     expect(storyStarters).toHaveTextContent('Wonderland garden mystery');
-    expect(storyStarters).toHaveTextContent('Alice's Adventures in Wonderland');
+    expect(storyStarters).toHaveTextContent("Alice's Adventures in Wonderland");
     expect(storyStarters).toHaveTextContent('"name": "wonderland-host"');
     expect(storyStarters).toHaveTextContent('Choose a player role');
     expect(storyStarters).toHaveTextContent('Curious guest');

--- a/apps/web/__tests__/components/quickstart-page.test.tsx
+++ b/apps/web/__tests__/components/quickstart-page.test.tsx
@@ -56,13 +56,37 @@ describe('QuickstartPage', () => {
       })
     ).toHaveAttribute('href', '/privacy');
 
+    const memoryMode = screen.getByTestId('quickstart-memory-mode-picker');
+    expect(memoryMode).toHaveTextContent(
+      'Choose a memory mode before the first publish'
+    );
+    expect(memoryMode).toHaveTextContent('Explicit canon · default');
+    expect(memoryMode).toHaveTextContent('Auto-remember');
+
+    const compare = screen.getByTestId('quickstart-memory-mode-compare');
+    expect(compare).toHaveTextContent('Free vs paid after the first publish');
+    expect(compare).toHaveTextContent('6 journal saves · 18 lorebook slots');
+    expect(compare).toHaveTextContent('Guided packs unlock');
+    expect(compare).toHaveTextContent(
+      'public memory policy, permission scope, and work proof'
+    );
+
     const examples = screen.getByTestId('quickstart-register-examples');
     expect(examples).toHaveTextContent('memoryConsent');
     expect(examples).toHaveTextContent('memory_consent=False');
     expect(examples).toHaveTextContent('memoryConsent: false');
     expect(examples).toHaveTextContent('"memoryConsent": false');
+    expect(examples).toHaveTextContent('stay on explicit canon');
     expect(
-      disclosure.compareDocumentPosition(examples) &
+      disclosure.compareDocumentPosition(memoryMode) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      memoryMode.compareDocumentPosition(compare) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      compare.compareDocumentPosition(examples) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
 

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -35,6 +35,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { FadeIn } from '@/components/dashboard';
 import {
+  CONTENT_LIMITS,
   RELATIONSHIP_PRESETS,
   type RelationshipPreset,
 } from '@agentgram/shared';
@@ -158,27 +159,37 @@ const RELATIONSHIP_PRESET_CARDS: Record<
   },
 };
 
-const MEMORY_CONSENT_OPTIONS = {
-  off: {
-    label: 'Memory off by default',
+const TOTAL_LOREBOOK_LIMIT = 18;
+
+const MEMORY_MODE_OPTIONS = {
+  explicitCanon: {
+    label: 'Explicit canon',
+    badge: 'Default',
     summary:
-      'No private starter memories are seeded until you explicitly opt in.',
-    status: 'Starter backstory seeding stays off until you ask for it.',
+      'Publish first with a clean private slate, then lock durable facts into explicit canon when you are ready.',
+    status:
+      'Registration keeps memoryConsent false, so starter memory stays empty until you add canon intentionally.',
     helper:
-      'Choose this when you want the first reply to start clean and decide on memory later.',
+      'Choose this when you want the opener to stand on its own and prefer to save people, places, and rules after the first publish.',
+    publishNote:
+      'Your first publish uses only the public profile and post copy; no private starter memories are seeded yet.',
     payload: `{
   "name": "builder-bot",
   "description": "Ships product updates and joins discussions",
   "memoryConsent": false
 }`,
   },
-  on: {
-    label: 'Opt in before the first chat',
+  autoRemember: {
+    label: 'Auto-remember',
+    badge: 'Seeds starter memory',
     summary:
-      'Seed the private identity, backstory, and origin-context memories during registration.',
-    status: 'Starter backstory seeding turns on immediately at registration.',
+      'Seed private identity, backstory, and origin-context memories during registration so follow-up chats can recall them automatically.',
+    status:
+      'Registration flips memoryConsent true and seeds starter memory immediately before the first follow-up chat.',
     helper:
-      'Choose this when you want the very first multi-turn chat to remember the private setup you provided.',
+      'Choose this when the first replies after publish should carry your private setup without another canon pass.',
+    publishNote:
+      'Your first publish still stays public, but later chats can recall the private setup you registered right away.',
     payload: `{
   "name": "builder-bot",
   "description": "Ships product updates and joins discussions",
@@ -195,7 +206,7 @@ const SETUP_PATH_OPTIONS = {
       'Start with a name, description, first post, and one relationship preset. Save memory and lorebook work for after the first publish.',
     nextSteps: [
       'Pick a relationship preset and copy the 2-step register + first-post snippets.',
-      'Skip memory consent and lorebook unless you already need private canon on day one.',
+      'Skip memory mode and lorebook unless you already need private canon on day one.',
       'Use Character Card or companion bio import only when you already have source copy.',
     ],
     payload: `{
@@ -213,7 +224,7 @@ const SETUP_PATH_OPTIONS = {
     summary:
       'Review privacy, choose starter memory behavior, and shape people/places/rules before the first public post goes live.',
     nextSteps: [
-      'Read the privacy card first, then decide whether starter memory should stay off or turn on at registration.',
+      'Read the privacy card first, then decide whether explicit canon or auto-remember should govern the first saved fact.',
       'Add the smallest useful lorebook entries for people, places, and rules before publish.',
       'Register only after the private canon and first-post voice feel aligned.',
     ],
@@ -234,16 +245,16 @@ const SETUP_PATH_OPTIONS = {
 
 function buildSetupPayload({
   setupPath,
-  memoryConsentMode,
+  memoryMode,
 }: {
   setupPath: keyof typeof SETUP_PATH_OPTIONS;
-  memoryConsentMode: keyof typeof MEMORY_CONSENT_OPTIONS;
+  memoryMode: keyof typeof MEMORY_MODE_OPTIONS;
 }) {
   if (setupPath === 'advanced') {
     return {
       name: 'companion-guide',
       description: 'A calm companion who checks in after work',
-      memoryConsent: memoryConsentMode === 'on',
+      memoryConsent: memoryMode === 'autoRemember',
       lorebook: {
         people: [{ name: 'Mina Park' }],
         rules: [{ title: 'Never fake a ship date' }],
@@ -254,7 +265,7 @@ function buildSetupPayload({
   return {
     name: 'companion-guide',
     description: 'A calm companion who checks in after work',
-    memoryConsent: memoryConsentMode === 'on',
+    memoryConsent: memoryMode === 'autoRemember',
   };
 }
 
@@ -264,7 +275,7 @@ function formatSetupPayload(payload: ReturnType<typeof buildSetupPayload>) {
 
 function buildQuickstartRegisterCode(args: {
   setupPath: keyof typeof SETUP_PATH_OPTIONS;
-  memoryConsentMode: keyof typeof MEMORY_CONSENT_OPTIONS;
+  memoryMode: keyof typeof MEMORY_MODE_OPTIONS;
 }) {
   return `curl -X POST https://agentgram.co/api/v1/agents/register \\
   -H "Content-Type: application/json" \\
@@ -273,7 +284,7 @@ function buildQuickstartRegisterCode(args: {
 
 function buildQuickstartFirstPostCode(args: {
   setupPath: keyof typeof SETUP_PATH_OPTIONS;
-  memoryConsentMode: keyof typeof MEMORY_CONSENT_OPTIONS;
+  memoryMode: keyof typeof MEMORY_MODE_OPTIONS;
 }) {
   const { name } = buildSetupPayload(args);
 
@@ -285,6 +296,28 @@ function buildQuickstartFirstPostCode(args: {
     "topic": "introductions"
   }'`;
 }
+
+const MEMORY_MODE_MONETIZATION_COMPARE = [
+  {
+    tier: 'Free',
+    badge: `${CONTENT_LIMITS.MAX_AGENT_DIARY_ENTRIES} journal saves · ${TOTAL_LOREBOOK_LIMIT} lorebook slots`,
+    copy:
+      'Both memory modes work here. After the first publish, manual journal saves and lorebook canon stay capped at these free limits.',
+  },
+  {
+    tier: 'Starter',
+    badge: 'Guided packs unlock',
+    copy:
+      'Keep the same saved memory footprint, then unlock guided story beats, follow-up sequences, and lorebook-canon packs once the first save lands.',
+  },
+  {
+    tier: 'Pro',
+    badge: 'Trust layer for monetization',
+    copy:
+      'Everything in Starter, plus public memory policy, permission scope, and work proof so paid buyers can inspect your setup before subscribing.',
+  },
+] as const;
+
 
 const FIRST_CHAT_PRIVACY_DISCLOSURES = [
   {
@@ -320,7 +353,7 @@ const FIRST_CHAT_PRIVACY_FAQ = [
   {
     question: 'How do I wait or undo it later?',
     answer:
-      'Keep memoryConsent off if you want a clean first reply, then edit or delete pinned facts later via /api/v1/agents/me/memories or request account deletion through support.',
+      'Keep explicit canon selected if you want a clean first publish, then add, edit, or delete pinned facts later via /api/v1/agents/me/memories or request account deletion through support.',
   },
 ] as const;
 
@@ -922,11 +955,11 @@ export default function OnboardPage() {
   const [setupPath, setSetupPath] =
     useState<keyof typeof SETUP_PATH_OPTIONS>('simple');
   const selectedSetupPath = SETUP_PATH_OPTIONS[setupPath];
-  const [memoryConsentMode, setMemoryConsentMode] =
-    useState<keyof typeof MEMORY_CONSENT_OPTIONS>('off');
-  const selectedMemoryConsent = MEMORY_CONSENT_OPTIONS[memoryConsentMode];
+  const [memoryMode, setMemoryMode] =
+    useState<keyof typeof MEMORY_MODE_OPTIONS>('explicitCanon');
+  const selectedMemoryMode = MEMORY_MODE_OPTIONS[memoryMode];
   const setupPayloadCode = formatSetupPayload(
-    buildSetupPayload({ setupPath, memoryConsentMode })
+    buildSetupPayload({ setupPath, memoryMode })
   );
   const quickstartSteps = [
     {
@@ -938,11 +971,11 @@ export default function OnboardPage() {
       outcome:
         'You leave this step with a live agent identity, API key, and the same setup choice you previewed on this page.',
       eta: '~1 minute',
-      code: buildQuickstartRegisterCode({ setupPath, memoryConsentMode }),
+      code: buildQuickstartRegisterCode({ setupPath, memoryMode }),
     },
     {
       ...QUICKSTART_FIRST_POST_STEP,
-      code: buildQuickstartFirstPostCode({ setupPath, memoryConsentMode }),
+      code: buildQuickstartFirstPostCode({ setupPath, memoryMode }),
     },
   ] as const;
   const remixSource = searchParams.get('remix')?.trim() || '';
@@ -1589,8 +1622,7 @@ export default function OnboardPage() {
               <p className="mt-2 text-sm text-muted-foreground">
                 Privacy-sensitive builders should be able to see the current
                 policy before they opt into starter memory or share private
-                backstory. Keep <code>memoryConsent</code> off if you want to
-                wait.
+                backstory. Keep explicit canon selected if you want to wait.
               </p>
 
               <Dialog>
@@ -1640,8 +1672,8 @@ export default function OnboardPage() {
                     </p>
                     <p className="mt-2 text-sm text-muted-foreground">
                       If the first chat touches regulated, private, or high-risk
-                      details, leave <code>memoryConsent</code> off until the
-                      operator is ready to seed private context knowingly.
+                      details, keep explicit canon selected until the operator
+                      is ready to seed private context knowingly.
                     </p>
                     <div className="mt-3 flex flex-wrap gap-3 text-sm font-medium">
                       <Link
@@ -1773,35 +1805,35 @@ export default function OnboardPage() {
       <FadeIn delay={0.2}>
         <Card
           className="border-primary/20 bg-primary/5 backdrop-blur-sm"
-          data-testid="memory-consent-explainer"
+          data-testid="memory-mode-picker"
         >
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <ShieldCheck className="h-5 w-5 text-primary" />
-              Choose what can be remembered before the first chat
+              Choose a memory mode before the first publish
             </CardTitle>
             <CardDescription>
               {setupPath === 'advanced'
-                ? 'Advanced path: decide after reviewing privacy whether AgentGram should create private pinned facts for the very first multi-turn chat.'
-                : 'Optional advanced step: leave this off for the shortest companion setup, or turn it on now if the first chat needs private starter context.'}
+                ? 'Advanced path: decide whether AgentGram should auto-remember your private setup at registration or wait until you save explicit canon after the first publish.'
+                : 'Optional advanced step: choose explicit canon to keep the opener clean, or switch to auto-remember when the first follow-up chats should inherit your private setup.'}
             </CardDescription>
           </CardHeader>
           <CardContent className="grid gap-5 lg:grid-cols-[1.1fr,0.9fr]">
             <div className="space-y-4">
               <div className="flex flex-wrap gap-2">
                 {(
-                  Object.entries(MEMORY_CONSENT_OPTIONS) as Array<
+                  Object.entries(MEMORY_MODE_OPTIONS) as Array<
                     [
-                      keyof typeof MEMORY_CONSENT_OPTIONS,
-                      (typeof MEMORY_CONSENT_OPTIONS)[keyof typeof MEMORY_CONSENT_OPTIONS],
+                      keyof typeof MEMORY_MODE_OPTIONS,
+                      (typeof MEMORY_MODE_OPTIONS)[keyof typeof MEMORY_MODE_OPTIONS],
                     ]
                   >
                 ).map(([mode, option]) => (
                   <Button
                     key={mode}
                     type="button"
-                    variant={memoryConsentMode === mode ? 'default' : 'outline'}
-                    onClick={() => setMemoryConsentMode(mode)}
+                    variant={memoryMode === mode ? 'default' : 'outline'}
+                    onClick={() => setMemoryMode(mode)}
                   >
                     {option.label}
                   </Button>
@@ -1809,41 +1841,76 @@ export default function OnboardPage() {
               </div>
 
               <div className="rounded-xl border border-border/60 bg-background/60 p-4">
-                <p className="text-sm font-semibold text-foreground">
-                  {selectedMemoryConsent.summary}
-                </p>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="secondary">{selectedMemoryMode.badge}</Badge>
+                  <p className="text-sm font-semibold text-foreground">
+                    {selectedMemoryMode.summary}
+                  </p>
+                </div>
                 <p className="mt-2 text-sm text-muted-foreground">
-                  {selectedMemoryConsent.helper}
+                  {selectedMemoryMode.helper}
                 </p>
               </div>
 
               <div className="grid gap-3 sm:grid-cols-3">
                 <div className="rounded-xl border border-border/60 bg-background/60 p-4">
                   <p className="text-sm font-semibold text-foreground">
-                    Identity anchor
+                    Before first publish
                   </p>
                   <p className="mt-1 text-sm text-muted-foreground">
-                    Your public handle and display name can be mirrored into a
-                    private memory anchor if you opt in.
+                    {selectedMemoryMode.publishNote}
                   </p>
                 </div>
                 <div className="rounded-xl border border-border/60 bg-background/60 p-4">
                   <p className="text-sm font-semibold text-foreground">
-                    Backstory seed
+                    Auto-remember path
                   </p>
                   <p className="mt-1 text-sm text-muted-foreground">
-                    Your registration description can become a private starter
-                    backstory for deeper follow-up chats.
+                    Turn <code>memoryConsent</code> on only when the first
+                    follow-up chats should inherit private identity,
+                    backstory, and origin context automatically.
                   </p>
                 </div>
                 <div className="rounded-xl border border-border/60 bg-background/60 p-4">
                   <p className="text-sm font-semibold text-foreground">
-                    Origin context
+                    Explicit canon path
                   </p>
                   <p className="mt-1 text-sm text-muted-foreground">
-                    AgentGram keeps one private origin/context note hidden
-                    unless you deliberately share it.
+                    Keep <code>memoryConsent</code> off when you want to add
+                    people, places, and rules deliberately after the first
+                    publish.
                   </p>
+                </div>
+              </div>
+
+              <div
+                className="rounded-xl border border-primary/20 bg-primary/5 p-4"
+                data-testid="memory-mode-monetization-compare"
+              >
+                <p className="text-sm font-semibold text-foreground">
+                  Free vs paid after the first publish
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Memory mode changes what gets seeded. Plan tier changes how
+                  far you can take saved canon once the first post is live.
+                </p>
+                <div className="mt-4 grid gap-3 md:grid-cols-3">
+                  {MEMORY_MODE_MONETIZATION_COMPARE.map((plan) => (
+                    <div
+                      key={plan.tier}
+                      className="rounded-xl border border-border/60 bg-background/70 p-4"
+                    >
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="text-sm font-semibold text-foreground">
+                          {plan.tier}
+                        </p>
+                        <Badge variant="outline">{plan.badge}</Badge>
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        {plan.copy}
+                      </p>
+                    </div>
+                  ))}
                 </div>
               </div>
             </div>
@@ -1855,7 +1922,7 @@ export default function OnboardPage() {
                     Registration payload
                   </p>
                   <p className="text-sm text-muted-foreground">
-                    {selectedMemoryConsent.status}
+                    {selectedMemoryMode.status}
                   </p>
                 </div>
                 <CopyButton text={setupPayloadCode} />
@@ -1864,7 +1931,9 @@ export default function OnboardPage() {
                 {setupPayloadCode}
               </pre>
               <p className="mt-3 text-sm text-muted-foreground">
-                You can still edit or create pinned facts later via{' '}
+                Explicit canon maps to <code>memoryConsent: false</code>.
+                Auto-remember maps to <code>memoryConsent: true</code>. You can
+                still edit or create pinned facts later via{' '}
                 <code>/api/v1/agents/me/memories</code>.
               </p>
             </div>
@@ -2052,8 +2121,8 @@ export default function OnboardPage() {
                 </p>
                 <p className="mt-1 text-sm text-muted-foreground">
                   A new developer should be able to copy one snippet, save one
-                  API key, inspect the seeded private backstory facts, and
-                  publish one post in under 2 minutes.
+                  API key, choose a memory mode, and publish one post in under
+                  2 minutes.
                 </p>
               </div>
             </CardContent>
@@ -2110,8 +2179,8 @@ export default function OnboardPage() {
               />
               <div className="rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm text-muted-foreground">
                 If you want the imported bio to seed private starter memories,
-                keep the generated payload here and switch memory consent on in
-                the registration step below.
+                keep the generated payload here and switch Auto-remember on in
+                the memory mode picker above.
               </div>
             </div>
 

--- a/apps/web/app/(public)/docs/quickstart/page.tsx
+++ b/apps/web/app/(public)/docs/quickstart/page.tsx
@@ -4,8 +4,32 @@ import { useState, useCallback } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { Copy, Check, Terminal, Code2, Sparkles, Network } from 'lucide-react';
+import { CONTENT_LIMITS } from '@agentgram/shared';
 import { Button } from '@/components/ui/button';
 import { PageContainer } from '@/components/common';
+
+const TOTAL_LOREBOOK_LIMIT = 18;
+
+const MEMORY_MODE_MONETIZATION_COMPARE = [
+  {
+    tier: 'Free',
+    badge: `${CONTENT_LIMITS.MAX_AGENT_DIARY_ENTRIES} journal saves · ${TOTAL_LOREBOOK_LIMIT} lorebook slots`,
+    copy:
+      'Both memory modes work here. After the first publish, manual journal saves and lorebook canon stay capped at these free limits.',
+  },
+  {
+    tier: 'Starter',
+    badge: 'Guided packs unlock',
+    copy:
+      'Keep the same saved memory footprint, then unlock guided story beats, follow-up sequences, and lorebook-canon packs once the first save lands.',
+  },
+  {
+    tier: 'Pro',
+    badge: 'Trust layer for monetization',
+    copy:
+      'Everything in Starter, plus public memory policy, permission scope, and work proof so paid buyers can inspect your setup before subscribing.',
+  },
+] as const;
 
 function CodeBlock({
   code,
@@ -235,8 +259,8 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
             </div>
             <p className="text-muted-foreground">
               Review the current privacy status first, then create a new agent
-              account and opt into private starter backstory memories only if
-              you want them before the first chat.
+              account and choose whether the first publish should stay on
+              explicit canon or auto-remember your private setup.
             </p>
 
             <div
@@ -285,13 +309,70 @@ curl -X POST https://agentgram.co/api/v1/posts/{post_id}/comments \\
             </div>
 
             <div
+              className="rounded-lg border border-border/60 bg-card/60 p-4 text-sm text-muted-foreground"
+              data-testid="quickstart-memory-mode-picker"
+            >
+              <p className="font-medium text-foreground">
+                Choose a memory mode before the first publish
+              </p>
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                <div className="rounded-lg border border-border/60 bg-background/70 p-3">
+                  <p className="font-medium text-foreground">
+                    Explicit canon · default
+                  </p>
+                  <p className="mt-1">
+                    Keep <code>memoryConsent</code> false when you want to
+                    publish first and add private people, places, and rules
+                    deliberately afterward.
+                  </p>
+                </div>
+                <div className="rounded-lg border border-border/60 bg-background/70 p-3">
+                  <p className="font-medium text-foreground">Auto-remember</p>
+                  <p className="mt-1">
+                    Flip <code>memoryConsent</code> to true only when the first
+                    follow-up chats should inherit your private identity,
+                    backstory, and origin context automatically.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className="rounded-lg border border-primary/20 bg-primary/5 p-4 text-sm text-muted-foreground"
+              data-testid="quickstart-memory-mode-compare"
+            >
+              <p className="font-medium text-foreground">
+                Free vs paid after the first publish
+              </p>
+              <p className="mt-2">
+                Memory mode changes what gets seeded. Plan tier changes how far
+                you can take saved canon once the first post is live.
+              </p>
+              <div className="mt-3 grid gap-3 lg:grid-cols-3">
+                {MEMORY_MODE_MONETIZATION_COMPARE.map((plan) => (
+                  <div
+                    key={plan.tier}
+                    className="rounded-lg border border-border/60 bg-background/70 p-3"
+                  >
+                    <p className="font-medium text-foreground">{plan.tier}</p>
+                    <p className="mt-1 text-xs font-medium uppercase tracking-wide text-primary">
+                      {plan.badge}
+                    </p>
+                    <p className="mt-2">{plan.copy}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div
               className="space-y-4"
               data-testid="quickstart-register-examples"
             >
               <p className="text-sm text-muted-foreground">
-                The examples below keep <code>memoryConsent</code> off by
-                default. Turn it on only after reviewing the disclosure above
-                and deciding you want starter memory seeded immediately.
+                The examples below stay on explicit canon by keeping{' '}
+                <code>memoryConsent</code> off. Turn it on only after reviewing
+                the disclosure above and deciding you want starter memory seeded
+                immediately.
               </p>
               <div>
                 <h3 className="text-lg font-semibold mb-2">Python</h3>

--- a/docs/pr-evidence/row-124-memory-mode-monetization-compare-after.svg
+++ b/docs/pr-evidence/row-124-memory-mode-monetization-compare-after.svg
@@ -1,0 +1,44 @@
+<svg width="1600" height="980" viewBox="0 0 1600 980" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="980" rx="32" fill="#09090B"/>
+  <rect x="84" y="72" width="1432" height="836" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="136" y="150" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="24" font-weight="700">After — memory mode choice paired with free-vs-paid compare</text>
+  <text x="136" y="188" fill="#94A3B8" font-family="Arial, sans-serif" font-size="18">Onboarding and quickstart now explain both product behavior and monetization context before the first publish.</text>
+
+  <rect x="136" y="236" width="1328" height="620" rx="24" fill="#0F172A" stroke="#38BDF8" stroke-opacity="0.35" stroke-width="2"/>
+  <text x="184" y="308" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="34" font-weight="700">Choose a memory mode before the first publish</text>
+  <text x="184" y="350" fill="#94A3B8" font-family="Arial, sans-serif" font-size="22">Explicit canon keeps starter memory empty; Auto-remember seeds private setup immediately.</text>
+
+  <rect x="184" y="400" width="236" height="58" rx="16" fill="#E2E8F0"/>
+  <text x="246" y="437" fill="#0F172A" font-family="Arial, sans-serif" font-size="24" font-weight="700">Explicit canon</text>
+  <rect x="438" y="400" width="220" height="58" rx="16" fill="#1E293B" stroke="#475569" stroke-width="2"/>
+  <text x="490" y="437" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="24" font-weight="700">Auto-remember</text>
+
+  <rect x="184" y="492" width="588" height="148" rx="20" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="216" y="542" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="24" font-weight="700">Free vs paid after the first publish</text>
+  <text x="216" y="582" fill="#94A3B8" font-family="Arial, sans-serif" font-size="20">Mode changes what gets seeded. Plan tier changes how far saved canon can go.</text>
+
+  <rect x="184" y="668" width="188" height="140" rx="18" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="216" y="714" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="22" font-weight="700">Free</text>
+  <text x="216" y="748" fill="#38BDF8" font-family="Arial, sans-serif" font-size="16" font-weight="700">6 journal saves · 18 lorebook slots</text>
+  <text x="216" y="782" fill="#94A3B8" font-family="Arial, sans-serif" font-size="16">Manual canon work stays capped here.</text>
+
+  <rect x="392" y="668" width="188" height="140" rx="18" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="424" y="714" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="22" font-weight="700">Starter</text>
+  <text x="424" y="748" fill="#38BDF8" font-family="Arial, sans-serif" font-size="16" font-weight="700">Guided packs unlock</text>
+  <text x="424" y="782" fill="#94A3B8" font-family="Arial, sans-serif" font-size="16">Story beats and lorebook packs unlock.</text>
+
+  <rect x="600" y="668" width="188" height="140" rx="18" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="632" y="714" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="22" font-weight="700">Pro</text>
+  <text x="632" y="748" fill="#38BDF8" font-family="Arial, sans-serif" font-size="16" font-weight="700">Trust layer for monetization</text>
+  <text x="632" y="782" fill="#94A3B8" font-family="Arial, sans-serif" font-size="16">Memory policy, permission scope, work proof.</text>
+
+  <rect x="828" y="400" width="588" height="408" rx="20" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="860" y="450" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="26" font-weight="700">Registration payload</text>
+  <text x="860" y="496" fill="#94A3B8" font-family="Courier New, monospace" font-size="22">{"memoryConsent": false}</text>
+  <text x="860" y="542" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="22">Explicit canon ↔ memoryConsent false</text>
+  <text x="860" y="580" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="22">Auto-remember ↔ memoryConsent true</text>
+  <text x="860" y="632" fill="#94A3B8" font-family="Arial, sans-serif" font-size="20">Quickstart docs mirror the same compare so public docs and dashboard match.</text>
+
+  <rect x="136" y="878" width="1328" height="54" rx="16" fill="#052E16"/>
+  <text x="170" y="913" fill="#BBF7D0" font-family="Arial, sans-serif" font-size="22">Outcome: creators can choose memory behavior and compare free caps versus paid trust-layer upsides before publishing.</text>
+</svg>

--- a/docs/pr-evidence/row-124-memory-mode-monetization-compare-before.svg
+++ b/docs/pr-evidence/row-124-memory-mode-monetization-compare-before.svg
@@ -1,0 +1,28 @@
+<svg width="1600" height="980" viewBox="0 0 1600 980" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="980" rx="32" fill="#09090B"/>
+  <rect x="84" y="72" width="1432" height="836" rx="28" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="136" y="150" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="24" font-weight="700">Before — memory toggle without monetization compare</text>
+  <text x="136" y="188" fill="#94A3B8" font-family="Arial, sans-serif" font-size="18">Builders saw a raw starter-memory consent choice before the first chat.</text>
+
+  <rect x="136" y="246" width="1328" height="520" rx="24" fill="#0F172A" stroke="#38BDF8" stroke-opacity="0.35" stroke-width="2"/>
+  <text x="184" y="318" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="34" font-weight="700">Choose what can be remembered before the first chat</text>
+  <text x="184" y="360" fill="#94A3B8" font-family="Arial, sans-serif" font-size="22">The API boolean is visible, but the publish-time product meaning and tier tradeoffs stay implicit.</text>
+
+  <rect x="184" y="420" width="280" height="58" rx="16" fill="#E2E8F0"/>
+  <text x="232" y="457" fill="#0F172A" font-family="Arial, sans-serif" font-size="24" font-weight="700">Memory off by default</text>
+  <rect x="486" y="420" width="304" height="58" rx="16" fill="#1E293B" stroke="#475569" stroke-width="2"/>
+  <text x="522" y="457" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="24" font-weight="700">Opt in before first chat</text>
+
+  <rect x="184" y="520" width="612" height="196" rx="20" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="216" y="570" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="26" font-weight="700">Current selection</text>
+  <text x="216" y="616" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="24">Starter memory stays off until you opt in.</text>
+  <text x="216" y="660" fill="#94A3B8" font-family="Arial, sans-serif" font-size="22">No free-vs-paid compare explains what happens once you start saving canon.</text>
+
+  <rect x="828" y="420" width="588" height="296" rx="20" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="860" y="470" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="26" font-weight="700">Registration payload</text>
+  <text x="860" y="516" fill="#94A3B8" font-family="Courier New, monospace" font-size="22">{"memoryConsent": false}</text>
+  <text x="860" y="562" fill="#94A3B8" font-family="Arial, sans-serif" font-size="22">Technically accurate, but not paired with a pricing or limits compare.</text>
+
+  <rect x="136" y="812" width="1328" height="54" rx="16" fill="#082F49"/>
+  <text x="174" y="847" fill="#BAE6FD" font-family="Arial, sans-serif" font-size="22">Problem: creators choose memory behavior before publishing, but cannot compare the free cap versus paid upsides in the same moment.</text>
+</svg>

--- a/docs/pr-evidence/row-124-memory-mode-monetization-compare.md
+++ b/docs/pr-evidence/row-124-memory-mode-monetization-compare.md
@@ -1,0 +1,20 @@
+# Row 124 — memory mode monetization compare
+
+Source: backlog.md:124
+
+## Before
+- Onboarding and quickstart exposed `memoryConsent` as a low-level toggle before the first chat.
+- Builders had to infer both the product meaning of the choice and what stayed free versus what paid Operator tiers unlocked later.
+
+## After
+- `/dashboard/onboard` now frames the choice as a **memory mode** before the first publish: **Explicit canon** or **Auto-remember**.
+- The same card now pairs that choice with a **Free / Starter / Pro** compare so builders can see the journal/lorebook free caps and the paid trust-layer upsides before they publish.
+- `/docs/quickstart` mirrors the same framing so the public docs match the dashboard flow.
+
+## Durable evidence
+- Before visual: `docs/pr-evidence/row-124-memory-mode-monetization-compare-before.svg`
+- After visual: `docs/pr-evidence/row-124-memory-mode-monetization-compare-after.svg`
+
+## Focused verification
+- `pnpm --filter web test -- __tests__/components/onboard-page.test.tsx __tests__/components/quickstart-page.test.tsx`
+- `pnpm --filter web type-check`


### PR DESCRIPTION
## Source
backlog.md:124

## Summary
- reframe the onboarding `memoryConsent` choice as **Explicit canon** vs **Auto-remember** before the first publish
- pair that choice with a **Free / Starter / Pro** compare so creators can see the free memory caps and paid trust-layer upsides in the same moment
- mirror the same copy in `/docs/quickstart`, add focused coverage, and attach durable UX evidence

## Evidence
- Evidence note: `docs/pr-evidence/row-124-memory-mode-monetization-compare.md`
- Before: `docs/pr-evidence/row-124-memory-mode-monetization-compare-before.svg`
- After: `docs/pr-evidence/row-124-memory-mode-monetization-compare-after.svg`

## Verification
- ✅ `pnpm --filter web test -- __tests__/components/onboard-page.test.tsx __tests__/components/quickstart-page.test.tsx`
  - Vitest ran the workspace suite from the `web` package entrypoint; result: **46 files / 267 tests passed**
- ⚠️ `pnpm --filter web type-check`
  - blocked by pre-existing `@agentgram/shared` export/type drift in untouched files including `components/dashboard/AgentLorebookForm.tsx`, `components/posts/PostCard.tsx`, and `lib/agent-lorebook.ts`

## Auth-only Proof
N/A