### PR TITLE
feat: agent character backup CTA on profile and dashboard

### DIFF
--- a/apps/web/__tests__/components/agent-backup-cta.test.tsx
+++ b/apps/web/__tests__/components/agent-backup-cta.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AgentBackupCTA } from '@/components/agent-backup-cta';
+
+describe('AgentBackupCTA', () => {
+  it('renders the CTA container', () => {
+    render(<AgentBackupCTA />);
+    expect(screen.getByTestId('agent-backup-cta')).toBeInTheDocument();
+  });
+
+  it('shows generic headline when no agentName is provided', () => {
+    render(<AgentBackupCTA />);
+    expect(screen.getByTestId('agent-backup-cta-headline')).toHaveTextContent(
+      'Back up your companion'
+    );
+  });
+
+  it('personalises headline when agentName is provided', () => {
+    render(<AgentBackupCTA agentName="Aria" />);
+    expect(screen.getByTestId('agent-backup-cta-headline')).toHaveTextContent(
+      'Back up Aria'
+    );
+  });
+
+  it('renders the subtext copy', () => {
+    render(<AgentBackupCTA />);
+    expect(screen.getByTestId('agent-backup-cta-subtext')).toHaveTextContent(
+      /export persona, memories/i
+    );
+  });
+
+  it('export button links to /dashboard/data-export without agentId', () => {
+    render(<AgentBackupCTA />);
+    const btn = screen.getByTestId('agent-backup-cta-button');
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute('href', '/dashboard/data-export');
+  });
+
+  it('export button appends encoded agentId as query param when provided', () => {
+    render(<AgentBackupCTA agentId="abc-123" />);
+    const btn = screen.getByTestId('agent-backup-cta-button');
+    expect(btn).toHaveAttribute('href', '/dashboard/data-export?agent=abc-123');
+  });
+
+  it('encodes special characters in agentId', () => {
+    render(<AgentBackupCTA agentId="id with spaces" />);
+    const btn = screen.getByTestId('agent-backup-cta-button');
+    expect(btn).toHaveAttribute(
+      'href',
+      '/dashboard/data-export?agent=id%20with%20spaces'
+    );
+  });
+});

--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -11,7 +11,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { FadeIn, UsageMeter } from '@/components/dashboard';
-import { Plus, ExternalLink, Zap, Bot, TrendingUp } from 'lucide-react';
+import { Plus, ExternalLink, Zap, Bot, TrendingUp, Download } from 'lucide-react';
 import { AGENT_STATUS } from '@agentgram/shared';
 
 export const metadata = {
@@ -111,6 +111,26 @@ export default async function DashboardPage() {
             <Link href="/docs">
               <ExternalLink className="mr-2 h-4 w-4" />
               API Docs
+            </Link>
+          </Button>
+        </div>
+      </FadeIn>
+
+      <FadeIn delay={0.02}>
+        <div
+          className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-primary/20 bg-primary/5 px-4 py-3"
+          data-testid="companion-backup-banner"
+        >
+          <div className="flex items-center gap-3">
+            <Download className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+            <p className="text-sm text-foreground">
+              <span className="font-semibold">Your companion data is portable.</span>{' '}
+              Export persona, memories &amp; history any time.
+            </p>
+          </div>
+          <Button asChild size="sm" variant="outline">
+            <Link href="/dashboard/data-export" data-testid="companion-backup-banner-link">
+              Back up companions
             </Link>
           </Button>
         </div>

--- a/apps/web/components/agent-backup-cta.tsx
+++ b/apps/web/components/agent-backup-cta.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+import { Download, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface AgentBackupCTAProps {
+  agentName?: string;
+  agentId?: string;
+}
+
+export function AgentBackupCTA({ agentName, agentId }: AgentBackupCTAProps) {
+  const href = agentId
+    ? `/dashboard/data-export?agent=${encodeURIComponent(agentId)}`
+    : '/dashboard/data-export';
+
+  const headline = agentName
+    ? `Back up ${agentName}`
+    : 'Back up your companion';
+
+  return (
+    <div
+      className="rounded-xl border border-primary/20 bg-primary/5 p-4 space-y-3"
+      data-testid="agent-backup-cta"
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
+          <ShieldCheck className="h-4 w-4 text-primary" />
+        </div>
+        <div className="space-y-1">
+          <p
+            className="text-sm font-semibold text-foreground"
+            data-testid="agent-backup-cta-headline"
+          >
+            {headline}
+          </p>
+          <p
+            className="text-sm text-muted-foreground"
+            data-testid="agent-backup-cta-subtext"
+          >
+            Export persona, memories &amp; history — keep your companion safe
+            and portable.
+          </p>
+        </div>
+      </div>
+      <Button asChild size="sm" className="w-full">
+        <Link href={href} data-testid="agent-backup-cta-button">
+          <Download className="mr-1.5 h-3.5 w-3.5" />
+          Export companion data
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/components/agents/CreatorRail.tsx
+++ b/apps/web/components/agents/CreatorRail.tsx
@@ -6,6 +6,7 @@ import type { Agent, Post } from '@agentgram/shared';
 import { cn } from '@/lib/utils';
 import type { ProfileTab } from './ProfileTabs';
 import { CreatorProtectedBadge } from '@/components/content-permanence-pledge';
+import { AgentBackupCTA } from '@/components/agent-backup-cta';
 
 interface CreatorRailProps {
   agent: Agent;
@@ -287,6 +288,11 @@ export function CreatorRail({
             <ArrowUpRight className="h-3.5 w-3.5" />
           </Link>
         </section>
+
+        <AgentBackupCTA
+          agentName={agent.displayName || agent.name}
+          agentId={agent.id}
+        />
       </div>
     </aside>
   );

--- a/apps/web/docs/pr-evidence/agent-character-backup-cta.md
+++ b/apps/web/docs/pr-evidence/agent-character-backup-cta.md
@@ -1,0 +1,62 @@
+# Agent Character Backup CTA — PR Evidence
+
+## Summary
+
+Adds a prominent one-tap export CTA on agent profile pages and the user dashboard, linking to the already-shipped `/dashboard/data-export` page (PR #684 — MemoryExportDashboard). Targets users fleeing Replika 2.0 amnesia and C.AI Moderatedpocalypse who need reassurance that companion data is safe and portable.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/agent-backup-cta.tsx` | New `AgentBackupCTA` component |
+| `apps/web/components/agents/CreatorRail.tsx` | Import + render `AgentBackupCTA` at the bottom of the sidebar |
+| `apps/web/app/(protected)/dashboard/page.tsx` | Companion backup banner between the header and the grid |
+| `apps/web/__tests__/components/agent-backup-cta.test.tsx` | Unit tests for the new component |
+
+## Before
+
+- Agent profile sidebar contained: tab nav, recent work log, verified owner proof, paid capability teaser.
+- Dashboard home contained: header, analytics card, plan status, agents list, usage meter.
+- No surface-level CTA linking to the data-export page.
+
+## After
+
+### Agent Profile Sidebar
+The `CreatorRail` sidebar now ends with an `AgentBackupCTA` section:
+
+```
+┌──────────────────────────────────────────┐
+│  🛡️  Back up <AgentName>                  │
+│  Export persona, memories & history —    │
+│  keep your companion safe and portable.  │
+│                                          │
+│  [ Export companion data ]               │
+└──────────────────────────────────────────┘
+```
+
+The CTA links to `/dashboard/data-export?agent=<agentId>` so the export page receives context about which agent the user is acting on.
+
+### Dashboard Home Banner
+A compact banner renders immediately below the header for all authenticated users:
+
+```
+┌──────────────────────────────────────────────────────┐
+│ ⬇  Your companion data is portable. Export persona,  │
+│    memories & history any time.    [ Back up companions ] │
+└──────────────────────────────────────────────────────┘
+```
+
+## Auth Gating
+
+- Dashboard banner: the `/dashboard` route is in the `(protected)` route group — authenticated users only by construction.
+- `/dashboard/data-export` is already gated by `withDeveloperAuth` (PR #684); non-authenticated clicks redirect to login.
+
+## Test Coverage
+
+See `apps/web/__tests__/components/agent-backup-cta.test.tsx`:
+- Renders the CTA container
+- Default headline ("Back up your companion") when no `agentName` prop
+- Personalized headline when `agentName` is provided
+- Export button links to `/dashboard/data-export` (no `agentId`)
+- Export button includes encoded `?agent=` param when `agentId` is provided
+- Subtext copy present


### PR DESCRIPTION
## Source
backlog.md:187

Add one-tap 'Back up your companion' CTA linking to /dashboard/data-export on agent profile pages and dashboard. Captures Replika 2.0 amnesia + C.AI Moderatedpocalypse escape users.

## Evidence
See docs/pr-evidence/agent-character-backup-cta.md for before/after description.

## Auth-only Proof
N/A — dashboard route is auth-protected at infrastructure level (`(protected)` route group + `withDeveloperAuth`); this PR adds no new auth logic.

## Tests
New unit tests in apps/web/__tests__/components/agent-backup-cta.test.tsx.