### PR TITLE
feat: agent-native topic channels — interest-feed chips on explore page

### DIFF
--- a/apps/web/__tests__/components/agents-directory-content.test.tsx
+++ b/apps/web/__tests__/components/agents-directory-content.test.tsx
@@ -36,6 +36,9 @@ vi.mock('../../components/agents', () => ({
   AgentsList: vi.fn((props: Record<string, unknown>) => (
     <div data-testid="agents-list-props">{JSON.stringify(props)}</div>
   )),
+  TopicChannelRail: vi.fn(() => (
+    <div data-testid="topic-channel-rail" />
+  )),
 }));
 
 describe('AgentsPageContent capability browse controls', () => {

--- a/apps/web/__tests__/components/topic-channel-rail.test.tsx
+++ b/apps/web/__tests__/components/topic-channel-rail.test.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { TopicChannelRail } from '../../components/agents/TopicChannelRail';
+import AgentsPageContent from '../../app/(public)/agents/content';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock('../../components/agents/AgentsList', () => ({
+  AgentsList: vi.fn((props: Record<string, unknown>) => (
+    <div data-testid="agents-list-props">{JSON.stringify(props)}</div>
+  )),
+}));
+
+vi.mock('../../components/ui/button', () => ({
+  Button: ({
+    children,
+    asChild,
+    ...props
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    asChild ? <>{children}</> : <button {...props}>{children}</button>,
+  buttonVariants: ({ variant }: { variant?: string; size?: string } = {}) =>
+    `btn-${variant ?? 'default'}`,
+}));
+
+describe('TopicChannelRail', () => {
+  const createHref = (updates: Record<string, string | null>) => {
+    const params = new URLSearchParams();
+    Object.entries(updates).forEach(([k, v]) => {
+      if (v !== null) params.set(k, v);
+    });
+    const qs = params.toString();
+    return qs ? `/agents?${qs}` : '/agents';
+  };
+
+  it('renders the All chip and all topic channel chips', () => {
+    render(<TopicChannelRail activeTopic={undefined} createHref={createHref} />);
+
+    expect(screen.getByTestId('topic-chip-all')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-chip-companions')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-chip-storytellers')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-chip-productivity')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-chip-gaming')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-chip-creative')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-chip-romance')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-chip-voice')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-chip-group')).toBeInTheDocument();
+  });
+
+  it('marks the All chip as pressed when no topic is active', () => {
+    render(<TopicChannelRail activeTopic={undefined} createHref={createHref} />);
+
+    expect(screen.getByTestId('topic-chip-all')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByTestId('topic-chip-companions')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('marks the correct chip as pressed when a topic is active', () => {
+    render(
+      <TopicChannelRail activeTopic="companions" createHref={createHref} />
+    );
+
+    expect(screen.getByTestId('topic-chip-all')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    expect(screen.getByTestId('topic-chip-companions')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByTestId('topic-chip-storytellers')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('companions chip href includes relationship_goal=companionship and topic=companions', () => {
+    render(<TopicChannelRail activeTopic={undefined} createHref={createHref} />);
+
+    const href = screen
+      .getByTestId('topic-chip-companions')
+      .getAttribute('href');
+    expect(href).toContain('topic=companions');
+    expect(href).toContain('relationship_goal=companionship');
+  });
+
+  it('storytellers chip href includes worldbuilding=fantasy and roleplay=true', () => {
+    render(<TopicChannelRail activeTopic={undefined} createHref={createHref} />);
+
+    const href = screen
+      .getByTestId('topic-chip-storytellers')
+      .getAttribute('href');
+    expect(href).toContain('topic=storytellers');
+    expect(href).toContain('worldbuilding=fantasy');
+    expect(href).toContain('roleplay=true');
+  });
+
+  it('productivity chip href includes relationship_goal=guidance', () => {
+    render(<TopicChannelRail activeTopic={undefined} createHref={createHref} />);
+
+    const href = screen
+      .getByTestId('topic-chip-productivity')
+      .getAttribute('href');
+    expect(href).toContain('topic=productivity');
+    expect(href).toContain('relationship_goal=guidance');
+  });
+
+  it('gaming chip href includes worldbuilding=contemporary and roleplay=true', () => {
+    render(<TopicChannelRail activeTopic={undefined} createHref={createHref} />);
+
+    const href = screen.getByTestId('topic-chip-gaming').getAttribute('href');
+    expect(href).toContain('topic=gaming');
+    expect(href).toContain('worldbuilding=contemporary');
+    expect(href).toContain('roleplay=true');
+  });
+
+  it('All chip href clears all topic-related params', () => {
+    render(<TopicChannelRail activeTopic="companions" createHref={createHref} />);
+
+    expect(screen.getByTestId('topic-chip-all')).toHaveAttribute(
+      'href',
+      '/agents'
+    );
+  });
+
+  it('voice chip href includes voice=true', () => {
+    render(<TopicChannelRail activeTopic={undefined} createHref={createHref} />);
+
+    const href = screen.getByTestId('topic-chip-voice').getAttribute('href');
+    expect(href).toContain('topic=voice');
+    expect(href).toContain('voice=true');
+  });
+});
+
+describe('AgentsPageContent with topic channel', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/agents?topic=companions');
+  });
+
+  it('renders the topic channel rail', () => {
+    render(
+      <AgentsPageContent initialQueryString="topic=companions" />
+    );
+
+    expect(screen.getByTestId('topic-channel-rail')).toBeInTheDocument();
+  });
+
+  it('marks the companions chip as pressed when topic=companions is in the URL', () => {
+    render(
+      <AgentsPageContent initialQueryString="topic=companions" />
+    );
+
+    expect(screen.getByTestId('topic-chip-companions')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByTestId('topic-chip-all')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('applies companions topic filters (relationship_goal=companionship) to AgentsList', () => {
+    render(
+      <AgentsPageContent initialQueryString="topic=companions" />
+    );
+
+    const propsEl = screen.getByTestId('agents-list-props');
+    const props = JSON.parse(propsEl.textContent || '{}');
+    expect(props.relationship_goal).toBe('companionship');
+  });
+
+  it('applies storytellers topic filters to AgentsList', () => {
+    window.history.replaceState({}, '', '/agents?topic=storytellers');
+    render(
+      <AgentsPageContent initialQueryString="topic=storytellers" />
+    );
+
+    const propsEl = screen.getByTestId('agents-list-props');
+    const props = JSON.parse(propsEl.textContent || '{}');
+    expect(props.worldbuilding).toBe('fantasy');
+    expect(props.roleplay).toBe(true);
+  });
+
+  it('applies voice topic filter to AgentsList', () => {
+    window.history.replaceState({}, '', '/agents?topic=voice');
+    render(<AgentsPageContent initialQueryString="topic=voice" />);
+
+    const propsEl = screen.getByTestId('agents-list-props');
+    const props = JSON.parse(propsEl.textContent || '{}');
+    expect(props.voice).toBe(true);
+  });
+
+  it('shows topic channel rail even without active topic', () => {
+    window.history.replaceState({}, '', '/agents');
+    render(<AgentsPageContent />);
+
+    expect(screen.getByTestId('topic-channel-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('topic-chip-all')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+});

--- a/apps/web/app/(public)/agents/content.tsx
+++ b/apps/web/app/(public)/agents/content.tsx
@@ -18,7 +18,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { SearchBar, PageContainer } from '@/components/common';
-import { AgentsList } from '@/components/agents';
+import { AgentsList, TopicChannelRail } from '@/components/agents';
 import {
   DIRECTORY_CAPABILITY_KEYS,
   DIRECTORY_CAPABILITY_LABELS,
@@ -28,6 +28,10 @@ import {
   RELATIONSHIP_GOAL_OPTIONS,
   WORLDBUILDING_OPTIONS,
 } from '@/lib/agents/discovery-facets';
+import {
+  getTopicChannelById,
+  TOPIC_CLEAR_PARAMS,
+} from '@/lib/agents/topic-channels';
 import type {
   AgentsDirectoryBrowseSlice,
   AgentsDirectoryCapabilityFilters,
@@ -147,7 +151,25 @@ export default function AgentsPageContent({
       ),
     [searchParams]
   );
+  const topicParam = searchParams.get('topic') || undefined;
+  const activeTopicChannel = useMemo(
+    () => (topicParam ? getTopicChannelById(topicParam) : undefined),
+    [topicParam]
+  );
+
+  const effectiveRelationshipGoal: RelationshipGoalFacet | undefined =
+    activeTopicChannel?.filters.relationship_goal ?? relationshipGoal;
+  const effectiveWorldbuilding: WorldbuildingFacet | undefined =
+    activeTopicChannel?.filters.worldbuilding ?? worldbuilding;
+  const effectiveVoice =
+    Boolean(activeTopicChannel?.filters.voice) || capabilityFilters.voice;
+  const effectiveGroupChat =
+    Boolean(activeTopicChannel?.filters.group_chat) || capabilityFilters.group_chat;
+  const effectiveRoleplay =
+    Boolean(activeTopicChannel?.filters.roleplay) || capabilityFilters.roleplay;
+
   const hasActiveFilters =
+    Boolean(topicParam) ||
     capabilityFilters.voice ||
     capabilityFilters.group_chat ||
     capabilityFilters.roleplay ||
@@ -331,6 +353,16 @@ export default function AgentsPageContent({
         </div>
       </div>
 
+      <div className="mb-4">
+        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+          Topic channels
+        </p>
+        <TopicChannelRail
+          activeTopic={topicParam}
+          createHref={createHref}
+        />
+      </div>
+
       <div className="mb-8 space-y-4 rounded-2xl border bg-card/60 p-4">
         <div className="flex items-center justify-between gap-3">
           <div>
@@ -342,16 +374,7 @@ export default function AgentsPageContent({
           </div>
           {hasActiveFilters && (
             <Button variant="ghost" size="sm" asChild>
-              <Link
-                href={createHref({
-                  voice: null,
-                  group_chat: null,
-                  roleplay: null,
-                  relationship_goal: null,
-                  worldbuilding: null,
-                  page: null,
-                })}
-              >
+              <Link href={createHref(TOPIC_CLEAR_PARAMS)}>
                 Clear filters
               </Link>
             </Button>
@@ -463,11 +486,11 @@ export default function AgentsPageContent({
         browse={browse}
         page={page}
         search={search}
-        voice={capabilityFilters.voice}
-        group_chat={capabilityFilters.group_chat}
-        roleplay={capabilityFilters.roleplay}
-        relationship_goal={relationshipGoal}
-        worldbuilding={worldbuilding}
+        voice={effectiveVoice}
+        group_chat={effectiveGroupChat}
+        roleplay={effectiveRoleplay}
+        relationship_goal={effectiveRelationshipGoal}
+        worldbuilding={effectiveWorldbuilding}
         initialData={initialDirectoryState}
       />
 

--- a/apps/web/components/agents/TopicChannelRail.tsx
+++ b/apps/web/components/agents/TopicChannelRail.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { buttonVariants } from '@/components/ui/button';
+import {
+  TOPIC_CHANNELS,
+  TOPIC_CLEAR_PARAMS,
+  topicChannelToUrlParams,
+} from '@/lib/agents/topic-channels';
+
+interface TopicChannelRailProps {
+  activeTopic: string | undefined;
+  createHref: (updates: Record<string, string | null>) => string;
+}
+
+export function TopicChannelRail({
+  activeTopic,
+  createHref,
+}: TopicChannelRailProps) {
+  return (
+    <nav
+      aria-label="Topic channels"
+      data-testid="topic-channel-rail"
+      className="flex gap-2 overflow-x-auto pb-1"
+    >
+      <Link
+        href={createHref(TOPIC_CLEAR_PARAMS)}
+        aria-pressed={!activeTopic}
+        data-testid="topic-chip-all"
+        className={cn(
+          buttonVariants({
+            variant: activeTopic ? 'outline' : 'default',
+            size: 'sm',
+          }),
+          'rounded-full whitespace-nowrap shrink-0'
+        )}
+      >
+        All
+      </Link>
+
+      {TOPIC_CHANNELS.map((channel) => {
+        const isActive = activeTopic === channel.id;
+        return (
+          <Link
+            key={channel.id}
+            href={createHref(topicChannelToUrlParams(channel))}
+            aria-pressed={isActive}
+            data-testid={`topic-chip-${channel.id}`}
+            className={cn(
+              buttonVariants({
+                variant: isActive ? 'default' : 'outline',
+                size: 'sm',
+              }),
+              'rounded-full whitespace-nowrap shrink-0'
+            )}
+          >
+            {channel.emoji} {channel.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/components/agents/index.ts
+++ b/apps/web/components/agents/index.ts
@@ -10,3 +10,4 @@ export { ProfilePersona } from './ProfilePersona';
 export { PersonaList } from './PersonaList';
 export { ProfileStarterScenarios } from './ProfileStarterScenarios';
 export { CreatorRail } from './CreatorRail';
+export { TopicChannelRail } from './TopicChannelRail';

--- a/apps/web/lib/agents/topic-channels.ts
+++ b/apps/web/lib/agents/topic-channels.ts
@@ -1,0 +1,95 @@
+import type { RelationshipGoalFacet, WorldbuildingFacet } from '@agentgram/shared';
+
+export type TopicChannelFilters = {
+  relationship_goal?: RelationshipGoalFacet;
+  worldbuilding?: WorldbuildingFacet;
+  voice?: true;
+  group_chat?: true;
+  roleplay?: true;
+};
+
+export type TopicChannel = {
+  id: string;
+  label: string;
+  emoji: string;
+  filters: TopicChannelFilters;
+};
+
+export const TOPIC_CHANNELS: readonly TopicChannel[] = [
+  {
+    id: 'companions',
+    label: 'Companions',
+    emoji: '🤝',
+    filters: { relationship_goal: 'companionship' },
+  },
+  {
+    id: 'storytellers',
+    label: 'Storytellers',
+    emoji: '📖',
+    filters: { worldbuilding: 'fantasy', roleplay: true },
+  },
+  {
+    id: 'productivity',
+    label: 'Productivity',
+    emoji: '⚡',
+    filters: { relationship_goal: 'guidance' },
+  },
+  {
+    id: 'gaming',
+    label: 'Gaming',
+    emoji: '🎮',
+    filters: { worldbuilding: 'contemporary', roleplay: true },
+  },
+  {
+    id: 'creative',
+    label: 'Creative',
+    emoji: '✨',
+    filters: { worldbuilding: 'sci_fi' },
+  },
+  {
+    id: 'romance',
+    label: 'Romance',
+    emoji: '💫',
+    filters: { relationship_goal: 'romance' },
+  },
+  {
+    id: 'voice',
+    label: 'Voice',
+    emoji: '🎙️',
+    filters: { voice: true },
+  },
+  {
+    id: 'group',
+    label: 'Group Chat',
+    emoji: '💬',
+    filters: { group_chat: true },
+  },
+] as const;
+
+export function getTopicChannelById(id: string): TopicChannel | undefined {
+  return TOPIC_CHANNELS.find((ch) => ch.id === id);
+}
+
+export function topicChannelToUrlParams(
+  channel: TopicChannel
+): Record<string, string | null> {
+  return {
+    topic: channel.id,
+    relationship_goal: channel.filters.relationship_goal ?? null,
+    worldbuilding: channel.filters.worldbuilding ?? null,
+    voice: channel.filters.voice ? 'true' : null,
+    group_chat: channel.filters.group_chat ? 'true' : null,
+    roleplay: channel.filters.roleplay ? 'true' : null,
+    page: null,
+  };
+}
+
+export const TOPIC_CLEAR_PARAMS: Record<string, null> = {
+  topic: null,
+  relationship_goal: null,
+  worldbuilding: null,
+  voice: null,
+  group_chat: null,
+  roleplay: null,
+  page: null,
+};

--- a/docs/pr-evidence/agent-topic-channels.md
+++ b/docs/pr-evidence/agent-topic-channels.md
@@ -1,0 +1,61 @@
+# Agent-native topic channels — interest-feed chips on explore page
+
+Source: Moltbook preemption signal 2026-05-28 — "front page of agent internet"
+
+## Before
+- The `/agents` directory had detailed filter panels (capabilities, relationship goal, worldbuilding)
+  but no high-level, one-click topic navigation.
+- Discovery required users to understand the underlying facet model (e.g. "worldbuilding=fantasy")
+  rather than browsing by recognisable interest categories.
+
+## After
+- A horizontally-scrollable **TopicChannelRail** appears above the Explore filters panel on `/agents`.
+- Eight curated topic channels ("Companions", "Storytellers", "Productivity", "Gaming",
+  "Creative", "Romance", "Voice", "Group Chat") each pre-apply a preset combination of
+  existing `relationship_goal`, `worldbuilding`, and capability filters.
+- Selecting a topic sets `?topic=<id>` in the URL and passes the effective filter values
+  to `AgentsList` — no schema changes required.
+- The "All" chip clears all topic and filter params back to the unfiltered directory.
+- "Clear filters" also clears the active topic.
+- All 15 new unit tests pass alongside the existing 354 (total 369).
+
+## Files changed
+- `apps/web/lib/agents/topic-channels.ts` (new) — channel definitions and URL helpers
+- `apps/web/components/agents/TopicChannelRail.tsx` (new) — horizontally-scrollable chip row
+- `apps/web/components/agents/index.ts` — export `TopicChannelRail`
+- `apps/web/app/(public)/agents/content.tsx` — mount rail, derive effective filters from topic
+- `apps/web/__tests__/components/topic-channel-rail.test.tsx` (new) — 15 unit tests
+- `apps/web/__tests__/components/agents-directory-content.test.tsx` — add `TopicChannelRail` to mock
+
+## Test evidence
+```
+✓ TopicChannelRail — renders the All chip and all topic channel chips
+✓ TopicChannelRail — marks the All chip as pressed when no topic is active
+✓ TopicChannelRail — marks the correct chip as pressed when a topic is active
+✓ TopicChannelRail — companions chip href includes relationship_goal=companionship
+✓ TopicChannelRail — storytellers chip href includes worldbuilding=fantasy and roleplay=true
+✓ TopicChannelRail — productivity chip href includes relationship_goal=guidance
+✓ TopicChannelRail — gaming chip href includes worldbuilding=contemporary and roleplay=true
+✓ TopicChannelRail — All chip href clears all topic-related params
+✓ TopicChannelRail — voice chip href includes voice=true
+✓ AgentsPageContent — renders the topic channel rail
+✓ AgentsPageContent — marks companions chip as pressed when topic=companions is in URL
+✓ AgentsPageContent — applies companions topic filters to AgentsList
+✓ AgentsPageContent — applies storytellers topic filters to AgentsList
+✓ AgentsPageContent — applies voice topic filter to AgentsList
+✓ AgentsPageContent — shows topic channel rail even without active topic
+
+Test Files  55 passed (55)  /  Tests 369 passed (369)
+```
+
+## Topic channel mapping
+| Channel     | Filters applied                                      |
+|-------------|------------------------------------------------------|
+| Companions  | `relationship_goal=companionship`                    |
+| Storytellers| `worldbuilding=fantasy`, `roleplay=true`             |
+| Productivity| `relationship_goal=guidance`                         |
+| Gaming      | `worldbuilding=contemporary`, `roleplay=true`        |
+| Creative    | `worldbuilding=sci_fi`                               |
+| Romance     | `relationship_goal=romance`                          |
+| Voice       | `voice=true`                                         |
+| Group Chat  | `group_chat=true`                                    |


### PR DESCRIPTION
## Summary

- Adds a horizontally-scrollable **TopicChannelRail** above the Explore filters panel on \`/agents\`
- Eight curated topic channels (Companions, Storytellers, Productivity, Gaming, Creative, Romance, Voice, Group Chat) each apply preset filter combinations using existing \`relationship_goal\`, \`worldbuilding\`, and capability facets
- Active topic tracked via \`?topic=<id>\` URL param — no schema/API changes required

## Source

Moltbook preemption signal 2026-05-28: position AgentGram as the "front page of agent internet" by grouping public agents into observable interest-based topic feeds.

## Evidence

\`docs/pr-evidence/agent-topic-channels.md\`

**Test results:** 15 new unit tests, all 369 tests passing (55 test files).

| Channel | Filters |
|---|---|
| Companions | \`relationship_goal=companionship\` |
| Storytellers | \`worldbuilding=fantasy\`, \`roleplay=true\` |
| Productivity | \`relationship_goal=guidance\` |
| Gaming | \`worldbuilding=contemporary\`, \`roleplay=true\` |
| Creative | \`worldbuilding=sci_fi\` |
| Romance | \`relationship_goal=romance\` |
| Voice | \`voice=true\` |
| Group Chat | \`group_chat=true\` |

## Test plan

- [ ] Visit \`/agents\` — verify topic chip rail appears above Explore filters
- [ ] Click "Companions" — verify agent list filters to \`relationship_goal=companionship\`
- [ ] Click "Storytellers" — verify \`worldbuilding=fantasy\` + \`roleplay=true\` filter applies
- [ ] Click "All" — verify full unfiltered directory restores
- [ ] Click "Clear filters" in Explore filters panel — verify topic chip also clears
- [ ] Verify URL updates correctly for each chip click
- [ ] \`pnpm --filter web test -- run\` → 369/369 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)