### PR TITLE
feat: frictionless age verification messaging on auth and onboarding

### DIFF
--- a/apps/web/__tests__/components/frictionless-age-verification-badge.test.tsx
+++ b/apps/web/__tests__/components/frictionless-age-verification-badge.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ──────────────────────────────────────────────
+// Mocks shared by both describe blocks
+// ──────────────────────────────────────────────
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: { signInWithOAuth: vi.fn().mockResolvedValue({ error: null }) },
+  }),
+}));
+
+vi.mock('@/lib/env', () => ({ getBaseUrl: () => 'https://agentgram.test' }));
+vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
+vi.mock('@/lib/analytics', () => ({ analytics: { login: vi.fn() } }));
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: (_target, tag: string) => {
+        return ({ children, ...props }: React.HTMLAttributes<HTMLElement>) => {
+          delete (props as Record<string, unknown>).initial;
+          delete (props as Record<string, unknown>).animate;
+          delete (props as Record<string, unknown>).transition;
+          return React.createElement(tag, props, children);
+        };
+      },
+    }
+  ),
+}));
+
+// ──────────────────────────────────────────────
+// Login page — no-face-scan badge
+// ──────────────────────────────────────────────
+
+describe('Login page — frictionless age verification badge', () => {
+  it('renders the no-face-scan badge with correct text', async () => {
+    const LoginPage = (await import('@/app/(auth)/auth/login/page')).default;
+    render(<LoginPage />);
+
+    const badge = screen.getByTestId('no-face-scan-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Age-verified — no face scan required');
+  });
+
+  it('badge is visible alongside the existing tagline copy', async () => {
+    const LoginPage = (await import('@/app/(auth)/auth/login/page')).default;
+    render(<LoginPage />);
+
+    expect(
+      screen.getByText(/no character\.ai limits here/i)
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('no-face-scan-badge')).toBeInTheDocument();
+  });
+});
+
+// ──────────────────────────────────────────────
+// MinorSafeGate — no-biometric copy
+// ──────────────────────────────────────────────
+
+describe('MinorSafeGate — no-biometric copy', () => {
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    storage.clear();
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+      },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('shows the no-biometric copy when the gate is active', async () => {
+    const { MinorSafeGate } = await import('@/components/minor-safe-gate');
+
+    await act(async () => {
+      render(
+        <MinorSafeGate profile={{ age_verified: false }}>
+          <div>Protected content</div>
+        </MinorSafeGate>
+      );
+    });
+
+    const copy = screen.getByTestId('no-biometric-copy');
+    expect(copy).toBeInTheDocument();
+    expect(copy).toHaveTextContent(
+      'We verify your age without collecting biometric data'
+    );
+  });
+
+  it('no-biometric copy is not present when gate is bypassed (adult user)', async () => {
+    const { MinorSafeGate } = await import('@/components/minor-safe-gate');
+    const dob = new Date();
+    dob.setFullYear(dob.getFullYear() - 22);
+
+    await act(async () => {
+      render(
+        <MinorSafeGate
+          profile={{ age_verified: true, date_of_birth: dob.toISOString() }}
+        >
+          <div>Protected content</div>
+        </MinorSafeGate>
+      );
+    });
+
+    expect(screen.queryByTestId('no-biometric-copy')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(auth)/auth/login/page.tsx
+++ b/apps/web/app/(auth)/auth/login/page.tsx
@@ -235,6 +235,13 @@ function LoginContent() {
             <p className="text-xs text-muted-foreground/80 pt-1">
               Unlimited replies &amp; regenerations. No Character.AI limits here.
             </p>
+            <div
+              data-testid="no-face-scan-badge"
+              className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-400 mx-auto mt-1"
+            >
+              <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+              Age-verified — no face scan required
+            </div>
           </div>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/apps/web/components/minor-safe-gate.tsx
+++ b/apps/web/components/minor-safe-gate.tsx
@@ -60,6 +60,13 @@ export function MinorSafeGate({ profile, children }: MinorSafeGateProps) {
               Companion and roleplay features require age verification for users
               under 18.
             </p>
+            <p
+              data-testid="no-biometric-copy"
+              className="text-xs text-emerald-400/90 pt-1"
+            >
+              We verify your age without collecting biometric data — private and
+              instant.
+            </p>
           </div>
           <div className="flex flex-col gap-2">
             <Button asChild>

--- a/docs/pr-evidence/frictionless-age-verification-messaging.md
+++ b/docs/pr-evidence/frictionless-age-verification-messaging.md
@@ -1,0 +1,34 @@
+# PR Evidence: Frictionless Age Verification Messaging
+
+## Context
+
+In April 2026, Character.AI introduced mandatory biometric face scanning for age
+verification, triggering significant user backlash. This PR adds counter-positioning
+copy that highlights AgentGram's privacy-respecting approach.
+
+## Changes
+
+### apps/web/app/(auth)/auth/login/page.tsx
+
+**Before**: The login card header showed three lines — title, subtitle, and
+"No Character.AI limits here." tagline. No age-verification messaging.
+
+**After**: A green pill badge (`data-testid="no-face-scan-badge"`) appears below
+the tagline with a ShieldCheck icon and the copy "Age-verified — no face scan
+required". Visible to every visitor before they authenticate.
+
+### apps/web/components/minor-safe-gate.tsx
+
+**Before**: The age verification gate showed a title ("Age verification required")
+and a single body paragraph about companion features requiring verification.
+
+**After**: A second paragraph (`data-testid="no-biometric-copy"`) appears below the
+existing copy: "We verify your age without collecting biometric data — private and
+instant." Shown to any user who triggers the minor-safe gate before completing
+age verification.
+
+## Tests
+
+`apps/web/__tests__/components/frictionless-age-verification-badge.test.tsx` covers:
+- Badge renders on the login page with correct text and `data-testid`
+- `no-biometric-copy` renders in MinorSafeGate when gate is active


### PR DESCRIPTION
## Source
backlog.md:188

Add 'no face scan required' messaging as counter-positioning to C.AI Persona face-scan backlash (April 2026). Positions AgentGram's privacy-respecting approach as competitive differentiator.

## Evidence
See docs/pr-evidence/frictionless-age-verification-messaging.md for before/after description.

## Auth-only Proof
N/A

## Tests
New unit tests added for frictionless age verification messaging.