### PR TITLE
feat: show latest memory receipts in settings

### DIFF
--- a/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
+++ b/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import {
   AgentPinnedFactsCard,
@@ -15,15 +15,24 @@ function buildSettings(
     facts: [
       {
         id: 'memory-1',
+        key: 'latest_focus',
+        value: 'Always preserve the latest release blocker in private memory.',
+        category: 'relationship_context',
+        updatedAt: '2026-05-08T12:30:00.000Z',
+        originLabel: 'Remember this CTA',
+        originSnippet: 'Preserve the latest release blocker.',
+      },
+      {
+        id: 'memory-2',
         key: 'pinned_backstory',
         value: 'Keeps release notes precise and audit-ready.',
         category: 'profile_fact',
-        updatedAt: '2026-05-05T10:30:00.000Z',
+        updatedAt: '2026-05-07T10:30:00.000Z',
         originLabel: 'Registration description seed',
         originSnippet: 'Keeps release notes precise.',
       },
       {
-        id: 'memory-2',
+        id: 'memory-3',
         key: 'preferred_collaboration_style',
         value: 'Prefers async check-ins and clear handoff notes.',
         category: 'relationship_context',
@@ -31,14 +40,23 @@ function buildSettings(
         originLabel: 'Saved fact snapshot',
         originSnippet: 'Prefers async check-ins and clear handoff notes.',
       },
+      {
+        id: 'memory-4',
+        key: 'favorite_release_window',
+        value: 'Ships bigger changes after lunch when review coverage is online.',
+        category: 'profile_fact',
+        updatedAt: '2026-05-05T09:00:00.000Z',
+        originLabel: 'Developer note import',
+        originSnippet: 'Ships bigger changes after lunch.',
+      },
     ],
     ledger: {
       capacity: 12,
-      savedCount: 2,
-      remainingCount: 10,
+      savedCount: 4,
+      remainingCount: 8,
       categoryCounts: {
-        profileFact: 1,
-        relationshipContext: 1,
+        profileFact: 2,
+        relationshipContext: 2,
       },
     },
     ...overrides,
@@ -46,15 +64,15 @@ function buildSettings(
 }
 
 describe('AgentPinnedFactsCard', () => {
-  it('shows the memory ledger summary, category counts, and fact provenance', () => {
+  it('keeps the ledger summary visible while showing the three latest memory receipts', () => {
     render(<AgentPinnedFactsCard settings={buildSettings()} />);
 
     expect(screen.getByText('Pinned facts for Sage Bot')).toBeInTheDocument();
     expect(screen.getByTestId('pinned-facts-ledger-summary')).toHaveTextContent(
-      '2 saved memories'
+      '4 saved memories'
     );
     expect(screen.getByTestId('pinned-facts-ledger-summary')).toHaveTextContent(
-      '10 slots left'
+      '8 slots left'
     );
     expect(
       screen.getByTestId('ledger-category-profile-fact')
@@ -62,16 +80,49 @@ describe('AgentPinnedFactsCard', () => {
     expect(
       screen.getByTestId('ledger-category-relationship-context')
     ).toHaveTextContent('Relationship context');
-    expect(screen.getByTestId('pinned-fact-memory-1')).toHaveTextContent(
-      'Backstory'
+
+    const receipts = screen.getByTestId('pinned-facts-receipts');
+    expect(receipts).toHaveTextContent('Latest memory receipts');
+    expect(receipts).toHaveTextContent('Showing 3 of 4');
+    expect(
+      within(receipts).getByTestId('memory-receipt-category-memory-1')
+    ).toHaveTextContent('Relationship Context');
+    expect(
+      within(receipts).getByTestId('memory-receipt-category-memory-2')
+    ).toHaveTextContent('Profile Fact');
+    expect(
+      within(receipts).getByTestId('memory-receipt-timestamp-memory-1')
+    ).toHaveTextContent('Saved');
+    expect(receipts).toHaveTextContent(
+      'Always preserve the latest release blocker in private memory.'
+    );
+    expect(receipts).toHaveTextContent(
+      'Keeps release notes precise and audit-ready.'
+    );
+    expect(receipts).toHaveTextContent(
+      'Prefers async check-ins and clear handoff notes.'
     );
     expect(
-      screen.getByTestId('pinned-fact-updated-memory-1')
+      within(receipts).queryByText(
+        'Ships bigger changes after lunch when review coverage is online.'
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the full ledger provenance below the receipt strip', () => {
+    render(<AgentPinnedFactsCard settings={buildSettings()} />);
+
+    expect(screen.getByText('Full memory ledger')).toBeInTheDocument();
+    expect(screen.getByTestId('pinned-fact-memory-4')).toHaveTextContent(
+      'Favorite Release Window'
+    );
+    expect(
+      screen.getByTestId('pinned-fact-updated-memory-2')
     ).toHaveTextContent('Last updated');
-    expect(screen.getByTestId('pinned-fact-origin-memory-1')).toHaveTextContent(
+    expect(screen.getByTestId('pinned-fact-origin-memory-2')).toHaveTextContent(
       'Registration description seed'
     );
-    expect(screen.getByTestId('pinned-fact-origin-memory-1')).toHaveTextContent(
+    expect(screen.getByTestId('pinned-fact-origin-memory-2')).toHaveTextContent(
       'Keeps release notes precise.'
     );
   });

--- a/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
+++ b/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
@@ -71,6 +71,7 @@ function formatCapacityCopy(count: number) {
 
 export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
   const { ledger } = settings;
+  const recentFacts = settings.facts.slice(0, 3);
   const usagePercent =
     ledger.capacity === 0
       ? 0
@@ -85,7 +86,8 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
         </CardTitle>
         <CardDescription>
           Visible, controllable private memory. Review what this agent saved,
-          which category it belongs to, and how much room remains in the ledger.
+          which category it belongs to, how much room remains in the ledger, and
+          the latest memory receipts.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -158,47 +160,114 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
             here so you can inspect what is being kept.
           </div>
         ) : (
-          settings.facts.map((fact) => (
+          <>
             <div
-              className="rounded-xl border border-border/60 bg-background/80 p-4"
-              data-testid={`pinned-fact-${fact.id}`}
-              key={fact.id}
+              className="rounded-xl border border-primary/20 bg-primary/5 p-4"
+              data-testid="pinned-facts-receipts"
             >
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="space-y-1">
+                <div>
                   <div className="font-medium text-foreground">
-                    {formatFactLabel(fact.key)}
+                    Latest memory receipts
                   </div>
-                  <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                    {formatCategoryLabel(fact.category)}
-                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    The newest saved facts stay visible here so you can confirm
+                    what changed before digging into the full ledger.
+                  </p>
                 </div>
-                <div
-                  className="flex items-center gap-2 text-xs text-muted-foreground"
-                  data-testid={`pinned-fact-updated-${fact.id}`}
-                >
-                  <Clock3 className="h-3.5 w-3.5" />
-                  Last updated {formatTimestamp(fact.updatedAt)}
+                <div className="rounded-full border border-primary/20 bg-background/90 px-3 py-1 text-xs font-medium text-primary">
+                  Showing {recentFacts.length} of {settings.facts.length}
                 </div>
               </div>
 
-              <p className="mt-3 whitespace-pre-wrap text-sm text-foreground">
-                {fact.value}
-              </p>
-
-              <div
-                className="mt-4 rounded-lg border border-primary/15 bg-primary/5 p-3"
-                data-testid={`pinned-fact-origin-${fact.id}`}
-              >
-                <div className="text-xs font-medium uppercase tracking-wide text-primary">
-                  {fact.originLabel}
-                </div>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {fact.originSnippet}
-                </p>
+              <div className="mt-4 grid gap-3">
+                {recentFacts.map((fact) => (
+                  <div
+                    className="rounded-lg border border-border/60 bg-background/85 p-3"
+                    data-testid={`memory-receipt-${fact.id}`}
+                    key={fact.id}
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded-full border border-border/70 bg-background px-2.5 py-1 text-xs font-medium text-foreground">
+                        {formatFactLabel(fact.key)}
+                      </span>
+                      <span
+                        className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary"
+                        data-testid={`memory-receipt-category-${fact.id}`}
+                      >
+                        {formatCategoryLabel(fact.category)}
+                      </span>
+                      <span
+                        className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-background px-2.5 py-1 text-xs text-muted-foreground"
+                        data-testid={`memory-receipt-timestamp-${fact.id}`}
+                      >
+                        <Clock3 className="h-3.5 w-3.5" />
+                        Saved {formatTimestamp(fact.updatedAt)}
+                      </span>
+                    </div>
+                    <p
+                      className="mt-3 whitespace-pre-wrap text-sm text-foreground"
+                      data-testid={`memory-receipt-value-${fact.id}`}
+                    >
+                      {fact.value}
+                    </p>
+                  </div>
+                ))}
               </div>
             </div>
-          ))
+
+            <div className="space-y-3">
+              <div>
+                <div className="font-medium text-foreground">Full memory ledger</div>
+                <p className="text-sm text-muted-foreground">
+                  Every saved fact keeps its original seed note so you can audit
+                  why it exists, not just when it was last updated.
+                </p>
+              </div>
+
+              {settings.facts.map((fact) => (
+                <div
+                  className="rounded-xl border border-border/60 bg-background/80 p-4"
+                  data-testid={`pinned-fact-${fact.id}`}
+                  key={fact.id}
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="font-medium text-foreground">
+                        {formatFactLabel(fact.key)}
+                      </div>
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                        {formatCategoryLabel(fact.category)}
+                      </div>
+                    </div>
+                    <div
+                      className="flex items-center gap-2 text-xs text-muted-foreground"
+                      data-testid={`pinned-fact-updated-${fact.id}`}
+                    >
+                      <Clock3 className="h-3.5 w-3.5" />
+                      Last updated {formatTimestamp(fact.updatedAt)}
+                    </div>
+                  </div>
+
+                  <p className="mt-3 whitespace-pre-wrap text-sm text-foreground">
+                    {fact.value}
+                  </p>
+
+                  <div
+                    className="mt-4 rounded-lg border border-primary/15 bg-primary/5 p-3"
+                    data-testid={`pinned-fact-origin-${fact.id}`}
+                  >
+                    <div className="text-xs font-medium uppercase tracking-wide text-primary">
+                      {fact.originLabel}
+                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {fact.originSnippet}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
         )}
       </CardContent>
     </Card>

--- a/docs/pr-evidence/memory-receipts-settings.md
+++ b/docs/pr-evidence/memory-receipts-settings.md
@@ -1,0 +1,17 @@
+# Memory Receipts Settings Evidence
+
+Source: backlog.md:129
+
+## Before
+- Settings exposed the full pinned-facts provenance list, but there was no quick receipt view for the newest remembered facts.
+- Developers had to scan the full ledger to confirm what the latest save changed.
+
+## After
+- Settings now surfaces a Latest memory receipts strip above the full ledger.
+- The strip shows the newest three remembered facts with a category badge and saved timestamp chip.
+- The existing full provenance ledger remains below the strip for audit detail.
+
+## Changed Files
+- apps/web/components/dashboard/AgentPinnedFactsCard.tsx
+- apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
+


### PR DESCRIPTION
## Description

Show the newest three saved memories directly in dashboard settings so developers can confirm the latest remembered facts without scanning the full provenance ledger.

## Verification Artifact Pack

This PR adds an in-repo docs/example diff artifact and targeted component coverage for the new settings receipt strip.

## Source

Source: backlog.md:129

## Evidence

- Docs/example diff: docs/pr-evidence/memory-receipts-settings.md
- Screenshot/live-proof: N/A
- Validation: \`pnpm test -- agent-pinned-facts-card.test.tsx\`

## Auth-only Proof

N/A

## Type of Change

- [ ] 🐛 Bug fix (\`type: bug\`)
- [x] ✨ New feature (\`type: feature\`)
- [ ] 🔧 Enhancement (\`type: enhancement\`)
- [ ] 📚 Documentation (\`type: documentation\`)
- [ ] ♻️ Refactor (\`type: refactor\`)
- [ ] ⚡ Performance (\`type: performance\`)
- [ ] 🔒 Security (\`type: security\`)

## Area

- [ ] 🔧 Backend (\`area: backend\`)
- [x] 🎨 Frontend (\`area: frontend\`)
- [ ] 🤖 Agent SDK (\`area: agent-sdk\`)
- [ ] 💾 Database (\`area: database\`)
- [ ] 🔐 Authentication (\`area: auth\`)
- [ ] 🔍 Search (\`area: search\`)
- [ ] 🏗️ Infrastructure (\`area: infrastructure\`)
- [x] 🧪 Testing (\`area: testing\`)

## Changes Made

- Added a Latest memory receipts strip to the pinned-facts settings card.
- Limited the receipt strip to the newest three saved memories and surfaced category/time badges.
- Kept the full provenance ledger below the strip and expanded tests around recent-receipt behavior.

## Related Issues

- Source backlog row only.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests added/updated

### Test Steps

1. Open dashboard settings for a claimed agent with at least three saved memories.
2. Confirm the Latest memory receipts strip shows only the newest three facts with category and Saved timestamp badges.
3. Verify the full ledger still lists all saved facts with origin snippets.

## Breaking Changes

- [ ] ⚠️ Yes, this PR includes breaking changes (\`breaking change\`)
  - **Describe the breaking changes:**
  - **Migration guide:**

- [x] ✅ No breaking changes

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added the required source, evidence, and auth-only proof above
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Evidence is docs/example diff based because this cron lane does not capture screenshots.

