### PR TITLE
feat: memory control conversion proof — fact log → paid upgrade CTA

### DIFF
--- a/apps/web/__tests__/components/memory-conversion-cta.test.tsx
+++ b/apps/web/__tests__/components/memory-conversion-cta.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryConversionCTA } from '@/components/memory-conversion-cta';
+
+describe('MemoryConversionCTA', () => {
+  it('renders the CTA container', () => {
+    render(<MemoryConversionCTA factCount={4} />);
+    expect(screen.getByTestId('memory-conversion-cta')).toBeInTheDocument();
+  });
+
+  it('shows generic headline with fact count when no agentLabel', () => {
+    render(<MemoryConversionCTA factCount={4} />);
+    expect(
+      screen.getByTestId('memory-conversion-cta-headline')
+    ).toHaveTextContent('Your AI remembers 4 facts about you');
+  });
+
+  it('uses agent label in headline when provided', () => {
+    render(<MemoryConversionCTA factCount={7} agentLabel="Sage Bot" />);
+    expect(
+      screen.getByTestId('memory-conversion-cta-headline')
+    ).toHaveTextContent('Sage Bot remembers 7 facts about you');
+  });
+
+  it('handles singular fact count correctly', () => {
+    render(<MemoryConversionCTA factCount={1} />);
+    expect(
+      screen.getByTestId('memory-conversion-cta-headline')
+    ).toHaveTextContent('Your AI remembers 1 fact about you');
+  });
+
+  it('renders the upgrade CTA linking to /pricing', () => {
+    render(<MemoryConversionCTA factCount={4} />);
+    const upgrade = screen.getByTestId('memory-conversion-cta-upgrade');
+    expect(upgrade).toBeInTheDocument();
+    expect(upgrade).toHaveAttribute('href', '/pricing');
+  });
+
+  it('renders the view-all link pointing to settings memory anchor', () => {
+    render(<MemoryConversionCTA factCount={4} />);
+    const viewAll = screen.getByTestId('memory-conversion-cta-view-all');
+    expect(viewAll).toBeInTheDocument();
+    expect(viewAll).toHaveAttribute('href', '/dashboard/settings#memory');
+  });
+
+  it('renders premium memory description copy', () => {
+    render(<MemoryConversionCTA factCount={4} />);
+    expect(
+      screen.getByText(
+        /unlimited facts, categories, and export/i
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
+++ b/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
@@ -15,6 +15,7 @@ import {
   X,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { MemoryConversionCTA } from '@/components/memory-conversion-cta';
 import {
   Card,
   CardContent,
@@ -725,6 +726,11 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
                 ))}
               </div>
             </div>
+
+            <MemoryConversionCTA
+              factCount={facts.length}
+              agentLabel={settings.agentLabel}
+            />
 
             <div
               className="rounded-xl border border-primary/20 bg-primary/5 p-4"

--- a/apps/web/components/memory-conversion-cta.tsx
+++ b/apps/web/components/memory-conversion-cta.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { Brain, Sparkles } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface MemoryConversionCTAProps {
+  factCount: number;
+  agentLabel?: string;
+}
+
+export function MemoryConversionCTA({
+  factCount,
+  agentLabel,
+}: MemoryConversionCTAProps) {
+  const factLabel =
+    factCount === 1 ? '1 fact' : `${factCount} facts`;
+  const headline = agentLabel
+    ? `${agentLabel} remembers ${factLabel} about you`
+    : `Your AI remembers ${factLabel} about you`;
+
+  return (
+    <div
+      className="rounded-xl border border-primary/20 bg-primary/5 p-4"
+      data-testid="memory-conversion-cta"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 shrink-0 rounded-md bg-primary/10 p-1.5">
+            <Brain className="h-4 w-4 text-primary" />
+          </div>
+          <div className="space-y-1">
+            <p
+              className="text-sm font-semibold text-foreground"
+              data-testid="memory-conversion-cta-headline"
+            >
+              {headline}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Unlock premium memory for unlimited facts, categories, and
+              export — so nothing important gets forgotten.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button asChild size="sm">
+            <Link
+              href="/pricing"
+              data-testid="memory-conversion-cta-upgrade"
+            >
+              <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+              Unlock Premium Memory
+            </Link>
+          </Button>
+          <Button asChild size="sm" variant="outline">
+            <Link
+              href="/dashboard/settings#memory"
+              data-testid="memory-conversion-cta-view-all"
+            >
+              View all memories
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/pr-evidence/memory-control-conversion-proof.md
+++ b/docs/pr-evidence/memory-control-conversion-proof.md
@@ -1,0 +1,89 @@
+# Memory Control Conversion Proof
+
+## Summary
+
+Connects the verified memory event log (pinned facts panel) to a paid upgrade
+CTA so users see their saved facts — then are prompted to unlock premium memory.
+Closes the KPI loop between memory engagement and paid conversion.
+
+## What Was Added
+
+### New component: `MemoryConversionCTA`
+
+**File**: `apps/web/components/memory-conversion-cta.tsx`
+
+A subtle banner/card that appears after the fact review log inside
+`AgentPinnedFactsCard`. It surfaces:
+
+- **Headline**: "{AgentLabel} remembers {N} facts about you" (dynamic count)
+- **Primary CTA**: "Unlock Premium Memory" → `/pricing`
+- **Secondary CTA**: "View all memories" → `/dashboard/settings#memory`
+- **Test ID**: `memory-conversion-cta`
+
+### Integration point
+
+**File**: `apps/web/components/dashboard/AgentPinnedFactsCard.tsx`
+
+`MemoryConversionCTA` is rendered between the `fact-review-log` section and
+the `pinned-facts-receipts` section when `facts.length > 0`.
+
+```
+[fact-review-log]             ← existing: lists facts to audit
+[MemoryConversionCTA]         ← NEW: upgrade prompt with fact count
+[pinned-facts-receipts]       ← existing: recent memory receipts
+[Full memory ledger]          ← existing: full editable ledger
+```
+
+## Component Structure Diff
+
+### Before (AgentPinnedFactsCard.tsx, abbreviated)
+
+```tsx
+{facts.length > 0 && (
+  <>
+    <div data-testid="fact-review-log">...</div>
+    <div data-testid="pinned-facts-receipts">...</div>
+    <div className="space-y-3">Full memory ledger...</div>
+  </>
+)}
+```
+
+### After
+
+```tsx
+{facts.length > 0 && (
+  <>
+    <div data-testid="fact-review-log">...</div>
+    <MemoryConversionCTA factCount={facts.length} agentLabel={settings.agentLabel} />
+    <div data-testid="pinned-facts-receipts">...</div>
+    <div className="space-y-3">Full memory ledger...</div>
+  </>
+)}
+```
+
+## KPI Measurement
+
+| Signal | How to measure |
+|---|---|
+| **Impression** | Page views of `/dashboard/settings` with `fact-review-log` visible |
+| **Click — upgrade** | Clicks on `data-testid="memory-conversion-cta-upgrade"` (href: `/pricing`) |
+| **Click — view all** | Clicks on `data-testid="memory-conversion-cta-view-all"` |
+| **Conversion** | Paid subscription starts where referrer includes `/dashboard/settings` |
+
+**Baseline**: 0 (no CTA existed before this PR)
+
+**Target**: >2% CTR on the upgrade CTA within 24 h of deploy, measured via
+analytics referrer from the memory panel to `/pricing`.
+
+**Readout cadence**: Next-day analytics check on `/pricing` page referrer from
+`/dashboard/settings`.
+
+## Test Coverage
+
+`apps/web/__tests__/components/memory-conversion-cta.test.tsx`
+
+- CTA renders with fact count (plural/singular)
+- Headline includes agent label when provided
+- Upgrade CTA links to `/pricing`
+- View-all link points to `/dashboard/settings#memory`
+- Premium copy is present


### PR DESCRIPTION
## Source
backlog.md:125

## Description
Connect the verified memory event log to a paid onboarding CTA. After users see their saved facts in the memory review panel, a MemoryConversionCTA appears prompting upgrade to premium memory features. Closes the KPI loop between memory engagement and paid conversion.

## Changes
- `MemoryConversionCTA` component (`apps/web/components/memory-conversion-cta.tsx`): shows "{AgentLabel} remembers {N} facts about you" + primary upgrade CTA → `/pricing` + secondary "View all memories" → `/dashboard/settings#memory`
- Integrated into `AgentPinnedFactsCard` between the fact review log and pinned-facts-receipts sections (only shown when facts exist)
- 7 test cases covering CTA render, fact count (singular/plural), agent label, upgrade link, view-all link, and premium copy

## Evidence
\`docs/pr-evidence/memory-control-conversion-proof.md\` — CTA placement, component structure diff (before/after), KPI measurement notes (click-through rate on upgrade CTA from memory panel)

## Auth-only Proof
N/A

## KPI Readout
- Measure: clicks on \`data-testid="memory-conversion-cta-upgrade"\` / unique memory panel views
- Baseline: 0 (no CTA existed before)
- Target: >2% CTR within 24h of deploy
- Readout: next-day analytics check on /pricing referrer from /dashboard/settings