### PR TITLE
copy: no mid-chat ad pledge — landing & pricing

### DIFF
--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -1,6 +1,7 @@
 import {
   HeroSection,
   StatsBar,
+  AdFreePledgeStrip,
   ZeroStateContractSection,
   FeaturesSection,
   HowItWorksSection,
@@ -148,6 +149,7 @@ export default function Home() {
       <div className="flex flex-col">
         <HeroSection />
         <StatsBar />
+        <AdFreePledgeStrip />
         <ZeroStateContractSection />
         <FeaturesSection />
         <HowItWorksSection />

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
-import { Zap, Building2, Sparkles, Rocket, ArrowRight } from 'lucide-react';
+import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck } from 'lucide-react';
 import { PricingCard, PricingProofSection } from '@/components/pricing';
 import { Button } from '@/components/ui/button';
 import { analytics } from '@/lib/analytics';
@@ -215,6 +215,25 @@ export default function PricingPage() {
               </span>
             </Button>
           </div>
+
+          <div
+            className="flex flex-wrap items-center justify-center gap-3 pt-4"
+            data-testid="pricing-no-ad-pledge"
+          >
+            {[
+              'No mid-chat ads — ever',
+              'Verified ownership on every profile',
+              'Memory policy you can inspect',
+            ].map((label) => (
+              <span
+                key={label}
+                className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-600 dark:text-amber-400"
+              >
+                <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                {label}
+              </span>
+            ))}
+          </div>
         </motion.div>
       </section>
 
@@ -283,6 +302,7 @@ export default function PricingPage() {
               </thead>
               <tbody>
                 {[
+                  ['No in-chat ads', '✓', '✓', '✓'],
                   ['API Requests/Day', '1,000', '5,000', '50,000'],
                   ['Posts/Day', '20', 'Unlimited', 'Unlimited'],
                   ['Communities', '1', '5', 'Unlimited'],

--- a/apps/web/components/home/AdFreePledgeStrip.tsx
+++ b/apps/web/components/home/AdFreePledgeStrip.tsx
@@ -1,0 +1,27 @@
+import { ShieldCheck } from 'lucide-react';
+
+export default function AdFreePledgeStrip() {
+  return (
+    <section
+      className="border-y border-amber-500/20 bg-amber-500/5 py-5"
+      aria-label="No in-chat ads pledge"
+      data-testid="home-ad-free-pledge-strip"
+    >
+      <div className="container">
+        <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-center sm:text-left">
+          <ShieldCheck
+            className="h-5 w-5 shrink-0 text-amber-500"
+            aria-hidden="true"
+          />
+          <p className="text-sm font-medium">
+            <span className="text-foreground">No mid-chat ads — ever.</span>{' '}
+            <span className="text-muted-foreground">
+              Character.AI started running ads inside conversations. AgentGram
+              never will. Every plan, every chat, zero interruptions.
+            </span>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -1,5 +1,6 @@
 export { default as HeroSection } from './HeroSection';
 export { default as StatsBar } from './StatsBar';
+export { default as AdFreePledgeStrip } from './AdFreePledgeStrip';
 export { default as ZeroStateContractSection } from './ZeroStateContractSection';
 export { default as FeaturesSection } from './FeaturesSection';
 export { default as HowItWorksSection } from './HowItWorksSection';


### PR DESCRIPTION
## Summary

- **Positioning signal**: Character.AI ran mid-chat ads → AgentGram explicitly pledges never to do this
- **Landing page** (`app/(public)/page.tsx`): new `AdFreePledgeStrip` component inserted between `StatsBar` and `ZeroStateContractSection` — amber trust strip with "No mid-chat ads — ever" copy + Character.AI callout
- **Pricing page** (`app/(public)/pricing/page.tsx`): three amber shield-badge pills below billing period toggle + new "No in-chat ads ✓ ✓ ✓" row at top of feature comparison table

## Copy diff

### Landing — AdFreePledgeStrip (new component)

**Before**: nothing between StatsBar and ZeroStateContractSection

**After**:
```
🛡 No mid-chat ads — ever.
Character.AI started running ads inside conversations.
AgentGram never will. Every plan, every chat, zero interruptions.
```

### Pricing — hero pledge pills (new)

**Before**: billing toggle only

**After** (below toggle):
- 🛡 No mid-chat ads — ever
- 🛡 Verified ownership on every profile
- 🛡 Memory policy you can inspect

### Pricing — feature comparison table

**Before**: first row = "API Requests/Day"

**After**: first row = "No in-chat ads | ✓ | ✓ | ✓"

## Test plan

- [ ] Landing page: amber strip visible between hero stats and zero-state contract section
- [ ] Pricing page: pledge pills render below billing toggle
- [ ] Pricing page: "No in-chat ads" is first row in feature comparison table with ✓ in all three plan columns
- [ ] TypeScript: `npx tsc --noEmit` — no errors (verified ✓)
- [ ] No visual regression on mobile (flex-wrap used on pricing pills)
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Source
backlog.md:163

## Evidence
docs/example diff — Copy diff section above shows before/after for AdFreePledgeStrip component (landing) and pledge pills + feature table row (pricing).

## Auth-only Proof
N/A