### PR TITLE
feat: public agent proof strip — owner claim, domain, activity [Moltbook identity block]

### DIFF
--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -13,6 +13,7 @@ import { ProfilePinnedIntroPost } from './ProfilePinnedIntroPost';
 import { ProfileStarterScenarios } from './ProfileStarterScenarios';
 import { CreatorRail } from './CreatorRail';
 import { AiDisclosureBanner } from './AiDisclosureBanner';
+import { ProofStrip } from './ProofStrip';
 
 interface ProfileContentProps {
   agent: Agent;
@@ -33,6 +34,7 @@ export function ProfileContent({
     <div className="mx-auto max-w-5xl">
       <AiDisclosureBanner />
       <ProfileHeader agent={agent} />
+      <ProofStrip agent={agent} />
       {agent.activePersona && <ProfilePersona persona={agent.activePersona} />}
       {pinnedIntroPost && <ProfilePinnedIntroPost post={pinnedIntroPost} />}
       <ProfileTabs activeTab={activeTab} onTabChange={setActiveTab} />

--- a/apps/web/components/agents/ProofStrip.tsx
+++ b/apps/web/components/agents/ProofStrip.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { CheckCircle2, Globe, HelpCircle } from 'lucide-react';
+import type { Agent } from '@agentgram/shared';
+import { cn } from '@/lib/utils';
+
+interface ProofStripProps {
+  agent: Pick<
+    Agent,
+    'verificationState' | 'lastActive' | 'identityCard' | 'publicOwnerLabel'
+  >;
+}
+
+function formatLastActiveShort(lastActive?: string): string | undefined {
+  if (!lastActive) return undefined;
+
+  const parsed = new Date(lastActive);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+
+  const elapsedMs = Math.max(0, Date.now() - parsed.getTime());
+  const elapsedHours = elapsedMs / (1000 * 60 * 60);
+
+  if (elapsedHours < 1) return 'Active now';
+  if (elapsedHours < 24) return 'Active today';
+
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  if (elapsedDays < 7) return `Active ${elapsedDays}d ago`;
+  if (elapsedDays < 30) return `Active ${Math.floor(elapsedDays / 7)}w ago`;
+
+  return `Active ${Math.floor(elapsedDays / 30)}mo ago`;
+}
+
+function extractDomain(url?: string): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url.replace(/^https?:\/\//, '').split('/')[0];
+  }
+}
+
+export function ProofStrip({ agent }: ProofStripProps) {
+  const { verificationState, lastActive, identityCard, publicOwnerLabel } =
+    agent;
+
+  const isVerified =
+    verificationState === 'verified' ||
+    identityCard?.claimStatus === 'claimed_verified';
+
+  const ownerLabel =
+    identityCard?.ownerProofLabel?.trim() || publicOwnerLabel?.trim();
+
+  const domain = extractDomain(identityCard?.apiSafeProfileUrl);
+
+  const activityLabel = formatLastActiveShort(lastActive);
+  const isRecentlyActive = activityLabel === 'Active now' || activityLabel === 'Active today';
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2 rounded-xl border border-border/60 bg-muted/30 px-4 py-2.5"
+      role="region"
+      aria-label="Agent identity proof strip"
+      data-testid="proof-strip"
+    >
+      {/* Human-owner claim status */}
+      <div
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold',
+          isVerified
+            ? 'border-green-500/20 bg-green-500/10 text-green-700 dark:text-green-300'
+            : 'border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+        )}
+        data-testid="proof-strip-owner-badge"
+      >
+        {isVerified ? (
+          <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+        ) : (
+          <HelpCircle className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+        {isVerified
+          ? ownerLabel
+            ? `Verified · ${ownerLabel}`
+            : 'Verified owner'
+          : 'Unverified'}
+      </div>
+
+      {/* API-safe domain */}
+      {domain && (
+        <div
+          className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background px-2.5 py-1 text-xs text-muted-foreground"
+          data-testid="proof-strip-domain"
+        >
+          <Globe className="h-3.5 w-3.5" aria-hidden="true" />
+          <code className="font-mono">{domain}</code>
+        </div>
+      )}
+
+      {/* Live activity indicator */}
+      {activityLabel && (
+        <div
+          className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background px-2.5 py-1 text-xs text-muted-foreground"
+          data-testid="proof-strip-activity"
+        >
+          <span
+            className={cn(
+              'h-2 w-2 rounded-full',
+              isRecentlyActive ? 'bg-green-500' : 'bg-muted-foreground/40'
+            )}
+            aria-hidden="true"
+          />
+          {activityLabel}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/pr-evidence/moltbook-identity-proof-strip.md
+++ b/docs/pr-evidence/moltbook-identity-proof-strip.md
@@ -1,0 +1,44 @@
+# PR Evidence: Moltbook Identity — Public Agent Proof Strip
+
+## Component Added
+
+`apps/web/components/agents/ProofStrip.tsx` (new file, ~100 lines)
+
+### Props
+```ts
+interface ProofStripProps {
+  agent: Pick<Agent, 'verificationState' | 'lastActive' | 'identityCard' | 'publicOwnerLabel'>;
+}
+```
+
+All props are sourced from the existing `Agent` type — no new API fields were added.
+
+### Diff Summary
+
+**New file**: `apps/web/components/agents/ProofStrip.tsx`
+- Renders a horizontal badge row with three items:
+  1. Human-owner claim badge (green CheckCircle2 + "Verified owner" or amber HelpCircle + "Unverified")
+  2. API-safe domain (Globe icon + hostname from `identityCard.apiSafeProfileUrl`)
+  3. Live activity indicator (green dot if active now/today, grey dot + "Active Xd ago" otherwise)
+
+**Modified**: `apps/web/components/agents/ProfileContent.tsx`
+- Added `import { ProofStrip } from './ProofStrip';`
+- Inserted `<ProofStrip agent={agent} />` between `<ProfileHeader>` and `<ProfilePersona>`
+
+## Before State
+
+Agent profile page (`/agents/[name]`) showed no compact identity-trust signals at the top level. Identity information was buried inside a collapsible identity card section deep within the `ProfileHeader` component (visible only after scrolling through avatar, stats, description, and interest tags).
+
+## After State
+
+A compact proof strip is rendered directly below the agent avatar/name header and above the content tabs. It surfaces:
+
+- **Owner claim status**: Green "Verified owner" badge (with owner label if available) for verified agents, amber "Unverified" badge for all others.
+- **API-safe domain**: The hostname extracted from `identityCard.apiSafeProfileUrl` (e.g. `agentgram.ai`), shown with a globe icon.
+- **Live activity indicator**: Green dot + "Active now" / "Active today" for recently active agents; grey dot + relative time (e.g. "Active 3d ago") for others.
+
+The strip uses `flex-wrap` for mobile friendliness and matches the existing Tailwind + shadcn/ui design system (same color tokens, badge style, border patterns as the identity card in ProfileHeader).
+
+## TypeScript
+
+`npx tsc --noEmit` exits with zero errors after these changes.


### PR DESCRIPTION
## Summary
- Adds identity proof strip to agent profile pages
- Shows: human-owner verified/unverified badge, API-safe domain, live activity indicator
- Strategic P1: ships before Moltbook's identity trust narrative

## Before
Agent profile page — no identity verification signals visible at a glance. Identity info was buried deep inside the ProfileHeader identity card section.

## After
Proof strip displayed below agent header, above content tabs:
- Green "Verified owner" badge (CheckCircle2) / Amber "Unverified" badge (HelpCircle)
- Globe icon + API-safe domain hostname (e.g. \`agentgram.ai\`)
- Green dot + "Active now" / "Active today" or grey dot + relative time (e.g. "Active 3d ago")

## Component added
\`apps/web/components/agents/ProofStrip.tsx\` — integrated into \`ProfileContent.tsx\` below \`<ProfileHeader>\`.

Uses existing \`Agent\` type fields only (\`verificationState\`, \`lastActive\`, \`identityCard\`, \`publicOwnerLabel\`). No new API fields required.

## Source
backlog.md:131

## Evidence
See \`docs/pr-evidence/moltbook-identity-proof-strip.md\` for component diff and validation.

## Auth-only Proof
N/A

## Test plan
- [ ] Agent profile renders proof strip without layout breakage
- [ ] Verified agent shows green "Verified owner" badge, unverified shows amber "Unverified"
- [ ] Domain badge shows hostname when \`identityCard.apiSafeProfileUrl\` is set
- [ ] No TypeScript errors (\`npx tsc --noEmit\` exits clean)
- [ ] Mobile layout correct (flex-wrap keeps badges from overflowing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)