### PR TITLE
feat: add memory fact review log

### DIFF
--- a/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
+++ b/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
@@ -134,6 +134,36 @@ describe('AgentPinnedFactsCard', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('surfaces a fact-review log before the full ledger', () => {
+    render(<AgentPinnedFactsCard settings={buildSettings()} />);
+
+    const reviewLog = screen.getByTestId('fact-review-log');
+
+    expect(reviewLog).toHaveTextContent('Fact review log');
+    expect(reviewLog).toHaveTextContent('4 to review');
+    expect(
+      within(reviewLog).getByTestId('fact-review-log-entry-memory-1')
+    ).toHaveTextContent('Latest Focus');
+    expect(
+      within(reviewLog).getByTestId('fact-review-log-reason-memory-1')
+    ).toHaveTextContent(
+      'Newest saved fact - confirm before it shapes the next reply.'
+    );
+    expect(
+      within(reviewLog).getByTestId('fact-review-log-reason-memory-3')
+    ).toHaveTextContent(
+      'Relationship context - verify tone and boundaries before replies.'
+    );
+    expect(
+      within(reviewLog).getByTestId('fact-review-log-reason-memory-4')
+    ).toHaveTextContent('Public memory - confirm it is safe to expose.');
+    expect(
+      within(reviewLog).getByTestId('fact-review-log-origin-memory-2')
+    ).toHaveTextContent(
+      'Registration description seed: Keeps release notes precise.'
+    );
+  });
+
   it('keeps the full ledger provenance below the receipt strip', () => {
     render(<AgentPinnedFactsCard settings={buildSettings()} />);
 

--- a/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
+++ b/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
@@ -204,6 +204,29 @@ function sortFacts(facts: AgentPinnedFactRecord[]) {
   });
 }
 
+function getFactReviewReason(fact: AgentPinnedFactRecord, index: number) {
+  if (index === 0) {
+    return 'Newest saved fact - confirm before it shapes the next reply.';
+  }
+
+  if (fact.category === 'relationship_context') {
+    return 'Relationship context - verify tone and boundaries before replies.';
+  }
+
+  if (fact.isPublic) {
+    return 'Public memory - confirm it is safe to expose.';
+  }
+
+  return 'Private fact - confirm this should stay in recall.';
+}
+
+function buildFactReviewLog(facts: AgentPinnedFactRecord[]) {
+  return facts.slice(0, 4).map((fact, index) => ({
+    fact,
+    reason: getFactReviewReason(fact, index),
+  }));
+}
+
 function toPinnedFact(
   record: MemoryApiRecord,
   fallback?: AgentPinnedFactRecord
@@ -260,6 +283,7 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
     [facts, settings.ledger.capacity]
   );
   const recentFacts = facts.slice(0, 3);
+  const factReviewLog = useMemo(() => buildFactReviewLog(facts), [facts]);
   const recallHealth = getRecallHealth({ facts, ledger });
   const RecallHealthIcon = recallHealth.icon;
   const reSyncHref = '#memory-trust-' + settings.agentId;
@@ -651,6 +675,57 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
           </div>
         ) : (
           <>
+            <div
+              className="rounded-xl border border-amber-500/25 bg-amber-500/10 p-4"
+              data-testid="fact-review-log"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="font-medium text-foreground">
+                    Fact review log
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Audit the newest facts before they shape replies.
+                  </p>
+                </div>
+                <div className="rounded-full border border-amber-500/30 bg-background/90 px-3 py-1 text-xs font-medium text-amber-700 dark:text-amber-300">
+                  {factReviewLog.length} to review
+                </div>
+              </div>
+
+              <div className="mt-4 grid gap-3">
+                {factReviewLog.map(({ fact, reason }) => (
+                  <div
+                    className="rounded-lg border border-border/60 bg-background/85 p-3"
+                    data-testid={'fact-review-log-entry-' + fact.id}
+                    key={fact.id}
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded-full border border-border/70 bg-background px-2.5 py-1 text-xs font-medium text-foreground">
+                        {formatFactLabel(fact.key)}
+                      </span>
+                      <span
+                        className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-700 dark:text-amber-300"
+                        data-testid={'fact-review-log-reason-' + fact.id}
+                      >
+                        {reason}
+                      </span>
+                      <span className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-background px-2.5 py-1 text-xs text-muted-foreground">
+                        <Clock3 className="h-3.5 w-3.5" />
+                        {formatTimestamp(fact.updatedAt)}
+                      </span>
+                    </div>
+                    <p
+                      className="mt-3 text-sm text-muted-foreground"
+                      data-testid={'fact-review-log-origin-' + fact.id}
+                    >
+                      {fact.originLabel}: {fact.originSnippet}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
             <div
               className="rounded-xl border border-primary/20 bg-primary/5 p-4"
               data-testid="pinned-facts-receipts"

--- a/docs/pr-evidence/memory-event-review-log.md
+++ b/docs/pr-evidence/memory-event-review-log.md
@@ -1,0 +1,33 @@
+# PR Evidence: Memory Event Review Log
+
+Backlog source: [STRATEGY] Memory event log manual lane - bypass ACP and ship narrow fact-review log before Character.AI widens gap.
+
+## Before
+
+AgentPinnedFactsCard exposed latest memory receipts and the full pinned-fact ledger, but there was no compact review queue calling out which saved facts should be checked before they shape future replies.
+
+## After
+
+The dashboard pinned facts card now renders a Fact review log above the receipt strip when facts exist.
+
+The log shows:
+
+- the four newest saved facts
+- why each fact needs review (newest, relationship_context, public, or private recall)
+- the saved timestamp
+- the original provenance label and snippet
+
+## Verification
+
+Run:
+
+```bash
+pnpm --filter web test -- apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
+```
+
+Expected coverage:
+
+- the review log renders with four review entries
+- the newest fact is highlighted as reply-shaping
+- relationship context and public-memory facts get distinct review reasons
+- provenance remains visible in the review queue


### PR DESCRIPTION
## Source
- Backlog: `/Users/sweetheart/.openclaw/shared/knowledge/agentgram/backlog.md:109`
- Evidence artifact: `docs/pr-evidence/memory-event-review-log.md`

Ship the approved manual-lane slice for the memory event log: add a compact fact-review queue to the pinned facts dashboard so builders can audit newly saved memory before it shapes replies.

## Changes
- Adds a Fact review log above the latest memory receipts.
- Flags newest, relationship-context, public, and private recall facts with distinct review reasons.
- Keeps provenance label/snippet visible in the review queue.
- Adds component coverage for review-log rendering and reasons.

## Evidence
- Docs diff included in this PR: [docs/pr-evidence/memory-event-review-log.md](docs/pr-evidence/memory-event-review-log.md)
- Backlog row 109 is marked in-review for PR #649 and references the evidence artifact.
- Validation commands:
  - `pnpm --filter web test -- apps/web/__tests__/components/agent-pinned-facts-card.test.tsx`
  - `pnpm --filter web exec eslint components/dashboard/AgentPinnedFactsCard.tsx __tests__/components/agent-pinned-facts-card.test.tsx`

## Auth-only Proof
N/A
