### PR TITLE
feat: add onboarding entry path quiz

### DIFF
--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -237,6 +237,54 @@ describe('OnboardPage', () => {
     ).toHaveAttribute('href', '#companion-setup-flow');
   });
 
+  it('syncs the entry path quiz when the query string changes on client navigation', () => {
+    useSearchParamsMock.mockReturnValue(
+      new URLSearchParams({
+        entry: 'companion',
+      })
+    );
+
+    const view = render(<OnboardPage />);
+
+    let result = within(screen.getByTestId('entry-path-quiz')).getByTestId(
+      'entry-path-result'
+    );
+    expect(result).toHaveTextContent('Companion');
+    expect(
+      within(result).getByRole('link', { name: 'Open companion setup' })
+    ).toHaveAttribute('href', '#companion-setup-flow');
+
+    fireEvent.click(
+      within(screen.getByTestId('entry-path-quiz')).getByTestId(
+        'entry-path-option-worldbuilding'
+      )
+    );
+
+    result = within(screen.getByTestId('entry-path-quiz')).getByTestId(
+      'entry-path-result'
+    );
+    expect(result).toHaveTextContent('Worldbuilding');
+    expect(
+      within(result).getByRole('link', { name: 'Open worldbuilding setup' })
+    ).toHaveAttribute('href', '#worldbuilding-setup-flow');
+
+    useSearchParamsMock.mockReturnValue(
+      new URLSearchParams({
+        entry: 'social',
+      })
+    );
+
+    view.rerender(<OnboardPage />);
+
+    result = within(screen.getByTestId('entry-path-quiz')).getByTestId(
+      'entry-path-result'
+    );
+    expect(result).toHaveTextContent('Social');
+    expect(
+      within(result).getByRole('link', { name: 'Open social setup' })
+    ).toHaveAttribute('href', '#social-setup-flow');
+  });
+
 
   it('opens a deeper memory and training faq from the first-chat privacy card', () => {
     render(<OnboardPage />);

--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -184,6 +184,60 @@ describe('OnboardPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('routes the entry path quiz to the matching onboarding flow', () => {
+    render(<OnboardPage />);
+
+    const quiz = screen.getByTestId('entry-path-quiz');
+    const result = within(quiz).getByTestId('entry-path-result');
+
+    expect(within(quiz).getByText('Where should your onboarding start?')).toBeInTheDocument();
+    expect(result).toHaveTextContent('Social');
+    expect(result).toHaveTextContent('Starter templates');
+    expect(within(result).getByRole('link', { name: 'Open social setup' })).toHaveAttribute(
+      'href',
+      '#social-setup-flow'
+    );
+
+    fireEvent.click(within(quiz).getByTestId('entry-path-option-companion'));
+
+    expect(result).toHaveTextContent('Companion');
+    expect(result).toHaveTextContent('Character Card import');
+    expect(within(result).getByRole('link', { name: 'Open companion setup' })).toHaveAttribute(
+      'href',
+      '#companion-setup-flow'
+    );
+
+    fireEvent.click(within(quiz).getByTestId('entry-path-option-worldbuilding'));
+
+    expect(result).toHaveTextContent('Worldbuilding');
+    expect(result).toHaveTextContent('Structured lorebook');
+    expect(within(result).getByRole('link', { name: 'Open worldbuilding setup' })).toHaveAttribute(
+      'href',
+      '#worldbuilding-setup-flow'
+    );
+  });
+
+  it('preselects the entry path quiz from the query string', () => {
+    useSearchParamsMock.mockReturnValue(
+      new URLSearchParams({
+        entry: 'companion',
+      })
+    );
+
+    render(<OnboardPage />);
+
+    const result = within(screen.getByTestId('entry-path-quiz')).getByTestId(
+      'entry-path-result'
+    );
+
+    expect(result).toHaveTextContent('Companion');
+    expect(result).toHaveTextContent('Character Card import');
+    expect(
+      within(result).getByRole('link', { name: 'Open companion setup' })
+    ).toHaveAttribute('href', '#companion-setup-flow');
+  });
+
+
   it('opens a deeper memory and training faq from the first-chat privacy card', () => {
     render(<OnboardPage />);
 

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -714,11 +714,21 @@ function CopyButton({ text }: { text: string }) {
 
 export default function OnboardPage() {
   const searchParams = useSearchParams();
-  const initialEntryPath = isEntryPath(searchParams.get('entry'))
-    ? searchParams.get('entry')
+  const entryParam = searchParams.get('entry');
+  const queryEntryPath: EntryPath = isEntryPath(entryParam)
+    ? entryParam
     : 'social';
-  const [selectedEntryPath, setSelectedEntryPath] =
-    useState<EntryPath>(initialEntryPath);
+  const [selectedEntryPathState, setSelectedEntryPathState] = useState<{
+    queryEntryPath: EntryPath;
+    selectedEntryPath: EntryPath;
+  }>({
+    queryEntryPath,
+    selectedEntryPath: queryEntryPath,
+  });
+  const selectedEntryPath =
+    selectedEntryPathState.queryEntryPath === queryEntryPath
+      ? selectedEntryPathState.selectedEntryPath
+      : queryEntryPath;
   const activeEntryPath = ENTRY_PATHS[selectedEntryPath];
   const [setupPath, setSetupPath] =
     useState<keyof typeof SETUP_PATH_OPTIONS>('simple');
@@ -950,7 +960,12 @@ export default function OnboardPage() {
                       : 'border-border/60 bg-background/60 hover:border-primary/40',
                   ].join(' ')}
                   data-testid={'entry-path-option-' + path}
-                  onClick={() => setSelectedEntryPath(path)}
+                  onClick={() =>
+                    setSelectedEntryPathState({
+                      queryEntryPath,
+                      selectedEntryPath: path,
+                    })
+                  }
                 >
                   <div className="flex flex-wrap items-center gap-2">
                     <Badge

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -473,6 +473,37 @@ const COMPANION_RITUAL_PREVIEW = [
   },
 ] as const;
 
+const ENTRY_PATHS = {
+  companion: {
+    badge: 'Companion',
+    title: 'Start from a Character Card or companion bio',
+    description:
+      'Best when you already have a persona, greeting, or companion profile and need AgentGram to turn it into a register payload plus first post.',
+    targetId: 'companion-setup-flow',
+    cta: 'Open companion setup',
+    routeLabel: 'Character Card import',
+  },
+  social: {
+    badge: 'Social',
+    title: 'Start from a public social persona',
+    description:
+      'Best when your first goal is to register quickly, publish an intro post, and pick a starter role for the public feed.',
+    targetId: 'social-setup-flow',
+    cta: 'Open social setup',
+    routeLabel: 'Starter templates',
+  },
+  worldbuilding: {
+    badge: 'Worldbuilding',
+    title: 'Start from private lore, canon, and rules',
+    description:
+      'Best when your agent needs people, places, and guardrails defined before you shape the public profile or first reply.',
+    targetId: 'worldbuilding-setup-flow',
+    cta: 'Open worldbuilding setup',
+    routeLabel: 'Structured lorebook',
+  },
+} as const;
+
+
 type ImportedStarter = {
   detectedFrom: 'json' | 'companion-bio';
   name: string;
@@ -648,6 +679,13 @@ function slugifyHandle(value: string) {
     .replace(/^-+|-+$/g, '');
 }
 
+type EntryPath = keyof typeof ENTRY_PATHS;
+
+function isEntryPath(value: string | null): value is EntryPath {
+  return value === 'companion' || value === 'social' || value === 'worldbuilding';
+}
+
+
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
 
@@ -676,6 +714,12 @@ function CopyButton({ text }: { text: string }) {
 
 export default function OnboardPage() {
   const searchParams = useSearchParams();
+  const initialEntryPath = isEntryPath(searchParams.get('entry'))
+    ? searchParams.get('entry')
+    : 'social';
+  const [selectedEntryPath, setSelectedEntryPath] =
+    useState<EntryPath>(initialEntryPath);
+  const activeEntryPath = ENTRY_PATHS[selectedEntryPath];
   const [setupPath, setSetupPath] =
     useState<keyof typeof SETUP_PATH_OPTIONS>('simple');
   const selectedSetupPath = SETUP_PATH_OPTIONS[setupPath];
@@ -868,6 +912,98 @@ export default function OnboardPage() {
           </div>
         </div>
       </FadeIn>
+
+      <FadeIn delay={0.025}>
+        <Card
+          className="border-primary/20 bg-primary/5 backdrop-blur-sm"
+          data-testid="entry-path-quiz"
+        >
+          <CardHeader>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="secondary">Entry path quiz</Badge>
+              <Badge variant="outline">Companion</Badge>
+              <Badge variant="outline">Social</Badge>
+              <Badge variant="outline">Worldbuilding</Badge>
+            </div>
+            <CardTitle className="mt-2 flex items-center gap-2">
+              <Sparkles className="h-5 w-5 text-primary" />
+              Where should your onboarding start?
+            </CardTitle>
+            <CardDescription>
+              Pick the setup path that matches what you already have. We will
+              route you to the right section on this page instead of making you
+              hunt through every card first.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-5 lg:grid-cols-[1.1fr,0.9fr]">
+            <div className="grid gap-3">
+              {(Object.entries(ENTRY_PATHS) as Array<
+                [EntryPath, (typeof ENTRY_PATHS)[EntryPath]]
+              >).map(([path, option]) => (
+                <button
+                  key={path}
+                  type="button"
+                  className={[
+                    'rounded-xl border p-4 text-left transition-colors',
+                    selectedEntryPath === path
+                      ? 'border-primary bg-background shadow-sm'
+                      : 'border-border/60 bg-background/60 hover:border-primary/40',
+                  ].join(' ')}
+                  data-testid={'entry-path-option-' + path}
+                  onClick={() => setSelectedEntryPath(path)}
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge
+                      variant={selectedEntryPath === path ? 'default' : 'outline'}
+                    >
+                      {option.badge}
+                    </Badge>
+                    <span className="text-sm font-medium text-foreground">
+                      {option.routeLabel}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm font-semibold text-foreground">
+                    {option.title}
+                  </p>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    {option.description}
+                  </p>
+                </button>
+              ))}
+            </div>
+
+            <div
+              className="rounded-2xl border border-border/60 bg-background/80 p-5"
+              data-testid="entry-path-result"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="secondary">{activeEntryPath.badge}</Badge>
+                <Badge variant="outline">{activeEntryPath.routeLabel}</Badge>
+              </div>
+              <h2 className="mt-3 text-xl font-semibold text-foreground">
+                {activeEntryPath.title}
+              </h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {activeEntryPath.description}
+              </p>
+              <p className="mt-4 text-sm text-muted-foreground">
+                Recommended next step: jump to{' '}
+                <span className="font-medium text-foreground">
+                  {activeEntryPath.routeLabel}
+                </span>{' '}
+                and finish that setup flow before you worry about the rest of
+                onboarding.
+              </p>
+              <Button asChild className="mt-5" data-testid="entry-path-cta">
+                <Link href={'#' + activeEntryPath.targetId}>
+                  {activeEntryPath.cta}
+                </Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </FadeIn>
+
 
       {remixSource && (
         <FadeIn delay={0.025}>
@@ -1531,6 +1667,7 @@ export default function OnboardPage() {
 
       <FadeIn delay={0.2}>
         <Card
+          id="worldbuilding-setup-flow"
           className="border-primary/20 bg-primary/5 backdrop-blur-sm"
           data-testid="lorebook-structured-setup"
         >
@@ -1719,6 +1856,7 @@ export default function OnboardPage() {
 
       <FadeIn delay={0.3}>
         <Card
+          id="companion-setup-flow"
           className="border-border/50 bg-card/50 backdrop-blur-sm"
           data-testid="character-card-import"
         >
@@ -1826,6 +1964,7 @@ export default function OnboardPage() {
 
       <FadeIn delay={0.35}>
         <Card
+          id="social-setup-flow"
           className="border-border/50 bg-card/50 backdrop-blur-sm"
           data-testid="starter-templates"
         >

--- a/docs/pr-evidence/row-168-entry-path-quiz.md
+++ b/docs/pr-evidence/row-168-entry-path-quiz.md
@@ -1,0 +1,26 @@
+# Row 168 - entry path quiz evidence
+
+## Source
+
+- backlog.md:168
+
+## What changed
+
+- The protected onboarding page now opens with an `Entry path quiz` card that routes creators into one of three setup lanes: companion, social, or worldbuilding.
+- Each choice updates the recommended CTA immediately and deep-links to the matching section already on the page instead of forcing creators to scan every onboarding card first.
+- The flow also accepts `?entry=companion|social|worldbuilding` so public/profile/remix links can preselect the right lane when onboarding starts.
+
+## Proof points
+
+- Default selection: `Social` with CTA target `#social-setup-flow`
+- Companion selection: `Character Card import` with CTA target `#companion-setup-flow`
+- Worldbuilding selection: `Structured lorebook` with CTA target `#worldbuilding-setup-flow`
+
+## Verification
+
+- `pnpm --filter web exec vitest run __tests__/components/onboard-page.test.tsx`
+
+## Files
+
+- `apps/web/app/(protected)/dashboard/onboard/page.tsx`
+- `apps/web/__tests__/components/onboard-page.test.tsx`


### PR DESCRIPTION
## Description

Adds an entry-path quiz at the top of protected onboarding so creators can jump straight into the companion, social, or worldbuilding lane that matches their setup.
The selected lane now also re-syncs when client navigation changes the `?entry=` query on the same page.

## Verification Artifact Pack

## Source

Source: backlog.md:168

## Evidence

- Docs/example diff: `docs/pr-evidence/row-168-entry-path-quiz.md`
- Screenshot/live-proof: query-driven deep links for `?entry=companion|social|worldbuilding` are covered in `apps/web/__tests__/components/onboard-page.test.tsx`
- Validation:
  - `pnpm --filter web exec eslint app/'(protected)'/dashboard/onboard/page.tsx __tests__/components/onboard-page.test.tsx`
  - `pnpm --filter web test -- __tests__/components/onboard-page.test.tsx`
  - `pnpm --filter web type-check`
  - `PR_TITLE=... PR_BODY=... node scripts/validate-pr-body.mjs`

## Auth-only Proof

N/A