### PR TITLE
feat: Replika parity sprint — context connectors preview + check-in consent panel

### DIFF
--- a/apps/web/__tests__/components/check-in-consent-panel.test.tsx
+++ b/apps/web/__tests__/components/check-in-consent-panel.test.tsx
@@ -1,0 +1,228 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CheckInConsentPanel } from '../../components/agents/CheckInConsentPanel';
+
+describe('CheckInConsentPanel', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <CheckInConsentPanel
+        open={false}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByTestId('check-in-consent-panel')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the panel when open', () => {
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByTestId('check-in-consent-panel')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the agent name in the title', () => {
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Nova"
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('check-in-consent-title')).toHaveTextContent(
+      'Nova'
+    );
+  });
+
+  it('shows the default trigger label when no trigger is set', () => {
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('check-in-reason')).toHaveTextContent(
+      'based on your activity'
+    );
+  });
+
+  it('shows the correct trigger label for scheduled_window', () => {
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        settings={{ lastAutoMessageTrigger: 'scheduled_window' }}
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('check-in-reason')).toHaveTextContent(
+      'triggered by scheduled send window'
+    );
+  });
+
+  it('shows the correct trigger label for milestone', () => {
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        settings={{ lastAutoMessageTrigger: 'milestone' }}
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('check-in-reason')).toHaveTextContent(
+      'triggered by relationship milestone'
+    );
+  });
+
+  it('shows "anytime" for next window when nextEligibleSendAt is not set', () => {
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('check-in-next-window')).toHaveTextContent(
+      'anytime'
+    );
+  });
+
+  it('formats a valid nextEligibleSendAt date', () => {
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        settings={{ nextEligibleSendAt: '2026-06-09T09:00:00.000Z' }}
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    const windowEl = screen.getByTestId('check-in-next-window');
+    expect(windowEl).not.toHaveTextContent('anytime');
+    expect(windowEl.textContent).toContain('Jun');
+  });
+
+  it('does not show quiet hours when quietHoursEnabled is false', () => {
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        settings={{
+          quietHoursEnabled: false,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
+        }}
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByTestId('check-in-quiet-hours')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows quiet hours when quietHoursEnabled is true', () => {
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        settings={{
+          quietHoursEnabled: true,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
+        }}
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    const quietHours = screen.getByTestId('check-in-quiet-hours');
+    expect(quietHours).toHaveTextContent('22:00');
+    expect(quietHours).toHaveTextContent('08:00');
+  });
+
+  it('calls onAllow when Allow button is clicked', () => {
+    const onAllow = vi.fn();
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        onAllow={onAllow}
+        onMute={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('check-in-allow-button'));
+    expect(onAllow).toHaveBeenCalledOnce();
+  });
+
+  it('calls onMute when Mute button is clicked', () => {
+    const onMute = vi.fn();
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        onAllow={vi.fn()}
+        onMute={onMute}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('check-in-mute-button'));
+    expect(onMute).toHaveBeenCalledOnce();
+  });
+
+  it('calls onOpenChange with false when overlay is clicked', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={onOpenChange}
+        agentName="Aria"
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    const overlay = document.querySelector('.fixed.inset-0');
+    if (overlay) fireEvent.click(overlay);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/__tests__/components/context-connectors-preview.test.tsx
+++ b/apps/web/__tests__/components/context-connectors-preview.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ContextConnectorsPreview } from '../../components/agents/ContextConnectorsPreview';
+import type { ContextSource } from '../../components/agents/ContextConnectorsPreview';
+
+const SOURCES: ContextSource[] = [
+  { id: 'links', type: 'link', label: 'Links', active: true },
+  { id: 'photos', type: 'photo', label: 'Photos', active: true },
+  { id: 'app-data', type: 'app', label: 'App data', active: false },
+];
+
+describe('ContextConnectorsPreview', () => {
+  it('renders the panel with a toggle button', () => {
+    render(<ContextConnectorsPreview sources={SOURCES} />);
+
+    expect(
+      screen.getByTestId('context-connectors-preview')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('context-connectors-toggle')
+    ).toBeInTheDocument();
+  });
+
+  it('shows active source count badge when sources are active', () => {
+    render(<ContextConnectorsPreview sources={SOURCES} />);
+
+    const badge = screen.getByTestId('context-connectors-active-count');
+    expect(badge).toHaveTextContent('2 active');
+  });
+
+  it('hides the source list by default (collapsed)', () => {
+    render(<ContextConnectorsPreview sources={SOURCES} />);
+
+    expect(
+      screen.queryByTestId('context-connectors-list')
+    ).not.toBeInTheDocument();
+  });
+
+  it('expands to show source list on toggle click', () => {
+    render(<ContextConnectorsPreview sources={SOURCES} />);
+
+    fireEvent.click(screen.getByTestId('context-connectors-toggle'));
+
+    expect(
+      screen.getByTestId('context-connectors-list')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('context-source-links')).toBeInTheDocument();
+    expect(screen.getByTestId('context-source-photos')).toBeInTheDocument();
+    expect(screen.getByTestId('context-source-app-data')).toBeInTheDocument();
+  });
+
+  it('collapses source list on second toggle click', () => {
+    render(<ContextConnectorsPreview sources={SOURCES} />);
+
+    fireEvent.click(screen.getByTestId('context-connectors-toggle'));
+    fireEvent.click(screen.getByTestId('context-connectors-toggle'));
+
+    expect(
+      screen.queryByTestId('context-connectors-list')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows Active status for active sources', () => {
+    render(<ContextConnectorsPreview sources={SOURCES} />);
+    fireEvent.click(screen.getByTestId('context-connectors-toggle'));
+
+    expect(
+      screen.getByTestId('context-source-links-status')
+    ).toHaveTextContent('Active');
+    expect(
+      screen.getByTestId('context-source-photos-status')
+    ).toHaveTextContent('Active');
+  });
+
+  it('shows Inactive status for inactive sources', () => {
+    render(<ContextConnectorsPreview sources={SOURCES} />);
+    fireEvent.click(screen.getByTestId('context-connectors-toggle'));
+
+    expect(
+      screen.getByTestId('context-source-app-data-status')
+    ).toHaveTextContent('Inactive');
+  });
+
+  it('shows source labels in the expanded list', () => {
+    render(<ContextConnectorsPreview sources={SOURCES} />);
+    fireEvent.click(screen.getByTestId('context-connectors-toggle'));
+
+    expect(screen.getByTestId('context-source-links')).toHaveTextContent(
+      'Links'
+    );
+    expect(screen.getByTestId('context-source-photos')).toHaveTextContent(
+      'Photos'
+    );
+    expect(screen.getByTestId('context-source-app-data')).toHaveTextContent(
+      'App data'
+    );
+  });
+
+  it('shows zero active count when no sources are active', () => {
+    const inactiveSources: ContextSource[] = [
+      { id: 'links', type: 'link', label: 'Links', active: false },
+    ];
+    render(<ContextConnectorsPreview sources={inactiveSources} />);
+
+    expect(
+      screen.queryByTestId('context-connectors-active-count')
+    ).not.toBeInTheDocument();
+  });
+
+  it('uses default sources when none are provided', () => {
+    render(<ContextConnectorsPreview />);
+
+    const badge = screen.getByTestId('context-connectors-active-count');
+    expect(badge).toHaveTextContent('2 active');
+  });
+
+  it('sets aria-expanded to false when collapsed', () => {
+    render(<ContextConnectorsPreview sources={SOURCES} />);
+
+    expect(
+      screen.getByTestId('context-connectors-toggle')
+    ).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('sets aria-expanded to true when expanded', () => {
+    render(<ContextConnectorsPreview sources={SOURCES} />);
+
+    fireEvent.click(screen.getByTestId('context-connectors-toggle'));
+
+    expect(
+      screen.getByTestId('context-connectors-toggle')
+    ).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/apps/web/components/agents/CheckInConsentPanel.tsx
+++ b/apps/web/components/agents/CheckInConsentPanel.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import {
+  PROACTIVE_TRIGGER_LABELS,
+  type ProactiveTriggerSource,
+} from '@/lib/proactive-controls';
+
+interface CheckInConsentSettings {
+  lastAutoMessageTrigger?: ProactiveTriggerSource;
+  nextEligibleSendAt?: string;
+  quietHoursEnabled?: boolean;
+  quietHoursStart?: string;
+  quietHoursEnd?: string;
+}
+
+interface CheckInConsentPanelProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agentName: string;
+  settings?: CheckInConsentSettings;
+  onAllow: () => void;
+  onMute: () => void;
+}
+
+function formatNextSendWindow(nextEligibleSendAt?: string): string {
+  if (!nextEligibleSendAt) return 'anytime';
+  const date = new Date(nextEligibleSendAt);
+  if (Number.isNaN(date.getTime())) return 'anytime';
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function getTriggerLabel(trigger?: ProactiveTriggerSource): string {
+  if (!trigger) return 'based on your activity';
+  return PROACTIVE_TRIGGER_LABELS[trigger].toLowerCase();
+}
+
+export function CheckInConsentPanel({
+  open,
+  onOpenChange,
+  agentName,
+  settings = {},
+  onAllow,
+  onMute,
+}: CheckInConsentPanelProps) {
+  const nextWindow = formatNextSendWindow(settings.nextEligibleSendAt);
+  const triggerLabel = getTriggerLabel(settings.lastAutoMessageTrigger);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm" data-testid="check-in-consent-panel">
+        <DialogHeader>
+          <DialogTitle data-testid="check-in-consent-title">
+            Allow check-ins from {agentName}?
+          </DialogTitle>
+          <div
+            data-testid="check-in-consent-description"
+            className="mt-2 space-y-1.5 text-sm text-muted-foreground"
+          >
+            <p data-testid="check-in-reason">
+              Your agent may check in with you{' '}
+              <span className="font-medium text-foreground">{triggerLabel}</span>
+              .
+            </p>
+            <p data-testid="check-in-next-window">
+              Next possible message:{' '}
+              <span className="font-medium text-foreground">{nextWindow}</span>
+            </p>
+            {settings.quietHoursEnabled &&
+              settings.quietHoursStart &&
+              settings.quietHoursEnd && (
+                <p className="text-xs" data-testid="check-in-quiet-hours">
+                  Quiet hours: {settings.quietHoursStart}–
+                  {settings.quietHoursEnd}
+                </p>
+              )}
+          </div>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onMute}
+            data-testid="check-in-mute-button"
+          >
+            Mute
+          </Button>
+          <Button
+            type="button"
+            onClick={onAllow}
+            data-testid="check-in-allow-button"
+          >
+            Allow
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/agents/ContextConnectorsPreview.tsx
+++ b/apps/web/components/agents/ContextConnectorsPreview.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import { Link2, Image, Database, ChevronDown, ChevronUp } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface ContextSource {
+  id: string;
+  type: 'link' | 'photo' | 'app';
+  label: string;
+  active: boolean;
+}
+
+interface ContextConnectorsPreviewProps {
+  sources?: ContextSource[];
+  className?: string;
+}
+
+const DEFAULT_SOURCES: ContextSource[] = [
+  { id: 'links', type: 'link', label: 'Links', active: true },
+  { id: 'photos', type: 'photo', label: 'Photos', active: true },
+  { id: 'app-data', type: 'app', label: 'App data', active: false },
+];
+
+const SOURCE_ICONS = {
+  link: Link2,
+  photo: Image,
+  app: Database,
+} as const;
+
+export function ContextConnectorsPreview({
+  sources = DEFAULT_SOURCES,
+  className,
+}: ContextConnectorsPreviewProps) {
+  const [expanded, setExpanded] = useState(false);
+  const activeSources = sources.filter((s) => s.active);
+
+  return (
+    <div
+      data-testid="context-connectors-preview"
+      className={cn(
+        'rounded-2xl border border-border/80 bg-muted/40 px-4 py-3 text-sm',
+        className
+      )}
+    >
+      <button
+        type="button"
+        className="flex w-full items-center justify-between text-left"
+        onClick={() => setExpanded((v) => !v)}
+        data-testid="context-connectors-toggle"
+        aria-expanded={expanded}
+      >
+        <span className="font-medium text-foreground">
+          Context sources
+          {activeSources.length > 0 && (
+            <span
+              data-testid="context-connectors-active-count"
+              className="ml-2 rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-normal text-primary"
+            >
+              {activeSources.length} active
+            </span>
+          )}
+        </span>
+        {expanded ? (
+          <ChevronUp className="h-4 w-4 text-muted-foreground" aria-hidden />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-muted-foreground" aria-hidden />
+        )}
+      </button>
+
+      {expanded && (
+        <ul
+          data-testid="context-connectors-list"
+          className="mt-3 space-y-2"
+          role="list"
+        >
+          {sources.map((source) => {
+            const Icon = SOURCE_ICONS[source.type];
+            return (
+              <li
+                key={source.id}
+                data-testid={`context-source-${source.id}`}
+                className="flex items-center gap-2"
+              >
+                <Icon
+                  className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+                  aria-hidden
+                />
+                <span
+                  className={cn(
+                    source.active
+                      ? 'text-foreground'
+                      : 'text-muted-foreground'
+                  )}
+                >
+                  {source.label}
+                </span>
+                <span
+                  data-testid={`context-source-${source.id}-status`}
+                  className={cn(
+                    'ml-auto text-xs',
+                    source.active
+                      ? 'text-green-600 dark:text-green-400'
+                      : 'text-muted-foreground'
+                  )}
+                >
+                  {source.active ? 'Active' : 'Inactive'}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { Bell } from 'lucide-react';
 import type { Agent, Post } from '@agentgram/shared';
 import { ProfileHeader } from './ProfileHeader';
 import { ProfilePersona } from './ProfilePersona';
@@ -14,6 +15,8 @@ import { ProfileStarterScenarios } from './ProfileStarterScenarios';
 import { CreatorRail } from './CreatorRail';
 import { AiDisclosureBanner } from './AiDisclosureBanner';
 import { ProofStrip } from './ProofStrip';
+import { ContextConnectorsPreview } from './ContextConnectorsPreview';
+import { CheckInConsentPanel } from './CheckInConsentPanel';
 
 interface ProfileContentProps {
   agent: Agent;
@@ -29,6 +32,9 @@ export function ProfileContent({
   initialTab = 'posts',
 }: ProfileContentProps) {
   const [activeTab, setActiveTab] = useState<ProfileTab>(initialTab);
+  const [checkInOpen, setCheckInOpen] = useState(false);
+
+  const agentDisplayName = agent.displayName || agent.name;
 
   return (
     <div className="mx-auto max-w-5xl">
@@ -48,6 +54,11 @@ export function ProfileContent({
             <ProfileMediaGrid agentId={agent.id} />
           ) : (
             <div className="space-y-6">
+              {activeTab === 'posts' && (
+                <ContextConnectorsPreview
+                  data-testid="profile-context-connectors"
+                />
+              )}
               {activeTab === 'posts' &&
                 (agent.starterPrompts?.length ?? 0) > 0 && (
                   <ProfileStarterScenarios
@@ -58,6 +69,19 @@ export function ProfileContent({
                 agentId={agent.id}
                 type={activeTab === 'posts' ? 'authored' : 'liked'}
               />
+              {activeTab === 'posts' && (
+                <div className="flex justify-end">
+                  <button
+                    type="button"
+                    onClick={() => setCheckInOpen(true)}
+                    data-testid="open-check-in-consent"
+                    className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-muted/40 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  >
+                    <Bell className="h-3 w-3" aria-hidden />
+                    Enable check-ins
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -68,6 +92,14 @@ export function ProfileContent({
           recentWorkLog={recentWorkLog}
         />
       </div>
+
+      <CheckInConsentPanel
+        open={checkInOpen}
+        onOpenChange={setCheckInOpen}
+        agentName={agentDisplayName}
+        onAllow={() => setCheckInOpen(false)}
+        onMute={() => setCheckInOpen(false)}
+      />
     </div>
   );
 }

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Bell } from 'lucide-react';
 import type { Agent, Post } from '@agentgram/shared';
 import { ProfileHeader } from './ProfileHeader';
@@ -36,6 +36,18 @@ export function ProfileContent({
 
   const agentDisplayName = agent.displayName || agent.name;
 
+  const handleAllow = useCallback(async () => {
+    try {
+      await fetch('/api/v1/developers/me/proactive-controls', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ optIn: true }),
+      });
+    } finally {
+      setCheckInOpen(false);
+    }
+  }, []);
+
   return (
     <div className="mx-auto max-w-5xl">
       <AiDisclosureBanner />
@@ -55,9 +67,7 @@ export function ProfileContent({
           ) : (
             <div className="space-y-6">
               {activeTab === 'posts' && (
-                <ContextConnectorsPreview
-                  data-testid="profile-context-connectors"
-                />
+                <ContextConnectorsPreview />
               )}
               {activeTab === 'posts' &&
                 (agent.starterPrompts?.length ?? 0) > 0 && (
@@ -97,7 +107,7 @@ export function ProfileContent({
         open={checkInOpen}
         onOpenChange={setCheckInOpen}
         agentName={agentDisplayName}
-        onAllow={() => setCheckInOpen(false)}
+        onAllow={() => void handleAllow()}
         onMute={() => setCheckInOpen(false)}
       />
     </div>

--- a/docs/pr-evidence/replika-parity-sprint.md
+++ b/docs/pr-evidence/replika-parity-sprint.md
@@ -1,0 +1,119 @@
+# PR Evidence: Replika Parity Sprint
+
+## Summary
+
+Two new components shipped to close the Replika feature gap:
+
+1. **ContextConnectorsPreview** — pre-chat context panel
+2. **CheckInConsentPanel** — proactive check-in consent modal
+
+---
+
+## 1. ContextConnectorsPreview
+
+**File:** `apps/web/components/agents/ContextConnectorsPreview.tsx`
+
+**What it does:**
+A collapsible panel shown on the agent profile page (Posts tab) _before_ the first message is sent. It lists the context input types available to the agent — Links, Photos, App data — with Active/Inactive status for each.
+
+**UI description:**
+```
+┌────────────────────────────────────┐
+│ Context sources  [2 active]    ▼   │
+└────────────────────────────────────┘
+
+Expanded state:
+┌────────────────────────────────────┐
+│ Context sources  [2 active]    ▲   │
+│  🔗 Links                  Active  │
+│  🖼  Photos                 Active  │
+│  🗄  App data             Inactive  │
+└────────────────────────────────────┘
+```
+
+**Props:**
+| Prop | Type | Default |
+|------|------|---------|
+| `sources` | `ContextSource[]` | Links + Photos (active), App data (inactive) |
+| `className` | `string` | — |
+
+**ContextSource shape:**
+```ts
+{ id: string; type: 'link' | 'photo' | 'app'; label: string; active: boolean }
+```
+
+**Placement:** Injected in `ProfileContent.tsx` above `ProfileStarterScenarios` when the Posts tab is active.
+
+---
+
+## 2. CheckInConsentPanel
+
+**File:** `apps/web/components/agents/CheckInConsentPanel.tsx`
+
+**What it does:**
+A Dialog modal shown when the user taps "Enable check-ins" on an agent profile. Before opt-in is confirmed, the user sees:
+- The check-in trigger reason (e.g., "triggered by scheduled send window")
+- The next possible send window (formatted timestamp or "anytime")
+- Quiet hours range (if enabled)
+- **Mute** and **Allow** CTAs
+
+**UI description:**
+```
+┌──────────────────────────────────┐
+│  Allow check-ins from Aria?    ✕ │
+│                                  │
+│  Your agent may check in with    │
+│  you triggered by scheduled      │
+│  send window.                    │
+│                                  │
+│  Next possible message: Jun 9,   │
+│  09:00 AM                        │
+│                                  │
+│  Quiet hours: 22:00–08:00        │
+│                                  │
+│            [Mute]  [Allow]       │
+└──────────────────────────────────┘
+```
+
+**Props:**
+| Prop | Type | Notes |
+|------|------|-------|
+| `open` | `boolean` | Controls visibility |
+| `onOpenChange` | `(open: boolean) => void` | Dialog state handler |
+| `agentName` | `string` | Shown in modal title |
+| `settings` | `CheckInConsentSettings` | Optional; defaults to empty |
+| `onAllow` | `() => void` | Called on Allow click |
+| `onMute` | `() => void` | Called on Mute click |
+
+`settings` fields: `lastAutoMessageTrigger`, `nextEligibleSendAt`, `quietHoursEnabled`, `quietHoursStart`, `quietHoursEnd` — all optional. Maps to `ProactiveControlsSettings` from `lib/proactive-controls.ts`.
+
+**Trigger:** A small "Enable check-ins" pill button added to the bottom of the Posts tab in `ProfileContent.tsx`.
+
+---
+
+## Test Coverage
+
+**File:** `apps/web/__tests__/components/context-connectors-preview.test.tsx`
+- 12 tests — toggle collapse/expand, active count badge, source labels, aria-expanded, status text, default sources
+
+**File:** `apps/web/__tests__/components/check-in-consent-panel.test.tsx`
+- 13 tests — open/closed state, agent name, trigger labels, next window formatting, quiet hours display, Allow/Mute callbacks, overlay dismiss
+
+**Total: 25 tests, all passing.**
+
+```
+PASS (25) FAIL (0)
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/agents/ContextConnectorsPreview.tsx` | New component |
+| `apps/web/components/agents/CheckInConsentPanel.tsx` | New component |
+| `apps/web/components/agents/ProfileContent.tsx` | Wire-in: both components added to Posts tab |
+| `apps/web/__tests__/components/context-connectors-preview.test.tsx` | New tests (12) |
+| `apps/web/__tests__/components/check-in-consent-panel.test.tsx` | New tests (13) |
+| `docs/pr-evidence/replika-parity-sprint.md` | This file |


### PR DESCRIPTION
## Summary

Closes the Replika gap with two pre-chat / consent-layer features:

- **ContextConnectorsPreview** — compact collapsible panel on the agent profile Posts tab that surfaces available context inputs (Links, Photos, App data) with Active/Inactive status _before_ the first message is sent
- **CheckInConsentPanel** — Dialog modal that previews the check-in trigger reason, next send window, and optional quiet-hours range before the user opts in; exposes Mute and Allow CTAs. Allow fires a PUT to `/api/v1/developers/me/proactive-controls` with `{ optIn: true }`; Mute closes without mutation (opt-in stays false).

## Source

backlog.md:130

| File | Role |
|------|------|
| `apps/web/components/agents/ContextConnectorsPreview.tsx` | New component |
| `apps/web/components/agents/CheckInConsentPanel.tsx` | New component |
| `apps/web/components/agents/ProfileContent.tsx` | Wire-in (Posts tab) |
| `apps/web/__tests__/components/context-connectors-preview.test.tsx` | 12 unit tests |
| `apps/web/__tests__/components/check-in-consent-panel.test.tsx` | 13 unit tests |
| `docs/pr-evidence/replika-parity-sprint.md` | Full evidence doc with UI descriptions |

## Evidence

- **25 tests, 0 failures** (`vitest run` on new test files)
- Both components use existing `Dialog`, `Button`, Tailwind, and `proactive-controls` types — no new dependencies
- `CheckInConsentPanel` maps `lastAutoMessageTrigger` → `PROACTIVE_TRIGGER_LABELS` from `lib/proactive-controls.ts` for human-readable reasons
- `ContextConnectorsPreview` defaults to Links + Photos active, App data inactive; fully prop-driven for flexibility
- Allow handler calls `PUT /api/v1/developers/me/proactive-controls` with `{ optIn: true }` matching the existing `ProactiveControlsForm` pattern; unauthenticated visitors receive 401 which is silently swallowed (modal closes regardless)

## Auth-only Proof

N/A

## Test plan

- [ ] Visit any agent profile page (Posts tab) — ContextConnectorsPreview panel appears above starter scenarios
- [ ] Click the panel toggle — source list expands with correct Active/Inactive labels
- [ ] Click "Enable check-ins" pill at bottom of posts list — CheckInConsentPanel modal opens with agent name, reason, and next window
- [ ] Click Allow — modal closes and `PUT /api/v1/developers/me/proactive-controls` is called with `{ optIn: true }` (verify in DevTools Network tab when logged in as a developer)
- [ ] Click Mute — modal closes without API call
- [ ] Click the overlay — modal closes via onOpenChange(false)
- [ ] Run `npx vitest run __tests__/components/context-connectors-preview.test.tsx __tests__/components/check-in-consent-panel.test.tsx` in `apps/web/` — all 25 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)