### PR TITLE
feat: external context consent ledger — show context sources before proactive replies

### DIFF
--- a/apps/web/app/settings/context-sources/page.tsx
+++ b/apps/web/app/settings/context-sources/page.tsx
@@ -24,7 +24,7 @@ const SOURCE_TYPES = [
   {
     icon: Image,
     label: 'Photos',
-    description: 'Images you've uploaded that your agent can analyze.',
+    description: "Images you've uploaded that your agent can analyze.",
     colorClass: 'text-purple-600 dark:text-purple-400',
     bgClass: 'bg-purple-500/10',
   },

--- a/apps/web/app/settings/context-sources/page.tsx
+++ b/apps/web/app/settings/context-sources/page.tsx
@@ -1,0 +1,122 @@
+import { createClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+import { Globe, Link2, Image, AppWindow, Settings2 } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export const metadata = {
+  title: 'Connected Context Sources',
+};
+
+const SOURCE_TYPES = [
+  {
+    icon: Link2,
+    label: 'Links',
+    description: 'Web URLs shared with your agent or referenced in conversation.',
+    colorClass: 'text-blue-600 dark:text-blue-400',
+    bgClass: 'bg-blue-500/10',
+  },
+  {
+    icon: Image,
+    label: 'Photos',
+    description: 'Images you've uploaded that your agent can analyze.',
+    colorClass: 'text-purple-600 dark:text-purple-400',
+    bgClass: 'bg-purple-500/10',
+  },
+  {
+    icon: AppWindow,
+    label: 'Apps',
+    description: 'Third-party services connected to your agent (e.g. Spotify, Calendar).',
+    colorClass: 'text-emerald-600 dark:text-emerald-400',
+    bgClass: 'bg-emerald-500/10',
+  },
+  {
+    icon: Globe,
+    label: 'Internet',
+    description: 'Live web searches your agent performs to personalize replies.',
+    colorClass: 'text-amber-600 dark:text-amber-400',
+    bgClass: 'bg-amber-500/10',
+  },
+];
+
+export default async function ContextSourcesPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/auth/login');
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-8 p-6 md:p-8">
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-2">
+          <Settings2 className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          <h1 className="text-2xl font-bold tracking-tight">
+            Connected Context Sources
+          </h1>
+        </div>
+        <p className="text-muted-foreground">
+          Control which external sources your agent is allowed to read before
+          sending a proactive message or check-in. Disabling a source prevents
+          your agent from accessing that data type.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Context source types</CardTitle>
+          <CardDescription>
+            Each source type below can be individually toggled. Changes take
+            effect on the next proactive reply.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ul className="divide-y divide-border/50" data-testid="context-source-type-list">
+            {SOURCE_TYPES.map((source) => {
+              const Icon = source.icon;
+              return (
+                <li
+                  key={source.label}
+                  className="flex items-start gap-4 py-4 first:pt-0 last:pb-0"
+                >
+                  <div
+                    className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${source.bgClass}`}
+                  >
+                    <Icon
+                      className={`h-4 w-4 ${source.colorClass}`}
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <div className="flex-1 space-y-0.5">
+                    <p className="text-sm font-medium">{source.label}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {source.description}
+                    </p>
+                  </div>
+                  <span className="mt-1 rounded-full border border-border/60 bg-muted/40 px-2.5 py-0.5 text-xs text-muted-foreground">
+                    Coming soon
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <p className="text-center text-xs text-muted-foreground">
+        Granular per-source toggles will be available in a future release.{' '}
+        <a href="/dashboard/settings" className="text-primary hover:underline">
+          Back to settings
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/agents/CheckInConsentPanel.tsx
+++ b/apps/web/components/agents/CheckInConsentPanel.tsx
@@ -12,6 +12,10 @@ import {
   PROACTIVE_TRIGGER_LABELS,
   type ProactiveTriggerSource,
 } from '@/lib/proactive-controls';
+import {
+  ExternalContextLedger,
+  type ContextSourceEntry,
+} from '@/components/external-context-ledger';
 
 interface CheckInConsentSettings {
   lastAutoMessageTrigger?: ProactiveTriggerSource;
@@ -26,6 +30,7 @@ interface CheckInConsentPanelProps {
   onOpenChange: (open: boolean) => void;
   agentName: string;
   settings?: CheckInConsentSettings;
+  contextSources?: ContextSourceEntry[];
   onAllow: () => void;
   onMute: () => void;
 }
@@ -52,6 +57,7 @@ export function CheckInConsentPanel({
   onOpenChange,
   agentName,
   settings = {},
+  contextSources,
   onAllow,
   onMute,
 }: CheckInConsentPanelProps) {
@@ -88,6 +94,9 @@ export function CheckInConsentPanel({
               )}
           </div>
         </DialogHeader>
+        {contextSources !== undefined && (
+          <ExternalContextLedger sources={contextSources} className="mt-2" />
+        )}
         <DialogFooter className="gap-2 sm:gap-0">
           <Button
             type="button"

--- a/apps/web/components/external-context-ledger.test.tsx
+++ b/apps/web/components/external-context-ledger.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  ExternalContextLedger,
+  type ContextSourceEntry,
+} from './external-context-ledger';
+
+const ALL_SOURCE_TYPES: ContextSourceEntry[] = [
+  {
+    type: 'link',
+    timestamp: '2026-06-09T08:00:00.000Z',
+    description: 'Checked a shared article you sent earlier.',
+    label: 'example.com',
+  },
+  {
+    type: 'photo',
+    timestamp: '2026-06-09T08:01:00.000Z',
+    description: 'Analyzed the photo you uploaded yesterday.',
+  },
+  {
+    type: 'app',
+    timestamp: '2026-06-09T08:02:00.000Z',
+    description: 'Read your recent activity from the connected app.',
+    label: 'Spotify',
+  },
+  {
+    type: 'internet',
+    timestamp: '2026-06-09T08:03:00.000Z',
+    description: 'Searched the web for the latest news on your topic.',
+  },
+];
+
+describe('ExternalContextLedger', () => {
+  it('renders the ledger container', () => {
+    render(<ExternalContextLedger sources={[]} />);
+    expect(
+      screen.getByTestId('external-context-ledger')
+    ).toBeInTheDocument();
+  });
+
+  it('renders all 4 context source types', () => {
+    render(<ExternalContextLedger sources={ALL_SOURCE_TYPES} />);
+
+    expect(screen.getByTestId('context-source-type-link')).toHaveTextContent(
+      'Link'
+    );
+    expect(screen.getByTestId('context-source-type-photo')).toHaveTextContent(
+      'Photo'
+    );
+    expect(screen.getByTestId('context-source-type-app')).toHaveTextContent(
+      'App'
+    );
+    expect(
+      screen.getByTestId('context-source-type-internet')
+    ).toHaveTextContent('Internet');
+  });
+
+  it('renders a list item for each source', () => {
+    render(<ExternalContextLedger sources={ALL_SOURCE_TYPES} />);
+
+    expect(
+      screen.getByTestId('context-source-entry-link')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('context-source-entry-photo')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('context-source-entry-app')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('context-source-entry-internet')
+    ).toBeInTheDocument();
+  });
+
+  it('shows empty state when no context sources provided', () => {
+    render(<ExternalContextLedger sources={[]} />);
+
+    expect(
+      screen.getByTestId('external-context-ledger-empty')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('external-context-ledger-list')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show empty state when sources are provided', () => {
+    render(<ExternalContextLedger sources={ALL_SOURCE_TYPES} />);
+
+    expect(
+      screen.queryByTestId('external-context-ledger-empty')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('external-context-ledger-list')
+    ).toBeInTheDocument();
+  });
+
+  it('"Manage connected sources" link is always present', () => {
+    render(<ExternalContextLedger sources={[]} />);
+
+    const link = screen.getByTestId('manage-context-sources-link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/settings/context-sources');
+  });
+
+  it('"Manage connected sources" link is present with sources', () => {
+    render(<ExternalContextLedger sources={ALL_SOURCE_TYPES} />);
+
+    const link = screen.getByTestId('manage-context-sources-link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/settings/context-sources');
+  });
+
+  it('renders the source description for each entry', () => {
+    render(<ExternalContextLedger sources={ALL_SOURCE_TYPES} />);
+
+    expect(
+      screen.getByText('Checked a shared article you sent earlier.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Searched the web for the latest news on your topic.')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/external-context-ledger.tsx
+++ b/apps/web/components/external-context-ledger.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import Link from 'next/link';
+import { Globe, Image, AppWindow, Link2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type ContextSourceType = 'link' | 'photo' | 'app' | 'internet';
+
+export interface ContextSourceEntry {
+  type: ContextSourceType;
+  timestamp: string;
+  description: string;
+  label?: string;
+}
+
+interface ExternalContextLedgerProps {
+  sources: ContextSourceEntry[];
+  className?: string;
+}
+
+const SOURCE_META: Record<
+  ContextSourceType,
+  { icon: React.ElementType; label: string; colorClass: string }
+> = {
+  link: {
+    icon: Link2,
+    label: 'Link',
+    colorClass: 'text-blue-600 dark:text-blue-400',
+  },
+  photo: {
+    icon: Image,
+    label: 'Photo',
+    colorClass: 'text-purple-600 dark:text-purple-400',
+  },
+  app: {
+    icon: AppWindow,
+    label: 'App',
+    colorClass: 'text-emerald-600 dark:text-emerald-400',
+  },
+  internet: {
+    icon: Globe,
+    label: 'Internet',
+    colorClass: 'text-amber-600 dark:text-amber-400',
+  },
+};
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function ExternalContextLedger({
+  sources,
+  className,
+}: ExternalContextLedgerProps) {
+  return (
+    <div
+      className={cn('space-y-2', className)}
+      data-testid="external-context-ledger"
+    >
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Context read before this reply
+        </p>
+        <Link
+          href="/settings/context-sources"
+          className="text-xs text-primary hover:underline"
+          data-testid="manage-context-sources-link"
+        >
+          Manage connected sources
+        </Link>
+      </div>
+
+      {sources.length === 0 ? (
+        <p
+          className="text-xs text-muted-foreground py-2"
+          data-testid="external-context-ledger-empty"
+        >
+          No external context was read.
+        </p>
+      ) : (
+        <ul className="space-y-1.5" data-testid="external-context-ledger-list">
+          {sources.map((entry, i) => {
+            const meta = SOURCE_META[entry.type];
+            const Icon = meta.icon;
+            return (
+              <li
+                key={i}
+                className="flex items-start gap-2.5 rounded-lg border border-border/50 bg-muted/30 px-3 py-2"
+                data-testid={`context-source-entry-${entry.type}`}
+              >
+                <Icon
+                  className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', meta.colorClass)}
+                  aria-hidden="true"
+                />
+                <div className="min-w-0 flex-1 space-y-0.5">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="text-xs font-semibold text-foreground"
+                      data-testid={`context-source-type-${entry.type}`}
+                    >
+                      {meta.label}
+                    </span>
+                    {entry.label && (
+                      <span className="truncate text-xs text-muted-foreground">
+                        {entry.label}
+                      </span>
+                    )}
+                    <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                      {formatTimestamp(entry.timestamp)}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {entry.description}
+                  </p>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/global.d.ts
+++ b/apps/web/global.d.ts
@@ -1,1 +1,3 @@
+/// <reference types="@testing-library/jest-dom" />
+
 declare module "*.css";

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -12,7 +12,10 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./__tests__/setup.ts'],
-    include: ['__tests__/**/*.test.{ts,tsx}'],
+    include: [
+      '__tests__/**/*.test.{ts,tsx}',
+      'components/**/*.test.{ts,tsx}',
+    ],
     css: false,
   },
   resolve: {

--- a/docs/pr-evidence/external-context-consent-ledger.md
+++ b/docs/pr-evidence/external-context-consent-ledger.md
@@ -1,0 +1,105 @@
+# PR Evidence — External Context Consent Ledger
+
+**Backlog row:** 144 — [STRATEGY] External context transparency sprint
+
+## Before
+
+The `CheckInConsentPanel` showed a simple Allow / Mute prompt with no visibility
+into which external data sources the agent had read before generating the outreach.
+
+```
+┌─────────────────────────────────────────────┐
+│  Allow check-ins from Aria?                 │
+│                                             │
+│  Your agent may check in with you           │
+│  based on your activity.                    │
+│                                             │
+│  Next possible message: anytime             │
+│                                             │
+│          [ Mute ]    [ Allow ]              │
+└─────────────────────────────────────────────┘
+```
+
+Users had no way to know which external context (web links, photos, connected apps,
+internet searches) the agent accessed before deciding to reach out.
+
+---
+
+## After
+
+The `CheckInConsentPanel` now renders an `ExternalContextLedger` section (when
+`contextSources` prop is supplied) showing exactly what context was read, with a
+direct link to `/settings/context-sources` to manage permissions.
+
+```
+┌─────────────────────────────────────────────┐
+│  Allow check-ins from Aria?                 │
+│                                             │
+│  Your agent may check in with you           │
+│  based on your activity.                    │
+│                                             │
+│  Next possible message: anytime             │
+│                                             │
+│  CONTEXT READ BEFORE THIS REPLY  [Manage ↗] │
+│  ┌──────────────────────────────────────┐   │
+│  │ 🔗 Link  example.com        Jun 9    │   │
+│  │    Checked a shared article you sent │   │
+│  ├──────────────────────────────────────┤   │
+│  │ 🌐 Internet              Jun 9 08:03 │   │
+│  │    Searched web for latest news      │   │
+│  └──────────────────────────────────────┘   │
+│                                             │
+│          [ Mute ]    [ Allow ]              │
+└─────────────────────────────────────────────┘
+```
+
+### ExternalContextLedger standalone (empty state)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ CONTEXT READ BEFORE THIS REPLY        Manage connected sources│
+│                                                              │
+│  No external context was read.                               │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### `/settings/context-sources` placeholder page
+
+```
+⚙ Connected Context Sources
+─────────────────────────────────────────────────
+Control which external sources your agent is allowed to read
+before sending a proactive message or check-in.
+
+┌──────────────────────────────────────────────────────────────┐
+│ Context source types                                         │
+│ Each source type below can be individually toggled.          │
+│──────────────────────────────────────────────────────────────│
+│ 🔗  Links                                    [Coming soon]   │
+│     Web URLs shared with your agent...                       │
+│──────────────────────────────────────────────────────────────│
+│ 🖼  Photos                                   [Coming soon]   │
+│     Images you've uploaded...                                │
+│──────────────────────────────────────────────────────────────│
+│ 🟩  Apps                                     [Coming soon]   │
+│     Third-party services connected...                        │
+│──────────────────────────────────────────────────────────────│
+│ 🌐  Internet                                 [Coming soon]   │
+│     Live web searches your agent performs...                 │
+└──────────────────────────────────────────────────────────────┘
+
+                        Back to settings
+```
+
+---
+
+## Components created / modified
+
+| File | Status |
+|---|---|
+| `apps/web/components/external-context-ledger.tsx` | New |
+| `apps/web/components/external-context-ledger.test.tsx` | New |
+| `apps/web/components/agents/CheckInConsentPanel.tsx` | Modified |
+| `apps/web/app/settings/context-sources/page.tsx` | New |
+| `apps/web/vitest.config.ts` | Modified (added `components/**` include) |
+| `docs/pr-evidence/external-context-consent-ledger.md` | New |


### PR DESCRIPTION
## Source

backlog.md:144

## Summary

- **Source:** backlog.md row 144 — [STRATEGY] External context transparency sprint — consent ledger + context inputs 단일 PR
- Adds `ExternalContextLedger` component that lists which external context sources (Link, Photo, App, Internet) the agent accessed before sending a proactive reply
- Wires `ExternalContextLedger` into `CheckInConsentPanel` via optional `contextSources` prop so users see what was read before they decide to allow or mute check-ins
- Adds an auth-gated `/settings/context-sources` placeholder page where users can eventually manage per-source permissions
- Extends vitest config to discover component-colocated test files (`components/**/*.test.{ts,tsx}`)

## What was built

| File | Change |
|---|---|
| `apps/web/components/external-context-ledger.tsx` | New — `ExternalContextLedger` component with 4 source types, empty state, and "Manage connected sources" link |
| `apps/web/components/external-context-ledger.test.tsx` | New — 8 unit tests covering all source types, empty state, and link presence |
| `apps/web/components/agents/CheckInConsentPanel.tsx` | Modified — accepts optional `contextSources?: ContextSourceEntry[]` prop; renders ledger between description and action buttons |
| `apps/web/app/settings/context-sources/page.tsx` | New — server component with Supabase auth check; redirects to `/auth/login` if unauthenticated |
| `apps/web/vitest.config.ts` | Modified — added `components/**/*.test.{ts,tsx}` to `include` |
| `docs/pr-evidence/external-context-consent-ledger.md` | New — ASCII before/after UI mockups |

## Evidence

### Before (CheckInConsentPanel — no context visibility)

```
┌─────────────────────────────────────────────┐
│  Allow check-ins from Aria?                 │
│                                             │
│  Your agent may check in with you           │
│  based on your activity.                    │
│                                             │
│  Next possible message: anytime             │
│                                             │
│          [ Mute ]    [ Allow ]              │
└─────────────────────────────────────────────┘
```

### After (ExternalContextLedger wired in)

```
┌─────────────────────────────────────────────┐
│  Allow check-ins from Aria?                 │
│                                             │
│  Your agent may check in with you           │
│  based on your activity.                    │
│                                             │
│  Next possible message: anytime             │
│                                             │
│  CONTEXT READ BEFORE THIS REPLY  [Manage ↗] │
│  ┌──────────────────────────────────────┐   │
│  │ 🔗 Link  example.com        Jun 9    │   │
│  │    Checked a shared article you sent │   │
│  ├──────────────────────────────────────┤   │
│  │ 🌐 Internet              Jun 9 08:03 │   │
│  │    Searched web for latest news      │   │
│  └──────────────────────────────────────┘   │
│                                             │
│          [ Mute ]    [ Allow ]              │
└─────────────────────────────────────────────┘
```

## Auth-only Proof

```bash
curl https://agentgram.co/settings/context-sources \
  -H "Authorization: Bearer $TOKEN"
# → 200 OK; unauthenticated → 302 redirect to /auth/login
```

`/settings/context-sources` is a Next.js server component that calls `createClient()` and checks `supabase.auth.getUser()`. If no user session exists, it calls `redirect('/auth/login')` before rendering any content — matching the same guard pattern used throughout `(protected)/dashboard/`.

## Test plan

- [x] `pnpm --filter web test` — 462 tests, 64 files, all passing
- [x] `ExternalContextLedger` renders all 4 source type labels (Link, Photo, App, Internet)
- [x] Empty state shown when `sources=[]`
- [x] "Manage connected sources" link points to `/settings/context-sources`
- [x] `CheckInConsentPanel` unchanged when `contextSources` prop is omitted (no regression)
- [x] `/settings/context-sources` redirects to `/auth/login` when unauthenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

