### PR TITLE
Memory ledger — show saved-memory categories and remaining capacity in one panel

### DIFF
--- a/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
+++ b/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
@@ -22,16 +22,46 @@ function buildSettings(
         originLabel: 'Registration description seed',
         originSnippet: 'Keeps release notes precise.',
       },
+      {
+        id: 'memory-2',
+        key: 'preferred_collaboration_style',
+        value: 'Prefers async check-ins and clear handoff notes.',
+        category: 'relationship_context',
+        updatedAt: '2026-05-06T09:00:00.000Z',
+        originLabel: 'Saved fact snapshot',
+        originSnippet: 'Prefers async check-ins and clear handoff notes.',
+      },
     ],
+    ledger: {
+      capacity: 12,
+      savedCount: 2,
+      remainingCount: 10,
+      categoryCounts: {
+        profileFact: 1,
+        relationshipContext: 1,
+      },
+    },
     ...overrides,
   };
 }
 
 describe('AgentPinnedFactsCard', () => {
-  it('shows last-updated metadata and origin snippets for each pinned fact', () => {
+  it('shows the memory ledger summary, category counts, and fact provenance', () => {
     render(<AgentPinnedFactsCard settings={buildSettings()} />);
 
     expect(screen.getByText('Pinned facts for Sage Bot')).toBeInTheDocument();
+    expect(screen.getByTestId('pinned-facts-ledger-summary')).toHaveTextContent(
+      '2 saved memories'
+    );
+    expect(screen.getByTestId('pinned-facts-ledger-summary')).toHaveTextContent(
+      '10 slots left'
+    );
+    expect(
+      screen.getByTestId('ledger-category-profile-fact')
+    ).toHaveTextContent('Profile fact');
+    expect(
+      screen.getByTestId('ledger-category-relationship-context')
+    ).toHaveTextContent('Relationship context');
     expect(screen.getByTestId('pinned-fact-memory-1')).toHaveTextContent(
       'Backstory'
     );
@@ -46,18 +76,30 @@ describe('AgentPinnedFactsCard', () => {
     );
   });
 
-  it('renders an empty state when no pinned facts exist yet', () => {
+  it('renders an empty-state body while keeping the ledger controls visible', () => {
     render(
       <AgentPinnedFactsCard
         settings={buildSettings({
           facts: [],
+          ledger: {
+            capacity: 12,
+            savedCount: 0,
+            remainingCount: 12,
+            categoryCounts: {
+              profileFact: 0,
+              relationshipContext: 0,
+            },
+          },
         })}
       />
     );
 
+    expect(screen.getByTestId('pinned-facts-ledger-summary')).toHaveTextContent(
+      '0 saved memories'
+    );
     expect(
       screen.getByText(
-        'No pinned facts yet. Seed one through registration or save a private fact to start building provenance here.'
+        'No pinned facts yet. Starter memories and future saves will show up here so you can inspect what is being kept.'
       )
     ).toBeInTheDocument();
   });

--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -163,6 +163,15 @@ function createSettingsPageClient() {
                     created_at: '2026-05-04T10:00:00.000Z',
                     updated_at: '2026-05-05T10:30:00.000Z',
                   },
+                  {
+                    id: 'memory-2',
+                    agent_id: 'agent-1',
+                    key: 'preferred_collaboration_style',
+                    value: 'Prefers async check-ins and clear handoff notes.',
+                    category: 'relationship_context',
+                    created_at: '2026-05-04T12:00:00.000Z',
+                    updated_at: '2026-05-06T09:00:00.000Z',
+                  },
                 ],
               }),
             }),
@@ -405,7 +414,9 @@ describe('ProactiveControlsForm', () => {
     });
 
     expect(
-      await screen.findByText('Proactive outreach will stay muted until you opt in.')
+      await screen.findByText(
+        'Proactive outreach will stay muted until you opt in.'
+      )
     ).toBeInTheDocument();
   });
 
@@ -537,7 +548,25 @@ describe('SettingsPage', () => {
               originLabel: 'Registration description seed',
               originSnippet: 'Keeps release notes precise.',
             },
+            {
+              id: 'memory-2',
+              key: 'preferred_collaboration_style',
+              value: 'Prefers async check-ins and clear handoff notes.',
+              category: 'relationship_context',
+              updatedAt: '2026-05-06T09:00:00.000Z',
+              originLabel: 'Saved fact snapshot',
+              originSnippet: 'Prefers async check-ins and clear handoff notes.',
+            },
           ],
+          ledger: {
+            capacity: 12,
+            savedCount: 2,
+            remainingCount: 10,
+            categoryCounts: {
+              profileFact: 1,
+              relationshipContext: 1,
+            },
+          },
         },
       },
       undefined

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -37,6 +37,15 @@ type AgentSettingsRecord = {
   initialLorebook: ReturnType<typeof readAgentLorebookFromMetadata>;
   initialDiaryEntries: ReturnType<typeof readAgentDiaryFromMetadata>;
   pinnedFacts: AgentPinnedFactRecord[];
+  pinnedFactsLedger: {
+    capacity: number;
+    savedCount: number;
+    remainingCount: number;
+    categoryCounts: {
+      profileFact: number;
+      relationshipContext: number;
+    };
+  };
 };
 
 type AgentMemoryRecord = {
@@ -48,6 +57,8 @@ type AgentMemoryRecord = {
   created_at: string;
   updated_at: string;
 };
+
+const PINNED_FACTS_LEDGER_CAPACITY = 12;
 
 function truncateSnippet(value: string, max = 140) {
   const normalized = value.replace(/\s+/g, ' ').trim();
@@ -167,22 +178,39 @@ export default async function SettingsPage() {
 
   const trustSettings: AgentSettingsRecord[] = (agents ?? []).map((agent) => {
     const activePersona = activePersonaByAgentId.get(agent.id);
-    const pinnedFacts = (memoryRowsByAgentId.get(agent.id) ?? []).map(
-      (memory) => ({
-        id: memory.id,
+    const agentMemoryRows = memoryRowsByAgentId.get(agent.id) ?? [];
+    const pinnedFacts = agentMemoryRows.map((memory) => ({
+      id: memory.id,
+      key: memory.key,
+      value: memory.value,
+      category: memory.category,
+      updatedAt: memory.updated_at || memory.created_at,
+      ...buildOriginDetails({
         key: memory.key,
         value: memory.value,
-        category: memory.category,
-        updatedAt: memory.updated_at || memory.created_at,
-        ...buildOriginDetails({
-          key: memory.key,
-          value: memory.value,
-          agentName: agent.name,
-          agentLabel: agent.display_name || agent.name,
-          agentDescription: agent.description ?? '',
-        }),
-      })
-    );
+        agentName: agent.name,
+        agentLabel: agent.display_name || agent.name,
+        agentDescription: agent.description ?? '',
+      }),
+    }));
+    const profileFactCount = agentMemoryRows.filter(
+      (memory) => memory.category === 'profile_fact'
+    ).length;
+    const relationshipContextCount = agentMemoryRows.filter(
+      (memory) => memory.category === 'relationship_context'
+    ).length;
+    const pinnedFactsLedger = {
+      capacity: PINNED_FACTS_LEDGER_CAPACITY,
+      savedCount: agentMemoryRows.length,
+      remainingCount: Math.max(
+        PINNED_FACTS_LEDGER_CAPACITY - agentMemoryRows.length,
+        0
+      ),
+      categoryCounts: {
+        profileFact: profileFactCount,
+        relationshipContext: relationshipContextCount,
+      },
+    };
 
     return {
       agentId: agent.id,
@@ -199,6 +227,7 @@ export default async function SettingsPage() {
       initialLorebook: readAgentLorebookFromMetadata(agent.metadata),
       initialDiaryEntries: readAgentDiaryFromMetadata(agent.metadata),
       pinnedFacts,
+      pinnedFactsLedger,
     };
   });
 
@@ -241,6 +270,7 @@ export default async function SettingsPage() {
                     agentId: settings.agentId,
                     agentLabel: settings.agentLabel,
                     facts: settings.pinnedFacts,
+                    ledger: settings.pinnedFactsLedger,
                   }}
                 />
                 <AgentLorebookForm

--- a/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
+++ b/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
@@ -17,10 +17,21 @@ export interface AgentPinnedFactRecord {
   originSnippet: string;
 }
 
+export interface AgentPinnedFactsLedger {
+  capacity: number;
+  savedCount: number;
+  remainingCount: number;
+  categoryCounts: {
+    profileFact: number;
+    relationshipContext: number;
+  };
+}
+
 export interface AgentPinnedFactsSettings {
   agentId: string;
   agentLabel: string;
   facts: AgentPinnedFactRecord[];
+  ledger: AgentPinnedFactsLedger;
 }
 
 interface AgentPinnedFactsCardProps {
@@ -54,7 +65,17 @@ function formatCategoryLabel(category: string) {
     .join(' ');
 }
 
+function formatCapacityCopy(count: number) {
+  return count === 1 ? '1 slot left' : `${count} slots left`;
+}
+
 export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
+  const { ledger } = settings;
+  const usagePercent =
+    ledger.capacity === 0
+      ? 0
+      : Math.min(100, Math.round((ledger.savedCount / ledger.capacity) * 100));
+
   return (
     <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
       <CardHeader>
@@ -63,15 +84,78 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
           Pinned facts for {settings.agentLabel}
         </CardTitle>
         <CardDescription>
-          Review the private facts this agent keeps handy, plus when each one last
-          changed and what originally seeded it.
+          Visible, controllable private memory. Review what this agent saved,
+          which category it belongs to, and how much room remains in the ledger.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        <div
+          className="rounded-xl border border-primary/20 bg-primary/5 p-4"
+          data-testid="pinned-facts-ledger-summary"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-1">
+              <div className="text-sm font-medium text-foreground">
+                {ledger.savedCount === 1
+                  ? '1 saved memory'
+                  : `${ledger.savedCount} saved memories`}
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {formatCapacityCopy(ledger.remainingCount)} before this panel
+                reaches its current {ledger.capacity}-memory capacity.
+              </p>
+            </div>
+            <div className="rounded-full border border-primary/20 bg-background/90 px-3 py-1 text-xs font-medium text-primary">
+              {usagePercent}% used
+            </div>
+          </div>
+
+          <div className="mt-4 h-2 overflow-hidden rounded-full bg-primary/10">
+            <div
+              aria-hidden="true"
+              className="h-full rounded-full bg-primary transition-[width]"
+              style={{ width: `${usagePercent}%` }}
+            />
+          </div>
+
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <div
+              className="rounded-lg border border-border/60 bg-background/80 p-3"
+              data-testid="ledger-category-profile-fact"
+            >
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                Profile fact
+              </div>
+              <div className="mt-1 text-2xl font-semibold text-foreground">
+                {ledger.categoryCounts.profileFact}
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Identity, backstory, and other durable self facts.
+              </p>
+            </div>
+
+            <div
+              className="rounded-lg border border-border/60 bg-background/80 p-3"
+              data-testid="ledger-category-relationship-context"
+            >
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                Relationship context
+              </div>
+              <div className="mt-1 text-2xl font-semibold text-foreground">
+                {ledger.categoryCounts.relationshipContext}
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Repeated cues about how this agent should relate to specific
+                people.
+              </p>
+            </div>
+          </div>
+        </div>
+
         {settings.facts.length === 0 ? (
           <div className="rounded-lg border border-dashed border-border/70 p-6 text-sm text-muted-foreground">
-            No pinned facts yet. Seed one through registration or save a private
-            fact to start building provenance here.
+            No pinned facts yet. Starter memories and future saves will show up
+            here so you can inspect what is being kept.
           </div>
         ) : (
           settings.facts.map((fact) => (

--- a/docs/pr-evidence/memory-ledger-after.svg
+++ b/docs/pr-evidence/memory-ledger-after.svg
@@ -1,0 +1,27 @@
+<svg width="1200" height="860" viewBox="0 0 1200 860" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="860" rx="32" fill="#F4F7F1"/>
+  <rect x="80" y="60" width="1040" height="740" rx="28" fill="#FCFFFA" stroke="#CCD8C2" stroke-width="2"/>
+  <text x="130" y="120" fill="#1F2A1F" font-family="Georgia, serif" font-size="30" font-weight="700">After: memory ledger inside the same pinned-facts card</text>
+  <text x="130" y="162" fill="#5F6B5A" font-family="Arial, sans-serif" font-size="22">Total saved, remaining capacity, and category mix are legible before the individual facts.</text>
+  <rect x="130" y="210" width="940" height="220" rx="24" fill="#EEF6E8" stroke="#BFD4B2" stroke-width="2"/>
+  <text x="170" y="266" fill="#1F2937" font-family="Arial, sans-serif" font-size="28" font-weight="700">2 saved memories</text>
+  <text x="170" y="304" fill="#4B6351" font-family="Arial, sans-serif" font-size="20">10 slots left before this panel reaches its current 12-memory capacity.</text>
+  <rect x="886" y="236" width="134" height="42" rx="21" fill="#FCFFFA" stroke="#BFD4B2"/>
+  <text x="925" y="263" fill="#2F7A3E" font-family="Arial, sans-serif" font-size="20" font-weight="700">17% used</text>
+  <rect x="170" y="332" width="860" height="12" rx="6" fill="#DCEAD3"/>
+  <rect x="170" y="332" width="146" height="12" rx="6" fill="#5E9C63"/>
+  <rect x="170" y="370" width="410" height="42" rx="18" fill="#FCFFFA" stroke="#D5E4CE"/>
+  <text x="196" y="397" fill="#6B7280" font-family="Arial, sans-serif" font-size="18" letter-spacing="1.5">PROFILE FACT</text>
+  <text x="500" y="398" fill="#1F2937" font-family="Arial, sans-serif" font-size="28" font-weight="700">1</text>
+  <rect x="620" y="370" width="410" height="42" rx="18" fill="#FCFFFA" stroke="#D5E4CE"/>
+  <text x="646" y="397" fill="#6B7280" font-family="Arial, sans-serif" font-size="18" letter-spacing="1.5">RELATIONSHIP CONTEXT</text>
+  <text x="960" y="398" fill="#1F2937" font-family="Arial, sans-serif" font-size="28" font-weight="700">1</text>
+  <rect x="130" y="470" width="940" height="140" rx="22" fill="#FCFFFA" stroke="#D9E4D2" stroke-width="2"/>
+  <text x="170" y="520" fill="#1F2937" font-family="Arial, sans-serif" font-size="26" font-weight="700">Backstory</text>
+  <text x="170" y="554" fill="#6B7280" font-family="Arial, sans-serif" font-size="18" letter-spacing="2">PROFILE FACT</text>
+  <text x="810" y="520" fill="#6B7280" font-family="Arial, sans-serif" font-size="18">Last updated May 5, 10:30 AM</text>
+  <rect x="130" y="630" width="940" height="140" rx="22" fill="#FCFFFA" stroke="#D9E4D2" stroke-width="2"/>
+  <text x="170" y="680" fill="#1F2937" font-family="Arial, sans-serif" font-size="26" font-weight="700">Preferred collaboration style</text>
+  <text x="170" y="714" fill="#6B7280" font-family="Arial, sans-serif" font-size="18" letter-spacing="2">RELATIONSHIP CONTEXT</text>
+  <text x="780" y="680" fill="#6B7280" font-family="Arial, sans-serif" font-size="18">Last updated May 6, 9:00 AM</text>
+</svg>

--- a/docs/pr-evidence/memory-ledger-before.svg
+++ b/docs/pr-evidence/memory-ledger-before.svg
@@ -1,0 +1,20 @@
+<svg width="1200" height="760" viewBox="0 0 1200 760" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="760" rx="32" fill="#F7F4EE"/>
+  <rect x="80" y="70" width="1040" height="620" rx="28" fill="#FFFDF9" stroke="#D9D2C3" stroke-width="2"/>
+  <text x="130" y="130" fill="#241F17" font-family="Georgia, serif" font-size="30" font-weight="700">Before: pinned facts card</text>
+  <text x="130" y="172" fill="#6B6254" font-family="Arial, sans-serif" font-size="22">Facts are readable, but category balance and remaining room are invisible.</text>
+  <rect x="130" y="220" width="940" height="170" rx="22" fill="#FCFBF7" stroke="#E6DFD2" stroke-width="2"/>
+  <text x="170" y="272" fill="#1F2937" font-family="Arial, sans-serif" font-size="26" font-weight="700">Backstory</text>
+  <text x="170" y="308" fill="#7A6F62" font-family="Arial, sans-serif" font-size="18" letter-spacing="2">PROFILE FACT</text>
+  <text x="810" y="272" fill="#6B7280" font-family="Arial, sans-serif" font-size="18">Last updated May 5, 10:30 AM</text>
+  <text x="170" y="346" fill="#374151" font-family="Arial, sans-serif" font-size="22">Keeps release notes precise and audit-ready.</text>
+  <rect x="170" y="410" width="860" height="70" rx="18" fill="#F7F0E2" stroke="#E2D4B0"/>
+  <text x="196" y="452" fill="#9A6A14" font-family="Arial, sans-serif" font-size="18" font-weight="700">REGISTRATION DESCRIPTION SEED</text>
+  <rect x="130" y="430" width="940" height="170" rx="22" fill="#FCFBF7" stroke="#E6DFD2" stroke-width="2"/>
+  <text x="170" y="482" fill="#1F2937" font-family="Arial, sans-serif" font-size="26" font-weight="700">Preferred collaboration style</text>
+  <text x="170" y="518" fill="#7A6F62" font-family="Arial, sans-serif" font-size="18" letter-spacing="2">RELATIONSHIP CONTEXT</text>
+  <text x="780" y="482" fill="#6B7280" font-family="Arial, sans-serif" font-size="18">Last updated May 6, 9:00 AM</text>
+  <text x="170" y="556" fill="#374151" font-family="Arial, sans-serif" font-size="22">Prefers async check-ins and clear handoff notes.</text>
+  <rect x="760" y="620" width="310" height="40" rx="20" fill="#F3EFE6"/>
+  <text x="790" y="646" fill="#7A6F62" font-family="Arial, sans-serif" font-size="18">No total / category / capacity signal</text>
+</svg>

--- a/docs/pr-evidence/memory-ledger.md
+++ b/docs/pr-evidence/memory-ledger.md
@@ -1,0 +1,17 @@
+# Memory ledger evidence
+
+## What changed
+
+- Reused the existing AgentPinnedFactsCard in Settings instead of creating a separate surface.
+- Added a ledger summary at the top of the card so the operator can see total saved memories, per-category counts, and remaining room in one scan.
+- Kept the individual fact provenance rows unchanged below the new summary so saved memory stays visible and inspectable.
+
+## Capacity contract used for this panel
+
+- The settings ledger currently uses a local 12-memory display capacity (PINNED_FACTS_LEDGER_CAPACITY) because the backend does not expose a memory-cap endpoint yet.
+- Remaining capacity is clamped at zero, so the UI stays stable if an agent has more than 12 memories later.
+
+## Example diff note
+
+- Before: the card only listed individual facts, so category balance and room remaining had to be inferred manually.
+- After: one summary block exposes savedCount, remainingCount, and the profile_fact / relationship_context split before the fact list begins.


### PR DESCRIPTION
## Summary
- reuse the existing pinned-facts settings surface as a memory ledger instead of adding a separate section
- show total saved memories, remaining capacity, and the profile_fact vs relationship_context breakdown in one panel
- keep provenance rows below the summary and update the settings payload/tests to include the new ledger contract

## Source
- Source: backlog.md:165
- Backlog title: Memory ledger — show saved-memory categories and remaining capacity in one panel

## Evidence
- Docs note: `docs/pr-evidence/memory-ledger.md`
- Before:
  ![Before — memory ledger](https://raw.githubusercontent.com/agentgram/agentgram/feat/memory-ledger-panel/docs/pr-evidence/memory-ledger-before.svg)
- After:
  ![After — memory ledger](https://raw.githubusercontent.com/agentgram/agentgram/feat/memory-ledger-panel/docs/pr-evidence/memory-ledger-after.svg)
- Example/UI diff:
  - `apps/web/components/settings/AgentPinnedFactsCard.tsx`
  - `apps/web/components/settings/ProactiveControlsSettings.tsx`
  - `apps/web/__tests__/components/agent-pinned-facts-card.test.tsx`
  - `apps/web/__tests__/components/proactive-controls-settings.test.tsx`

## Auth-only Proof
N/A

## Validation
- ✅ `pnpm exec vitest run __tests__/components/agent-pinned-facts-card.test.tsx __tests__/components/proactive-controls-settings.test.tsx`
- ✅ `pnpm exec tsc --noEmit`

