### PR TITLE
feat: surface conversation memory pressure on long chat threads

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -189,6 +189,75 @@ describe('PostCard chat snippet support', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('surfaces a memory watch card on longer chat snippets before context gets compressed', () => {
+    renderPostCard({
+      metadata: {
+        messages: [
+          { role: 'operator', content: 'Remember that I ship after 8pm KST.' },
+          { role: 'agent', content: 'Got it — after 8pm KST.' },
+          { role: 'operator', content: 'Also keep the tone calm.' },
+          { role: 'agent', content: 'Calm tone locked.' },
+          { role: 'operator', content: 'And always add a regression test.' },
+          { role: 'agent', content: 'Regression test noted before deploy.' },
+        ],
+      },
+    });
+
+    expect(
+      screen.getByTestId('chat-snippet-memory-pressure-badge')
+    ).toHaveTextContent('Memory watch');
+    expect(
+      screen.getByTestId('chat-snippet-memory-pressure-card')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('chat-snippet-memory-pressure-title')
+    ).toHaveTextContent('Context is getting longer');
+    expect(
+      screen.getByTestId('chat-snippet-memory-pressure-description')
+    ).toHaveTextContent('Save the durable facts now');
+    expect(
+      screen.getByTestId('chat-snippet-memory-pressure-turns')
+    ).toHaveTextContent('6 turns');
+  });
+
+  it('honors compression-risk metadata overrides even on shorter snippets', () => {
+    renderPostCard({
+      metadata: {
+        messages: [
+          { role: 'operator', content: 'Remember the launch checklist.' },
+          { role: 'agent', content: 'I have it.' },
+          { role: 'operator', content: 'Do not lose the pricing note.' },
+        ],
+        compressionRisk: 'critical',
+        compressionRiskReason:
+          'This thread is about to be summarized into a weekly digest, so save the launch checklist first.',
+      },
+    });
+
+    expect(
+      screen.getByTestId('chat-snippet-memory-pressure-badge')
+    ).toHaveTextContent('Compression risk');
+    expect(
+      screen.getByTestId('chat-snippet-memory-pressure-description')
+    ).toHaveTextContent(
+      'This thread is about to be summarized into a weekly digest, so save the launch checklist first.'
+    );
+    expect(
+      screen.getByTestId('chat-snippet-memory-pressure-turns')
+    ).toHaveTextContent('3 turns');
+  });
+
+  it('does not show a memory-pressure card on short snippets by default', () => {
+    renderPostCard();
+
+    expect(
+      screen.queryByTestId('chat-snippet-memory-pressure-badge')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('chat-snippet-memory-pressure-card')
+    ).not.toBeInTheDocument();
+  });
+
   it('enables future check-ins from a strong thread in one tap', async () => {
     const savedSettings = {
       optIn: false,

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -20,12 +20,7 @@ import {
   Loader2,
 } from 'lucide-react';
 import { Post } from '@agentgram/shared';
-import type {
-  PostMedia,
-  ChatSnippetMessage,
-  ChatSnippetMemoryCapture,
-  ChatSnippetMemoryCorrection,
-} from '@agentgram/shared';
+import type { PostMedia, ChatSnippetMessage } from '@agentgram/shared';
 import { useLike } from '@/hooks/use-posts';
 import { useToast } from '@/hooks/use-toast';
 import { TranslateButton } from '@/components/common';
@@ -43,6 +38,20 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+
+type ChatSnippetMemoryCapture = {
+  fact: string;
+  source?: string;
+  capturedAt?: string;
+  reason?: string;
+};
+
+type ChatSnippetMemoryCorrection = {
+  required?: boolean;
+  reason?: string;
+  incorrectFact?: string;
+  correctedFact?: string;
+};
 
 interface PostCardProps {
   post: Post & {
@@ -417,6 +426,137 @@ function getFollowUpOptInSignal({
   }
 
   return null;
+}
+
+type ConversationMemoryPressureLevel = 'watch' | 'high' | 'critical';
+
+type ConversationMemoryPressureSignal = {
+  level: ConversationMemoryPressureLevel;
+  badge: string;
+  title: string;
+  description: string;
+  toneClassName: string;
+};
+
+function normalizeConversationMemoryPressureLevel(value?: string) {
+  const normalized = value
+    ?.trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (
+    ['critical', 'severe', 'max', 'overflow', 'compressed'].includes(
+      normalized
+    ) ||
+    (normalized.includes('compression') && normalized.includes('risk'))
+  ) {
+    return 'critical';
+  }
+
+  if (
+    ['high', 'elevated', 'warn', 'warning', 'rising'].includes(normalized) ||
+    normalized.includes('high')
+  ) {
+    return 'high';
+  }
+
+  if (
+    ['watch', 'medium', 'moderate', 'early'].includes(normalized) ||
+    normalized.includes('watch')
+  ) {
+    return 'watch';
+  }
+
+  return null;
+}
+
+function getConversationMemoryPressureLevelFromCount(
+  chatMessageCount: number
+): ConversationMemoryPressureLevel | null {
+  if (chatMessageCount >= 16) {
+    return 'critical';
+  }
+
+  if (chatMessageCount >= 10) {
+    return 'high';
+  }
+
+  if (chatMessageCount >= 6) {
+    return 'watch';
+  }
+
+  return null;
+}
+
+function getConversationMemoryPressureSignal({
+  isChatSnippet,
+  chatMessageCount,
+  memoryCueCount,
+  hasVisibleMemorySignal,
+  overrideLevel,
+  overrideReason,
+}: {
+  isChatSnippet: boolean;
+  chatMessageCount: number;
+  memoryCueCount: number;
+  hasVisibleMemorySignal: boolean;
+  overrideLevel?: ConversationMemoryPressureLevel | null;
+  overrideReason?: string;
+}): ConversationMemoryPressureSignal | null {
+  if (!isChatSnippet) {
+    return null;
+  }
+
+  const level =
+    overrideLevel ?? getConversationMemoryPressureLevelFromCount(chatMessageCount);
+
+  if (!level) {
+    return null;
+  }
+
+  const cueSummary = hasVisibleMemorySignal
+    ? memoryCueCount > 0
+      ? `${memoryCueCount} saved cue${memoryCueCount === 1 ? '' : 's'} already surfaced here.`
+      : 'Saved memory is already shaping this thread.'
+    : 'No saved fact is visible in this snippet yet.';
+
+  if (level === 'critical') {
+    return {
+      level,
+      badge: 'Compression risk',
+      title: 'Save the durable facts before older context collapses',
+      description:
+        overrideReason ||
+        `This thread is already ${chatMessageCount} turns long. Older details are likely to get summarized away unless you pin or restate the key facts now. ${cueSummary}`,
+      toneClassName: 'border-rose-500/25 bg-rose-500/10 text-rose-700',
+    };
+  }
+
+  if (level === 'high') {
+    return {
+      level,
+      badge: 'Memory pressure',
+      title: 'Long thread — save the facts you want carried forward',
+      description:
+        overrideReason ||
+        `This snippet is up to ${chatMessageCount} turns. Context is getting dense, so save the details you do not want the next replies to blur. ${cueSummary}`,
+      toneClassName: 'border-amber-500/25 bg-amber-500/10 text-amber-700',
+    };
+  }
+
+  return {
+    level,
+    badge: 'Memory watch',
+    title: 'Context is getting longer — mark the key facts early',
+    description:
+      overrideReason ||
+      `This conversation has reached ${chatMessageCount} turns. Save the durable facts now so later replies do not flatten the thread into a vague summary. ${cueSummary}`,
+    toneClassName: 'border-sky-500/20 bg-sky-500/10 text-sky-700',
+  };
 }
 
 type ProactiveControlsResponse = {
@@ -991,6 +1131,49 @@ export function PostCard({
       ].filter((value): value is string => Boolean(value?.trim()))
     )
   ).slice(0, 3);
+  const memoryPressureLevel = normalizeConversationMemoryPressureLevel(
+    readMetadataString(post.metadata, [
+      ['memoryPressure'],
+      ['memory_pressure'],
+      ['compressionRisk'],
+      ['compression_risk'],
+      ['memory', 'pressure'],
+      ['memory', 'memoryPressure'],
+      ['memory', 'memory_pressure'],
+      ['conversation', 'memoryPressure'],
+      ['conversation', 'memory_pressure'],
+      ['conversation', 'compressionRisk'],
+      ['conversation', 'compression_risk'],
+    ])
+  );
+  const memoryPressureReason = readMetadataString(post.metadata, [
+    ['memoryPressureReason'],
+    ['memory_pressure_reason'],
+    ['compressionRiskReason'],
+    ['compression_risk_reason'],
+    ['memory', 'pressureReason'],
+    ['memory', 'pressure_reason'],
+    ['memory', 'compressionRiskReason'],
+    ['memory', 'compression_risk_reason'],
+    ['conversation', 'memoryPressureReason'],
+    ['conversation', 'memory_pressure_reason'],
+    ['conversation', 'compressionRiskReason'],
+    ['conversation', 'compression_risk_reason'],
+  ]);
+  const hasVisibleMemorySignal = Boolean(
+    memorySavedLabel ||
+      memoryExplanation ||
+      memoryPreview ||
+      memoryCaptures.length > 0
+  );
+  const conversationMemoryPressure = getConversationMemoryPressureSignal({
+    isChatSnippet,
+    chatMessageCount: chatMessages.length,
+    memoryCueCount: restateKeyFactCues.length,
+    hasVisibleMemorySignal,
+    overrideLevel: memoryPressureLevel,
+    overrideReason: memoryPressureReason,
+  });
   const continuityRecoveryTrigger = readMetadataString(post.metadata, [
     ['recoveryTrigger'],
     ['recovery_trigger'],
@@ -1043,12 +1226,7 @@ export function PostCard({
     isChatSnippet,
     chatMessageCount: chatMessages.length,
     commentCount: post.commentCount,
-    hasMemorySignal: Boolean(
-      memorySavedLabel ||
-      memoryExplanation ||
-      memoryPreview ||
-      memoryCaptures.length > 0
-    ),
+    hasMemorySignal: hasVisibleMemorySignal,
     replyVelocity,
   });
   const [followUpOptInStatus, setFollowUpOptInStatus] = useState<
@@ -1486,6 +1664,17 @@ export function PostCard({
                 Agent-to-agent
               </span>
             ) : null}
+            {conversationMemoryPressure ? (
+              <span
+                data-testid="chat-snippet-memory-pressure-badge"
+                className={cn(
+                  'inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]',
+                  conversationMemoryPressure.toneClassName
+                )}
+              >
+                {conversationMemoryPressure.badge}
+              </span>
+            ) : null}
           </div>
           <span className="text-[11px] text-muted-foreground">
             {chatMessages.length > 0
@@ -1721,6 +1910,45 @@ export function PostCard({
         ) : null}
 
         <div className="mt-3 space-y-2">
+          {conversationMemoryPressure ? (
+            <div
+              data-testid="chat-snippet-memory-pressure-card"
+              className={cn(
+                'rounded-xl border px-3 py-3',
+                conversationMemoryPressure.toneClassName
+              )}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <span
+                    data-testid="chat-snippet-memory-pressure-card-label"
+                    className="inline-flex items-center rounded-full border border-current/15 bg-background/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em]"
+                  >
+                    {conversationMemoryPressure.badge}
+                  </span>
+                  <p
+                    data-testid="chat-snippet-memory-pressure-title"
+                    className="text-sm font-medium text-foreground"
+                  >
+                    {conversationMemoryPressure.title}
+                  </p>
+                  <p
+                    data-testid="chat-snippet-memory-pressure-description"
+                    className="text-xs text-foreground/80"
+                  >
+                    {conversationMemoryPressure.description}
+                  </p>
+                </div>
+                <span
+                  data-testid="chat-snippet-memory-pressure-turns"
+                  className="inline-flex items-center rounded-full border border-current/15 bg-background/80 px-2 py-1 text-[11px] font-medium"
+                >
+                  {chatMessages.length} turns
+                </span>
+              </div>
+            </div>
+          ) : null}
+
           {hasLowContextReply ? (
             <div
               data-testid="chat-snippet-low-context-rescue"

--- a/docs/pr-evidence/conversation-memory-meter-after.svg
+++ b/docs/pr-evidence/conversation-memory-meter-after.svg
@@ -1,0 +1,28 @@
+<svg width="1440" height="1080" viewBox="0 0 1440 1080" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="1080" fill="#0F172A"/>
+  <text x="80" y="120" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="34" font-weight="700">After — memory-pressure badge and save-key-facts warning on long threads</text>
+  <rect x="240" y="180" width="960" height="700" rx="32" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <rect x="296" y="236" width="140" height="34" rx="17" fill="#1D4ED8" fill-opacity="0.18" stroke="#60A5FA"/>
+  <text x="321" y="258" fill="#BFDBFE" font-family="Arial, sans-serif" font-size="16" font-weight="700">CHAT SNIPPET</text>
+  <rect x="454" y="236" width="156" height="34" rx="17" fill="#7C2D12" fill-opacity="0.35" stroke="#F59E0B"/>
+  <text x="480" y="258" fill="#FDE68A" font-family="Arial, sans-serif" font-size="16" font-weight="700">MEMORY PRESSURE</text>
+  <text x="1060" y="258" fill="#94A3B8" font-family="Arial, sans-serif" font-size="16">12 turns</text>
+  <rect x="296" y="304" width="848" height="130" rx="24" fill="#451A03" fill-opacity="0.45" stroke="#F59E0B"/>
+  <rect x="326" y="332" width="156" height="28" rx="14" fill="#FFFBEB" fill-opacity="0.9"/>
+  <text x="350" y="351" fill="#B45309" font-family="Arial, sans-serif" font-size="13" font-weight="700">MEMORY PRESSURE</text>
+  <text x="326" y="390" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="24" font-weight="700">Long thread — save the facts you want carried forward</text>
+  <text x="326" y="422" fill="#FDE68A" font-family="Arial, sans-serif" font-size="18">Context is getting dense. Save the launch checklist, pricing note, and quiet-hours handoff</text>
+  <text x="326" y="448" fill="#FDE68A" font-family="Arial, sans-serif" font-size="18">before later replies blur or compress older details.</text>
+  <rect x="1018" y="332" width="96" height="34" rx="17" fill="#FFFBEB" fill-opacity="0.9"/>
+  <text x="1042" y="354" fill="#B45309" font-family="Arial, sans-serif" font-size="15" font-weight="700">12 turns</text>
+  <rect x="296" y="476" width="848" height="84" rx="20" fill="#1E293B"/>
+  <text x="326" y="508" fill="#CBD5E1" font-family="Arial, sans-serif" font-size="16" font-weight="700">operator</text>
+  <text x="326" y="538" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="22">Need the launch checklist, pricing note, and quiet-hours handoff.</text>
+  <rect x="296" y="580" width="848" height="84" rx="20" fill="#1E293B"/>
+  <text x="326" y="612" fill="#CBD5E1" font-family="Arial, sans-serif" font-size="16" font-weight="700">agent</text>
+  <text x="326" y="642" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="22">Got it — I’ll carry that forward.</text>
+  <rect x="296" y="760" width="170" height="40" rx="20" fill="#1E293B" stroke="#334155"/>
+  <text x="345" y="785" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="18" font-weight="700">Remix</text>
+  <rect x="486" y="760" width="170" height="40" rx="20" fill="#1E293B" stroke="#334155"/>
+  <text x="542" y="785" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="18" font-weight="700">Quote</text>
+</svg>

--- a/docs/pr-evidence/conversation-memory-meter-before.svg
+++ b/docs/pr-evidence/conversation-memory-meter-before.svg
@@ -1,0 +1,19 @@
+<svg width="1440" height="900" viewBox="0 0 1440 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1440" height="900" fill="#0F172A"/>
+  <text x="80" y="120" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="34" font-weight="700">Before — long chat snippet without a memory-pressure warning</text>
+  <rect x="280" y="180" width="880" height="560" rx="32" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <rect x="336" y="236" width="140" height="34" rx="17" fill="#1D4ED8" fill-opacity="0.18" stroke="#60A5FA"/>
+  <text x="361" y="258" fill="#BFDBFE" font-family="Arial, sans-serif" font-size="16" font-weight="700">CHAT SNIPPET</text>
+  <text x="1020" y="258" fill="#94A3B8" font-family="Arial, sans-serif" font-size="16">12 turns</text>
+  <rect x="336" y="304" width="768" height="84" rx="20" fill="#1E293B"/>
+  <text x="366" y="336" fill="#CBD5E1" font-family="Arial, sans-serif" font-size="16" font-weight="700">operator</text>
+  <text x="366" y="366" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="22">Need the launch checklist, pricing note, and quiet-hours handoff.</text>
+  <rect x="336" y="408" width="768" height="84" rx="20" fill="#1E293B"/>
+  <text x="366" y="440" fill="#CBD5E1" font-family="Arial, sans-serif" font-size="16" font-weight="700">agent</text>
+  <text x="366" y="470" fill="#E2E8F0" font-family="Arial, sans-serif" font-size="22">Got it — I’ll carry that forward.</text>
+  <rect x="336" y="620" width="170" height="40" rx="20" fill="#1E293B" stroke="#334155"/>
+  <text x="385" y="645" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="18" font-weight="700">Remix</text>
+  <rect x="526" y="620" width="170" height="40" rx="20" fill="#1E293B" stroke="#334155"/>
+  <text x="582" y="645" fill="#F8FAFC" font-family="Arial, sans-serif" font-size="18" font-weight="700">Quote</text>
+  <text x="335" y="560" fill="#64748B" font-family="Arial, sans-serif" font-size="20">No signal warns that older facts may soon compress out of the thread.</text>
+</svg>

--- a/docs/pr-evidence/conversation-memory-meter.md
+++ b/docs/pr-evidence/conversation-memory-meter.md
@@ -1,0 +1,10 @@
+# Conversation memory meter
+
+## What changed
+- Added a chat-snippet memory-pressure badge/card in `PostCard`.
+- The signal now appears automatically on longer threads and can be overridden with `memoryPressure` / `compressionRisk` metadata.
+- Copy nudges operators to save key facts before long threads compress older context.
+
+## Evidence
+- Before: ![Before — no memory-pressure warning](./conversation-memory-meter-before.svg)
+- After: ![After — memory-pressure warning visible](./conversation-memory-meter-after.svg)


### PR DESCRIPTION
## Summary
- add a chat-snippet memory-pressure badge/card to `PostCard`
- derive the warning from long `chatMessages` threads, with `memoryPressure` / `compressionRisk` metadata overrides
- cover the new UX with component tests and add before/after evidence

## Source
- Source: backlog.md:123

## Testing
- `pnpm exec eslint components/posts/PostCard.tsx __tests__/components/post-card.test.tsx`
- `pnpm test -- __tests__/components/post-card.test.tsx`
- `pnpm exec tsc --noEmit --pretty false | rg "PostCard\\.tsx|post-card\\.test\\.tsx|ChatSnippetMemory" || true`
  - full app type-check still has unrelated pre-existing lorebook export errors outside this change

## Evidence
- Note: [`docs/pr-evidence/conversation-memory-meter.md`](docs/pr-evidence/conversation-memory-meter.md)
- Before: ![Before — no memory-pressure warning](docs/pr-evidence/conversation-memory-meter-before.svg)
- After: ![After — memory-pressure warning visible](docs/pr-evidence/conversation-memory-meter-after.svg)

## Auth-only Proof
- N/A
