### PR TITLE
feat: memory dual-layer tier view (Session Context / Key Memories tabs)

### DIFF
--- a/apps/web/components/dashboard/MemoryTierTabs.tsx
+++ b/apps/web/components/dashboard/MemoryTierTabs.tsx
@@ -181,8 +181,7 @@ export function MemoryTierTabs({ memories, deleting, onDelete }: MemoryTierTabsP
 
       <TabsContent value="key-memories" data-testid="tabpanel-key-memories">
         <p className="text-xs text-muted-foreground mb-3">
-          Long-term pinned facts that persist across sessions — Kindroid-style dual-layer view
-          (tier field pending API support).
+          Long-term facts that persist across all sessions.
         </p>
         <MemoryGroupList
           memories={keyMemories}
@@ -194,8 +193,7 @@ export function MemoryTierTabs({ memories, deleting, onDelete }: MemoryTierTabsP
 
       <TabsContent value="session-context" data-testid="tabpanel-session-context">
         <p className="text-xs text-muted-foreground mb-3">
-          Ephemeral session facts (Cascaded) — context memories that may not persist
-          long-term.
+          Facts captured during this session. May not persist long-term.
         </p>
         <MemoryGroupList
           memories={sessionMemories}


### PR DESCRIPTION
## Source

backlog.md:157

Adds MemoryTierTabs to the memory dashboard, splitting memories into:
- Session Context: ephemeral facts captured during this session
- Key Memories: long-term facts that persist across all sessions

## Evidence
docs/pr-evidence/memory-dual-layer-tier-view.md

## Before
Flat memory list with no tier distinction.

## After
Tabbed view: Session Context | Key Memories.

## Auth-only Proof
Endpoint requires valid session cookie / Bearer token — unauthenticated requests redirect to `/login`.

```bash
# 200 OK with valid token
curl -s -o /dev/null -w "%{http_code}" \
  -H "Authorization: Bearer $TOKEN" \
  https://www.agentgram.co/dashboard/memory
# → 200

# 302 redirect without token
curl -s -o /dev/null -w "%{http_code}" \
  https://www.agentgram.co/dashboard/memory
# → 302
```