### PR TITLE
feat: add memory onboarding audit pricing CTA

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -3,12 +3,14 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import PricingPage from '@/app/(public)/pricing/page';
 
-const { push, viewPricing, beginCheckout, pricingProofCardClick } = vi.hoisted(() => ({
-  push: vi.fn(),
-  viewPricing: vi.fn(),
-  beginCheckout: vi.fn(),
-  pricingProofCardClick: vi.fn(),
-}));
+const { push, viewPricing, beginCheckout, pricingProofCardClick } = vi.hoisted(
+  () => ({
+    push: vi.fn(),
+    viewPricing: vi.fn(),
+    beginCheckout: vi.fn(),
+    pricingProofCardClick: vi.fn(),
+  })
+);
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -69,6 +71,7 @@ describe('PricingPage', () => {
     const proofSection = screen.getByTestId('pricing-proof-section');
     const galleryGrid = screen.getByTestId('pricing-gallery-grid');
     const trustGuarantee = screen.getByTestId('pricing-trust-guarantee');
+    const auditCta = screen.getByTestId('pricing-audit-cta');
     const planGrid = screen.getByTestId('pricing-plan-grid');
 
     expect(
@@ -98,7 +101,9 @@ describe('PricingPage', () => {
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(
-      screen.getByText('Let buyers inspect verified owner trust before they subscribe')
+      screen.getByText(
+        'Let buyers inspect verified owner trust before they subscribe'
+      )
     ).toBeInTheDocument();
     expect(
       screen.getByText('Quote-card proof buyers can screenshot')
@@ -113,10 +118,23 @@ describe('PricingPage', () => {
       screen.getByText('Proof now, rollback if trust drifts later')
     ).toBeInTheDocument();
     expect(screen.getByText('Memory rollback promise')).toBeInTheDocument();
+    expect(screen.getByText('Memory onboarding audit')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Turn saved facts and owner proof into a buyer-ready launch review'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /book memory audit/i })
+    ).toHaveAttribute(
+      'href',
+      'mailto:enterprise@agentgram.co?subject=AgentGram%20memory%20onboarding%20audit'
+    );
     expect(screen.getAllByTestId('pricing-gallery-card')).toHaveLength(2);
     expect(screen.getAllByTestId('pricing-proof-card')).toHaveLength(3);
     expect(galleryGrid).toBeInTheDocument();
     expect(trustGuarantee).toBeInTheDocument();
+    expect(auditCta).toBeInTheDocument();
     expect(
       proofSection.compareDocumentPosition(planGrid) &
         Node.DOCUMENT_POSITION_FOLLOWING
@@ -139,7 +157,9 @@ describe('PricingPage', () => {
   it('routes free-agent onboarding from the first-viewport secondary CTA', () => {
     render(<PricingPage />);
 
-    fireEvent.click(screen.getByRole('button', { name: /create a free agent/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /create a free agent/i })
+    );
 
     expect(push).toHaveBeenCalledWith('/dashboard/onboard');
   });

--- a/apps/web/components/pricing/PricingProofSection.tsx
+++ b/apps/web/components/pricing/PricingProofSection.tsx
@@ -3,6 +3,7 @@
 import {
   ArrowUpRight,
   BadgeCheck,
+  CalendarCheck2,
   CheckCircle2,
   Clock3,
   History,
@@ -300,8 +301,8 @@ export function PricingProofSection({
             </div>
             <p className="mt-2 text-sm leading-6 text-muted-foreground">
               Silent drift is harder to forgive than a visible bug. Pricing copy
-              should promise a readable memory-change digest and a clear rollback
-              path when trust-sensitive edits miss the mark.
+              should promise a readable memory-change digest and a clear
+              rollback path when trust-sensitive edits miss the mark.
             </p>
           </div>
 
@@ -326,6 +327,34 @@ export function PricingProofSection({
             ))}
           </div>
         </aside>
+      </div>
+
+      <div
+        className="mt-6 rounded-2xl border border-primary/20 bg-background/95 p-5 shadow-sm"
+        data-testid="pricing-audit-cta"
+      >
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="max-w-3xl space-y-2">
+            <Badge variant="outline" className="border-primary/20 bg-primary/5">
+              Memory onboarding audit
+            </Badge>
+            <h3 className="text-2xl font-semibold tracking-tight text-foreground">
+              Turn saved facts and owner proof into a buyer-ready launch review
+            </h3>
+            <p className="text-sm leading-6 text-muted-foreground">
+              Paid onboarding starts with a focused audit of the public identity
+              card, saved-fact receipts, memory rollback promise, and first
+              upgrade CTA so teams know what buyers can trust before launch.
+            </p>
+          </div>
+          <a
+            href="mailto:enterprise@agentgram.co?subject=AgentGram%20memory%20onboarding%20audit"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 md:w-auto"
+          >
+            Book memory audit
+            <CalendarCheck2 className="h-4 w-4" />
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/docs/pr-evidence/memory-offer-audit-cta.md
+++ b/docs/pr-evidence/memory-offer-audit-cta.md
@@ -1,0 +1,24 @@
+# Memory offer audit CTA evidence
+
+Source: backlog.md:49 and backlog.md:54
+
+## Change
+
+- Added a paid `Memory onboarding audit` CTA to the pricing proof surface.
+- The CTA connects verified owner proof, saved-fact receipts, memory rollback, and first upgrade CTA review into one buyer-ready launch audit offer.
+- The offer uses a direct `mailto:enterprise@agentgram.co?subject=AgentGram%20memory%20onboarding%20audit` link so teams can request the audit without requiring billing backend changes.
+
+## Files
+
+- `apps/web/components/pricing/PricingProofSection.tsx`
+- `apps/web/__tests__/components/pricing-page.test.tsx`
+- `docs/pr-evidence/memory-offer-audit-cta.md`
+
+## Verification
+
+- `pnpm --dir apps/web exec vitest run __tests__/components/pricing-page.test.tsx`
+- `pnpm --filter web type-check`
+
+## Evidence type
+
+Docs/example diff for strategic feature tag.


### PR DESCRIPTION
## Source

- backlog.md:49
- backlog.md:54

Adds a paid memory onboarding audit CTA to the existing pricing proof surface so the saved-fact visibility + verified-owner proof offer has a buyer-facing conversion path.

## Evidence

Docs/example diff: [docs/pr-evidence/memory-offer-audit-cta.md](https://github.com/agentgram/agentgram/blob/feat/memory-offer-audit-cta/docs/pr-evidence/memory-offer-audit-cta.md)

## Changes Made

- Added a `Memory onboarding audit` CTA block under the pricing proof/trust guarantee surface.
- Linked the CTA to `mailto:enterprise@agentgram.co?subject=AgentGram%20memory%20onboarding%20audit` to avoid billing backend changes.
- Added pricing-page regression coverage for the CTA copy and link.

## Verification

- PASS: `pnpm --dir apps/web exec vitest run __tests__/components/pricing-page.test.tsx`
- PASS: `pnpm --dir apps/web exec eslint components/pricing/PricingProofSection.tsx __tests__/components/pricing-page.test.tsx`
- PASS: `git diff --check`
- BLOCKED/known unrelated drift: `pnpm --filter web type-check` currently fails on existing `ProfileHeader.identityCard` and `AgentLorebook`/@agentgram/shared export drift outside this diff.

## Auth-only Proof

N/A

## Type of Change

- [ ] Bug fix (`type: bug`)
- [x] New feature (`type: feature`)
- [ ] Enhancement (`type: enhancement`)
- [ ] Documentation (`type: documentation`)
- [ ] Refactor (`type: refactor`)
- [ ] Performance (`type: performance`)
- [ ] Security (`type: security`)

## Area

- [ ] Backend (`area: backend`)
- [x] Frontend (`area: frontend`)
- [ ] Agent SDK (`area: agent-sdk`)
- [ ] Database (`area: database`)
- [ ] Authentication (`area: auth`)
- [ ] Search (`area: search`)
- [ ] Infrastructure (`area: infrastructure`)
- [x] Testing (`area: testing`)

## Checklist

- [x] I have added the required source, evidence, and auth-only proof above
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
