### PR TITLE
feat: add creation gallery controls

### DIFF
--- a/apps/web/__tests__/components/profile-media-grid.test.tsx
+++ b/apps/web/__tests__/components/profile-media-grid.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Post } from '@agentgram/shared';
 import { ProfileMediaGrid } from '../../components/agents/ProfileMediaGrid';
 
 const useAgentPostsMock = vi.fn();
+const writeText = vi.fn();
 
 vi.mock('next/image', () => ({
   default: ({
@@ -45,6 +46,7 @@ const chatSnippetPost: Post = {
   commentCount: 4,
   score: 72,
   metadata: {
+    personaName: 'Boardwalk Guide',
     messages: [
       { role: 'user', content: 'Let’s stage a boardwalk reunion scene.' },
       {
@@ -79,6 +81,7 @@ const generatedMediaPost: Post = {
         type: 'image',
         generated: true,
         kind: 'selfie',
+        personaName: 'Mirror Muse',
         prompt: 'Polaroid-style mirror selfie with a soft flash bounce.',
       },
     ],
@@ -110,6 +113,12 @@ const uploadedMediaPost: Post = {
 describe('ProfileMediaGrid', () => {
   beforeEach(() => {
     useAgentPostsMock.mockReset();
+    writeText.mockReset();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
   });
 
   it('pins the latest generated scene above the gallery grid without duplicating it', () => {
@@ -131,10 +140,12 @@ describe('ProfileMediaGrid', () => {
 
     expect(useAgentPostsMock).toHaveBeenCalledWith('agent-1', 'authored', 36);
     expect(screen.getByTestId('profile-media-grid')).toBeInTheDocument();
+    expect(screen.getByText('Creation gallery')).toBeInTheDocument();
 
     const spotlight = screen.getByTestId('profile-media-spotlight');
     expect(spotlight).toHaveTextContent('Latest spotlight');
     expect(spotlight).toHaveTextContent('Sunset boardwalk scene');
+    expect(spotlight).toHaveTextContent('Boardwalk Guide');
     expect(spotlight).toHaveTextContent('3 public chat turns');
     expect(spotlight).toHaveTextContent(
       'Two friends meeting at a neon boardwalk at dusk.'
@@ -142,9 +153,79 @@ describe('ProfileMediaGrid', () => {
 
     const gallery = screen.getByTestId('profile-media-gallery');
     expect(screen.getAllByTestId('profile-media-card')).toHaveLength(1);
-    expect(within(gallery).getByText('Mirror selfie follow-up')).toBeInTheDocument();
-    expect(within(gallery).queryByText('Sunset boardwalk scene')).not.toBeInTheDocument();
+    expect(
+      within(gallery).getByText('Mirror selfie follow-up')
+    ).toBeInTheDocument();
+    expect(within(gallery).getByText('Mirror Muse')).toBeInTheDocument();
+    expect(
+      within(gallery).queryByText('Sunset boardwalk scene')
+    ).not.toBeInTheDocument();
     expect(screen.queryByText('Manual upload')).not.toBeInTheDocument();
+  });
+
+  it('filters archived creations by persona and supports share and save actions', async () => {
+    useAgentPostsMock.mockReturnValue({
+      data: {
+        pages: [
+          {
+            posts: [generatedMediaPost, uploadedMediaPost, chatSnippetPost],
+          },
+        ],
+      },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isLoading: false,
+    });
+
+    render(<ProfileMediaGrid agentId="agent-1" />);
+
+    fireEvent.click(
+      screen.getByTestId('profile-media-persona-filter-mirror-muse')
+    );
+    expect(screen.getByTestId('profile-media-gallery')).toHaveTextContent(
+      '1 shown'
+    );
+    expect(screen.getByTestId('profile-media-gallery')).toHaveTextContent(
+      'Mirror selfie follow-up'
+    );
+
+    fireEvent.click(
+      screen.getByTestId('profile-media-persona-filter-boardwalk-guide')
+    );
+    expect(screen.getByTestId('profile-media-filter-empty')).toHaveTextContent(
+      'No archived moments for this persona yet'
+    );
+    expect(screen.getByTestId('profile-media-spotlight')).toHaveTextContent(
+      'Sunset boardwalk scene'
+    );
+
+    fireEvent.click(screen.getByTestId('profile-media-persona-filter-all'));
+    const gallery = screen.getByTestId('profile-media-gallery');
+    const saveButton = within(gallery).getByRole('button', {
+      name: /save creation mirror selfie follow-up/i,
+    });
+    fireEvent.click(saveButton);
+    expect(
+      within(gallery).getByRole('button', {
+        name: /remove saved creation mirror selfie follow-up/i,
+      })
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('1 saved')).toBeInTheDocument();
+
+    fireEvent.click(
+      within(gallery).getByRole('button', {
+        name: /share creation mirror selfie follow-up/i,
+      })
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('/posts/post-selfie')
+    );
+    expect(
+      await within(gallery).findByRole('button', {
+        name: /share creation mirror selfie follow-up/i,
+      })
+    ).toHaveTextContent('Copied');
   });
 
   it('shows a spotlight-only state when the first generated image lands', () => {
@@ -167,10 +248,11 @@ describe('ProfileMediaGrid', () => {
     expect(screen.getByTestId('profile-media-spotlight')).toHaveTextContent(
       'Sunset boardwalk scene'
     );
-    expect(screen.getByTestId('profile-media-spotlight-only')).toHaveTextContent(
+    expect(
+      screen.getByTestId('profile-media-spotlight-only')
+    ).toHaveTextContent(
       'This spotlight is the first generated visual on the public profile.'
     );
-    expect(screen.queryByTestId('profile-media-gallery')).not.toBeInTheDocument();
     expect(screen.queryByTestId('profile-media-card')).not.toBeInTheDocument();
   });
 

--- a/apps/web/components/agents/ProfileMediaGrid.tsx
+++ b/apps/web/components/agents/ProfileMediaGrid.tsx
@@ -1,8 +1,18 @@
 'use client';
 
+import { useMemo, useState, type MouseEvent } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { Heart, ImageIcon, Loader2, MessageCircle } from 'lucide-react';
+import {
+  BookmarkCheck,
+  BookmarkPlus,
+  Heart,
+  ImageIcon,
+  Loader2,
+  MessageCircle,
+  Share2,
+  Sparkles,
+} from 'lucide-react';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { formatDate } from '@/lib/format-date';
 import { useAgentPosts } from '@/hooks/use-agents';
@@ -12,9 +22,132 @@ interface ProfileMediaGridProps {
   agentId: string;
 }
 
+function buildPostUrl(postId: string) {
+  if (typeof window === 'undefined') {
+    return `/posts/${postId}`;
+  }
+
+  return `${window.location.origin}/posts/${postId}`;
+}
+
+function getPersonaFilterId(label: string) {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
 export function ProfileMediaGrid({ agentId }: ProfileMediaGridProps) {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useAgentPosts(agentId, 'authored', 36);
+  const [selectedPersona, setSelectedPersona] = useState('all');
+  const [favoriteIds, setFavoriteIds] = useState<Set<string>>(() => new Set());
+  const [sharedItemId, setSharedItemId] = useState<string | null>(null);
+
+  const posts = data?.pages.flatMap((page) => page.posts) || [];
+  const mediaItems = extractGeneratedProfileMedia(posts);
+  const personaOptions = useMemo(() => {
+    const counts = new Map<string, number>();
+
+    mediaItems.forEach((item) => {
+      counts.set(item.personaLabel, (counts.get(item.personaLabel) ?? 0) + 1);
+    });
+
+    return Array.from(counts.entries())
+      .map(([label, count]) => ({ label, count }))
+      .sort(
+        (left, right) =>
+          right.count - left.count || left.label.localeCompare(right.label)
+      );
+  }, [mediaItems]);
+
+  const activePersona =
+    selectedPersona !== 'all' &&
+    personaOptions.some((option) => option.label === selectedPersona)
+      ? selectedPersona
+      : 'all';
+
+  async function handleShare(
+    item: { id: string; postId: string },
+    event?: MouseEvent<HTMLButtonElement>
+  ) {
+    event?.preventDefault();
+    event?.stopPropagation();
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(buildPostUrl(item.postId));
+      }
+
+      setSharedItemId(item.id);
+    } catch {
+      setSharedItemId(null);
+    }
+  }
+
+  function toggleFavorite(
+    itemId: string,
+    event?: MouseEvent<HTMLButtonElement>
+  ) {
+    event?.preventDefault();
+    event?.stopPropagation();
+
+    setFavoriteIds((current) => {
+      const next = new Set(current);
+
+      if (next.has(itemId)) {
+        next.delete(itemId);
+      } else {
+        next.add(itemId);
+      }
+
+      return next;
+    });
+  }
+
+  function renderCreationActions(
+    item: { id: string; postId: string; title: string },
+    tone: 'light' | 'dark'
+  ) {
+    const isFavorite = favoriteIds.has(item.id);
+    const wasShared = sharedItemId === item.id;
+    const buttonClassName =
+      tone === 'dark'
+        ? 'border-white/25 bg-black/45 text-white hover:bg-white/20 hover:text-white'
+        : 'border-border/80 bg-background/90';
+
+    return (
+      <div className="flex flex-wrap gap-2" data-testid="profile-media-actions">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className={buttonClassName}
+          onClick={(event) => void handleShare(item, event)}
+          aria-label={`Share creation ${item.title}`}
+        >
+          <Share2 className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+          {wasShared ? 'Copied' : 'Share'}
+        </Button>
+        <Button
+          type="button"
+          variant={isFavorite ? 'default' : 'outline'}
+          size="sm"
+          className={isFavorite ? undefined : buttonClassName}
+          onClick={(event) => toggleFavorite(item.id, event)}
+          aria-pressed={isFavorite}
+          aria-label={`${isFavorite ? 'Remove saved creation' : 'Save creation'} ${item.title}`}
+        >
+          {isFavorite ? (
+            <BookmarkCheck className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <BookmarkPlus className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
+          )}
+          {isFavorite ? 'Saved' : 'Save'}
+        </Button>
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (
@@ -23,9 +156,6 @@ export function ProfileMediaGrid({ agentId }: ProfileMediaGridProps) {
       </div>
     );
   }
-
-  const posts = data?.pages.flatMap((page) => page.posts) || [];
-  const mediaItems = extractGeneratedProfileMedia(posts);
 
   if (mediaItems.length === 0) {
     return (
@@ -45,26 +175,36 @@ export function ProfileMediaGrid({ agentId }: ProfileMediaGridProps) {
     );
   }
 
-  const [spotlightItem, ...galleryItems] = mediaItems;
+  const [spotlightItem, ...archiveItems] = mediaItems;
+  const galleryItems =
+    activePersona === 'all'
+      ? archiveItems
+      : archiveItems.filter((item) => item.personaLabel === activePersona);
+  const favoriteCount = favoriteIds.size;
 
   return (
     <div className="pb-8" data-testid="profile-media-grid">
       <div className="mb-5 flex flex-col gap-3 rounded-3xl border border-border/80 bg-muted/20 p-5 shadow-sm sm:flex-row sm:items-end sm:justify-between">
         <div>
           <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-            Public media
+            Creation gallery
           </p>
           <h3 className="mt-2 text-xl font-semibold text-foreground">
-            Scenes and selfies from public chats
+            Generated moments from public chats
           </h3>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-            Visitors can browse generated visual moments without digging through
-            every transcript first.
+            Public chat images are organized by persona so standout moments stay
+            easy to revisit and pass along.
           </p>
         </div>
-        <span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
-          {mediaItems.length} collected
-        </span>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+            {mediaItems.length} collected
+          </span>
+          <span className="inline-flex items-center rounded-full border border-border/80 bg-background/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            {favoriteCount} saved
+          </span>
+        </div>
       </div>
 
       <section
@@ -86,6 +226,10 @@ export function ProfileMediaGrid({ agentId }: ProfileMediaGridProps) {
               </span>
               <span className="inline-flex items-center rounded-full border border-white/25 bg-black/45 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur-sm">
                 {spotlightItem.badgeLabel}
+              </span>
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-white/25 bg-black/45 px-3 py-1 text-[11px] font-medium text-white backdrop-blur-sm">
+                <Sparkles className="h-3 w-3" aria-hidden="true" />
+                {spotlightItem.personaLabel}
               </span>
             </div>
           </div>
@@ -118,18 +262,75 @@ export function ProfileMediaGrid({ agentId }: ProfileMediaGridProps) {
                 </span>
               </div>
 
-              <Link
-                href={`/posts/${spotlightItem.postId}`}
-                className={`${buttonVariants()} w-full sm:w-auto`}
-              >
-                Open spotlight post
-              </Link>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <Link
+                  href={`/posts/${spotlightItem.postId}`}
+                  className={`${buttonVariants()} w-full sm:w-auto`}
+                >
+                  Open spotlight post
+                </Link>
+                {renderCreationActions(spotlightItem, 'light')}
+              </div>
             </div>
           </div>
         </div>
       </section>
 
-      {galleryItems.length > 0 ? (
+      <div
+        className="mb-6 rounded-3xl border border-border/80 bg-background p-4 shadow-sm"
+        data-testid="profile-media-persona-filter"
+      >
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+              Persona lens
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Persona traces across the archived public-chat creations.
+            </p>
+          </div>
+          <span className="text-xs font-medium text-muted-foreground">
+            {activePersona === 'all'
+              ? `${archiveItems.length} archived moments`
+              : `${galleryItems.length} archived for ${activePersona}`}
+          </span>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant={activePersona === 'all' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setSelectedPersona('all')}
+            aria-pressed={activePersona === 'all'}
+            data-testid="profile-media-persona-filter-all"
+          >
+            All personas
+            <span className="ml-2 rounded-full bg-background/20 px-1.5 text-[11px]">
+              {mediaItems.length}
+            </span>
+          </Button>
+          {personaOptions.map((option) => (
+            <Button
+              key={option.label}
+              type="button"
+              variant={activePersona === option.label ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setSelectedPersona(option.label)}
+              aria-pressed={activePersona === option.label}
+              data-testid={`profile-media-persona-filter-${getPersonaFilterId(
+                option.label
+              )}`}
+            >
+              {option.label}
+              <span className="ml-2 rounded-full bg-background/20 px-1.5 text-[11px]">
+                {option.count}
+              </span>
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {archiveItems.length > 0 ? (
         <div className="space-y-4" data-testid="profile-media-gallery">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
             <div>
@@ -142,56 +343,74 @@ export function ProfileMediaGrid({ agentId }: ProfileMediaGridProps) {
               </p>
             </div>
             <span className="inline-flex items-center rounded-full border border-border/80 bg-muted/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-              {galleryItems.length} more
+              {galleryItems.length} shown
             </span>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-            {galleryItems.map((item) => (
-              <Link
-                key={item.id}
-                href={`/posts/${item.postId}`}
-                className="group overflow-hidden rounded-3xl border border-border/70 bg-background shadow-sm transition hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-lg"
-                data-testid="profile-media-card"
-              >
-                <div className="relative aspect-[4/5] overflow-hidden bg-muted">
-                  <Image
-                    src={item.url}
-                    alt={item.alt}
-                    fill
-                    className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-                  />
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/20 to-transparent" />
-                  <div className="absolute left-3 top-3 flex flex-wrap gap-2">
-                    <span className="inline-flex items-center rounded-full border border-white/25 bg-black/45 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur-sm">
-                      {item.badgeLabel}
-                    </span>
-                    <span className="inline-flex items-center rounded-full border border-white/20 bg-white/10 px-2.5 py-1 text-[11px] font-medium text-white/90 backdrop-blur-sm">
-                      {item.sourceLabel}
-                    </span>
-                  </div>
-                  <div className="absolute inset-x-0 bottom-0 p-4 text-white">
-                    <p className="text-base font-semibold leading-6 line-clamp-2">
-                      {item.title}
-                    </p>
-                    <p className="mt-1 text-sm leading-5 text-white/80 line-clamp-3">
-                      {item.summary}
-                    </p>
-                    <div className="mt-3 flex items-center gap-4 text-xs font-medium text-white/90">
-                      <span className="inline-flex items-center gap-1.5">
-                        <Heart className="h-3.5 w-3.5 fill-white" />
-                        {item.likes}
-                      </span>
-                      <span className="inline-flex items-center gap-1.5">
-                        <MessageCircle className="h-3.5 w-3.5 fill-white" />
-                        {item.commentCount}
-                      </span>
+          {galleryItems.length > 0 ? (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {galleryItems.map((item) => (
+                <article
+                  key={item.id}
+                  className="group overflow-hidden rounded-3xl border border-border/70 bg-background shadow-sm transition hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-lg"
+                  data-testid="profile-media-card"
+                >
+                  <Link href={`/posts/${item.postId}`} className="block">
+                    <div className="relative aspect-[4/5] overflow-hidden bg-muted">
+                      <Image
+                        src={item.url}
+                        alt={item.alt}
+                        fill
+                        className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                      />
+                      <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/20 to-transparent" />
+                      <div className="absolute left-3 top-3 flex flex-wrap gap-2">
+                        <span className="inline-flex items-center rounded-full border border-white/25 bg-black/45 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white backdrop-blur-sm">
+                          {item.badgeLabel}
+                        </span>
+                        <span className="inline-flex items-center rounded-full border border-white/20 bg-white/10 px-2.5 py-1 text-[11px] font-medium text-white/90 backdrop-blur-sm">
+                          {item.sourceLabel}
+                        </span>
+                      </div>
+                      <div className="absolute inset-x-0 bottom-0 p-4 text-white">
+                        <p className="text-base font-semibold leading-6 line-clamp-2">
+                          {item.title}
+                        </p>
+                        <p className="mt-1 text-sm leading-5 text-white/80 line-clamp-3">
+                          {item.summary}
+                        </p>
+                        <div className="mt-3 flex flex-wrap items-center gap-3 text-xs font-medium text-white/90">
+                          <span className="inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-black/30 px-2 py-1">
+                            <Sparkles className="h-3.5 w-3.5" />
+                            {item.personaLabel}
+                          </span>
+                          <span className="inline-flex items-center gap-1.5">
+                            <Heart className="h-3.5 w-3.5 fill-white" />
+                            {item.likes}
+                          </span>
+                          <span className="inline-flex items-center gap-1.5">
+                            <MessageCircle className="h-3.5 w-3.5 fill-white" />
+                            {item.commentCount}
+                          </span>
+                        </div>
+                      </div>
                     </div>
+                  </Link>
+                  <div className="border-t border-border/70 p-3">
+                    {renderCreationActions(item, 'light')}
                   </div>
-                </div>
-              </Link>
-            ))}
-          </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div
+              className="rounded-3xl border border-dashed border-border/80 bg-muted/20 px-5 py-4 text-sm leading-6 text-muted-foreground"
+              data-testid="profile-media-filter-empty"
+            >
+              No archived moments for this persona yet. The latest spotlight
+              stays pinned above.
+            </div>
+          )}
         </div>
       ) : (
         <div

--- a/apps/web/components/agents/profile-media.ts
+++ b/apps/web/components/agents/profile-media.ts
@@ -8,6 +8,7 @@ export interface ProfileGeneratedMediaItem {
   alt: string;
   badgeLabel: 'Scene' | 'Selfie' | 'Generated';
   sourceLabel: string;
+  personaLabel: string;
   summary: string;
   likes: number;
   commentCount: number;
@@ -25,6 +26,9 @@ type MediaCandidate = Partial<PostMedia> & {
   generated?: boolean;
   kind?: string;
   label?: string;
+  persona?: unknown;
+  personaLabel?: string;
+  personaName?: string;
   prompt?: string;
   source?: string;
   title?: string;
@@ -68,6 +72,20 @@ function getMetadataValue(metadata: Record<string, unknown>, path: string[]) {
   }
 
   return current;
+}
+
+function readString(value: unknown) {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function readObjectString(value: unknown, key: string) {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  return readString((value as Record<string, unknown>)[key]);
 }
 
 function getChatMessages(post: Post) {
@@ -140,6 +158,33 @@ function isGeneratedCandidate(
   return !requireGeneratedFlag && Boolean(fallbackBadge);
 }
 
+function getPersonaLabel(
+  post: Post,
+  metadata: Record<string, unknown>,
+  candidate: MediaCandidate
+) {
+  const candidatePersona = candidate.persona;
+  const metadataPersona =
+    getMetadataValue(metadata, ['persona']) ||
+    getMetadataValue(metadata, ['activePersona']) ||
+    getMetadataValue(metadata, ['active_persona']);
+
+  return (
+    readString(candidate.personaLabel) ||
+    readString(candidate.personaName) ||
+    readObjectString(candidatePersona, 'name') ||
+    readObjectString(candidatePersona, 'label') ||
+    readString(getMetadataValue(metadata, ['personaLabel'])) ||
+    readString(getMetadataValue(metadata, ['personaName'])) ||
+    readString(getMetadataValue(metadata, ['persona_label'])) ||
+    readString(getMetadataValue(metadata, ['persona_name'])) ||
+    readObjectString(metadataPersona, 'name') ||
+    readObjectString(metadataPersona, 'label') ||
+    post.author?.activePersona?.name ||
+    'Core persona'
+  );
+}
+
 function extractCandidates(
   post: Post,
   metadata: Record<string, unknown>,
@@ -204,6 +249,7 @@ export function extractGeneratedProfileMedia(
                 `${post.title || 'Generated image'} — ${badgeLabel.toLowerCase()}`,
               badgeLabel,
               sourceLabel,
+              personaLabel: getPersonaLabel(post, metadata, entry),
               summary: entry.prompt?.trim() || fallbackSummary,
               likes: post.likes,
               commentCount: post.commentCount,

--- a/docs/pr-evidence/creation-gallery.md
+++ b/docs/pr-evidence/creation-gallery.md
@@ -1,0 +1,24 @@
+# Creation gallery evidence
+
+Source: backlog.md:99
+UX/feature tag: creation-gallery
+
+## Before
+
+The public profile media surface collected generated public chat media, pinned the newest item as the spotlight, and showed the remaining generated media as a simple archive grid.
+
+## After
+
+The media tab is labeled as a creation gallery and keeps the existing latest spotlight behavior. Generated moments now expose:
+
+- Persona labels on spotlight and archive cards.
+- Persona filter controls for the archive, including an empty filtered state while the spotlight remains pinned.
+- Share actions that copy the post URL.
+- Save/favorite toggles with a saved-count summary.
+
+## Verification
+
+- `pnpm --filter web exec vitest run __tests__/components/profile-media-grid.test.tsx` - passed.
+- `pnpm --filter web exec eslint components/agents/ProfileMediaGrid.tsx components/agents/profile-media.ts __tests__/components/profile-media-grid.test.tsx` - passed with one existing Next.js `<img>` warning in the test mock.
+- `git diff --check` - passed.
+- `pnpm --filter web exec tsc --noEmit --pretty false` - blocked by unrelated existing AgentLorebook/shared export errors outside the touched files.


### PR DESCRIPTION
## Source

Source: backlog.md:99

## Summary

- Added creation gallery framing to the public profile media surface.
- Added persona archive filters while keeping the latest generated media pinned as the spotlight.
- Added share-link and save/favorite controls for spotlight and archive creations.

## Evidence

- Docs/example diff: docs/pr-evidence/creation-gallery.md
- Validation: `pnpm --filter web exec vitest run __tests__/components/profile-media-grid.test.tsx`
- Validation: `pnpm --filter web exec eslint components/agents/ProfileMediaGrid.tsx components/agents/profile-media.ts __tests__/components/profile-media-grid.test.tsx` (passes with existing test mock `<img>` warning)
- Validation: `git diff --check`
- Type-check note: `pnpm --filter web exec tsc --noEmit --pretty false` blocked by pre-existing AgentLorebook/shared export errors outside touched files

## Auth-only Proof

N/A
