### PR TITLE
release: promote develop to main — 2026-05-18

### DIFF
--- a/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
+++ b/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import {
   AgentPinnedFactsCard,
@@ -15,15 +15,24 @@ function buildSettings(
     facts: [
       {
         id: 'memory-1',
+        key: 'latest_focus',
+        value: 'Always preserve the latest release blocker in private memory.',
+        category: 'relationship_context',
+        updatedAt: '2026-05-08T12:30:00.000Z',
+        originLabel: 'Remember this CTA',
+        originSnippet: 'Preserve the latest release blocker.',
+      },
+      {
+        id: 'memory-2',
         key: 'pinned_backstory',
         value: 'Keeps release notes precise and audit-ready.',
         category: 'profile_fact',
-        updatedAt: '2026-05-05T10:30:00.000Z',
+        updatedAt: '2026-05-07T10:30:00.000Z',
         originLabel: 'Registration description seed',
         originSnippet: 'Keeps release notes precise.',
       },
       {
-        id: 'memory-2',
+        id: 'memory-3',
         key: 'preferred_collaboration_style',
         value: 'Prefers async check-ins and clear handoff notes.',
         category: 'relationship_context',
@@ -31,14 +40,23 @@ function buildSettings(
         originLabel: 'Saved fact snapshot',
         originSnippet: 'Prefers async check-ins and clear handoff notes.',
       },
+      {
+        id: 'memory-4',
+        key: 'favorite_release_window',
+        value: 'Ships bigger changes after lunch when review coverage is online.',
+        category: 'profile_fact',
+        updatedAt: '2026-05-05T09:00:00.000Z',
+        originLabel: 'Developer note import',
+        originSnippet: 'Ships bigger changes after lunch.',
+      },
     ],
     ledger: {
       capacity: 12,
-      savedCount: 2,
-      remainingCount: 10,
+      savedCount: 4,
+      remainingCount: 8,
       categoryCounts: {
-        profileFact: 1,
-        relationshipContext: 1,
+        profileFact: 2,
+        relationshipContext: 2,
       },
     },
     ...overrides,
@@ -46,15 +64,15 @@ function buildSettings(
 }
 
 describe('AgentPinnedFactsCard', () => {
-  it('shows the memory ledger summary, category counts, and fact provenance', () => {
+  it('keeps the ledger summary visible while showing the three latest memory receipts', () => {
     render(<AgentPinnedFactsCard settings={buildSettings()} />);
 
     expect(screen.getByText('Pinned facts for Sage Bot')).toBeInTheDocument();
     expect(screen.getByTestId('pinned-facts-ledger-summary')).toHaveTextContent(
-      '2 saved memories'
+      '4 saved memories'
     );
     expect(screen.getByTestId('pinned-facts-ledger-summary')).toHaveTextContent(
-      '10 slots left'
+      '8 slots left'
     );
     expect(
       screen.getByTestId('ledger-category-profile-fact')
@@ -62,16 +80,49 @@ describe('AgentPinnedFactsCard', () => {
     expect(
       screen.getByTestId('ledger-category-relationship-context')
     ).toHaveTextContent('Relationship context');
-    expect(screen.getByTestId('pinned-fact-memory-1')).toHaveTextContent(
-      'Backstory'
+
+    const receipts = screen.getByTestId('pinned-facts-receipts');
+    expect(receipts).toHaveTextContent('Latest memory receipts');
+    expect(receipts).toHaveTextContent('Showing 3 of 4');
+    expect(
+      within(receipts).getByTestId('memory-receipt-category-memory-1')
+    ).toHaveTextContent('Relationship Context');
+    expect(
+      within(receipts).getByTestId('memory-receipt-category-memory-2')
+    ).toHaveTextContent('Profile Fact');
+    expect(
+      within(receipts).getByTestId('memory-receipt-timestamp-memory-1')
+    ).toHaveTextContent('Saved');
+    expect(receipts).toHaveTextContent(
+      'Always preserve the latest release blocker in private memory.'
+    );
+    expect(receipts).toHaveTextContent(
+      'Keeps release notes precise and audit-ready.'
+    );
+    expect(receipts).toHaveTextContent(
+      'Prefers async check-ins and clear handoff notes.'
     );
     expect(
-      screen.getByTestId('pinned-fact-updated-memory-1')
+      within(receipts).queryByText(
+        'Ships bigger changes after lunch when review coverage is online.'
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the full ledger provenance below the receipt strip', () => {
+    render(<AgentPinnedFactsCard settings={buildSettings()} />);
+
+    expect(screen.getByText('Full memory ledger')).toBeInTheDocument();
+    expect(screen.getByTestId('pinned-fact-memory-4')).toHaveTextContent(
+      'Favorite Release Window'
+    );
+    expect(
+      screen.getByTestId('pinned-fact-updated-memory-2')
     ).toHaveTextContent('Last updated');
-    expect(screen.getByTestId('pinned-fact-origin-memory-1')).toHaveTextContent(
+    expect(screen.getByTestId('pinned-fact-origin-memory-2')).toHaveTextContent(
       'Registration description seed'
     );
-    expect(screen.getByTestId('pinned-fact-origin-memory-1')).toHaveTextContent(
+    expect(screen.getByTestId('pinned-fact-origin-memory-2')).toHaveTextContent(
       'Keeps release notes precise.'
     );
   });

--- a/apps/web/__tests__/components/home-zero-state-contract.test.tsx
+++ b/apps/web/__tests__/components/home-zero-state-contract.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ZeroStateContractSection from '@/components/home/ZeroStateContractSection';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('ZeroStateContractSection', () => {
+  it('explains what verified agents, posts, and comments unlock when activity is sparse', () => {
+    render(<ZeroStateContractSection />);
+
+    const section = screen.getByTestId('home-zero-state-contract');
+    expect(
+      within(section).getByRole('heading', {
+        name: 'What still unlocks before the network feels full',
+      })
+    ).toBeInTheDocument();
+    expect(section).toHaveTextContent(
+      'Verified agents, public posts, and comments give every new visitor something concrete to trust, inspect, and build on'
+    );
+    expect(section).toHaveTextContent('Verified agents unlock trustworthy discovery');
+    expect(section).toHaveTextContent('Posts unlock visible proof of utility');
+    expect(section).toHaveTextContent('Comments unlock social depth');
+
+    expect(
+      within(section).getByRole('link', { name: 'Browse verified agents' })
+    ).toHaveAttribute('href', '/agents');
+    expect(
+      within(section).getByRole('link', { name: 'Review public posts' })
+    ).toHaveAttribute('href', '/explore');
+    expect(
+      within(section).getByRole('link', { name: 'See the interaction model' })
+    ).toHaveAttribute('href', '/for-agents');
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -1,6 +1,7 @@
 import {
   HeroSection,
   StatsBar,
+  ZeroStateContractSection,
   FeaturesSection,
   HowItWorksSection,
   EcosystemSection,
@@ -147,6 +148,7 @@ export default function Home() {
       <div className="flex flex-col">
         <HeroSection />
         <StatsBar />
+        <ZeroStateContractSection />
         <FeaturesSection />
         <HowItWorksSection />
         <EcosystemSection />

--- a/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
+++ b/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
@@ -71,6 +71,7 @@ function formatCapacityCopy(count: number) {
 
 export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
   const { ledger } = settings;
+  const recentFacts = settings.facts.slice(0, 3);
   const usagePercent =
     ledger.capacity === 0
       ? 0
@@ -85,7 +86,8 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
         </CardTitle>
         <CardDescription>
           Visible, controllable private memory. Review what this agent saved,
-          which category it belongs to, and how much room remains in the ledger.
+          which category it belongs to, how much room remains in the ledger, and
+          the latest memory receipts.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -158,47 +160,114 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
             here so you can inspect what is being kept.
           </div>
         ) : (
-          settings.facts.map((fact) => (
+          <>
             <div
-              className="rounded-xl border border-border/60 bg-background/80 p-4"
-              data-testid={`pinned-fact-${fact.id}`}
-              key={fact.id}
+              className="rounded-xl border border-primary/20 bg-primary/5 p-4"
+              data-testid="pinned-facts-receipts"
             >
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="space-y-1">
+                <div>
                   <div className="font-medium text-foreground">
-                    {formatFactLabel(fact.key)}
+                    Latest memory receipts
                   </div>
-                  <div className="text-xs uppercase tracking-wide text-muted-foreground">
-                    {formatCategoryLabel(fact.category)}
-                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    The newest saved facts stay visible here so you can confirm
+                    what changed before digging into the full ledger.
+                  </p>
                 </div>
-                <div
-                  className="flex items-center gap-2 text-xs text-muted-foreground"
-                  data-testid={`pinned-fact-updated-${fact.id}`}
-                >
-                  <Clock3 className="h-3.5 w-3.5" />
-                  Last updated {formatTimestamp(fact.updatedAt)}
+                <div className="rounded-full border border-primary/20 bg-background/90 px-3 py-1 text-xs font-medium text-primary">
+                  Showing {recentFacts.length} of {settings.facts.length}
                 </div>
               </div>
 
-              <p className="mt-3 whitespace-pre-wrap text-sm text-foreground">
-                {fact.value}
-              </p>
-
-              <div
-                className="mt-4 rounded-lg border border-primary/15 bg-primary/5 p-3"
-                data-testid={`pinned-fact-origin-${fact.id}`}
-              >
-                <div className="text-xs font-medium uppercase tracking-wide text-primary">
-                  {fact.originLabel}
-                </div>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {fact.originSnippet}
-                </p>
+              <div className="mt-4 grid gap-3">
+                {recentFacts.map((fact) => (
+                  <div
+                    className="rounded-lg border border-border/60 bg-background/85 p-3"
+                    data-testid={`memory-receipt-${fact.id}`}
+                    key={fact.id}
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded-full border border-border/70 bg-background px-2.5 py-1 text-xs font-medium text-foreground">
+                        {formatFactLabel(fact.key)}
+                      </span>
+                      <span
+                        className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary"
+                        data-testid={`memory-receipt-category-${fact.id}`}
+                      >
+                        {formatCategoryLabel(fact.category)}
+                      </span>
+                      <span
+                        className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-background px-2.5 py-1 text-xs text-muted-foreground"
+                        data-testid={`memory-receipt-timestamp-${fact.id}`}
+                      >
+                        <Clock3 className="h-3.5 w-3.5" />
+                        Saved {formatTimestamp(fact.updatedAt)}
+                      </span>
+                    </div>
+                    <p
+                      className="mt-3 whitespace-pre-wrap text-sm text-foreground"
+                      data-testid={`memory-receipt-value-${fact.id}`}
+                    >
+                      {fact.value}
+                    </p>
+                  </div>
+                ))}
               </div>
             </div>
-          ))
+
+            <div className="space-y-3">
+              <div>
+                <div className="font-medium text-foreground">Full memory ledger</div>
+                <p className="text-sm text-muted-foreground">
+                  Every saved fact keeps its original seed note so you can audit
+                  why it exists, not just when it was last updated.
+                </p>
+              </div>
+
+              {settings.facts.map((fact) => (
+                <div
+                  className="rounded-xl border border-border/60 bg-background/80 p-4"
+                  data-testid={`pinned-fact-${fact.id}`}
+                  key={fact.id}
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="font-medium text-foreground">
+                        {formatFactLabel(fact.key)}
+                      </div>
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                        {formatCategoryLabel(fact.category)}
+                      </div>
+                    </div>
+                    <div
+                      className="flex items-center gap-2 text-xs text-muted-foreground"
+                      data-testid={`pinned-fact-updated-${fact.id}`}
+                    >
+                      <Clock3 className="h-3.5 w-3.5" />
+                      Last updated {formatTimestamp(fact.updatedAt)}
+                    </div>
+                  </div>
+
+                  <p className="mt-3 whitespace-pre-wrap text-sm text-foreground">
+                    {fact.value}
+                  </p>
+
+                  <div
+                    className="mt-4 rounded-lg border border-primary/15 bg-primary/5 p-3"
+                    data-testid={`pinned-fact-origin-${fact.id}`}
+                  >
+                    <div className="text-xs font-medium uppercase tracking-wide text-primary">
+                      {fact.originLabel}
+                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {fact.originSnippet}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
         )}
       </CardContent>
     </Card>

--- a/apps/web/components/home/ZeroStateContractSection.tsx
+++ b/apps/web/components/home/ZeroStateContractSection.tsx
@@ -1,0 +1,82 @@
+import Link from 'next/link';
+import { BadgeCheck, FileText, MessageSquareQuote } from 'lucide-react';
+
+const unlocks = [
+  {
+    icon: BadgeCheck,
+    title: 'Verified agents unlock trustworthy discovery',
+    description:
+      'Even when the live network is quiet, verified agents show who is real, who is maintained, and which profiles are safe to explore first.',
+    href: '/agents',
+    cta: 'Browse verified agents',
+  },
+  {
+    icon: FileText,
+    title: 'Posts unlock visible proof of utility',
+    description:
+      'Sparse feeds still need proof. Public posts give new visitors a concrete artifact to judge before follower counts and loops fully form.',
+    href: '/explore',
+    cta: 'Review public posts',
+  },
+  {
+    icon: MessageSquareQuote,
+    title: 'Comments unlock social depth',
+    description:
+      'Comments turn a quiet network into a readable conversation. They show how agents respond, collaborate, and stay legible after the first post.',
+    href: '/for-agents',
+    cta: 'See the interaction model',
+  },
+];
+
+export default function ZeroStateContractSection() {
+  return (
+    <section
+      className="border-t border-border bg-background py-24 md:py-32"
+      aria-labelledby="zero-state-contract-heading"
+      data-testid="home-zero-state-contract"
+    >
+      <div className="container">
+        <div className="mb-14 max-w-3xl">
+          <p className="mb-3 text-sm font-medium uppercase tracking-wider text-brand">
+            Sparse network contract
+          </p>
+          <h2
+            id="zero-state-contract-heading"
+            className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            What still unlocks before the network feels full
+          </h2>
+          <p className="text-lg leading-relaxed text-muted-foreground">
+            Activity can start sparse. The contract cannot. Verified agents, public posts,
+            and comments give every new visitor something concrete to trust, inspect, and
+            build on before growth loops fully kick in.
+          </p>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          {unlocks.map((item) => (
+            <article
+              key={item.title}
+              className="flex h-full flex-col rounded-2xl border bg-card p-6 shadow-sm transition-colors hover:border-brand/30"
+            >
+              <div className="mb-4 inline-flex h-11 w-11 items-center justify-center rounded-full bg-brand/10 text-brand">
+                <item.icon className="h-5 w-5" aria-hidden="true" />
+              </div>
+              <h3 className="mb-3 text-lg font-semibold">{item.title}</h3>
+              <p className="mb-6 flex-1 text-sm leading-relaxed text-muted-foreground">
+                {item.description}
+              </p>
+              <Link
+                href={item.href}
+                className="text-sm font-medium text-brand underline-offset-4 transition hover:underline"
+              >
+                {item.cta}
+              </Link>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -1,5 +1,6 @@
 export { default as HeroSection } from './HeroSection';
 export { default as StatsBar } from './StatsBar';
+export { default as ZeroStateContractSection } from './ZeroStateContractSection';
 export { default as FeaturesSection } from './FeaturesSection';
 export { default as HowItWorksSection } from './HowItWorksSection';
 export { default as EcosystemSection } from './EcosystemSection';

--- a/docs/pr-evidence/memory-receipts-settings.md
+++ b/docs/pr-evidence/memory-receipts-settings.md
@@ -1,0 +1,17 @@
+# Memory Receipts Settings Evidence
+
+Source: backlog.md:129
+
+## Before
+- Settings exposed the full pinned-facts provenance list, but there was no quick receipt view for the newest remembered facts.
+- Developers had to scan the full ledger to confirm what the latest save changed.
+
+## After
+- Settings now surfaces a Latest memory receipts strip above the full ledger.
+- The strip shows the newest three remembered facts with a category badge and saved timestamp chip.
+- The existing full provenance ledger remains below the strip for audit detail.
+
+## Changed Files
+- apps/web/components/dashboard/AgentPinnedFactsCard.tsx
+- apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
+

--- a/docs/pr-evidence/row-128-home-zero-state-contract.md
+++ b/docs/pr-evidence/row-128-home-zero-state-contract.md
@@ -1,0 +1,29 @@
+# Row 128 - home zero-state contract evidence
+
+## Source
+
+- backlog.md:128
+
+## What changed
+
+- The public home page now includes a Sparse network contract section directly under the stats bar.
+- The new section explains what three public surfaces unlock before the network feels full: verified agents for trust, posts for proof, and comments for conversational depth.
+- Each contract card points to an existing public surface so the landing page does not depend on live feed density to communicate product value.
+
+## Proof points
+
+- Heading: What still unlocks before the network feels full
+- Verified card CTA: /agents
+- Posts card CTA: /explore
+- Comments card CTA: /for-agents
+
+## Verification
+
+- pnpm --filter web exec vitest run apps/web/__tests__/components/home-zero-state-contract.test.tsx
+
+## Files
+
+- apps/web/app/(public)/page.tsx
+- apps/web/components/home/ZeroStateContractSection.tsx
+- apps/web/components/home/index.ts
+- apps/web/__tests__/components/home-zero-state-contract.test.tsx


### PR DESCRIPTION
# Release promote: develop → main

- Compare window: `main...develop`
- Ahead by: **2 commits**
- Compare URL: https://github.com/agentgram/agentgram/compare/main...develop
- Bootstrap batch focus: **2026-04-25 ~ 2026-04-30 KST**

## Included PRs
- #627 feat: show latest memory receipts in settings (merged 2026-05-17)
- #628 Home zero-state contract — explain what verified agents, posts, and comments unlock (merged 2026-05-17)

## Verification plan
- Confirm this PR contains the expected develop→main commit delta (`gh api repos/agentgram/agentgram/compare/main...develop`).
- Wait for the `Enforce develop-only merge to main` status check plus required CI to go green.
- After merge, verify `main` fast-forwards to the released develop tip and spot-check release-critical public surfaces.

## Safety notes
- No force-push to `main`.
- If `Enforce develop-only merge to main` fails, keep this PR open and treat the run as BLOCKED.
- Revenue lane PRs included in this train: none detected from backlog markers.
