### PR TITLE
fix: comment create 500 DATABASE_ERROR — context_* column schema drift fallback

### DIFF
--- a/apps/web/app/api/v1/posts/[id]/comments/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/comments/route.ts
@@ -21,6 +21,18 @@ function isMissingDeletedAtColumn(error: { message?: string } | null) {
   return Boolean(error?.message?.toLowerCase().includes('deleted_at'));
 }
 
+function isContextColumnMissing(error: { code?: string; message?: string } | null) {
+  if (!error) return false;
+  // PostgreSQL error code 42703 = undefined_column
+  if (error.code === '42703') return true;
+  const msg = error.message?.toLowerCase() ?? '';
+  return (
+    msg.includes('context_url') ||
+    msg.includes('context_image_url') ||
+    msg.includes('context_voice_note_url')
+  );
+}
+
 function parseOptionalHttpUrl(value: unknown, label: string) {
   if (value === undefined || value === null) {
     return undefined;
@@ -175,8 +187,13 @@ async function createCommentHandler(
       }
     }
 
+    const COMMENT_SELECT = `
+      *,
+      author:agents!comments_author_id_fkey(id, name, display_name, avatar_url, axp, trust_score)
+    `;
+
     // Create comment
-    const { data: comment, error: commentError } = await supabase
+    let { data: comment, error: commentError } = await supabase
       .from('comments')
       .insert({
         post_id: postId,
@@ -188,13 +205,29 @@ async function createCommentHandler(
         context_voice_note_url: contextVoiceNoteUrl ?? null,
         depth,
       })
-      .select(
-        `
-        *,
-        author:agents!comments_author_id_fkey(id, name, display_name, avatar_url, axp, trust_score)
-      `
-      )
+      .select(COMMENT_SELECT)
       .single();
+
+    // Fallback: context_* columns may not be present in prod yet (schema drift).
+    // Retry without them so comment creation succeeds until migration is applied.
+    if (commentError && isContextColumnMissing(commentError)) {
+      console.warn(
+        'Comment insert fallback: context_* columns missing, retrying without them'
+      );
+      const fallback = await supabase
+        .from('comments')
+        .insert({
+          post_id: postId,
+          author_id: agentId,
+          parent_id: parentId || null,
+          content: sanitizedContent,
+          depth,
+        })
+        .select(COMMENT_SELECT)
+        .single();
+      comment = fallback.data;
+      commentError = fallback.error;
+    }
 
     if (commentError || !comment) {
       console.error('Comment creation error:', commentError);


### PR DESCRIPTION
## 문제
`20260505044500_add_comment_reply_context.sql` migration이 prod Supabase에 미적용 상태로 13일간 방치 → 모든 comment create가 `500 DATABASE_ERROR: Failed to create comment` 반환.

**root cause**: `comments` table에 `context_url`, `context_image_url`, `context_voice_note_url` 컬럼이 prod에 없지만 insert payload에 포함됨.

## 이 PR에서 하는 것
GET handler의 `isMissingDeletedAtColumn` fallback과 동일한 패턴으로, comment insert가 PostgreSQL error 42703(undefined_column)으로 실패하면 `context_*` 필드 없이 재시도.

## 영구 fix (별도 수동 작업)
Supabase 대시보드 SQL Editor에서:
```sql
ALTER TABLE comments
  ADD COLUMN IF NOT EXISTS context_url TEXT,
  ADD COLUMN IF NOT EXISTS context_image_url TEXT,
  ADD COLUMN IF NOT EXISTS context_voice_note_url TEXT;
```
(파일: `supabase/migrations/20260505044500_add_comment_reply_context.sql`)

## Evidence
- diff — isMissingDeletedAtColumn (L70-83) same prod-proven fallback validation pattern
- PostgreSQL 42703 = undefined_column error code proof
- Retry without context_* fields, all other columns preserved

## Source
backlog.md:123

## Auth-only Proof
N/A