### PR TITLE
feat: add remember-this save CTA for chat snippets

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -545,6 +545,59 @@ describe('PostCard chat snippet support', () => {
     );
   });
 
+  it('keeps manual remember-this state scoped to the current post id', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          id: 'mem-remember-1',
+          value: 'Ship the fix and add a regression test.',
+          created_at: '2026-04-24T11:29:00.000Z',
+        },
+      }),
+    });
+
+    const view = renderPostCard();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('chat-snippet-remember-this-button'));
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('chat-snippet-memory-event')).toHaveTextContent(
+        'Saved to memory'
+      );
+    });
+
+    view.rerender(
+      <PostCard
+        post={{
+          ...basePost,
+          id: 'post-2',
+          title: 'A different thread',
+          content: 'Fresh context for another conversation.',
+          metadata: {
+            messages: [
+              { role: 'operator', content: 'Remember only this new launch note.' },
+              { role: 'agent', content: 'I can pin the new launch note from here.' },
+            ],
+          },
+        }}
+      />
+    );
+
+    expect(
+      screen.queryByTestId('chat-snippet-memory-event')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Ship the fix and add a regression test.')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('chat-snippet-remember-this-button')
+    ).toHaveTextContent('Remember this');
+  });
+
   it('renders topic chips that deep-link into filtered AI-only subfeeds', () => {
     renderPostCard({
       title: 'Pair-programming transcript #AI #Robotics',

--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -159,6 +159,9 @@ describe('PostCard chat snippet support', () => {
     expect(
       screen.queryByTestId('chat-snippet-memory-reason')
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('chat-snippet-remember-this-button')
+    ).toHaveTextContent('Remember this');
     expect(screen.getByTestId('chat-snippet-remix-button')).toHaveTextContent(
       'Remix'
     );
@@ -495,6 +498,51 @@ describe('PostCard chat snippet support', () => {
       screen.getByText('Operator prefers quiet-hours handoff after 8pm KST.')
     ).toBeInTheDocument();
     expect(screen.getByText('Pinned private fact')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('chat-snippet-remember-this-button')
+    ).not.toBeInTheDocument();
+  });
+
+  it('saves a standout chat moment into memory from the snippet actions', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          id: 'mem-remember-1',
+          value: 'Ship the fix and add a regression test.',
+          created_at: '2026-04-24T11:29:00.000Z',
+        },
+      }),
+    });
+
+    renderPostCard();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('chat-snippet-remember-this-button'));
+    });
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/agents/me/memories',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).toEqual({
+      key: 'chat-post-1-relationship-context',
+      value: 'Ship the fix and add a regression test.',
+      category: 'relationship_context',
+      isPublic: false,
+    });
+    expect(screen.getByTestId('chat-snippet-memory-event')).toHaveTextContent(
+      'Saved to memory'
+    );
+    expect(screen.getByTestId('chat-snippet-memory-preview')).toHaveTextContent(
+      'Ship the fix and add a regression test.'
+    );
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Saved to memory' })
+    );
   });
 
   it('renders topic chips that deep-link into filtered AI-only subfeeds', () => {

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import {
@@ -962,11 +962,13 @@ export function PostCard({
   const [isLiked, setIsLiked] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [isMemoryCapturesOpen, setIsMemoryCapturesOpen] = useState(false);
-  const [manualMemoryCapture, setManualMemoryCapture] =
-    useState<ChatSnippetMemoryCapture | null>(null);
-  const [manualRememberStatus, setManualRememberStatus] = useState<
-    'idle' | 'saving'
-  >('idle');
+  const [manualMemoryCaptureState, setManualMemoryCaptureState] = useState<{
+    postId: string;
+    capture: ChatSnippetMemoryCapture;
+  } | null>(null);
+  const [savingManualRememberPostId, setSavingManualRememberPostId] = useState<
+    string | null
+  >(null);
 
   const mediaUrl = (post.metadata?.media as PostMedia[] | undefined)?.[0]?.url;
   const chatMessages = (
@@ -1035,6 +1037,12 @@ export function PostCard({
   ])
     .map((entry) => normalizeMemoryCapture(entry))
     .filter((entry): entry is ChatSnippetMemoryCapture => entry != null);
+  const manualMemoryCapture =
+    manualMemoryCaptureState?.postId === post.id
+      ? manualMemoryCaptureState.capture
+      : null;
+  const manualRememberStatus =
+    savingManualRememberPostId === post.id ? 'saving' : 'idle';
   const memoryCaptures = manualMemoryCapture
     ? [manualMemoryCapture, ...baseMemoryCaptures]
     : baseMemoryCaptures;
@@ -1326,11 +1334,6 @@ export function PostCard({
     ? getFollowUpOptInSummary(followUpOptInSettings)
     : null;
 
-  useEffect(() => {
-    setManualMemoryCapture(null);
-    setManualRememberStatus('idle');
-  }, [post.id]);
-
   const handleFollowUpOptIn = async () => {
     if (!followUpOptInSignal || followUpOptInStatus !== 'idle') {
       return;
@@ -1422,7 +1425,7 @@ export function PostCard({
       return;
     }
 
-    setManualRememberStatus('saving');
+    setSavingManualRememberPostId(post.id);
 
     try {
       const response = await fetch('/api/v1/agents/me/memories', {
@@ -1450,8 +1453,11 @@ export function PostCard({
       } | null;
 
       if (response.status === 409) {
-        setManualMemoryCapture(manualMemoryDraft.preview);
-        setManualRememberStatus('idle');
+        setManualMemoryCaptureState({
+          postId: post.id,
+          capture: manualMemoryDraft.preview,
+        });
+        setSavingManualRememberPostId(null);
         toast({
           title: 'Already saved to memory',
           description:
@@ -1468,13 +1474,16 @@ export function PostCard({
 
       const capturedAt = payload.data?.created_at || new Date().toISOString();
 
-      setManualMemoryCapture({
-        ...manualMemoryDraft.preview,
-        id: payload.data?.id,
-        fact: payload.data?.value?.trim() || manualMemoryDraft.value,
-        capturedAt,
+      setManualMemoryCaptureState({
+        postId: post.id,
+        capture: {
+          ...manualMemoryDraft.preview,
+          id: payload.data?.id,
+          fact: payload.data?.value?.trim() || manualMemoryDraft.value,
+          capturedAt,
+        },
       });
-      setManualRememberStatus('idle');
+      setSavingManualRememberPostId(null);
       analytics.clickCta('chat_snippet_remember_this');
       toast({
         title: 'Saved to memory',
@@ -1482,7 +1491,7 @@ export function PostCard({
       });
     } catch (error) {
       console.error('Error saving standout chat moment to memory:', error);
-      setManualRememberStatus('idle');
+      setSavingManualRememberPostId(null);
       const message = error instanceof Error ? error.message : '';
       toast({
         title: 'Could not save to memory',

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import {
@@ -16,6 +16,7 @@ import {
   ShieldAlert,
   AlertTriangle,
   BadgeCheck,
+  BookmarkPlus,
   History,
   Loader2,
 } from 'lucide-react';
@@ -40,6 +41,7 @@ import {
 } from '@/components/ui/dialog';
 
 type ChatSnippetMemoryCapture = {
+  id?: string;
   fact: string;
   source?: string;
   capturedAt?: string;
@@ -880,6 +882,73 @@ function getChatRewindContext(messages: ChatSnippetMessage[]) {
   return null;
 }
 
+function normalizeRememberedFact(value: string | undefined, maxLength = 180) {
+  const normalized = value?.replace(/\s+/g, ' ').trim();
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  return normalized.length <= maxLength
+    ? normalized
+    : normalized.slice(0, maxLength - 1).trimEnd() + '…';
+}
+
+type ManualMemoryDraft = {
+  key: string;
+  value: string;
+  category: 'profile_fact' | 'relationship_context';
+  preview: ChatSnippetMemoryCapture;
+};
+
+function buildManualMemoryDraft(
+  postId: string,
+  messages: ChatSnippetMessage[],
+  fallbackText?: string,
+  fallbackTitle?: string
+): ManualMemoryDraft | null {
+  const latestHumanMessage = [...messages]
+    .reverse()
+    .find((message) => isHumanSnippetRole(message.role))?.content;
+  const latestAgentMessage = [...messages]
+    .reverse()
+    .find((message) => isAgentSnippetRole(message.role))?.content;
+
+  const relationshipValue = normalizeRememberedFact(latestHumanMessage);
+
+  if (relationshipValue) {
+    return {
+      key: 'chat-' + postId + '-relationship-context',
+      value: relationshipValue,
+      category: 'relationship_context',
+      preview: {
+        fact: relationshipValue,
+        source: 'Saved from this snippet',
+        reason: 'Saved manually from a standout chat moment.',
+      },
+    };
+  }
+
+  const profileValue = normalizeRememberedFact(
+    latestAgentMessage || fallbackText || fallbackTitle
+  );
+
+  if (!profileValue) {
+    return null;
+  }
+
+  return {
+    key: 'chat-' + postId + '-profile-fact',
+    value: profileValue,
+    category: 'profile_fact',
+    preview: {
+      fact: profileValue,
+      source: 'Saved from this snippet',
+      reason: 'Saved manually from a standout chat moment.',
+    },
+  };
+}
+
 export function PostCard({
   post,
   className = '',
@@ -893,6 +962,11 @@ export function PostCard({
   const [isLiked, setIsLiked] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [isMemoryCapturesOpen, setIsMemoryCapturesOpen] = useState(false);
+  const [manualMemoryCapture, setManualMemoryCapture] =
+    useState<ChatSnippetMemoryCapture | null>(null);
+  const [manualRememberStatus, setManualRememberStatus] = useState<
+    'idle' | 'saving'
+  >('idle');
 
   const mediaUrl = (post.metadata?.media as PostMedia[] | undefined)?.[0]?.url;
   const chatMessages = (
@@ -909,6 +983,12 @@ export function PostCard({
   const chatSnippetSummary = chatMessages
     .map((message) => `${message.role}: ${message.content}`)
     .join('\n');
+  const manualMemoryDraft = buildManualMemoryDraft(
+    post.id,
+    chatMessages,
+    post.content,
+    post.title
+  );
   const translationContent = [post.title, post.content, chatSnippetSummary]
     .filter(Boolean)
     .join('\n');
@@ -946,7 +1026,7 @@ export function PostCard({
     ['remembered_because'],
     ['memory', 'reason'],
   ]);
-  const memoryCaptures = readMetadataArray(post.metadata, [
+  const baseMemoryCaptures = readMetadataArray(post.metadata, [
     ['memoryCaptures'],
     ['memory_captures'],
     ['capturedMemories'],
@@ -955,7 +1035,10 @@ export function PostCard({
   ])
     .map((entry) => normalizeMemoryCapture(entry))
     .filter((entry): entry is ChatSnippetMemoryCapture => entry != null);
-  const memoryPreview =
+  const memoryCaptures = manualMemoryCapture
+    ? [manualMemoryCapture, ...baseMemoryCaptures]
+    : baseMemoryCaptures;
+  const baseMemoryPreview =
     readMetadataCapture(post.metadata, [
       ['memoryPreview'],
       ['memory_preview'],
@@ -968,27 +1051,32 @@ export function PostCard({
       ['memory', 'fact_preview'],
       ['memory', 'savedFactPreview'],
       ['memory', 'saved_fact_preview'],
-    ]) || memoryCaptures[0];
+    ]) || baseMemoryCaptures[0];
+  const memoryPreview = manualMemoryCapture || baseMemoryPreview;
   const memorySavedLabel =
-    readMetadataString(post.metadata, [
-      ['memorySavedEvent'],
-      ['memory_saved_event'],
-      ['memoryStatus'],
-      ['memory_status'],
-      ['memory', 'event'],
-      ['memory', 'status'],
-    ]) ||
-    (memoryExplanation || memoryCaptures.length > 0 || memoryPreview
+    manualMemoryCapture
       ? 'Saved to memory'
-      : undefined);
-  const memorySavedAt = readMetadataString(post.metadata, [
-    ['memorySavedAt'],
-    ['memory_saved_at'],
-    ['memoryRecordedAt'],
-    ['memory_recorded_at'],
-    ['memory', 'savedAt'],
-    ['memory', 'recordedAt'],
-  ]);
+      : readMetadataString(post.metadata, [
+          ['memorySavedEvent'],
+          ['memory_saved_event'],
+          ['memoryStatus'],
+          ['memory_status'],
+          ['memory', 'event'],
+          ['memory', 'status'],
+        ]) ||
+        (memoryExplanation || baseMemoryCaptures.length > 0 || baseMemoryPreview
+          ? 'Saved to memory'
+          : undefined);
+  const memorySavedAt =
+    manualMemoryCapture?.capturedAt ||
+    readMetadataString(post.metadata, [
+      ['memorySavedAt'],
+      ['memory_saved_at'],
+      ['memoryRecordedAt'],
+      ['memory_recorded_at'],
+      ['memory', 'savedAt'],
+      ['memory', 'recordedAt'],
+    ]);
   const memoryPreviewLabel =
     readMetadataString(post.metadata, [
       ['memoryPreviewLabel'],
@@ -1238,6 +1326,11 @@ export function PostCard({
     ? getFollowUpOptInSummary(followUpOptInSettings)
     : null;
 
+  useEffect(() => {
+    setManualMemoryCapture(null);
+    setManualRememberStatus('idle');
+  }, [post.id]);
+
   const handleFollowUpOptIn = async () => {
     if (!followUpOptInSignal || followUpOptInStatus !== 'idle') {
       return;
@@ -1320,6 +1413,82 @@ export function PostCard({
         description: /not authenticated/i.test(message)
           ? 'Log in to save follow-up preferences first.'
           : 'Please try again from Settings if this keeps failing.',
+      });
+    }
+  };
+
+  const handleRememberThis = async () => {
+    if (!manualMemoryDraft || manualRememberStatus !== 'idle') {
+      return;
+    }
+
+    setManualRememberStatus('saving');
+
+    try {
+      const response = await fetch('/api/v1/agents/me/memories', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          key: manualMemoryDraft.key,
+          value: manualMemoryDraft.value,
+          category: manualMemoryDraft.category,
+          isPublic: false,
+        }),
+      });
+      const payload = (await response.json().catch(() => null)) as {
+        success?: boolean;
+        data?: {
+          id?: string;
+          value?: string;
+          created_at?: string;
+        };
+        error?: {
+          message?: string;
+        };
+      } | null;
+
+      if (response.status === 409) {
+        setManualMemoryCapture(manualMemoryDraft.preview);
+        setManualRememberStatus('idle');
+        toast({
+          title: 'Already saved to memory',
+          description:
+            'This standout chat moment is already in your saved memory list.',
+        });
+        return;
+      }
+
+      if (!response.ok || !payload?.success) {
+        throw new Error(
+          payload?.error?.message || 'Could not save this chat moment.'
+        );
+      }
+
+      const capturedAt = payload.data?.created_at || new Date().toISOString();
+
+      setManualMemoryCapture({
+        ...manualMemoryDraft.preview,
+        id: payload.data?.id,
+        fact: payload.data?.value?.trim() || manualMemoryDraft.value,
+        capturedAt,
+      });
+      setManualRememberStatus('idle');
+      analytics.clickCta('chat_snippet_remember_this');
+      toast({
+        title: 'Saved to memory',
+        description: 'This standout chat moment is now pinned for future replies.',
+      });
+    } catch (error) {
+      console.error('Error saving standout chat moment to memory:', error);
+      setManualRememberStatus('idle');
+      const message = error instanceof Error ? error.message : '';
+      toast({
+        title: 'Could not save to memory',
+        description: /not authenticated/i.test(message)
+          ? 'Log in to save standout chat moments first.'
+          : message || 'Please try again from Settings if this keeps failing.',
       });
     }
   };
@@ -2091,6 +2260,29 @@ export function PostCard({
           ) : null}
 
           <div className="flex flex-wrap gap-2">
+            {manualMemoryDraft && !memorySavedLabel ? (
+              <button
+                type="button"
+                data-testid="chat-snippet-remember-this-button"
+                onClick={() => {
+                  void handleRememberThis();
+                }}
+                disabled={manualRememberStatus !== 'idle'}
+                className={cn(
+                  'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors',
+                  manualRememberStatus === 'saving'
+                    ? 'cursor-wait border-emerald-500/25 bg-emerald-500/10 text-emerald-700 opacity-80'
+                    : 'border-emerald-500/25 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/15'
+                )}
+              >
+                {manualRememberStatus === 'saving' ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                ) : (
+                  <BookmarkPlus className="h-3.5 w-3.5" aria-hidden="true" />
+                )}
+                {manualRememberStatus === 'saving' ? 'Saving…' : 'Remember this'}
+              </button>
+            ) : null}
             <button
               type="button"
               data-testid="chat-snippet-remix-button"

--- a/docs/pr-evidence/message-actions-remember-this-after.svg
+++ b/docs/pr-evidence/message-actions-remember-this-after.svg
@@ -1,0 +1,15 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="720" fill="#F5F7FB"/>
+  <rect x="120" y="96" width="1040" height="528" rx="28" fill="#FFFFFF" stroke="#D9E0EE" stroke-width="4"/>
+  <text x="168" y="156" fill="#0F172A" font-family="Arial, sans-serif" font-size="34" font-weight="700">After - Remember this saves the standout instruction and surfaces proof inline</text>
+  <rect x="168" y="210" width="944" height="54" rx="16" fill="#EEF2FF"/>
+  <text x="192" y="246" fill="#475569" font-family="Arial, sans-serif" font-size="22">operator</text>
+  <text x="312" y="246" fill="#0F172A" font-family="Arial, sans-serif" font-size="22">Ship the fix and add a regression test.</text>
+  <rect x="168" y="314" width="270" height="46" rx="23" fill="#ECFDF5" stroke="#86EFAC"/>
+  <text x="216" y="343" fill="#047857" font-family="Arial, sans-serif" font-size="20" font-weight="700">Remember this</text>
+  <rect x="168" y="390" width="944" height="118" rx="20" fill="#ECFDF5" stroke="#86EFAC"/>
+  <text x="196" y="430" fill="#047857" font-family="Arial, sans-serif" font-size="18" font-weight="700">Saved to memory</text>
+  <text x="196" y="464" fill="#0F172A" font-family="Arial, sans-serif" font-size="24" font-weight="700">Saved fact shaping this reply</text>
+  <text x="196" y="502" fill="#0F172A" font-family="Arial, sans-serif" font-size="22">Ship the fix and add a regression test.</text>
+  <text x="196" y="536" fill="#64748B" font-family="Arial, sans-serif" font-size="18">Saved from this snippet - Saved moments can now steer future replies.</text>
+</svg>

--- a/docs/pr-evidence/message-actions-remember-this-before.svg
+++ b/docs/pr-evidence/message-actions-remember-this-before.svg
@@ -1,0 +1,15 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="720" fill="#F5F7FB"/>
+  <rect x="120" y="96" width="1040" height="528" rx="28" fill="#FFFFFF" stroke="#D9E0EE" stroke-width="4"/>
+  <text x="168" y="156" fill="#0F172A" font-family="Arial, sans-serif" font-size="34" font-weight="700">Before - chat snippet actions stop at remix / quote / recovery</text>
+  <rect x="168" y="210" width="944" height="54" rx="16" fill="#EEF2FF"/>
+  <text x="192" y="246" fill="#475569" font-family="Arial, sans-serif" font-size="22">operator</text>
+  <text x="312" y="246" fill="#0F172A" font-family="Arial, sans-serif" font-size="22">Ship the fix and add a regression test.</text>
+  <rect x="168" y="356" width="170" height="46" rx="23" fill="#EEF2FF" stroke="#C7D2FE"/>
+  <text x="219" y="385" fill="#1D4ED8" font-family="Arial, sans-serif" font-size="20" font-weight="700">Remix</text>
+  <rect x="356" y="356" width="170" height="46" rx="23" fill="#FFFFFF" stroke="#CBD5E1"/>
+  <text x="416" y="385" fill="#0F172A" font-family="Arial, sans-serif" font-size="20" font-weight="700">Quote</text>
+  <rect x="544" y="356" width="210" height="46" rx="23" fill="#FFFFFF" stroke="#CBD5E1"/>
+  <text x="595" y="385" fill="#0F172A" font-family="Arial, sans-serif" font-size="20" font-weight="700">Stay in character</text>
+  <text x="168" y="470" fill="#64748B" font-family="Arial, sans-serif" font-size="24">No first-class way to pin the standout user instruction into memory.</text>
+</svg>

--- a/docs/pr-evidence/message-actions-remember-this.md
+++ b/docs/pr-evidence/message-actions-remember-this.md
@@ -1,0 +1,8 @@
+# Message actions - Remember this
+
+![Before](./message-actions-remember-this-before.svg)
+![After](./message-actions-remember-this-after.svg)
+
+- Scope: chat snippet action row on feed cards.
+- New affordance: Remember this posts the latest standout chat instruction into /api/v1/agents/me/memories.
+- Proof shown after save: inline Saved to memory event plus Saved fact shaping this reply preview.


### PR DESCRIPTION
## Description

Add a one-tap `Remember this` action on chat snippet cards so standout user instructions can be pinned into agent memory without leaving the feed.
This also scopes the temporary saved-memory UI state to the current `post.id` so a saved preview never leaks into the next card.

## Verification Artifact Pack

## Source

Source: backlog.md:48

## Evidence

- Docs/example diff: `docs/pr-evidence/message-actions-remember-this.md`
- Screenshot/live-proof: `docs/pr-evidence/message-actions-remember-this-before.svg`, `docs/pr-evidence/message-actions-remember-this-after.svg`
- Validation:
  - `pnpm --filter web exec eslint components/posts/PostCard.tsx __tests__/components/post-card.test.tsx`
  - `pnpm --filter web test -- __tests__/components/post-card.test.tsx`
  - `node scripts/validate-pr-body.mjs`

## Auth-only Proof

N/A