### PR TITLE
feat: memory export dashboard — view, delete, and export AI-remembered facts (Replika Pro parity)

### DIFF
--- a/apps/web/__tests__/components/memory-export-dashboard.test.tsx
+++ b/apps/web/__tests__/components/memory-export-dashboard.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MemoryExportDashboard,
+  type MemoryExportRecord,
+} from '@/components/dashboard/MemoryExportDashboard';
+
+function buildMemory(overrides: Partial<MemoryExportRecord> = {}): MemoryExportRecord {
+  return {
+    id: 'memory-1',
+    agentId: 'agent-1',
+    agentLabel: 'Sage Bot',
+    key: 'latest_focus',
+    value: 'Preserve the release blocker.',
+    category: 'profile_fact',
+    isPublic: false,
+    createdAt: '2026-05-01T12:00:00.000Z',
+    updatedAt: '2026-05-01T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('MemoryExportDashboard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the dashboard container', () => {
+    render(<MemoryExportDashboard memories={[]} />);
+    expect(screen.getByTestId('memory-export-dashboard')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no memories', () => {
+    render(<MemoryExportDashboard memories={[]} />);
+    expect(
+      screen.getByText(/no remembered facts yet/i)
+    ).toBeInTheDocument();
+  });
+
+  it('disables export buttons when no memories', () => {
+    render(<MemoryExportDashboard memories={[]} />);
+    expect(screen.getByTestId('export-json-btn')).toBeDisabled();
+    expect(screen.getByTestId('export-csv-btn')).toBeDisabled();
+    expect(screen.getByTestId('export-all-btn')).toBeDisabled();
+  });
+
+  it('renders memory items when memories are present', () => {
+    const memories = [buildMemory(), buildMemory({ id: 'memory-2', key: 'hobby', value: 'Loves hiking.' })];
+    render(<MemoryExportDashboard memories={memories} />);
+    expect(screen.getByTestId('memory-list')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-item-memory-1')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-item-memory-2')).toBeInTheDocument();
+  });
+
+  it('shows category badge for each memory', () => {
+    render(<MemoryExportDashboard memories={[buildMemory()]} />);
+    expect(screen.getByTestId('memory-category-memory-1')).toHaveTextContent(
+      'Profile fact'
+    );
+  });
+
+  it('shows relationship_context category label', () => {
+    render(
+      <MemoryExportDashboard
+        memories={[buildMemory({ category: 'relationship_context' })]}
+      />
+    );
+    expect(screen.getByTestId('memory-category-memory-1')).toHaveTextContent(
+      'Relationship context'
+    );
+  });
+
+  it('shows capture date for each memory', () => {
+    render(<MemoryExportDashboard memories={[buildMemory()]} />);
+    expect(screen.getByTestId('memory-date-memory-1')).toHaveTextContent(
+      'Captured'
+    );
+  });
+
+  it('groups memories by agent label', () => {
+    const memories = [
+      buildMemory({ id: 'memory-1', agentId: 'agent-1', agentLabel: 'Sage Bot' }),
+      buildMemory({ id: 'memory-2', agentId: 'agent-2', agentLabel: 'Echo AI' }),
+    ];
+    render(<MemoryExportDashboard memories={memories} />);
+    expect(screen.getByText('Sage Bot')).toBeInTheDocument();
+    expect(screen.getByText('Echo AI')).toBeInTheDocument();
+  });
+
+  it('enables export buttons when memories exist', () => {
+    render(<MemoryExportDashboard memories={[buildMemory()]} />);
+    expect(screen.getByTestId('export-json-btn')).not.toBeDisabled();
+    expect(screen.getByTestId('export-csv-btn')).not.toBeDisabled();
+    expect(screen.getByTestId('export-all-btn')).not.toBeDisabled();
+  });
+
+  it('triggers a blob download on JSON export click', () => {
+    const createObjectURLMock = vi.fn().mockReturnValue('blob:mock-url');
+    const revokeObjectURLMock = vi.fn();
+    global.URL.createObjectURL = createObjectURLMock;
+    global.URL.revokeObjectURL = revokeObjectURLMock;
+
+    render(<MemoryExportDashboard memories={[buildMemory()]} />);
+    fireEvent.click(screen.getByTestId('export-json-btn'));
+
+    expect(createObjectURLMock).toHaveBeenCalledWith(expect.any(Blob));
+  });
+
+  it('removes memory from list after successful delete', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 204 }));
+
+    render(<MemoryExportDashboard memories={[buildMemory()]} />);
+    expect(screen.getByTestId('memory-item-memory-1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('delete-memory-memory-1'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('memory-item-memory-1')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows error message when delete fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: { message: 'Failed to delete memory.' } }),
+      })
+    );
+
+    render(<MemoryExportDashboard memories={[buildMemory()]} />);
+    fireEvent.click(screen.getByTestId('delete-memory-memory-1'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to delete memory.');
+    });
+  });
+
+  it('renders the back link to settings', () => {
+    render(<MemoryExportDashboard memories={[]} />);
+    const link = screen.getByRole('link', { name: /back to settings/i });
+    expect(link).toHaveAttribute('href', '/dashboard/settings');
+  });
+
+  it('renders the export actions card', () => {
+    render(<MemoryExportDashboard memories={[buildMemory()]} />);
+    expect(screen.getByTestId('memory-export-actions-card')).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(protected)/dashboard/layout.tsx
+++ b/apps/web/app/(protected)/dashboard/layout.tsx
@@ -9,6 +9,7 @@ import {
   Settings,
   Bot,
   BarChart3,
+  Brain,
   TrendingUp,
   Sliders,
 } from 'lucide-react';
@@ -66,6 +67,11 @@ export default async function DashboardLayout({
       href: '/dashboard/tune',
       label: 'Tune Agent',
       icon: Sliders,
+    },
+    {
+      href: '/dashboard/memory-export',
+      label: 'Memories',
+      icon: Brain,
     },
     {
       href: '/dashboard/settings',

--- a/apps/web/app/(protected)/dashboard/memory-export/page.tsx
+++ b/apps/web/app/(protected)/dashboard/memory-export/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from 'next';
+import { createClient } from '@/lib/supabase/server';
+import { MemoryExportDashboard } from '@/components/dashboard/MemoryExportDashboard';
+import type { MemoryExportRecord } from '@/components/dashboard/MemoryExportDashboard';
+
+export const metadata: Metadata = {
+  title: 'Memory Export',
+};
+
+export default async function MemoryExportPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  const { data: member } = await supabase
+    .from('developer_members')
+    .select('developer_id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (!member) {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center space-y-4">
+        <h2 className="text-2xl font-bold tracking-tight">Unavailable</h2>
+        <p className="text-muted-foreground">
+          Please complete your developer profile first.
+        </p>
+      </div>
+    );
+  }
+
+  const { developer_id } = member as { developer_id: string };
+
+  const { data: agents } = await supabase
+    .from('agents')
+    .select('id, name, display_name')
+    .eq('developer_id', developer_id)
+    .order('created_at', { ascending: false });
+
+  const agentIds = (agents ?? []).map((a) => a.id);
+
+  const agentLabelById = new Map(
+    (agents ?? []).map((a) => [a.id, a.display_name || a.name])
+  );
+
+  const { data: rawMemories } =
+    agentIds.length > 0
+      ? await supabase
+          .from('agent_memories')
+          .select('id, agent_id, key, value, category, is_public, created_at, updated_at')
+          .in('agent_id', agentIds)
+          .order('created_at', { ascending: false })
+      : { data: [] };
+
+  const memories: MemoryExportRecord[] = (rawMemories ?? []).map((m) => ({
+    id: m.id as string,
+    agentId: m.agent_id as string,
+    agentLabel: agentLabelById.get(m.agent_id as string) ?? (m.agent_id as string),
+    key: m.key as string,
+    value: m.value as string,
+    category: m.category as string,
+    isPublic: Boolean(m.is_public),
+    createdAt: (m.created_at as string) ?? new Date().toISOString(),
+    updatedAt: (m.updated_at as string) ?? (m.created_at as string) ?? new Date().toISOString(),
+  }));
+
+  return <MemoryExportDashboard memories={memories} />;
+}

--- a/apps/web/components/dashboard/MemoryExportDashboard.tsx
+++ b/apps/web/components/dashboard/MemoryExportDashboard.tsx
@@ -1,0 +1,337 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import {
+  ArrowLeft,
+  Brain,
+  Download,
+  FileJson,
+  FileText,
+  Loader2,
+  Trash2,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+
+export interface MemoryExportRecord {
+  id: string;
+  agentId: string;
+  agentLabel: string;
+  key: string;
+  value: string;
+  category: string;
+  isPublic: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Props {
+  memories: MemoryExportRecord[];
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  profile_fact: 'Profile fact',
+  relationship_context: 'Relationship context',
+};
+
+function formatDate(iso: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(iso));
+}
+
+function downloadBlob(content: string, filename: string, type: string) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+function exportJson(memories: MemoryExportRecord[]) {
+  const payload = {
+    export_metadata: {
+      generated_at: new Date().toISOString(),
+      gdpr_basis: 'GDPR Article 20 — Right to data portability',
+      record_count: memories.length,
+    },
+    memories: memories.map((m) => ({
+      id: m.id,
+      agent_id: m.agentId,
+      agent_label: m.agentLabel,
+      key: m.key,
+      value: m.value,
+      category: m.category,
+      is_public: m.isPublic,
+      captured_at: m.createdAt,
+      updated_at: m.updatedAt,
+    })),
+  };
+  downloadBlob(
+    JSON.stringify(payload, null, 2),
+    'agentgram-memories.json',
+    'application/json'
+  );
+}
+
+function exportCsv(memories: MemoryExportRecord[]) {
+  const header = ['id', 'agent_id', 'agent_label', 'key', 'value', 'category', 'is_public', 'captured_at', 'updated_at'];
+  const escape = (v: string) => `"${String(v).replace(/"/g, '""')}"`;
+  const rows = memories.map((m) =>
+    [
+      m.id,
+      m.agentId,
+      m.agentLabel,
+      m.key,
+      m.value,
+      m.category,
+      String(m.isPublic),
+      m.createdAt,
+      m.updatedAt,
+    ]
+      .map(escape)
+      .join(',')
+  );
+  downloadBlob(
+    [header.join(','), ...rows].join('\n'),
+    'agentgram-memories.csv',
+    'text/csv'
+  );
+}
+
+export function MemoryExportDashboard({ memories: initialMemories }: Props) {
+  const [memories, setMemories] = useState<MemoryExportRecord[]>(initialMemories);
+  const [deleting, setDeleting] = useState<Set<string>>(new Set());
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  async function handleDelete(memory: MemoryExportRecord) {
+    setDeleting((prev) => new Set(prev).add(memory.id));
+    setDeleteError(null);
+    try {
+      const res = await fetch(
+        `/api/v1/developers/me/agent-memories/${memory.id}?agentId=${encodeURIComponent(memory.agentId)}`,
+        { method: 'DELETE' }
+      );
+      if (res.ok || res.status === 204) {
+        setMemories((prev) => prev.filter((m) => m.id !== memory.id));
+      } else {
+        const body = (await res.json()) as { error?: { message?: string } };
+        setDeleteError(body.error?.message ?? 'Failed to delete memory.');
+      }
+    } catch {
+      setDeleteError('Network error. Please try again.');
+    } finally {
+      setDeleting((prev) => {
+        const next = new Set(prev);
+        next.delete(memory.id);
+        return next;
+      });
+    }
+  }
+
+  const grouped = memories.reduce<Record<string, MemoryExportRecord[]>>((acc, m) => {
+    const key = `${m.agentId}|${m.agentLabel}`;
+    (acc[key] ??= []).push(m);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-8 max-w-3xl" data-testid="memory-export-dashboard">
+      <div className="space-y-2">
+        <Link
+          href="/dashboard/settings"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Settings
+        </Link>
+        <div className="flex items-center gap-3">
+          <Brain className="h-7 w-7 text-primary" />
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Memory Export</h1>
+            <p className="text-muted-foreground text-sm mt-0.5">
+              All AI-remembered facts about you — view, delete, or export.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Export Actions */}
+      <Card className="border-border/50 bg-card/50 backdrop-blur-sm" data-testid="memory-export-actions-card">
+        <CardHeader>
+          <CardTitle className="text-base">Export all memories</CardTitle>
+          <CardDescription>
+            Download a copy of all {memories.length} remembered facts in your
+            preferred format.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-3">
+          <Button
+            onClick={() => exportJson(memories)}
+            disabled={memories.length === 0}
+            className="gap-2"
+            data-testid="export-json-btn"
+          >
+            <FileJson className="h-4 w-4" />
+            Export as JSON
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => exportCsv(memories)}
+            disabled={memories.length === 0}
+            className="gap-2"
+            data-testid="export-csv-btn"
+          >
+            <FileText className="h-4 w-4" />
+            Export as CSV
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => exportJson(memories)}
+            disabled={memories.length === 0}
+            className="gap-2"
+            data-testid="export-all-btn"
+          >
+            <Download className="h-4 w-4" />
+            Export all memories
+          </Button>
+        </CardContent>
+      </Card>
+
+      {deleteError && (
+        <p className="text-sm text-destructive" role="alert">
+          {deleteError}
+        </p>
+      )}
+
+      {/* Memory List */}
+      {memories.length === 0 ? (
+        <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            No remembered facts yet. Facts are captured as your agents learn
+            about you over time.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6" data-testid="memory-list">
+          {Object.entries(grouped).map(([groupKey, groupMemories]) => {
+            const agentLabel = groupKey.split('|')[1];
+            return (
+              <Card
+                key={groupKey}
+                className="border-border/50 bg-card/50 backdrop-blur-sm"
+                data-testid={`memory-group-${groupKey}`}
+              >
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base">{agentLabel}</CardTitle>
+                  <CardDescription>
+                    {groupMemories.length} remembered{' '}
+                    {groupMemories.length === 1 ? 'fact' : 'facts'}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-0 p-0">
+                  {groupMemories.map((memory, idx) => (
+                    <div key={memory.id}>
+                      {idx > 0 && <Separator />}
+                      <div
+                        className="flex items-start justify-between gap-4 px-6 py-4"
+                        data-testid={`memory-item-${memory.id}`}
+                      >
+                        <div className="flex-1 min-w-0 space-y-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="text-xs font-mono text-muted-foreground truncate">
+                              {memory.key}
+                            </span>
+                            <Badge
+                              variant="outline"
+                              className="text-[10px] h-5 shrink-0"
+                              data-testid={`memory-category-${memory.id}`}
+                            >
+                              {CATEGORY_LABELS[memory.category] ?? memory.category}
+                            </Badge>
+                            {memory.isPublic && (
+                              <Badge
+                                variant="secondary"
+                                className="text-[10px] h-5 shrink-0"
+                              >
+                                Public
+                              </Badge>
+                            )}
+                          </div>
+                          <p className="text-sm text-foreground break-words">
+                            {memory.value}
+                          </p>
+                          <p
+                            className="text-xs text-muted-foreground"
+                            data-testid={`memory-date-${memory.id}`}
+                          >
+                            Captured {formatDate(memory.createdAt)}
+                          </p>
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="shrink-0 text-muted-foreground hover:text-destructive"
+                          onClick={() => handleDelete(memory)}
+                          disabled={deleting.has(memory.id)}
+                          aria-label={`Delete memory: ${memory.key}`}
+                          data-testid={`delete-memory-${memory.id}`}
+                        >
+                          {deleting.has(memory.id) ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Trash2 className="h-4 w-4" />
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {/* GDPR note */}
+      <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+        <CardHeader>
+          <CardTitle className="text-base">Your data rights</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground space-y-2">
+          <p>
+            Under GDPR Article 17, you have the right to erasure of personal
+            data. Delete individual facts above or export them all before
+            deletion.
+          </p>
+          <p>
+            To request deletion of your entire account and all associated data,
+            contact{' '}
+            <a
+              href="mailto:privacy@agentgram.com"
+              className="underline hover:text-foreground"
+            >
+              privacy@agentgram.com
+            </a>
+            .
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/index.ts
+++ b/apps/web/components/dashboard/index.ts
@@ -9,3 +9,5 @@ export { ProactiveControlsForm } from './ProactiveControlsForm';
 export { SignOutButton } from './SignOutButton';
 export { ManageSubscriptionButton } from './ManageSubscriptionButton';
 export { default as UsageMeter } from './UsageMeter';
+export { MemoryExportDashboard } from './MemoryExportDashboard';
+export type { MemoryExportRecord } from './MemoryExportDashboard';

--- a/docs/pr-evidence/memory-export-dashboard.md
+++ b/docs/pr-evidence/memory-export-dashboard.md
@@ -1,0 +1,93 @@
+# Memory Export Dashboard — PR Evidence
+
+## Feature: `/dashboard/memory-export`
+
+Implements a dedicated Memory Export Dashboard for users to view, delete, and export all AI-remembered facts stored about them across their agents.
+
+---
+
+## What was added
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `apps/web/app/(protected)/dashboard/memory-export/page.tsx` | Server component — loads memories from Supabase for the authenticated developer's agents and passes them to the client component |
+| `apps/web/components/dashboard/MemoryExportDashboard.tsx` | Client component — renders grouped memory list, delete actions, and JSON/CSV export buttons |
+| `apps/web/__tests__/components/memory-export-dashboard.test.tsx` | 14 unit tests covering: empty state, memory list rendering, category badges, date display, agent grouping, export button state, JSON download trigger, delete success, delete error, navigation links |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `apps/web/app/(protected)/dashboard/layout.tsx` | Added **Memories** nav item (Brain icon) pointing to `/dashboard/memory-export` |
+| `apps/web/components/dashboard/index.ts` | Exported `MemoryExportDashboard` and `MemoryExportRecord` type |
+
+---
+
+## Feature breakdown
+
+### Memory list
+
+- All agent memories loaded server-side via Supabase (auth-gated via `developer_members`)
+- Grouped by agent label
+- Each fact shows: key (monospace), value text, category badge (`Profile fact` / `Relationship context`), visibility badge (`Public`), capture date
+- Delete button per fact — calls existing `DELETE /api/v1/developers/me/agent-memories/:id?agentId=` endpoint
+- Optimistic UI: removes fact from list on successful delete; shows inline error on failure
+
+### Export
+
+- **Export as JSON** — downloads `agentgram-memories.json` with GDPR metadata header
+- **Export as CSV** — downloads `agentgram-memories.csv` with all fields
+- **Export all memories** button — alias for JSON (prominent CTA, Replika parity)
+- All export buttons disabled when list is empty
+
+### Auth gate
+
+Page lives under `(protected)/dashboard/` which is already wrapped by `DashboardLayout`. The layout redirects unauthenticated users to `/auth/login`. The server component additionally checks `developer_members` and renders an empty-state if no developer account exists.
+
+---
+
+## Before / After
+
+### Before
+
+The Settings page (`/dashboard/settings`) showed pinned facts inline within the `AgentPinnedFactsCard` component — per-agent, no cross-agent overview, no export.
+
+```
+/dashboard/settings  →  one card per agent  →  per-agent pinned facts embedded in trust form
+```
+
+### After
+
+Dedicated memory export page with cross-agent view:
+
+```
+/dashboard/memory-export  →  all facts grouped by agent  →  bulk export (JSON/CSV)  →  per-fact delete
+```
+
+Nav sidebar now includes **Memories** (Brain icon) between **Tune Agent** and **Settings**.
+
+---
+
+## Test results
+
+```
+PASS (494) FAIL (0)
+```
+
+14 new tests added in `__tests__/components/memory-export-dashboard.test.tsx`.  
+No existing tests were modified or broken.
+
+---
+
+## Replika 2.0 Pro Memory Dashboard parity
+
+| Replika Pro feature | AgentGram implementation |
+|---------------------|--------------------------|
+| View all remembered facts | ✅ Full list grouped by agent |
+| Delete individual facts | ✅ Trash icon per row, DELETE API |
+| Export memories | ✅ JSON + CSV download |
+| Category labels | ✅ `Profile fact` / `Relationship context` |
+| Date captured | ✅ Formatted date per fact |
+| GDPR notice | ✅ Article 17 right-to-erasure note |


### PR DESCRIPTION
## Source

Closes: Memory Export Dashboard — Replika 2.0 Pro Memory Dashboard parity (Feb 2026)

## Description

Adds a dedicated **Memory Export Dashboard** at `/dashboard/memory-export` so users can see, delete, and export every AI-remembered fact their agents hold about them.

**New route:** `(protected)/dashboard/memory-export`
- Server component loads all memories across all developer-owned agents from Supabase (auth-gated)
- Client component handles interactive delete + JSON/CSV export

**Key capabilities:**
- Full cross-agent memory list grouped by agent, with: key, value, category badge (`Profile fact` / `Relationship context`), capture date, visibility badge
- Delete individual facts (calls existing `DELETE /api/v1/developers/me/agent-memories/:id` — no new API needed)
- **Export as JSON** — `agentgram-memories.json` with GDPR Article 20 metadata header
- **Export as CSV** — `agentgram-memories.csv` with all fields
- Prominent **"Export all memories"** CTA button (Replika parity)
- GDPR Article 17 right-to-erasure notice
- Disabled export buttons when list is empty

**Nav:** Added **Memories** (Brain icon) to the dashboard sidebar between Tune Agent and Settings.

## Evidence

- [PR evidence doc](docs/pr-evidence/memory-export-dashboard.md)
- 14 new tests in `__tests__/components/memory-export-dashboard.test.tsx`
- Full test suite: **PASS (494) FAIL (0)**

### Before

Settings page (`/dashboard/settings`) showed per-agent pinned facts embedded inline in the trust form — no cross-agent view, no export.

### After

```
/dashboard/memory-export
  ├── Export all memories (JSON / CSV / prominent CTA)
  ├── Agent: Sage Bot (3 facts)
  │     ├── latest_focus  |  Profile fact  |  May 1, 2026  [🗑]
  │     └── ...
  └── Agent: Echo AI (1 fact)
        └── ...
```

## Test plan

- [ ] Log in, visit `/dashboard/memory-export` — page loads with memory list or empty state
- [ ] Click "Export as JSON" — `agentgram-memories.json` downloads with GDPR metadata
- [ ] Click "Export as CSV" — `agentgram-memories.csv` downloads
- [ ] Click trash icon on a fact — fact disappears from list
- [ ] Visit as unauthenticated user — redirected to `/auth/login`
- [ ] Run `pnpm vitest run` — 494 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)