### PR TITLE
[STRATEGY] Release proof conversion sprint - paid onboarding CTA KPI readout

### DIFF
--- a/apps/web/__tests__/components/login-conversion-kpi-readout.test.tsx
+++ b/apps/web/__tests__/components/login-conversion-kpi-readout.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LoginConversionKpiReadout } from '@/components/LoginConversionKpiReadout';
+
+describe('LoginConversionKpiReadout', () => {
+  it('renders the KPI readout container', () => {
+    render(<LoginConversionKpiReadout />);
+    expect(
+      screen.getByTestId('login-conversion-kpi-readout')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the paid onboarding badge', () => {
+    render(<LoginConversionKpiReadout />);
+    expect(screen.getByText('Paid onboarding')).toBeInTheDocument();
+  });
+
+  it('renders the heading', () => {
+    render(<LoginConversionKpiReadout />);
+    expect(
+      screen.getByText('What your login unlocks with Pro')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the KPI table', () => {
+    render(<LoginConversionKpiReadout />);
+    expect(screen.getByTestId('login-kpi-table')).toBeInTheDocument();
+  });
+
+  it('renders all three KPI rows', () => {
+    render(<LoginConversionKpiReadout />);
+    const rows = screen.getAllByTestId('login-kpi-row');
+    expect(rows).toHaveLength(3);
+  });
+
+  it('renders API requests KPI with free and pro values', () => {
+    render(<LoginConversionKpiReadout />);
+    expect(screen.getByText('API requests / day')).toBeInTheDocument();
+    expect(screen.getByText('1,000')).toBeInTheDocument();
+    expect(screen.getByText('50,000')).toBeInTheDocument();
+  });
+
+  it('renders simulations KPI', () => {
+    render(<LoginConversionKpiReadout />);
+    expect(screen.getByText('Simulations / month')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+  });
+
+  it('renders AX scans KPI', () => {
+    render(<LoginConversionKpiReadout />);
+    expect(screen.getByText('AX scans / month')).toBeInTheDocument();
+    expect(screen.getByText('200')).toBeInTheDocument();
+  });
+
+  it('renders the pricing CTA link', () => {
+    render(<LoginConversionKpiReadout />);
+    const cta = screen.getByTestId('login-conversion-cta');
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute('href', '/pricing');
+    expect(screen.getByText('See full paid onboarding')).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(auth)/auth/login/page.tsx
+++ b/apps/web/app/(auth)/auth/login/page.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/card';
 import { toast } from '@/hooks/use-toast';
 import { analytics } from '@/lib/analytics';
+import { LoginConversionKpiReadout } from '@/components/LoginConversionKpiReadout';
 
 const loginReadinessItems = [
   {
@@ -210,6 +211,7 @@ function LoginContent() {
         </div>
       </section>
 
+      <div className="flex flex-col gap-4">
       <Card
         data-testid="auth-login-card"
         className="flex min-h-[520px] flex-col overflow-hidden border-muted/50 bg-card/70 shadow-2xl backdrop-blur-xl"
@@ -309,6 +311,8 @@ function LoginContent() {
           </Link>
         </CardFooter>
       </Card>
+      <LoginConversionKpiReadout />
+      </div>
     </motion.div>
   );
 }

--- a/apps/web/components/LoginConversionKpiReadout.tsx
+++ b/apps/web/components/LoginConversionKpiReadout.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowRight, CheckCircle2, TrendingUp, Zap } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+
+const conversionKpis = [
+  {
+    label: 'API requests / day',
+    free: '1,000',
+    pro: '50,000',
+    icon: Zap,
+  },
+  {
+    label: 'Simulations / month',
+    free: '0',
+    pro: '100',
+    icon: TrendingUp,
+  },
+  {
+    label: 'AX scans / month',
+    free: '3',
+    pro: '200',
+    icon: CheckCircle2,
+  },
+] as const;
+
+export function LoginConversionKpiReadout() {
+  return (
+    <div
+      className="mt-6 w-full max-w-md rounded-2xl border border-primary/15 bg-primary/5 p-5 shadow-sm"
+      data-testid="login-conversion-kpi-readout"
+    >
+      <div className="flex items-center justify-between">
+        <Badge
+          variant="outline"
+          className="border-primary/20 bg-background/70 text-xs"
+        >
+          Paid onboarding
+        </Badge>
+        <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
+          Pro tier
+        </span>
+      </div>
+
+      <h2 className="mt-3 text-base font-semibold tracking-tight text-foreground">
+        What your login unlocks with Pro
+      </h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Your OAuth proof is the first step. Upgrade to see the full KPI
+        surface.
+      </p>
+
+      <div
+        className="mt-4 divide-y divide-border/60 rounded-xl border border-border/70 bg-background/90"
+        data-testid="login-kpi-table"
+      >
+        <div className="grid grid-cols-3 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          <span>Metric</span>
+          <span className="text-center">Free</span>
+          <span className="text-center text-primary">Pro</span>
+        </div>
+        {conversionKpis.map(({ label, free, pro, icon: Icon }) => (
+          <div
+            key={label}
+            className="grid grid-cols-3 items-center px-4 py-3 text-sm"
+            data-testid="login-kpi-row"
+          >
+            <div className="flex items-center gap-2 text-foreground">
+              <Icon className="h-3.5 w-3.5 shrink-0 text-primary" />
+              <span className="leading-tight">{label}</span>
+            </div>
+            <span className="text-center text-muted-foreground">{free}</span>
+            <span className="text-center font-semibold text-primary">{pro}</span>
+          </div>
+        ))}
+      </div>
+
+      <Link
+        href="/pricing"
+        className="mt-4 flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        data-testid="login-conversion-cta"
+      >
+        See full paid onboarding
+        <ArrowRight className="h-4 w-4" />
+      </Link>
+    </div>
+  );
+}

--- a/docs/pr-evidence/release-proof-conversion-sprint.md
+++ b/docs/pr-evidence/release-proof-conversion-sprint.md
@@ -1,0 +1,39 @@
+# Release Proof Conversion Sprint — PR Evidence
+
+## What changed
+
+Added `LoginConversionKpiReadout` component that renders below the auth login card.
+The component connects restored login proof (OAuth SSO, Developer access, Redirect guard)
+to a paid onboarding KPI readout showing Free vs Pro capacity deltas.
+
+## Before (auth login page)
+
+Login card only: OAuth buttons + ToS footer. No conversion surface below the fold.
+
+## After
+
+Login card + `LoginConversionKpiReadout` panel stacked in the same right column.
+
+KPI table rendered (data-testid=login-kpi-table):
+
+| Metric                | Free    | Pro    |
+| --------------------- | ------- | ------ |
+| API requests / day    | 1,000   | 50,000 |
+| Simulations / month   | 0       | 100    |
+| AX scans / month      | 3       | 200    |
+
+CTA: "See full paid onboarding" → /pricing (data-testid=login-conversion-cta)
+
+## Test surface
+
+`apps/web/__tests__/components/login-conversion-kpi-readout.test.tsx`
+- 9 tests, all pass
+- Covers: container render, badge, heading, KPI table, all 3 rows, Free/Pro values, pricing CTA
+
+## Regression
+
+`apps/web/__tests__/components/auth-login-page.test.tsx` — 2/2 pass (no regression)
+
+## Route reachable
+
+`/auth/login` — publicly reachable, no auth gate.


### PR DESCRIPTION
Source: backlog.md:49

Release proof conversion sprint: turn restored login/comment proof into paid onboarding CTA KPI readout.

## What changed

- Added `LoginConversionKpiReadout` component (`apps/web/components/LoginConversionKpiReadout.tsx`)
- Renders below the auth login card with a Free vs Pro KPI comparison table
- CTA links to `/pricing` for full paid onboarding flow

## Evidence

```diff
// apps/web/app/(auth)/auth/login/page.tsx
+ import { LoginConversionKpiReadout } from '@/components/LoginConversionKpiReadout';

  // Inside LoginContent return:
+ <div className="flex flex-col gap-4">
    <Card data-testid="auth-login-card">...</Card>
+   <LoginConversionKpiReadout />
+ </div>
```

KPI table rendered at `data-testid="login-kpi-table"`:

| Metric | Free | Pro |
|--------|------|-----|
| API requests / day | 1,000 | 50,000 |
| Simulations / month | 0 | 100 |
| AX scans / month | 3 | 200 |

See full evidence: [docs/pr-evidence/release-proof-conversion-sprint.md](docs/pr-evidence/release-proof-conversion-sprint.md)

## Tests

- `apps/web/__tests__/components/login-conversion-kpi-readout.test.tsx` — 9 tests, all pass
- `apps/web/__tests__/components/auth-login-page.test.tsx` — 2 tests, all pass (no regression)

## Route

`/auth/login` — publicly reachable, no auth gate required.