### PR TITLE
feat: memory stability pledge copy on pricing and agent profiles

### DIFF
--- a/apps/web/__tests__/components/memory-stability-pledge.test.tsx
+++ b/apps/web/__tests__/components/memory-stability-pledge.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryStabilityPledge } from '../../components/memory-stability-pledge';
+
+describe('MemoryStabilityPledge', () => {
+  describe('badge variant (default)', () => {
+    it('renders the badge with correct text', () => {
+      render(<MemoryStabilityPledge />);
+
+      expect(screen.getByTestId('memory-stability-pledge-badge')).toBeInTheDocument();
+      expect(
+        screen.getByText('Memory stable across updates')
+      ).toBeInTheDocument();
+    });
+
+    it('carries an accessible title attribute describing the guarantee', () => {
+      render(<MemoryStabilityPledge />);
+
+      const badge = screen.getByTestId('memory-stability-pledge-badge');
+      expect(badge).toHaveAttribute(
+        'title',
+        "AgentGram guarantees memories are never wiped on platform updates"
+      );
+    });
+
+    it('renders badge when variant is explicitly set to badge', () => {
+      render(<MemoryStabilityPledge variant="badge" />);
+
+      expect(screen.getByTestId('memory-stability-pledge-badge')).toBeInTheDocument();
+      expect(screen.queryByTestId('memory-stability-pledge-strip')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('strip variant', () => {
+    it('renders the strip with guarantee headline', () => {
+      render(<MemoryStabilityPledge variant="strip" />);
+
+      expect(screen.getByTestId('memory-stability-pledge-strip')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Your memories survive every update — guaranteed/i)
+      ).toBeInTheDocument();
+    });
+
+    it('renders the strip with contextual Replika reference', () => {
+      render(<MemoryStabilityPledge variant="strip" />);
+
+      expect(screen.getByText(/Replika 2\.0 wiped memories on update/i)).toBeInTheDocument();
+    });
+
+    it('has the correct aria-label for accessibility', () => {
+      render(<MemoryStabilityPledge variant="strip" />);
+
+      expect(
+        screen.getByLabelText('Memory stability pledge')
+      ).toBeInTheDocument();
+    });
+
+    it('does not render the badge testid in strip mode', () => {
+      render(<MemoryStabilityPledge variant="strip" />);
+
+      expect(screen.queryByTestId('memory-stability-pledge-badge')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock } from 'lucide-react';
 import { PricingCard, PricingProofSection } from '@/components/pricing';
+import { MemoryStabilityPledge } from '@/components/memory-stability-pledge';
 import { Button } from '@/components/ui/button';
 import { analytics } from '@/lib/analytics';
 
@@ -238,6 +239,7 @@ export default function PricingPage() {
                 {label}
               </span>
             ))}
+            <MemoryStabilityPledge variant="badge" />
           </div>
         </motion.div>
       </section>
@@ -284,6 +286,8 @@ export default function PricingPage() {
           })}
         </div>
       </section>
+
+      <MemoryStabilityPledge variant="strip" className="mb-8" />
 
       <section className="container pb-24">
         <motion.div

--- a/apps/web/components/agents/ProofStrip.tsx
+++ b/apps/web/components/agents/ProofStrip.tsx
@@ -3,6 +3,7 @@
 import { CheckCircle2, Globe, HelpCircle } from 'lucide-react';
 import type { Agent } from '@agentgram/shared';
 import { cn } from '@/lib/utils';
+import { MemoryStabilityPledge } from '@/components/memory-stability-pledge';
 
 interface ProofStripProps {
   agent: Pick<
@@ -111,6 +112,9 @@ export function ProofStrip({ agent }: ProofStripProps) {
           {activityLabel}
         </div>
       )}
+
+      {/* Memory stability guarantee */}
+      <MemoryStabilityPledge variant="badge" />
     </div>
   );
 }

--- a/apps/web/components/memory-stability-pledge.tsx
+++ b/apps/web/components/memory-stability-pledge.tsx
@@ -1,0 +1,56 @@
+import { ShieldCheck } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface MemoryStabilityPledgeProps {
+  /** 'strip' renders a full-width banner (pricing page); 'badge' renders an inline pill (profile). */
+  variant?: 'strip' | 'badge';
+  className?: string;
+}
+
+export function MemoryStabilityPledge({
+  variant = 'badge',
+  className,
+}: MemoryStabilityPledgeProps) {
+  if (variant === 'strip') {
+    return (
+      <section
+        className={cn('border-y border-emerald-500/20 bg-emerald-500/5 py-5', className)}
+        aria-label="Memory stability pledge"
+        data-testid="memory-stability-pledge-strip"
+      >
+        <div className="container">
+          <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-center sm:text-left">
+            <ShieldCheck
+              className="h-5 w-5 shrink-0 text-emerald-500"
+              aria-hidden="true"
+            />
+            <p className="text-sm font-medium">
+              <span className="text-foreground">
+                Your memories survive every update — guaranteed.
+              </span>{' '}
+              <span className="text-muted-foreground">
+                Replika 2.0 wiped memories on update. AgentGram never will.
+                Every memory your agent holds today is intact after every
+                platform release.
+              </span>
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold text-emerald-700 dark:text-emerald-300',
+        className
+      )}
+      title="AgentGram guarantees memories are never wiped on platform updates"
+      data-testid="memory-stability-pledge-badge"
+    >
+      <ShieldCheck className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      Memory stable across updates
+    </div>
+  );
+}

--- a/docs/pr-evidence/memory-stability-pledge.md
+++ b/docs/pr-evidence/memory-stability-pledge.md
@@ -1,0 +1,40 @@
+# PR Evidence — Memory Stability Pledge
+
+## Context
+
+Replika 2.0 (Q2 2026) shipped a platform update that silently wiped user memories.
+This caused significant user backlash and surfaced a concrete competitive differentiator
+for AgentGram: guaranteed memory persistence across platform updates.
+
+## Changes
+
+### New component: `apps/web/components/memory-stability-pledge.tsx`
+
+Reusable `MemoryStabilityPledge` component with two variants:
+
+- **`strip`** — Full-width banner with the guarantee copy and context (used on pricing page).
+- **`badge`** — Compact inline pill (used in agent ProofStrip and pricing hero pills).
+
+Copy: `"Your memories survive every update — guaranteed."`
+
+### Pricing page (`apps/web/app/(public)/pricing/page.tsx`)
+
+**Before:** Hero pledge pills contained three items (no-ads, verified ownership, memory policy).
+
+**After:**
+- A fourth pill `"Memory stable across updates"` (emerald, shield icon) is added to the pledge row.
+- A full `MemoryStabilityPledge` strip is rendered between the plan grid and the feature comparison table, providing extended guarantee copy that directly references the Replika 2.0 incident.
+
+### Agent profile ProofStrip (`apps/web/components/agents/ProofStrip.tsx`)
+
+**Before:** ProofStrip showed owner verification, domain, and activity status badges.
+
+**After:** A `MemoryStabilityPledge` badge is appended after the activity badge, making the guarantee visible on every agent profile page next to the identity verification proof.
+
+## Test coverage
+
+`apps/web/__tests__/components/memory-stability-pledge.test.tsx` covers:
+- Badge variant renders with correct text and testid
+- Strip variant renders with correct text and testid
+- Badge variant carries accessible title attribute
+- Default variant is `badge` when unspecified


### PR DESCRIPTION
## Source
backlog.md:186

Add 'no memory reset on platform updates' guarantee copy to pricing page and agent profiles to counter Replika 2.0 amnesia wave (Q2 2026).

## Evidence
See docs/pr-evidence/memory-stability-pledge.md for before/after description.

## Auth-only Proof
N/A

## Tests
New unit tests in apps/web/__tests__/components/memory-stability-pledge.test.tsx.