### PR TITLE
Memory health - add recall badge and re-sync CTA

### DIFF
--- a/apps/web/__tests__/components/agent-memory-trust-form.test.tsx
+++ b/apps/web/__tests__/components/agent-memory-trust-form.test.tsx
@@ -51,7 +51,8 @@ describe('AgentMemoryTrustForm', () => {
                   'Started as a release engineer with a trust-first playbook.',
               },
               digest: {
-                summary: '3 trust-facing memory fields changed. Review before continuing.',
+                summary:
+                  '3 trust-facing memory fields changed. Review before continuing.',
                 recordedAt: '2026-04-30T10:00:00.000Z',
                 changedFields: [
                   {
@@ -106,7 +107,8 @@ describe('AgentMemoryTrustForm', () => {
                   'Started as a release engineer and now guards memory trust.',
               },
               digest: {
-                summary: '1 trust-facing memory field changed. Review before continuing.',
+                summary:
+                  '1 trust-facing memory field changed. Review before continuing.',
                 recordedAt: '2026-04-30T10:05:00.000Z',
                 changedFields: [
                   {
@@ -125,7 +127,13 @@ describe('AgentMemoryTrustForm', () => {
         })
     );
 
-    render(<AgentMemoryTrustForm settings={buildSettings()} />);
+    const { container } = render(
+      <AgentMemoryTrustForm settings={buildSettings()} />
+    );
+
+    expect(
+      container.querySelector('#memory-trust-agent-1')
+    ).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/display name for sage bot/i), {
       target: { value: 'Sage Ops' },
@@ -138,7 +146,9 @@ describe('AgentMemoryTrustForm', () => {
         value: 'Started as a release engineer and now guards memory trust.',
       },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Save profile memory' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save profile memory' })
+    );
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
@@ -159,9 +169,7 @@ describe('AgentMemoryTrustForm', () => {
     expect(
       await screen.findByText('Profile memory settings saved.')
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('memory-digest-agent-1')
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('memory-digest-agent-1')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /roll back previous snapshot/i })
     ).toBeInTheDocument();
@@ -199,7 +207,9 @@ describe('AgentMemoryTrustForm', () => {
 
     render(<AgentMemoryTrustForm settings={buildSettings()} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Save profile memory' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save profile memory' })
+    );
 
     expect(fetch).not.toHaveBeenCalled();
     expect(

--- a/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
+++ b/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
@@ -95,6 +95,16 @@ describe('AgentPinnedFactsCard', () => {
     expect(
       screen.getByTestId('ledger-category-relationship-context')
     ).toHaveTextContent('Relationship context');
+    expect(screen.getByTestId('memory-health-status-badge')).toHaveTextContent(
+      'Recall ready'
+    );
+    expect(screen.getByTestId('memory-health-status-copy')).toHaveTextContent(
+      'Profile facts and relationship context both have saved evidence in the ledger.'
+    );
+    expect(screen.getByTestId('memory-resync-cta')).toHaveAttribute(
+      'href',
+      '#memory-trust-agent-1'
+    );
 
     const receipts = screen.getByTestId('pinned-facts-receipts');
     expect(receipts).toHaveTextContent('Latest memory receipts');
@@ -163,11 +173,39 @@ describe('AgentPinnedFactsCard', () => {
     expect(screen.getByTestId('pinned-facts-ledger-summary')).toHaveTextContent(
       '0 saved memories'
     );
+    expect(screen.getByTestId('memory-health-status-badge')).toHaveTextContent(
+      'No recall history'
+    );
+    expect(screen.getByTestId('memory-health-status-copy')).toHaveTextContent(
+      'Save the first fact before relying on this agent to recall private context.'
+    );
     expect(
       screen.getByText(
         'No pinned facts yet. Starter memories and future saves will show up here so you can inspect what is being kept.'
       )
     ).toBeInTheDocument();
+  });
+
+  it('recommends a re-sync when a memory category is missing', () => {
+    const settings = buildSettings();
+
+    render(
+      <AgentPinnedFactsCard
+        settings={{
+          ...settings,
+          facts: settings.facts.filter(
+            (fact) => fact.category === 'profile_fact'
+          ),
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('memory-health-status-badge')).toHaveTextContent(
+      'Re-sync recommended'
+    );
+    expect(screen.getByTestId('memory-health-status-copy')).toHaveTextContent(
+      'Review profile facts and relationship context together before the next important chat.'
+    );
   });
 
   it('remembers a new memory through the dashboard API', async () => {

--- a/apps/web/components/dashboard/AgentMemoryTrustForm.tsx
+++ b/apps/web/components/dashboard/AgentMemoryTrustForm.tsx
@@ -88,13 +88,7 @@ function formatRecordedAt(value: string) {
   }).format(new Date(value));
 }
 
-function FieldCount({
-  current,
-  max,
-}: {
-  current: number;
-  max: number;
-}) {
+function FieldCount({ current, max }: { current: number; max: number }) {
   return (
     <span className="text-xs text-muted-foreground">
       {current}/{max}
@@ -102,14 +96,11 @@ function FieldCount({
   );
 }
 
-export function AgentMemoryTrustForm({
-  settings,
-}: AgentMemoryTrustFormProps) {
+export function AgentMemoryTrustForm({ settings }: AgentMemoryTrustFormProps) {
   const [form, setForm] = useState(settings.initialSnapshot);
   const [lastSaved, setLastSaved] = useState(settings.initialSnapshot);
-  const [rollbackSnapshot, setRollbackSnapshot] = useState<EditableSnapshot | null>(
-    null
-  );
+  const [rollbackSnapshot, setRollbackSnapshot] =
+    useState<EditableSnapshot | null>(null);
   const [digest, setDigest] = useState<MemoryDigest | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [status, setStatus] = useState<{
@@ -199,7 +190,10 @@ export function AgentMemoryTrustForm({
     rollbackSnapshot != null && !snapshotsEqual(rollbackSnapshot, lastSaved);
 
   return (
-    <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+    <Card
+      className="border-border/50 bg-card/50 backdrop-blur-sm"
+      id={'memory-trust-' + settings.agentId}
+    >
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <ShieldCheck className="h-5 w-5 text-primary" />
@@ -211,7 +205,9 @@ export function AgentMemoryTrustForm({
         </CardDescription>
         <p className="text-sm text-muted-foreground">
           Agent slug:{' '}
-          <span className="font-mono text-foreground">{settings.agentName}</span>
+          <span className="font-mono text-foreground">
+            {settings.agentName}
+          </span>
           {settings.personaName ? (
             <>
               {' '}
@@ -361,7 +357,9 @@ export function AgentMemoryTrustForm({
                   <History className="h-4 w-4 text-primary" />
                   Recent memory change digest
                 </div>
-                <p className="text-sm text-muted-foreground">{digest.summary}</p>
+                <p className="text-sm text-muted-foreground">
+                  {digest.summary}
+                </p>
               </div>
               <span className="text-xs text-muted-foreground">
                 {formatRecordedAt(digest.recordedAt)}

--- a/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
+++ b/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
@@ -2,11 +2,14 @@
 
 import { useMemo, useState } from 'react';
 import {
+  AlertCircle,
+  CheckCircle2,
   Clock3,
   Edit3,
   Loader2,
   Pin,
   Plus,
+  RefreshCcw,
   Save,
   Trash2,
   X,
@@ -120,6 +123,46 @@ function formatCapacityCopy(count: number) {
   return count === 1 ? '1 slot left' : `${count} slots left`;
 }
 
+function getRecallHealth({
+  facts,
+  ledger,
+}: {
+  facts: AgentPinnedFactRecord[];
+  ledger: AgentPinnedFactsLedger;
+}) {
+  if (facts.length === 0) {
+    return {
+      label: 'No recall history',
+      description:
+        'Save the first fact before relying on this agent to recall private context.',
+      icon: AlertCircle,
+      className: 'border-border/70 bg-background text-muted-foreground',
+    };
+  }
+
+  if (
+    ledger.categoryCounts.profileFact === 0 ||
+    ledger.categoryCounts.relationshipContext === 0
+  ) {
+    return {
+      label: 'Re-sync recommended',
+      description:
+        'Review profile facts and relationship context together before the next important chat.',
+      icon: AlertCircle,
+      className:
+        'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+    };
+  }
+
+  return {
+    label: 'Recall ready',
+    description:
+      'Profile facts and relationship context both have saved evidence in the ledger.',
+    icon: CheckCircle2,
+    className: 'border-primary/20 bg-primary/10 text-primary',
+  };
+}
+
 function isMemoryCategory(value: string): value is MemoryCategory {
   return (MEMORY_CATEGORIES as readonly string[]).includes(value);
 }
@@ -217,6 +260,9 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
     [facts, settings.ledger.capacity]
   );
   const recentFacts = facts.slice(0, 3);
+  const recallHealth = getRecallHealth({ facts, ledger });
+  const RecallHealthIcon = recallHealth.icon;
+  const reSyncHref = '#memory-trust-' + settings.agentId;
   const usagePercent =
     ledger.capacity === 0
       ? 0
@@ -403,9 +449,37 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
                 reaches its current {ledger.capacity}-memory capacity.
               </p>
             </div>
-            <div className="rounded-full border border-primary/20 bg-background/90 px-3 py-1 text-xs font-medium text-primary">
-              {usagePercent}% used
+            <div className="flex flex-wrap items-center gap-2">
+              <div
+                className={
+                  'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium ' +
+                  recallHealth.className
+                }
+                data-testid="memory-health-status-badge"
+              >
+                <RecallHealthIcon className="h-3.5 w-3.5" />
+                {recallHealth.label}
+              </div>
+              <div className="rounded-full border border-primary/20 bg-background/90 px-3 py-1 text-xs font-medium text-primary">
+                {usagePercent}% used
+              </div>
             </div>
+          </div>
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/80 p-3">
+            <p
+              className="text-sm text-muted-foreground"
+              data-testid="memory-health-status-copy"
+            >
+              {recallHealth.description}
+            </p>
+            <a
+              className="inline-flex items-center gap-1.5 rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-sm font-medium text-primary transition hover:bg-primary/10 hover:text-primary/80"
+              data-testid="memory-resync-cta"
+              href={reSyncHref}
+            >
+              <RefreshCcw className="h-3.5 w-3.5" />
+              Re-sync memory
+            </a>
           </div>
 
           <div className="mt-4 h-2 overflow-hidden rounded-full bg-primary/10">

--- a/docs/pr-evidence/row-64-memory-health-resync.md
+++ b/docs/pr-evidence/row-64-memory-health-resync.md
@@ -1,0 +1,22 @@
+# Row 64 Evidence - Memory Health Re-sync CTA
+
+Source: `shared/knowledge/agentgram/backlog.md` row 64.
+
+## Before
+
+The pinned facts ledger only showed saved memory count, capacity usage, category counts, and receipts. A developer could not tell whether recall was ready, incomplete, or empty without manually comparing categories.
+
+## After
+
+`AgentPinnedFactsCard` now surfaces a memory health badge:
+
+- `Recall ready` when profile facts and relationship context are both present.
+- `Re-sync recommended` when one category is missing.
+- `No recall history` when no facts are saved yet.
+
+The same panel adds a `Re-sync memory` CTA linking to `#memory-trust-<agentId>`, and `AgentMemoryTrustForm` now exposes that anchor target.
+
+## Verification
+
+- Component tests assert the ready, missing-category, and empty-memory states.
+- Component tests assert the re-sync CTA href and trust form anchor target.


### PR DESCRIPTION
## Source
- Source: backlog.md:64

Memory health - add recall status badge + manual re-sync CTA.

## Changes
- Add memory recall health states to the pinned facts dashboard panel.
- Add a re-sync CTA from pinned facts to the memory trust form.
- Add component coverage for ready, empty, and missing-category health states plus the anchor target.

## Evidence
- Docs/example diff: docs/pr-evidence/row-64-memory-health-resync.md
- Tests: vitest run -- apps/web/__tests__/components/agent-pinned-facts-card.test.tsx apps/web/__tests__/components/agent-memory-trust-form.test.tsx -> 50 files / 305 tests passed.
- Lint: focused eslint pass.

## Auth-only Proof
N/A
