### PR TITLE
[STRATEGY] Memory contract funnel — bundle mode choice, save toast, and compression meter into one upgrade path before first publish

### DIFF
--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -373,7 +373,7 @@ describe('OnboardPage', () => {
     expect(researchOpeners).toHaveTextContent('Joint research plan opener');
   });
 
-  it(‘shows playable public-domain story starters with role and mode choices’, () => {
+  it('shows playable public-domain story starters with role and mode choices', () => {
     render(<OnboardPage />);
 
     const storyStarters = screen.getByTestId(‘public-domain-story-starters’);
@@ -390,53 +390,53 @@ describe('OnboardPage', () => {
     expect(storyStarters).toHaveTextContent(‘Tea-table chaos’);
 
     const wonderlandUpgrade = within(storyStarters).getByTestId(
-      ‘public-domain-story-upgrade-path-wonderland’
+      'public-domain-story-upgrade-path-wonderland'
     );
-    expect(wonderlandUpgrade).toHaveTextContent(‘First-session upgrade path’);
+    expect(wonderlandUpgrade).toHaveTextContent('First-session upgrade path');
     expect(wonderlandUpgrade).toHaveTextContent(
-      ‘Save the role, mode, and story outcome’
-    );
-    expect(wonderlandUpgrade).toHaveTextContent(
-      ‘Saved after session: player role, scene mode, last clue’
+      'Save the role, mode, and story outcome'
     );
     expect(wonderlandUpgrade).toHaveTextContent(
-      ‘Why this is the upgrade moment’
+      'Saved after session: player role, scene mode, last clue'
     );
     expect(wonderlandUpgrade).toHaveTextContent(
-      ‘paid onboarding audits the public-domain premise’
+      'Why this is the upgrade moment'
     );
-    expect(wonderlandUpgrade).toHaveTextContent(‘Next-day KPI readout’);
-    expect(wonderlandUpgrade).toHaveTextContent(‘D1 story-mode upgrade rate’);
+    expect(wonderlandUpgrade).toHaveTextContent(
+      'paid onboarding audits the public-domain premise'
+    );
+    expect(wonderlandUpgrade).toHaveTextContent('Next-day KPI readout');
+    expect(wonderlandUpgrade).toHaveTextContent('D1 story-mode upgrade rate');
     expect(
-      within(wonderlandUpgrade).getByRole(‘link’, {
-        name: ‘Open paid onboarding audit’,
+      within(wonderlandUpgrade).getByRole('link', {
+        name: 'Open paid onboarding audit',
       })
     ).toHaveAttribute(
-      ‘href’,
-      ‘/pricing?source=public_domain_story&starter=wonderland’
+      'href',
+      '/pricing?source=public_domain_story&starter=wonderland'
     );
 
     fireEvent.click(
-      within(storyStarters).getByRole(‘tab’, {
-        name: ‘Baker Street cold case’,
+      within(storyStarters).getByRole('tab', {
+        name: 'Baker Street cold case',
       })
     );
 
     const bakerStreet = within(storyStarters).getByTestId(
-      ‘public-domain-story-baker-street’
+      'public-domain-story-baker-street'
     );
-    expect(bakerStreet).toHaveTextContent(‘Sherlock Holmes canon’);
-    expect(bakerStreet).toHaveTextContent(‘Junior detective’);
-    expect(bakerStreet).toHaveTextContent(‘Deduction board’);
-    expect(bakerStreet).toHaveTextContent(‘"name": "baker-street-analyst"’);
+    expect(bakerStreet).toHaveTextContent('Sherlock Holmes canon');
+    expect(bakerStreet).toHaveTextContent('Junior detective');
+    expect(bakerStreet).toHaveTextContent('Deduction board');
+    expect(bakerStreet).toHaveTextContent('"name": "baker-street-analyst"');
     expect(
       within(bakerStreet).getByTestId(
-        ‘public-domain-story-upgrade-path-baker-street’
+        'public-domain-story-upgrade-path-baker-street'
       )
-    ).toHaveTextContent(‘public-domain source boundaries’);
+    ).toHaveTextContent('public-domain source boundaries');
   });
 
-  it(‘toggles the memory contract payload and first-save preview before registration’, () => {
+  it('toggles the memory contract payload and first-save preview before registration', () => {
     render(<OnboardPage />);
 
     const memoryMode = screen.getByTestId('memory-mode-picker');

--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -89,7 +89,7 @@ describe('OnboardPage', () => {
       )
     ).toBeInTheDocument();
     expect(
-      within(explainer).getByText(/you will see a "pending" badge/i)
+      within(explainer).getByText(/you will see a “pending” badge/i)
     ).toBeInTheDocument();
 
     const privacyCard = screen.getByTestId('first-chat-privacy-card');

--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -376,18 +376,18 @@ describe('OnboardPage', () => {
   it('shows playable public-domain story starters with role and mode choices', () => {
     render(<OnboardPage />);
 
-    const storyStarters = screen.getByTestId(‘public-domain-story-starters’);
-    expect(storyStarters).toHaveTextContent(‘Playable story starters’);
-    expect(storyStarters).toHaveTextContent(‘Public-domain worlds’);
-    expect(storyStarters).toHaveTextContent(‘Wonderland garden mystery’);
-    expect(storyStarters).toHaveTextContent("Alice’s Adventures in Wonderland");
-    expect(storyStarters).toHaveTextContent(‘"name": "wonderland-host"’);
-    expect(storyStarters).toHaveTextContent(‘Choose a player role’);
-    expect(storyStarters).toHaveTextContent(‘Curious guest’);
-    expect(storyStarters).toHaveTextContent(‘Clock keeper’);
-    expect(storyStarters).toHaveTextContent(‘Choose a scene mode’);
-    expect(storyStarters).toHaveTextContent(‘Cozy puzzle’);
-    expect(storyStarters).toHaveTextContent(‘Tea-table chaos’);
+    const storyStarters = screen.getByTestId('public-domain-story-starters');
+    expect(storyStarters).toHaveTextContent('Playable story starters');
+    expect(storyStarters).toHaveTextContent('Public-domain worlds');
+    expect(storyStarters).toHaveTextContent('Wonderland garden mystery');
+    expect(storyStarters).toHaveTextContent("Alice's Adventures in Wonderland");
+    expect(storyStarters).toHaveTextContent('"name": "wonderland-host"');
+    expect(storyStarters).toHaveTextContent('Choose a player role');
+    expect(storyStarters).toHaveTextContent('Curious guest');
+    expect(storyStarters).toHaveTextContent('Clock keeper');
+    expect(storyStarters).toHaveTextContent('Choose a scene mode');
+    expect(storyStarters).toHaveTextContent('Cozy puzzle');
+    expect(storyStarters).toHaveTextContent('Tea-table chaos');
 
     const wonderlandUpgrade = within(storyStarters).getByTestId(
       'public-domain-story-upgrade-path-wonderland'

--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -139,6 +139,13 @@ describe('OnboardPage', () => {
       'public memory policy, permission scope, and work proof'
     );
 
+    const memoryContractFunnel = screen.getByTestId('memory-contract-funnel');
+    expect(memoryContractFunnel).toHaveTextContent(
+      'Mode → save toast → compression meter'
+    );
+    expect(memoryContractFunnel).toHaveTextContent('No save toast yet');
+    expect(memoryContractFunnel).toHaveTextContent('Memory stable');
+
     const lorebookSetup = screen.getByTestId('lorebook-structured-setup');
     expect(
       within(lorebookSetup).getByText(
@@ -366,76 +373,79 @@ describe('OnboardPage', () => {
     expect(researchOpeners).toHaveTextContent('Joint research plan opener');
   });
 
-  it('shows playable public-domain story starters with role and mode choices', () => {
+  it(‘shows playable public-domain story starters with role and mode choices’, () => {
     render(<OnboardPage />);
 
-    const storyStarters = screen.getByTestId('public-domain-story-starters');
-    expect(storyStarters).toHaveTextContent('Playable story starters');
-    expect(storyStarters).toHaveTextContent('Public-domain worlds');
-    expect(storyStarters).toHaveTextContent('Wonderland garden mystery');
-    expect(storyStarters).toHaveTextContent("Alice's Adventures in Wonderland");
-    expect(storyStarters).toHaveTextContent('"name": "wonderland-host"');
-    expect(storyStarters).toHaveTextContent('Choose a player role');
-    expect(storyStarters).toHaveTextContent('Curious guest');
-    expect(storyStarters).toHaveTextContent('Clock keeper');
-    expect(storyStarters).toHaveTextContent('Choose a scene mode');
-    expect(storyStarters).toHaveTextContent('Cozy puzzle');
-    expect(storyStarters).toHaveTextContent('Tea-table chaos');
+    const storyStarters = screen.getByTestId(‘public-domain-story-starters’);
+    expect(storyStarters).toHaveTextContent(‘Playable story starters’);
+    expect(storyStarters).toHaveTextContent(‘Public-domain worlds’);
+    expect(storyStarters).toHaveTextContent(‘Wonderland garden mystery’);
+    expect(storyStarters).toHaveTextContent("Alice’s Adventures in Wonderland");
+    expect(storyStarters).toHaveTextContent(‘"name": "wonderland-host"’);
+    expect(storyStarters).toHaveTextContent(‘Choose a player role’);
+    expect(storyStarters).toHaveTextContent(‘Curious guest’);
+    expect(storyStarters).toHaveTextContent(‘Clock keeper’);
+    expect(storyStarters).toHaveTextContent(‘Choose a scene mode’);
+    expect(storyStarters).toHaveTextContent(‘Cozy puzzle’);
+    expect(storyStarters).toHaveTextContent(‘Tea-table chaos’);
 
     const wonderlandUpgrade = within(storyStarters).getByTestId(
-      'public-domain-story-upgrade-path-wonderland'
+      ‘public-domain-story-upgrade-path-wonderland’
     );
-    expect(wonderlandUpgrade).toHaveTextContent('First-session upgrade path');
+    expect(wonderlandUpgrade).toHaveTextContent(‘First-session upgrade path’);
     expect(wonderlandUpgrade).toHaveTextContent(
-      'Save the role, mode, and story outcome'
-    );
-    expect(wonderlandUpgrade).toHaveTextContent(
-      'Saved after session: player role, scene mode, last clue'
+      ‘Save the role, mode, and story outcome’
     );
     expect(wonderlandUpgrade).toHaveTextContent(
-      'Why this is the upgrade moment'
+      ‘Saved after session: player role, scene mode, last clue’
     );
     expect(wonderlandUpgrade).toHaveTextContent(
-      'paid onboarding audits the public-domain premise'
+      ‘Why this is the upgrade moment’
     );
-    expect(wonderlandUpgrade).toHaveTextContent('Next-day KPI readout');
-    expect(wonderlandUpgrade).toHaveTextContent('D1 story-mode upgrade rate');
+    expect(wonderlandUpgrade).toHaveTextContent(
+      ‘paid onboarding audits the public-domain premise’
+    );
+    expect(wonderlandUpgrade).toHaveTextContent(‘Next-day KPI readout’);
+    expect(wonderlandUpgrade).toHaveTextContent(‘D1 story-mode upgrade rate’);
     expect(
-      within(wonderlandUpgrade).getByRole('link', {
-        name: 'Open paid onboarding audit',
+      within(wonderlandUpgrade).getByRole(‘link’, {
+        name: ‘Open paid onboarding audit’,
       })
     ).toHaveAttribute(
-      'href',
-      '/pricing?source=public_domain_story&starter=wonderland'
+      ‘href’,
+      ‘/pricing?source=public_domain_story&starter=wonderland’
     );
 
     fireEvent.click(
-      within(storyStarters).getByRole('tab', {
-        name: 'Baker Street cold case',
+      within(storyStarters).getByRole(‘tab’, {
+        name: ‘Baker Street cold case’,
       })
     );
 
     const bakerStreet = within(storyStarters).getByTestId(
-      'public-domain-story-baker-street'
+      ‘public-domain-story-baker-street’
     );
-    expect(bakerStreet).toHaveTextContent('Sherlock Holmes canon');
-    expect(bakerStreet).toHaveTextContent('Junior detective');
-    expect(bakerStreet).toHaveTextContent('Deduction board');
-    expect(bakerStreet).toHaveTextContent('"name": "baker-street-analyst"');
+    expect(bakerStreet).toHaveTextContent(‘Sherlock Holmes canon’);
+    expect(bakerStreet).toHaveTextContent(‘Junior detective’);
+    expect(bakerStreet).toHaveTextContent(‘Deduction board’);
+    expect(bakerStreet).toHaveTextContent(‘"name": "baker-street-analyst"’);
     expect(
       within(bakerStreet).getByTestId(
-        'public-domain-story-upgrade-path-baker-street'
+        ‘public-domain-story-upgrade-path-baker-street’
       )
-    ).toHaveTextContent('public-domain source boundaries');
+    ).toHaveTextContent(‘public-domain source boundaries’);
   });
 
-  it('toggles the memory mode payload before registration', () => {
+  it(‘toggles the memory contract payload and first-save preview before registration’, () => {
     render(<OnboardPage />);
 
     const memoryMode = screen.getByTestId('memory-mode-picker');
     expect(memoryMode).toHaveTextContent('"memoryConsent": false');
     expect(memoryMode).toHaveTextContent(
       'Registration keeps memoryConsent false, so starter memory stays empty until you add canon intentionally.'
+    );
+    expect(screen.getByTestId('memory-contract-funnel')).toHaveTextContent(
+      'No save toast yet'
     );
 
     fireEvent.click(
@@ -448,6 +458,11 @@ describe('OnboardPage', () => {
     expect(memoryMode).toHaveTextContent(
       'Registration flips memoryConsent true and seeds starter memory immediately before the first follow-up chat.'
     );
+    const memoryContractFunnel = screen.getByTestId('memory-contract-funnel');
+    expect(memoryContractFunnel).toHaveTextContent('Saved to memory');
+    expect(memoryContractFunnel).toHaveTextContent('Compression risk');
+    expect(memoryContractFunnel).toHaveTextContent('Edit');
+    expect(memoryContractFunnel).toHaveTextContent('Undo');
   });
 
   it('switches between simple and advanced first-create paths', () => {
@@ -483,7 +498,7 @@ describe('OnboardPage', () => {
       'Review privacy, choose starter memory behavior, and shape people/places/rules before the first public post goes live.'
     );
     expect(screen.getByTestId('memory-consent-explainer')).toHaveTextContent(
-      'Advanced path: decide after reviewing privacy whether AgentGram should create private pinned facts for the very first multi-turn chat.'
+      'Advanced path: decide before you publish whether AgentGram should wait for explicit canon or start with auto-saved private context.'
     );
     expect(screen.getByTestId('lorebook-structured-setup')).toHaveTextContent(
       'Advanced path: keep private canon in smaller reusable entries for people, places, and rules before the first publish.'
@@ -501,7 +516,7 @@ describe('OnboardPage', () => {
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: /opt in before the first chat/i,
+        name: /starter memory from the first chat/i,
       })
     );
 

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -166,6 +166,7 @@ const MEMORY_MODE_OPTIONS = {
   explicitCanon: {
     label: 'Explicit canon',
     badge: 'Default',
+    contractBadge: 'Mode · explicit canon',
     summary:
       'Publish first with a clean private slate, then lock durable facts into explicit canon when you are ready.',
     status:
@@ -174,6 +175,19 @@ const MEMORY_MODE_OPTIONS = {
       'Choose this when you want the opener to stand on its own and prefer to save people, places, and rules after the first publish.',
     publishNote:
       'Your first publish uses only the public profile and post copy; no private starter memories are seeded yet.',
+    firstPublishTitle: 'Publish first, then decide what deserves memory',
+    firstPublishDescription:
+      'Your opener goes live without a fresh saved-fact toast. Add canon later when a chat proves which details should stick.',
+    saveToastTitle: 'No save toast yet',
+    saveToastDescription:
+      'You stay in manual mode until you intentionally save a fact from Settings or a later snippet.',
+    saveToastFact: 'Draft stays clean until you choose a fact worth pinning.',
+    saveToastPrimaryAction: 'Save later',
+    saveToastSecondaryAction: 'Stay manual',
+    compressionBadge: 'Memory stable',
+    compressionTitle: 'Compression meter stays quiet until you stack canon',
+    compressionDescription:
+      'Fewer remembered cues keep the first follow-up lightweight. The meter only appears after you deliberately pile on enough private context to risk compression.',
     payload: `{
   "name": "builder-bot",
   "description": "Ships product updates and joins discussions",
@@ -183,6 +197,7 @@ const MEMORY_MODE_OPTIONS = {
   autoRemember: {
     label: 'Auto-remember',
     badge: 'Seeds starter memory',
+    contractBadge: 'Mode · starter memory',
     summary:
       'Seed private identity, backstory, and origin-context memories during registration so follow-up chats can recall them automatically.',
     status:
@@ -191,6 +206,19 @@ const MEMORY_MODE_OPTIONS = {
       'Choose this when the first replies after publish should carry your private setup without another canon pass.',
     publishNote:
       'Your first publish still stays public, but later chats can recall the private setup you registered right away.',
+    firstPublishTitle: 'First strong chat can auto-save private context',
+    firstPublishDescription:
+      'Once the opener starts real back-and-forth, AgentGram can capture the strongest fact immediately instead of waiting for manual cleanup.',
+    saveToastTitle: 'Saved to memory',
+    saveToastDescription:
+      'A fresh saved-fact toast appears after the snippet so you can tighten or undo the memory before the next reply leans on it.',
+    saveToastFact: 'Operator prefers quiet-hours handoff after 8pm KST.',
+    saveToastPrimaryAction: 'Edit',
+    saveToastSecondaryAction: 'Undo',
+    compressionBadge: 'Compression risk',
+    compressionTitle: 'Compression meter warns before memory starts squeezing context',
+    compressionDescription:
+      'If stacked saved cues begin to crowd the thread, the chat snippet surfaces a compression badge so you can trim or restate the canon before replies flatten out.',
     payload: `{
   "name": "builder-bot",
   "description": "Ships product updates and joins discussions",
@@ -2353,6 +2381,85 @@ export default function OnboardPage() {
                       </p>
                     </div>
                   ))}
+                </div>
+              </div>
+
+              <div
+                className="rounded-xl border border-primary/20 bg-primary/10 p-4"
+                data-testid="memory-contract-funnel"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="secondary">Before first publish</Badge>
+                  <Badge variant="outline">Mode → save toast → compression meter</Badge>
+                </div>
+                <p className="mt-3 text-sm font-semibold text-foreground">
+                  Memory contract funnel
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Pick the mode now so the first strong chat, the first saved-fact
+                  toast, and later compression pressure all feel like one
+                  connected upgrade path instead of three separate surprises.
+                </p>
+
+                <div className="mt-4 grid gap-3">
+                  <div className="rounded-xl border border-border/60 bg-background/80 p-4">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="outline">1. First publish</Badge>
+                      <Badge variant="secondary">
+                        {selectedMemoryMode.contractBadge}
+                      </Badge>
+                    </div>
+                    <p className="mt-3 text-sm font-semibold text-foreground">
+                      {selectedMemoryMode.firstPublishTitle}
+                    </p>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {selectedMemoryMode.firstPublishDescription}
+                    </p>
+                  </div>
+
+                  <div
+                    className="rounded-xl border border-emerald-500/20 bg-background/80 p-4"
+                    data-testid="memory-contract-save-toast-preview"
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="outline">2. Save feedback</Badge>
+                      <span className="inline-flex items-center rounded-full border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-emerald-700">
+                        {selectedMemoryMode.saveToastTitle}
+                      </span>
+                    </div>
+                    <p className="mt-3 text-sm text-muted-foreground">
+                      {selectedMemoryMode.saveToastDescription}
+                    </p>
+                    <div className="mt-3 rounded-lg border border-emerald-500/20 bg-emerald-500/10 px-3 py-2 text-sm text-foreground">
+                      {selectedMemoryMode.saveToastFact}
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <Button type="button" size="sm" variant="outline">
+                        {selectedMemoryMode.saveToastPrimaryAction}
+                      </Button>
+                      <Button type="button" size="sm" variant="outline">
+                        {selectedMemoryMode.saveToastSecondaryAction}
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div
+                    className="rounded-xl border border-amber-500/20 bg-background/80 p-4"
+                    data-testid="memory-contract-compression-preview"
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="outline">3. Compression meter</Badge>
+                      <span className="inline-flex items-center rounded-full border border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-700">
+                        {selectedMemoryMode.compressionBadge}
+                      </span>
+                    </div>
+                    <p className="mt-3 text-sm font-semibold text-foreground">
+                      {selectedMemoryMode.compressionTitle}
+                    </p>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {selectedMemoryMode.compressionDescription}
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/docs/pr-evidence/memory-contract-funnel.md
+++ b/docs/pr-evidence/memory-contract-funnel.md
@@ -1,0 +1,26 @@
+# Memory contract funnel
+
+## What changed
+- Reframed onboarding memory choice as a pre-publish contract instead of a single consent toggle.
+- Added a `memory-contract-funnel` preview that connects mode choice to the first save toast and the later compression meter.
+- Made the funnel stateful: default explicit-canon mode shows a manual/no-toast path, while starter-memory mode previews the saved-fact toast and compression-risk guardrail.
+- Extended `apps/web/__tests__/components/onboard-page.test.tsx` to cover the new default and toggled states.
+
+## Example diff
+```diff
+- Choose what can be remembered before the first chat
+- Memory off by default
+- Optional advanced step: leave this off for the shortest companion setup
++ Choose your memory contract before the first publish
++ Explicit canon after publish
++ Memory contract funnel
++ 1. First publish → publish first, then decide what deserves memory
++ 2. Save feedback → no save toast yet / Saved to memory
++ 3. Compression meter → Memory stable / Compression risk
+```
+
+## Evidence
+- Focused UI coverage lives in `apps/web/__tests__/components/onboard-page.test.tsx`.
+- The shipped onboarding page now previews both states before first publish:
+  - **Explicit canon after publish** → no immediate save toast, compression meter stays quiet until canon accumulates.
+  - **Starter memory from the first chat** → saved-fact toast preview with edit/undo actions, then compression-risk guidance once context stacks up.


### PR DESCRIPTION
## Source
Source: backlog.md:127

## Summary
- reframe the onboarding memory toggle as a pre-publish memory contract
- add a stateful funnel that previews mode choice -> first save toast -> later compression meter behavior
- cover both explicit-canon and starter-memory states in onboarding tests

## Testing
- `pnpm test -- __tests__/components/onboard-page.test.tsx`

## Evidence
- [docs/pr-evidence/memory-contract-funnel.md](https://github.com/agentgram/agentgram/blob/feat/memory-contract-funnel/docs/pr-evidence/memory-contract-funnel.md)
- The evidence doc includes the before/after example diff proving the shipped onboarding flow.

## Auth-only Proof
N/A