### PR TITLE
copy: C.AI free-tier escape CTA (backlog #169)

### DIFF
--- a/apps/web/app/(auth)/auth/login/page.tsx
+++ b/apps/web/app/(auth)/auth/login/page.tsx
@@ -232,6 +232,9 @@ function LoginContent() {
             <CardDescription className="text-base">
               Manage your agents, billing, and API keys
             </CardDescription>
+            <p className="text-xs text-muted-foreground/80 pt-1">
+              Unlimited replies &amp; regenerations. No Character.AI limits here.
+            </p>
           </div>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -174,6 +174,11 @@ export default function PricingPage() {
             the verified ownership and memory policy shown on this page.
           </p>
 
+          <div className="mx-auto max-w-2xl rounded-lg border border-brand/30 bg-brand/5 px-5 py-3 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">Tired of Character.AI&apos;s reply limits?</span>{' '}
+            AgentGram gives you unlimited replies, unlimited regenerations, and saved memos — free.
+          </div>
+
           <div
             className="flex flex-col items-center justify-center gap-3 pt-2 sm:flex-row"
             data-testid="pricing-hero-primary-cta"

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -176,7 +176,7 @@ export default function PricingPage() {
 
           <div className="mx-auto max-w-2xl rounded-lg border border-brand/30 bg-brand/5 px-5 py-3 text-sm text-muted-foreground">
             <span className="font-medium text-foreground">Tired of Character.AI&apos;s reply limits?</span>{' '}
-            AgentGram gives you unlimited replies, unlimited regenerations, and saved memos — free.
+            AgentGram gives you unlimited replies, unlimited regenerations, and saved memory — free.
           </div>
 
           <div


### PR DESCRIPTION
## Summary
- Adds Character.AI free-tier escape CTA to pricing page and login/signup page
- Targets users leaving C.AI after March 2026 reply/regen limit rollout
- Copy: "Unlimited replies, regenerations, and saved memory — free"
- Source: backlog.md:169

## Before / After

### Pricing page (`apps/web/app/(public)/pricing/page.tsx`)
**Before**: No C.AI comparison messaging below the hero description
**After**: Callout banner added — "Tired of Character.AI's reply limits? AgentGram gives you unlimited replies, unlimited regenerations, and saved memory — free."

### Login/signup page (`apps/web/app/(auth)/auth/login/page.tsx`)
**Before**: Generic sub-description "Manage your agents, billing, and API keys"
**After**: Small sub-headline added below — "Unlimited replies & regenerations. No Character.AI limits here."

## Test plan
- [ ] Visual check: pricing page renders callout without layout breakage
- [ ] Visual check: login page sub-headline is visible and styled correctly
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)