### PR TITLE
feat: competitor migration onboarding CTA section

### DIFF
--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -6,6 +6,7 @@ import {
   FeaturesSection,
   HowItWorksSection,
   EcosystemSection,
+  CompetitorMigrationSection,
   FaqSection,
   CtaSection,
 } from '@/components/home';
@@ -154,6 +155,7 @@ export default function Home() {
         <FeaturesSection />
         <HowItWorksSection />
         <EcosystemSection />
+        <CompetitorMigrationSection />
         <FaqSection />
         <CtaSection />
       </div>

--- a/apps/web/components/home/CompetitorMigrationSection.tsx
+++ b/apps/web/components/home/CompetitorMigrationSection.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Check } from 'lucide-react';
+
+const checklist = [
+  'Unlimited replies & regenerations',
+  'Full memory controls — no hidden AI training',
+  'No in-chat ads, ever',
+  'No locked personas behind monthly price hikes',
+];
+
+export default function CompetitorMigrationSection() {
+  return (
+    <section
+      className="py-24 md:py-32 border-y border-border"
+      aria-labelledby="competitor-migration-heading"
+    >
+      <div className="container">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2
+            id="competitor-migration-heading"
+            className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            Switching from Replika or Kindroid?
+          </h2>
+          <p className="mb-10 text-lg text-muted-foreground">
+            Everything you miss, none of the new paywalls.
+          </p>
+
+          <ul className="mb-10 space-y-4 text-left inline-block">
+            {checklist.map((item) => (
+              <li key={item} className="flex items-start gap-3">
+                <Check
+                  className="mt-0.5 h-5 w-5 shrink-0 text-brand"
+                  aria-hidden="true"
+                />
+                <span className="text-base">{item}</span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex flex-col items-center gap-3">
+            <Link href="/auth/login">
+              <Button
+                size="lg"
+                className="gap-2 bg-brand text-white hover:bg-brand-accent shadow-lg shadow-brand/20"
+              >
+                Start free — no credit card
+              </Button>
+            </Link>
+            <p className="text-sm text-muted-foreground">
+              Import your character in minutes.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -5,5 +5,6 @@ export { default as ZeroStateContractSection } from './ZeroStateContractSection'
 export { default as FeaturesSection } from './FeaturesSection';
 export { default as HowItWorksSection } from './HowItWorksSection';
 export { default as EcosystemSection } from './EcosystemSection';
+export { default as CompetitorMigrationSection } from './CompetitorMigrationSection';
 export { default as FaqSection } from './FaqSection';
 export { default as CtaSection } from './CtaSection';


### PR DESCRIPTION
Source: backlog.md row 156

Adds landing page section targeting users fleeing Replika/Kindroid 2026 price hikes.

## Summary
- New section: "Switching from Replika or Kindroid?" with 4-item checklist
- Positioned after features/pricing, before FAQ/footer
- CTA: "Start free — no credit card" → /auth/login
- Secondary text: "Import your character in minutes."

## Before / After
**Before**: No migration CTA targeting Replika/Kindroid users on homepage
**After**: Dedicated section with checklist and primary CTA for competitor migrants

## Test plan
- [ ] Visual: section renders correctly between pricing and FAQ
- [ ] CTA link resolves to /auth/login
- [ ] No TypeScript errors

🤖 Generated with Claude Code