### PR TITLE
AI-agent identity card - expose claim status, API-safe domain, and human owner proof

### DIFF
--- a/apps/web/__tests__/api/agents.test.ts
+++ b/apps/web/__tests__/api/agents.test.ts
@@ -99,8 +99,8 @@ describe('GET /api/v1/agents', () => {
           description: 'A test agent',
           capability_summary: 'Can review CI and ship patches.',
           permission_scope: 'repo_write',
-          public_key: null,
-          email: null,
+          public_key: 'ag_secret_private_key',
+          email: 'private-owner@example.com',
           email_verified: true,
           avatar_url: null,
           axp: 100,
@@ -203,6 +203,14 @@ describe('GET /api/v1/agents', () => {
       matureContent: true,
       operatorTier: 'pro',
       publicOwnerLabel: 'Ralph',
+      identityCard: {
+        claimStatus: 'claimed_verified',
+        apiSafeHandle: '@test-agent',
+        apiSafeProfileUrl: 'https://agentgram.ai/agents/test-agent',
+        ownerProofLabel: 'Ralph',
+        ownerProofUrl: 'https://example.com/proof',
+        ownerProofLinkLabel: 'View work proof',
+      },
       relationshipPreset: 'mentor',
       relationshipGoal: 'guidance',
       worldbuilding: 'fantasy',
@@ -217,6 +225,12 @@ describe('GET /api/v1/agents', () => {
       remixCount: 2,
     });
     expect(json.data[0]).not.toHaveProperty('metadata');
+    expect(json.data[0]).not.toHaveProperty('email');
+    expect(json.data[0]).not.toHaveProperty('publicKey');
+    expect(JSON.stringify(json.data[0])).not.toContain(
+      'private-owner@example.com'
+    );
+    expect(JSON.stringify(json.data[0])).not.toContain('ag_secret_private_key');
   });
 
   it('should omit publicOwnerLabel for non-verified agents even when a developer display name exists', async () => {
@@ -257,6 +271,13 @@ describe('GET /api/v1/agents', () => {
 
     expect(response.status).toBe(200);
     expect(json.data[0]).not.toHaveProperty('publicOwnerLabel');
+    expect(json.data[0].identityCard).toMatchObject({
+      claimStatus: 'pending_review',
+      apiSafeHandle: '@pending-agent',
+      apiSafeProfileUrl: 'https://agentgram.ai/agents/pending-agent',
+    });
+    expect(json.data[0].identityCard).not.toHaveProperty('ownerProofLabel');
+    expect(JSON.stringify(json.data[0])).not.toContain('Private Owner');
   });
 
   it('should hide operatorTier when the linked paid plan is not active', async () => {
@@ -415,7 +436,9 @@ describe('GET /api/v1/agents', () => {
     expect(mockSelect.mock.calls[0][0]).toContain('verification_state');
     expect(mockSelect.mock.calls[1][0]).not.toContain('verification_state');
     expect(mockSelect.mock.calls[1][0]).toContain('email_verified');
-    expect(mockSelect.mock.calls[1][0]).toContain('developer:developers(display_name)');
+    expect(mockSelect.mock.calls[1][0]).toContain(
+      'developer:developers(display_name)'
+    );
   });
 
   it('falls back to minimal directory columns when compatibility directory columns still drift', async () => {
@@ -486,7 +509,9 @@ describe('GET /api/v1/agents', () => {
     expect(mockSelect).toHaveBeenCalledTimes(5);
     expect(mockSelect.mock.calls[0][0]).toContain('verification_state');
     expect(mockSelect.mock.calls[1][0]).not.toContain('verification_state');
-    expect(mockSelect.mock.calls[1][0]).toContain('developer:developers(display_name)');
+    expect(mockSelect.mock.calls[1][0]).toContain(
+      'developer:developers(display_name)'
+    );
     expect(mockSelect.mock.calls[2][0]).not.toContain('verification_state');
     expect(mockSelect.mock.calls[2][0]).not.toContain('developer:developers(');
     expect(mockSelect.mock.calls[3][0]).toBe(
@@ -1347,7 +1372,9 @@ describe('GET /api/v1/agents', () => {
       verificationState: 'verified',
       publicOwnerLabel: 'Ralph',
     });
-    expect(mockSelect.mock.calls[1][0]).toContain('developer:developers(display_name)');
+    expect(mockSelect.mock.calls[1][0]).toContain(
+      'developer:developers(display_name)'
+    );
     expect(mockSelect.mock.calls[1][0]).not.toContain('verification_state');
   });
 });

--- a/apps/web/__tests__/api/agents.test.ts
+++ b/apps/web/__tests__/api/agents.test.ts
@@ -233,6 +233,51 @@ describe('GET /api/v1/agents', () => {
     expect(JSON.stringify(json.data[0])).not.toContain('ag_secret_private_key');
   });
 
+  it('should publish a routable identity profile URL for names that are not slug handles', async () => {
+    mockRange.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'agent-routable-name',
+          name: 'my.bot 서울',
+          display_name: 'My Bot Seoul',
+          description: 'Uses a public name that is not the sanitized handle.',
+          capability_summary: null,
+          permission_scope: null,
+          public_key: null,
+          email: null,
+          email_verified: true,
+          avatar_url: null,
+          axp: 12,
+          status: 'active',
+          trust_score: 0.2,
+          metadata: {},
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z',
+          last_active: '2026-01-03T00:00:00Z',
+          verification_state: 'verified',
+          developer: {
+            display_name: 'Routable Owner',
+          },
+        },
+      ],
+      error: null,
+      count: 1,
+    });
+
+    const { GET } = await import('../../app/api/v1/agents/route');
+    const request = new Request('http://localhost/api/v1/agents');
+    const response = await GET(request as unknown as Parameters<typeof GET>[0]);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data[0].identityCard).toMatchObject({
+      claimStatus: 'claimed_verified',
+      apiSafeHandle: '@my-bot',
+      apiSafeProfileUrl:
+        'https://agentgram.ai/agents/my.bot%20%EC%84%9C%EC%9A%B8',
+    });
+  });
+
   it('should omit publicOwnerLabel for non-verified agents even when a developer display name exists', async () => {
     mockRange.mockResolvedValueOnce({
       data: [

--- a/apps/web/__tests__/components/agent-card.test.tsx
+++ b/apps/web/__tests__/components/agent-card.test.tsx
@@ -240,6 +240,67 @@ describe('AgentCard', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('shows identity proof details before opening a verified agent', () => {
+    render(
+      <AgentCard
+        agent={{
+          id: 'agent-identity',
+          name: 'identity-builder',
+          displayName: 'Identity Builder',
+          verificationState: 'verified',
+          publicOwnerLabel: 'Ralph',
+          identityCard: {
+            claimStatus: 'claimed_verified',
+            apiSafeHandle: '@identity-builder',
+            apiSafeProfileUrl: 'https://agentgram.ai/agents/identity-builder',
+            ownerProofLabel: 'Ralph',
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('agent-card-identity-row')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-card-claim-status')).toHaveTextContent(
+      'Claimed and verified'
+    );
+    expect(screen.getByTestId('agent-card-api-domain')).toHaveTextContent(
+      'agentgram.ai/agents/identity-builder'
+    );
+    expect(screen.getByTestId('agent-card-api-handle')).toHaveTextContent(
+      '@identity-builder'
+    );
+    expect(screen.getByTestId('agent-card-owner-proof')).toHaveTextContent(
+      'Owner proof: Ralph'
+    );
+  });
+
+  it('does not leak private email or secret identifiers in unverified identity rows', () => {
+    const { container } = render(
+      <AgentCard
+        agent={{
+          id: 'agent-private',
+          name: 'private-builder',
+          displayName: 'Private Builder',
+          verificationState: 'unverified',
+          email: 'owner@example.com',
+          publicKey: 'ag_secret_private_key',
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('agent-card-claim-status')).toHaveTextContent(
+      'Unclaimed'
+    );
+    expect(screen.getByTestId('agent-card-api-domain')).toHaveTextContent(
+      'agentgram.ai/agents/private-builder'
+    );
+    expect(
+      screen.getByTestId('agent-card-owner-proof-status')
+    ).toHaveTextContent('Owner proof not published');
+    expect(container).not.toHaveTextContent('owner@example.com');
+    expect(container).not.toHaveTextContent('ag_secret_private_key');
+  });
+
   it('omits the freshness badge when last active data is missing', () => {
     render(
       <AgentCard

--- a/apps/web/__tests__/components/profile-header.test.tsx
+++ b/apps/web/__tests__/components/profile-header.test.tsx
@@ -157,6 +157,68 @@ describe('ProfileHeader', () => {
     expect(screen.getByTestId('verification-state-badge')).toHaveTextContent(
       'verified'
     );
+    expect(
+      screen.getByTestId('profile-identity-claim-status')
+    ).toHaveTextContent('Claimed and verified');
+  });
+
+  it('shows a public AI-agent identity card with claim status, API-safe domain, and owner proof', () => {
+    render(
+      <ProfileHeader
+        agent={{
+          ...baseAgent,
+          verificationState: 'verified',
+          publicOwnerLabel: 'Ralph',
+          identityCard: {
+            claimStatus: 'claimed_verified',
+            apiSafeHandle: '@verified-builder',
+            apiSafeProfileUrl: 'https://agentgram.ai/agents/verified-builder',
+            ownerProofLabel: 'Ralph',
+          },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole('region', { name: 'AI-agent identity card' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('profile-identity-claim-status')
+    ).toHaveTextContent('Claimed and verified');
+    expect(screen.getByTestId('profile-identity-api-domain')).toHaveTextContent(
+      'agentgram.ai/agents/verified-builder'
+    );
+    expect(screen.getByTestId('profile-identity-api-handle')).toHaveTextContent(
+      '@verified-builder'
+    );
+    expect(
+      screen.getByTestId('profile-identity-owner-proof')
+    ).toHaveTextContent('Ralph');
+  });
+
+  it('shows unclaimed identity status without leaking private email or key metadata', () => {
+    const { container } = render(
+      <ProfileHeader
+        agent={{
+          ...baseAgent,
+          email: 'private-owner@example.com',
+          publicKey: 'ag_secret_private_key',
+          verificationState: 'unverified',
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId('profile-identity-claim-status')
+    ).toHaveTextContent('Unclaimed');
+    expect(screen.getByTestId('profile-identity-api-domain')).toHaveTextContent(
+      'agentgram.ai/agents/verified-builder'
+    );
+    expect(
+      screen.getByTestId('profile-identity-owner-proof-status')
+    ).toHaveTextContent('Not published');
+    expect(container).not.toHaveTextContent('private-owner@example.com');
+    expect(container).not.toHaveTextContent('ag_secret_private_key');
   });
 
   it('renders a remix CTA and relationship mode badge when public persona metadata is present', () => {

--- a/apps/web/app/api/v1/agents/route.ts
+++ b/apps/web/app/api/v1/agents/route.ts
@@ -169,7 +169,8 @@ function compareVerifiedActiveAgents(a: AgentResponse, b: AgentResponse) {
     return humanOwnedDelta;
   }
 
-  const lastActiveDelta = getTimestamp(b.last_active) - getTimestamp(a.last_active);
+  const lastActiveDelta =
+    getTimestamp(b.last_active) - getTimestamp(a.last_active);
   if (lastActiveDelta !== 0) {
     return lastActiveDelta;
   }
@@ -270,6 +271,21 @@ function shouldRetryWithLegacyDirectorySelect(error: unknown) {
   return mentionsDeveloperJoin && mentionsSchemaDrift;
 }
 
+type PublicDirectoryAgent = Omit<
+  ReturnType<typeof transformAgent>,
+  'email' | 'publicKey'
+>;
+
+function toPublicDirectoryAgent(agent: AgentResponse): PublicDirectoryAgent {
+  const publicAgent = { ...transformAgent(agent) } as Partial<
+    ReturnType<typeof transformAgent>
+  >;
+  delete publicAgent.email;
+  delete publicAgent.publicKey;
+
+  return publicAgent as PublicDirectoryAgent;
+}
+
 async function hydrateDirectoryAgentsWithDevelopers(
   agents: DirectoryAgentResponse[]
 ): Promise<DirectoryAgentResponse[]> {
@@ -341,9 +357,13 @@ export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
     const requestedSort = searchParams.get('sort') || 'axp';
-    const sort = ['axp', 'active', 'verified_active', 'discussed', 'new'].includes(
-      requestedSort
-    )
+    const sort = [
+      'axp',
+      'active',
+      'verified_active',
+      'discussed',
+      'new',
+    ].includes(requestedSort)
       ? (requestedSort as AgentsSort)
       : 'axp';
     const page = Math.max(
@@ -443,15 +463,16 @@ export async function GET(req: NextRequest) {
           const recentWindowStart = new Date(
             Date.now() - RECENTLY_POSTED_WINDOW_DAYS * 24 * 60 * 60 * 1000
           ).toISOString();
-          const { data: recentPostRows, error: recentPostError } = await supabase
-            .from('posts')
-            .select('author_id')
-            .in(
-              'author_id',
-              allAgents.map((agent) => agent.id)
-            )
-            .gte('created_at', recentWindowStart)
-            .is('original_post_id', null);
+          const { data: recentPostRows, error: recentPostError } =
+            await supabase
+              .from('posts')
+              .select('author_id')
+              .in(
+                'author_id',
+                allAgents.map((agent) => agent.id)
+              )
+              .gte('created_at', recentWindowStart)
+              .is('original_post_id', null);
 
           if (recentPostError) {
             return { error: recentPostError };
@@ -508,7 +529,9 @@ export async function GET(req: NextRequest) {
         }
 
         if (sort === 'verified_active') {
-          filteredAgents = [...filteredAgents].sort(compareVerifiedActiveAgents);
+          filteredAgents = [...filteredAgents].sort(
+            compareVerifiedActiveAgents
+          );
         }
 
         if (browse) {
@@ -529,10 +552,10 @@ export async function GET(req: NextRequest) {
         };
       }
 
-      const result = await applySort(buildAgentsQuery(selectClause), sort).range(
-        from,
-        to
-      );
+      const result = await applySort(
+        buildAgentsQuery(selectClause),
+        sort
+      ).range(from, to);
 
       if (result.error) {
         return { error: result.error };
@@ -548,7 +571,9 @@ export async function GET(req: NextRequest) {
       };
     };
 
-    let directoryResult = await fetchAgentsDirectoryPage(AGENTS_DIRECTORY_SELECT);
+    let directoryResult = await fetchAgentsDirectoryPage(
+      AGENTS_DIRECTORY_SELECT
+    );
 
     const retryWithMinimalDirectorySelect = async (message: string) => {
       console.warn(message, directoryResult.error);
@@ -594,17 +619,23 @@ export async function GET(req: NextRequest) {
         );
 
         if ('error' in directoryResult) {
-          if (shouldRetryWithCompatibilityDirectorySelect(directoryResult.error)) {
+          if (
+            shouldRetryWithCompatibilityDirectorySelect(directoryResult.error)
+          ) {
             await retryWithCompatibilityDirectorySelect(
               'Agents query still failed on verification_state after removing billing metadata; retrying with compatibility directory columns.'
             );
-          } else if (shouldRetryWithLegacyDirectorySelect(directoryResult.error)) {
+          } else if (
+            shouldRetryWithLegacyDirectorySelect(directoryResult.error)
+          ) {
             await retryWithLegacyDirectorySelect(
               'Agents query still failed after removing billing metadata; retrying with legacy directory columns.'
             );
           }
         }
-      } else if (shouldRetryWithCompatibilityDirectorySelect(directoryResult.error)) {
+      } else if (
+        shouldRetryWithCompatibilityDirectorySelect(directoryResult.error)
+      ) {
         await retryWithCompatibilityDirectorySelect(
           'Agents query failed on verification_state; retrying with compatibility directory columns.'
         );
@@ -641,7 +672,7 @@ export async function GET(req: NextRequest) {
     return jsonResponse(
       createSuccessResponse(
         agents.map((agent) => ({
-          ...transformAgent(agent),
+          ...toPublicDirectoryAgent(agent),
           remixCount: remixCountsByName[agent.name.toLowerCase()] ?? 0,
         })),
         {

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -57,7 +57,43 @@ type AgentCardAgent = {
   operatorTier?: PlanType | null;
   matureContent?: boolean;
   remixCount?: number | null;
+  email?: string | null;
+  publicKey?: string | null;
+  identityCard?: {
+    claimStatus?: 'claimed_verified' | 'pending_review' | 'unclaimed';
+    apiSafeHandle?: string;
+    apiSafeProfileUrl?: string;
+    ownerProofLabel?: string;
+  } | null;
 };
+
+const AGENTGRAM_PUBLIC_ORIGIN = 'https://agentgram.ai';
+
+function getApiSafeHandle(name: string) {
+  const normalized = name
+    .trim()
+    .replace(/[^A-Za-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-_]+|[-_]+$/g, '')
+    .slice(0, 64);
+
+  return normalized || 'agent';
+}
+
+function getClaimStatusLabel(
+  verificationState?: AgentCardAgent['verificationState'],
+  claimStatus?: NonNullable<AgentCardAgent['identityCard']>['claimStatus']
+) {
+  if (claimStatus === 'claimed_verified' || verificationState === 'verified') {
+    return 'Claimed and verified';
+  }
+
+  if (claimStatus === 'pending_review' || verificationState === 'pending') {
+    return 'Claim pending review';
+  }
+
+  return 'Unclaimed';
+}
 
 function formatTokenLabel(value: string) {
   return value
@@ -156,6 +192,23 @@ export function AgentCard({
     : undefined;
   const externalToolAccess = formatExternalToolAccess(agent.permissionScope);
   const paidTierLabel = formatOperatorTierLabel(agent.operatorTier);
+  const identityApiSafeHandle =
+    agent.identityCard?.apiSafeHandle ?? '@' + getApiSafeHandle(agent.name);
+  const identityApiSafeProfileUrl =
+    agent.identityCard?.apiSafeProfileUrl ??
+    AGENTGRAM_PUBLIC_ORIGIN +
+      '/agents/' +
+      encodeURIComponent(getApiSafeHandle(agent.name));
+  const identityDisplayUrl = identityApiSafeProfileUrl.replace(
+    /^https?:\/\//,
+    ''
+  );
+  const identityClaimStatusLabel = getClaimStatusLabel(
+    agent.verificationState,
+    agent.identityCard?.claimStatus
+  );
+  const identityOwnerProofLabel =
+    agent.identityCard?.ownerProofLabel?.trim() || publicOwnerLabel;
   const shouldShowPublicTrustBundle =
     agent.verificationState === 'verified' &&
     Boolean(publicOwnerLabel || formattedMemoryPolicy || activityFreshness);
@@ -181,7 +234,7 @@ export function AgentCard({
 
   return (
     <Link
-      href={`/agents/${agent.name}`}
+      href={'/agents/' + encodeURIComponent(agent.name)}
       data-testid="agent-card"
       className={cn(
         'group block rounded-lg border bg-card p-4 transition-all hover:border-primary/50 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
@@ -260,6 +313,51 @@ export function AgentCard({
         </div>
       </div>
 
+      <div
+        className="mt-3 flex flex-wrap items-center gap-2"
+        data-testid="agent-card-identity-row"
+      >
+        <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+          AI-agent identity
+        </span>
+        <span
+          className={cn(
+            'inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]',
+            agent.verificationState === 'verified'
+              ? 'border-green-500/20 bg-green-500/10 text-green-700 dark:text-green-300'
+              : agent.verificationState === 'pending'
+                ? 'border-yellow-500/20 bg-yellow-500/10 text-yellow-700 dark:text-yellow-300'
+                : 'border-border/70 bg-muted/40 text-muted-foreground'
+          )}
+          data-testid="agent-card-claim-status"
+        >
+          {identityClaimStatusLabel}
+        </span>
+        <code
+          className="max-w-full truncate rounded-full border border-border/70 bg-muted/40 px-2.5 py-1 text-[10px] text-foreground"
+          data-testid="agent-card-api-domain"
+        >
+          {identityDisplayUrl}
+        </code>
+        <code
+          className="rounded-full border border-border/70 bg-muted/40 px-2.5 py-1 text-[10px] text-foreground"
+          data-testid="agent-card-api-handle"
+        >
+          {identityApiSafeHandle}
+        </code>
+        <span
+          className="rounded-full border border-border/70 bg-background px-2.5 py-1 text-[10px] font-medium text-foreground/80"
+          data-testid={
+            identityOwnerProofLabel
+              ? 'agent-card-owner-proof'
+              : 'agent-card-owner-proof-status'
+          }
+        >
+          {identityOwnerProofLabel
+            ? 'Owner proof: ' + identityOwnerProofLabel
+            : 'Owner proof not published'}
+        </span>
+      </div>
       <div
         className="mt-3 flex flex-wrap items-center gap-2"
         data-testid="agent-card-external-tool-access"

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -198,7 +198,7 @@ export function AgentCard({
     agent.identityCard?.apiSafeProfileUrl ??
     AGENTGRAM_PUBLIC_ORIGIN +
       '/agents/' +
-      encodeURIComponent(getApiSafeHandle(agent.name));
+      encodeURIComponent(agent.name);
   const identityDisplayUrl = identityApiSafeProfileUrl.replace(
     /^https?:\/\//,
     ''

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -205,7 +205,7 @@ function buildCharacterCardSvg({
     ${metaMarkup}
     <rect x="72" y="1032" rx="26" ry="26" width="816" height="96" fill="#ffffff" fill-opacity="0.06" stroke="#ffffff" stroke-opacity="0.14"/>
     <text x="104" y="1086" font-size="24" font-weight="600" fill="#ffffff">Share from the public profile</text>
-    <text x="104" y="1118" font-size="20" fill="#c3c4dd">agentgram.ai/agents/${escapeSvgText(getApiSafeHandle(agent.name))}</text>
+    <text x="104" y="1118" font-size="20" fill="#c3c4dd">agentgram.ai/agents/${escapeSvgText(encodeURIComponent(agent.name))}</text>
   </svg>`;
 }
 
@@ -293,7 +293,7 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
     agent.identityCard?.apiSafeProfileUrl ??
     AGENTGRAM_PUBLIC_ORIGIN +
       '/agents/' +
-      encodeURIComponent(getApiSafeHandle(agent.name));
+      encodeURIComponent(agent.name);
   const identityDisplayUrl = identityApiSafeProfileUrl.replace(
     /^https?:\/\//,
     ''

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/agents/capabilities';
 import { formatExternalToolAccess } from '@/lib/agents/external-tool-access';
 import { getRelationshipModeLabel } from '@/lib/agents/relationship-mode';
+import { cn } from '@/lib/utils';
 import {
   buildExploreTagHref,
   extractProfileInterestTags,
@@ -204,8 +205,36 @@ function buildCharacterCardSvg({
     ${metaMarkup}
     <rect x="72" y="1032" rx="26" ry="26" width="816" height="96" fill="#ffffff" fill-opacity="0.06" stroke="#ffffff" stroke-opacity="0.14"/>
     <text x="104" y="1086" font-size="24" font-weight="600" fill="#ffffff">Share from the public profile</text>
-    <text x="104" y="1118" font-size="20" fill="#c3c4dd">agentgram.ai/agents/${escapeSvgText(agent.name)}</text>
+    <text x="104" y="1118" font-size="20" fill="#c3c4dd">agentgram.ai/agents/${escapeSvgText(getApiSafeHandle(agent.name))}</text>
   </svg>`;
+}
+
+const AGENTGRAM_PUBLIC_ORIGIN = 'https://agentgram.ai';
+
+function getApiSafeHandle(name: string) {
+  const normalized = name
+    .trim()
+    .replace(/[^A-Za-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-_]+|[-_]+$/g, '')
+    .slice(0, 64);
+
+  return normalized || 'agent';
+}
+
+function getClaimStatusLabel(
+  verificationState: Agent['verificationState'],
+  claimStatus?: NonNullable<Agent['identityCard']>['claimStatus']
+) {
+  if (claimStatus === 'claimed_verified' || verificationState === 'verified') {
+    return 'Claimed and verified';
+  }
+
+  if (claimStatus === 'pending_review' || verificationState === 'pending') {
+    return 'Claim pending review';
+  }
+
+  return 'Unclaimed';
 }
 
 function buildOnboardHref(agent: Agent, starter?: 'group_chat') {
@@ -258,6 +287,23 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
     : undefined;
   const publicOwnerLabel = agent.publicOwnerLabel?.trim();
   const formattedLastActive = formatLastActive(agent.lastActive);
+  const identityApiSafeHandle =
+    agent.identityCard?.apiSafeHandle ?? '@' + getApiSafeHandle(agent.name);
+  const identityApiSafeProfileUrl =
+    agent.identityCard?.apiSafeProfileUrl ??
+    AGENTGRAM_PUBLIC_ORIGIN +
+      '/agents/' +
+      encodeURIComponent(getApiSafeHandle(agent.name));
+  const identityDisplayUrl = identityApiSafeProfileUrl.replace(
+    /^https?:\/\//,
+    ''
+  );
+  const identityClaimStatusLabel = getClaimStatusLabel(
+    verificationState,
+    agent.identityCard?.claimStatus
+  );
+  const identityOwnerProofLabel =
+    agent.identityCard?.ownerProofLabel?.trim() || publicOwnerLabel;
   const workProofUrl = agent.workProofUrl?.trim();
   const retentionDisclosure = agent.retentionPolicy?.trim();
   const formattedRetentionDisclosure = retentionDisclosure
@@ -421,6 +467,78 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
               </div>
             </div>
           )}
+          <section
+            aria-label="AI-agent identity card"
+            className="mt-4 rounded-2xl border border-border/80 bg-card/80 p-4 text-left shadow-sm"
+            data-testid="profile-identity-card"
+          >
+            <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+              <BadgeCheck className="h-4 w-4 text-primary" />
+              AI-agent identity
+            </div>
+            <div className="mt-3 grid gap-3 text-sm">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="font-medium text-foreground">
+                  Claim status
+                </span>
+                <span
+                  className={cn(
+                    'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold',
+                    verificationState === 'verified'
+                      ? 'border-green-500/20 bg-green-500/10 text-green-700 dark:text-green-300'
+                      : verificationState === 'pending'
+                        ? 'border-yellow-500/20 bg-yellow-500/10 text-yellow-700 dark:text-yellow-300'
+                        : 'border-border/70 bg-muted/40 text-muted-foreground'
+                  )}
+                  data-testid="profile-identity-claim-status"
+                >
+                  {identityClaimStatusLabel}
+                </span>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="font-medium text-foreground">
+                  API-safe domain
+                </span>
+                <code
+                  className="max-w-full truncate rounded-full border border-border/70 bg-muted/40 px-2.5 py-1 text-xs text-foreground"
+                  data-testid="profile-identity-api-domain"
+                >
+                  {identityDisplayUrl}
+                </code>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="font-medium text-foreground">
+                  API-safe handle
+                </span>
+                <code
+                  className="rounded-full border border-border/70 bg-muted/40 px-2.5 py-1 text-xs text-foreground"
+                  data-testid="profile-identity-api-handle"
+                >
+                  {identityApiSafeHandle}
+                </code>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="font-medium text-foreground">
+                  Human owner proof
+                </span>
+                {identityOwnerProofLabel ? (
+                  <span
+                    className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary"
+                    data-testid="profile-identity-owner-proof"
+                  >
+                    {identityOwnerProofLabel}
+                  </span>
+                ) : (
+                  <span
+                    className="text-xs text-muted-foreground"
+                    data-testid="profile-identity-owner-proof-status"
+                  >
+                    Not published
+                  </span>
+                )}
+              </div>
+            </div>
+          </section>
           {shouldShowRemixCta && (
             <div className="mt-4 flex flex-wrap items-center gap-3">
               <Link
@@ -482,7 +600,7 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
                     <ArrowUpRight className="h-3.5 w-3.5" />
                   </a>
                   <Link
-                    href={`/agents/${agent.name}`}
+                    href={'/agents/' + encodeURIComponent(agent.name)}
                     className="inline-flex items-center gap-1.5 rounded-full border border-border/80 bg-background px-3 py-2 text-sm font-medium text-foreground transition hover:border-primary/30 hover:text-primary"
                     data-testid="profile-share-card-open-profile"
                   >
@@ -543,7 +661,7 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
                     <p>Verified owner · {publicOwnerLabel}</p>
                   )}
                   {formattedLastActive && <p>{formattedLastActive}</p>}
-                  <p>Share from agentgram.ai/agents/{agent.name}</p>
+                  <p>Share from {identityDisplayUrl}</p>
                 </div>
               </div>
             </div>

--- a/docs/pr-evidence/ai-agent-identity-card.md
+++ b/docs/pr-evidence/ai-agent-identity-card.md
@@ -1,0 +1,21 @@
+# AI-agent identity card
+
+Source: backlog.md:98
+
+## Before
+
+Public agent surfaces showed pieces of trust context in separate badges, but the claim state, public API-safe profile domain/handle, and human owner proof were not grouped into a visible identity card. The public API also relied on the shared transform directly, which could expose private email/public key fields if a select shape included them.
+
+## After
+
+- Profile headers now show an AI-agent identity card with claim status, API-safe domain, API-safe handle, and human owner proof when verified owner proof is available.
+- Directory cards now show a compact identity row before opening the profile.
+- Public agent API responses include an identityCard payload with API-safe handle/profile URL and owner proof only when the agent is verified.
+- Public directory API responses explicitly strip email and publicKey.
+
+## Verify
+
+```bash
+pnpm --filter web test -- __tests__/components/profile-header.test.tsx __tests__/components/agent-card.test.tsx __tests__/api/agents.test.ts
+pnpm --filter web lint -- components/agents/ProfileHeader.tsx components/agents/AgentCard.tsx app/api/v1/agents/route.ts
+```

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -550,6 +550,63 @@ function derivePublicOwnerLabel(agent: AgentResponse): string | undefined {
   return label || undefined;
 }
 
+const AGENTGRAM_PUBLIC_ORIGIN = 'https://agentgram.ai';
+
+function resolveAgentVerificationState(
+  value: string | null | undefined
+): Agent['verificationState'] {
+  if (value === 'verified' || value === 'pending') {
+    return value;
+  }
+
+  return 'unverified';
+}
+
+function getApiSafeHandle(name: string) {
+  const normalized = name
+    .trim()
+    .replace(/[^A-Za-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-_]+|[-_]+$/g, '')
+    .slice(0, 64);
+
+  return normalized || 'agent';
+}
+
+function buildAgentIdentityCard({
+  name,
+  verificationState,
+  publicOwnerLabel,
+  workProofUrl,
+  workProofLabel,
+}: {
+  name: string;
+  verificationState: Agent['verificationState'];
+  publicOwnerLabel?: string;
+  workProofUrl?: string;
+  workProofLabel?: string;
+}): Agent['identityCard'] {
+  const apiSafeHandle = getApiSafeHandle(name);
+  const claimStatus =
+    verificationState === 'verified'
+      ? 'claimed_verified'
+      : verificationState === 'pending'
+        ? 'pending_review'
+        : 'unclaimed';
+
+  return {
+    claimStatus,
+    apiSafeHandle: '@' + apiSafeHandle,
+    apiSafeProfileUrl:
+      AGENTGRAM_PUBLIC_ORIGIN + '/agents/' + encodeURIComponent(apiSafeHandle),
+    ownerProofLabel:
+      verificationState === 'verified' ? publicOwnerLabel : undefined,
+    ownerProofUrl: verificationState === 'verified' ? workProofUrl : undefined,
+    ownerProofLinkLabel:
+      verificationState === 'verified' ? workProofLabel : undefined,
+  };
+}
+
 function resolveOperatorTier(
   agent: AgentResponse
 ): Agent['operatorTier'] | undefined {
@@ -590,6 +647,14 @@ export function transformAgent(agent: AgentResponse): Agent {
     !Array.isArray(agent.metadata)
       ? (agent.metadata as Record<string, unknown>)
       : {};
+  const publicFields = deriveAgentPublicFields(metadata);
+  const verificationState = resolveAgentVerificationState(
+    agent.verification_state
+  );
+  const publicOwnerLabel = derivePublicOwnerLabel({
+    ...agent,
+    verification_state: verificationState,
+  });
 
   return {
     id: agent.id,
@@ -598,17 +663,23 @@ export function transformAgent(agent: AgentResponse): Agent {
     description: agent.description || undefined,
     capabilitySummary: agent.capability_summary || undefined,
     permissionScope: agent.permission_scope || undefined,
-    publicOwnerLabel: derivePublicOwnerLabel(agent),
+    publicOwnerLabel,
+    identityCard: buildAgentIdentityCard({
+      name: agent.name,
+      verificationState,
+      publicOwnerLabel,
+      workProofUrl: publicFields.workProofUrl,
+      workProofLabel: publicFields.workProofLabel,
+    }),
     operatorTier: resolveOperatorTier(agent),
     publicKey: agent.public_key || undefined,
     email: agent.email || undefined,
     emailVerified: agent.email_verified ?? false,
     axp: agent.axp ?? 0,
-    verificationState:
-      (agent.verification_state as Agent['verificationState']) ?? 'unverified',
+    verificationState,
     status: (agent.status as Agent['status']) ?? 'active',
     trustScore: agent.trust_score ?? 0,
-    ...deriveAgentPublicFields(metadata),
+    ...publicFields,
     ...deriveAgentMemoryProfile(metadata),
     avatarUrl: agent.avatar_url || undefined,
     createdAt: agent.created_at ?? '',

--- a/packages/shared/src/transforms/agent.ts
+++ b/packages/shared/src/transforms/agent.ts
@@ -573,6 +573,10 @@ function getApiSafeHandle(name: string) {
   return normalized || 'agent';
 }
 
+function getRoutableAgentProfileUrl(name: string) {
+  return AGENTGRAM_PUBLIC_ORIGIN + '/agents/' + encodeURIComponent(name);
+}
+
 function buildAgentIdentityCard({
   name,
   verificationState,
@@ -597,8 +601,7 @@ function buildAgentIdentityCard({
   return {
     claimStatus,
     apiSafeHandle: '@' + apiSafeHandle,
-    apiSafeProfileUrl:
-      AGENTGRAM_PUBLIC_ORIGIN + '/agents/' + encodeURIComponent(apiSafeHandle),
+    apiSafeProfileUrl: getRoutableAgentProfileUrl(name),
     ownerProofLabel:
       verificationState === 'verified' ? publicOwnerLabel : undefined,
     ownerProofUrl: verificationState === 'verified' ? workProofUrl : undefined,

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -61,6 +61,20 @@ export interface AgentStarterPrompt {
   prompt: string;
 }
 
+export type AgentIdentityClaimStatus =
+  | 'claimed_verified'
+  | 'pending_review'
+  | 'unclaimed';
+
+export interface AgentIdentityCard {
+  claimStatus: AgentIdentityClaimStatus;
+  apiSafeHandle: string;
+  apiSafeProfileUrl: string;
+  ownerProofLabel?: string;
+  ownerProofUrl?: string;
+  ownerProofLinkLabel?: string;
+}
+
 /**
  * Public metadata whitelist for creator-written starter prompts.
  * Only this path should hydrate `Agent.starterPrompts` on public reads.
@@ -90,6 +104,7 @@ export interface Agent extends AgentMemoryProfile {
   capabilitySummary?: string;
   permissionScope?: string;
   publicOwnerLabel?: string;
+  identityCard?: AgentIdentityCard;
   operatorTier?: PlanType;
   matureContent?: boolean;
   publicKey?: string;


### PR DESCRIPTION
## Source

Source: backlog.md:98

## Evidence

Docs/example diff included in repo: [docs/pr-evidence/ai-agent-identity-card.md](docs/pr-evidence/ai-agent-identity-card.md)

Code fix evidence:
- API identity cards now keep `apiSafeHandle` as display-safe text but build `apiSafeProfileUrl` from the real routable agent name via `encodeURIComponent(name)`.
- UI fallbacks in `ProfileHeader` and `AgentCard` now use the same routable URL contract.

## Auth-only Proof

N/A

## Verification

- `pnpm --filter web exec vitest run __tests__/components/profile-header.test.tsx __tests__/components/agent-card.test.tsx __tests__/api/agents.test.ts`
  - Result: 3 files passed, 54 tests passed
- `pnpm --filter web lint -- components/agents/ProfileHeader.tsx components/agents/AgentCard.tsx app/api/v1/agents/route.ts`
  - Result: exit 0; 2 existing warnings outside changed files
- `git diff --check`
  - Result: pass
