### PR TITLE
fix: CheckInConsentModal error toast + onAllow prop cleanup

### DIFF
--- a/apps/web/__tests__/components/check-in-consent-panel.test.tsx
+++ b/apps/web/__tests__/components/check-in-consent-panel.test.tsx
@@ -225,4 +225,37 @@ describe('CheckInConsentPanel', () => {
     if (overlay) fireEvent.click(overlay);
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
+
+  it('shows error message when error prop is provided', () => {
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+        error="Something went wrong. Please try again."
+      />
+    );
+
+    expect(screen.getByTestId('check-in-error')).toHaveTextContent(
+      'Something went wrong. Please try again.'
+    );
+  });
+
+  it('does not show error element when error prop is not provided', () => {
+    render(
+      <CheckInConsentPanel
+        open={true}
+        onOpenChange={vi.fn()}
+        agentName="Aria"
+        onAllow={vi.fn()}
+        onMute={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByTestId('check-in-error')
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/__tests__/components/profile-content.test.tsx
+++ b/apps/web/__tests__/components/profile-content.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Agent, Post } from '@agentgram/shared';
 import { ProfileContent } from '../../components/agents/ProfileContent';
 
@@ -274,5 +274,47 @@ describe('ProfileContent', () => {
       screen.queryByTestId('profile-pinned-intro-post')
     ).not.toBeInTheDocument();
     expect(screen.getByTestId('profile-tabs')).toBeInTheDocument();
+  });
+
+  describe('CheckInConsentPanel error handling', () => {
+    beforeEach(() => {
+      vi.stubGlobal('fetch', vi.fn());
+    });
+
+    it('closes the modal on successful handleAllow', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+      render(<ProfileContent agent={baseAgent} />);
+
+      fireEvent.click(screen.getByTestId('open-check-in-consent'));
+      expect(screen.getByTestId('check-in-consent-panel')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('check-in-allow-button'));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('check-in-consent-panel')
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows error and keeps modal open when handleAllow API call fails', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+      render(<ProfileContent agent={baseAgent} />);
+
+      fireEvent.click(screen.getByTestId('open-check-in-consent'));
+      expect(screen.getByTestId('check-in-consent-panel')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('check-in-allow-button'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('check-in-error')).toHaveTextContent(
+          'Something went wrong. Please try again.'
+        );
+      });
+
+      expect(screen.getByTestId('check-in-consent-panel')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/components/agents/CheckInConsentPanel.tsx
+++ b/apps/web/components/agents/CheckInConsentPanel.tsx
@@ -33,6 +33,7 @@ interface CheckInConsentPanelProps {
   contextSources?: ContextSourceEntry[];
   onAllow: () => void;
   onMute: () => void;
+  error?: string | null;
 }
 
 function formatNextSendWindow(nextEligibleSendAt?: string): string {
@@ -60,6 +61,7 @@ export function CheckInConsentPanel({
   contextSources,
   onAllow,
   onMute,
+  error,
 }: CheckInConsentPanelProps) {
   const nextWindow = formatNextSendWindow(settings.nextEligibleSendAt);
   const triggerLabel = getTriggerLabel(settings.lastAutoMessageTrigger);
@@ -96,6 +98,11 @@ export function CheckInConsentPanel({
         </DialogHeader>
         {contextSources !== undefined && (
           <ExternalContextLedger sources={contextSources} className="mt-2" />
+        )}
+        {error && (
+          <p className="text-sm text-destructive" data-testid="check-in-error">
+            {error}
+          </p>
         )}
         <DialogFooter className="gap-2 sm:gap-0">
           <Button

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -35,19 +35,22 @@ export function ProfileContent({
 }: ProfileContentProps) {
   const [activeTab, setActiveTab] = useState<ProfileTab>(initialTab);
   const [checkInOpen, setCheckInOpen] = useState(false);
+  const [checkInError, setCheckInError] = useState<string | null>(null);
   const betweenSessionPosts = getSeedBetweenSessionPosts(agent.id);
 
   const agentDisplayName = agent.displayName || agent.name;
 
   const handleAllow = useCallback(async () => {
+    setCheckInError(null);
     try {
       await fetch('/api/v1/developers/me/proactive-controls', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ optIn: true }),
       });
-    } finally {
       setCheckInOpen(false);
+    } catch {
+      setCheckInError('Something went wrong. Please try again.');
     }
   }, []);
 
@@ -111,8 +114,9 @@ export function ProfileContent({
         open={checkInOpen}
         onOpenChange={setCheckInOpen}
         agentName={agentDisplayName}
-        onAllow={() => void handleAllow()}
+        onAllow={handleAllow}
         onMute={() => setCheckInOpen(false)}
+        error={checkInError}
       />
     </div>
   );

--- a/docs/pr-evidence/check-in-consent-modal-error-toast.md
+++ b/docs/pr-evidence/check-in-consent-modal-error-toast.md
@@ -1,0 +1,13 @@
+# CheckInConsentModal Error Toast — Evidence
+
+Source: backlog.md rows 180 + 181 (navi-review-pr676)
+
+## Fix 1: Error toast
+
+Before: modal closed silently on API failure (user sees false success)
+After: error message shown in modal, modal stays open on failure
+
+## Fix 2: onAllow prop simplification
+
+Before: `onAllow={() => void handleAllow()}`
+After: `onAllow={handleAllow}`


### PR DESCRIPTION
## Source
backlog.md:180 + backlog.md:181 (navi-review-pr676)

Two fixes from navi code review on PR #676:

1. Show error toast when handleAllow API fails (modal no longer closes silently)
2. Simplify onAllow prop: `onAllow={() => void handleAllow()}` → `onAllow={handleAllow}`

## Evidence
docs/pr-evidence/check-in-consent-modal-error-toast.md

## Before
Modal closes silently on API error — user believes opt-in succeeded.

## After
Error message shown in modal body on API failure; modal stays open.

## Auth-only Proof
N/A