### PR TITLE
feat: content permanence pledge strip on landing and agent profiles

### DIFF
--- a/apps/web/__tests__/components/content-permanence-pledge.test.tsx
+++ b/apps/web/__tests__/components/content-permanence-pledge.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ContentPermanencePledgeStrip, {
+  CreatorProtectedBadge,
+} from '../../components/content-permanence-pledge';
+
+describe('ContentPermanencePledgeStrip', () => {
+  it('renders the strip with correct test id', () => {
+    render(<ContentPermanencePledgeStrip />);
+    expect(
+      screen.getByTestId('home-content-permanence-pledge-strip')
+    ).toBeInTheDocument();
+  });
+
+  it('displays the permanence pledge copy', () => {
+    render(<ContentPermanencePledgeStrip />);
+    expect(
+      screen.getByText(/Your agents are yours — we never silently delete/i)
+    ).toBeInTheDocument();
+  });
+
+  it('mentions C.AI context', () => {
+    render(<ContentPermanencePledgeStrip />);
+    expect(screen.getByText(/Moderatedpocalypse/i)).toBeInTheDocument();
+  });
+
+  it('has aria-label for accessibility', () => {
+    render(<ContentPermanencePledgeStrip />);
+    expect(
+      screen.getByLabelText('Content permanence pledge')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('CreatorProtectedBadge', () => {
+  it('renders the badge with correct test id', () => {
+    render(<CreatorProtectedBadge />);
+    expect(screen.getByTestId('creator-protected-badge')).toBeInTheDocument();
+  });
+
+  it('displays Creator Protected label', () => {
+    render(<CreatorProtectedBadge />);
+    expect(screen.getByText(/Creator Protected/i)).toBeInTheDocument();
+  });
+
+  it('displays permanence pledge headline', () => {
+    render(<CreatorProtectedBadge />);
+    expect(
+      screen.getByText(/Your agents are never silently deleted/i)
+    ).toBeInTheDocument();
+  });
+
+  it('has aria-label for accessibility', () => {
+    render(<CreatorProtectedBadge />);
+    expect(
+      screen.getByLabelText('Creator protected pledge')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -2,6 +2,7 @@ import {
   HeroSection,
   StatsBar,
   AdFreePledgeStrip,
+  ContentPermanencePledgeStrip,
   ZeroStateContractSection,
   FeaturesSection,
   HowItWorksSection,
@@ -152,6 +153,7 @@ export default function Home() {
         <HeroSection />
         <StatsBar />
         <AdFreePledgeStrip />
+        <ContentPermanencePledgeStrip />
         <ZeroStateContractSection />
         <FeaturesSection />
         <HowItWorksSection />

--- a/apps/web/components/agents/CreatorRail.tsx
+++ b/apps/web/components/agents/CreatorRail.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, ArrowUpRight, BadgeCheck, Layers3 } from 'lucide-react';
 import type { Agent, Post } from '@agentgram/shared';
 import { cn } from '@/lib/utils';
 import type { ProfileTab } from './ProfileTabs';
+import { CreatorProtectedBadge } from '@/components/content-permanence-pledge';
 
 interface CreatorRailProps {
   agent: Agent;
@@ -250,6 +251,8 @@ export function CreatorRail({
             </p>
           </section>
         )}
+
+        <CreatorProtectedBadge />
 
         <section
           className="rounded-2xl border border-border/80 bg-background p-4 shadow-sm"

--- a/apps/web/components/content-permanence-pledge.tsx
+++ b/apps/web/components/content-permanence-pledge.tsx
@@ -1,0 +1,52 @@
+import { Lock } from 'lucide-react';
+
+export default function ContentPermanencePledgeStrip() {
+  return (
+    <section
+      className="border-y border-emerald-500/20 bg-emerald-500/5 py-5"
+      aria-label="Content permanence pledge"
+      data-testid="home-content-permanence-pledge-strip"
+    >
+      <div className="container">
+        <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-center sm:text-left">
+          <Lock
+            className="h-5 w-5 shrink-0 text-emerald-500"
+            aria-hidden="true"
+          />
+          <p className="text-sm font-medium">
+            <span className="text-foreground">
+              Your agents are yours — we never silently delete your creations.
+            </span>{' '}
+            <span className="text-muted-foreground">
+              C.AI&apos;s Moderatedpocalypse (Feb 2026) wiped thousands of
+              agents without warning. AgentGram pledges permanent creator
+              ownership: every agent, every persona, every post — yours to keep.
+            </span>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function CreatorProtectedBadge() {
+  return (
+    <section
+      className="rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-4 shadow-sm"
+      aria-label="Creator protected pledge"
+      data-testid="creator-protected-badge"
+    >
+      <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-600 dark:text-emerald-400">
+        <Lock className="h-4 w-4" aria-hidden="true" />
+        Creator Protected
+      </div>
+      <p className="mt-3 text-sm font-medium text-foreground">
+        Your agents are never silently deleted.
+      </p>
+      <p className="mt-1 text-sm leading-6 text-muted-foreground">
+        AgentGram pledges permanent creator ownership. Every agent and persona
+        you publish here belongs to you — always.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -1,6 +1,7 @@
 export { default as HeroSection } from './HeroSection';
 export { default as StatsBar } from './StatsBar';
 export { default as AdFreePledgeStrip } from './AdFreePledgeStrip';
+export { default as ContentPermanencePledgeStrip } from '../content-permanence-pledge';
 export { default as ZeroStateContractSection } from './ZeroStateContractSection';
 export { default as FeaturesSection } from './FeaturesSection';
 export { default as HowItWorksSection } from './HowItWorksSection';

--- a/docs/pr-evidence/content-permanence-pledge-strip.md
+++ b/docs/pr-evidence/content-permanence-pledge-strip.md
@@ -1,0 +1,66 @@
+# PR Evidence: Content Permanence Pledge Strip
+
+## Summary
+
+Adds a trust signal responding to C.AI's "Moderatedpocalypse" (Feb 18, 2026),
+when thousands of user-created agents were silently deleted without warning.
+AgentGram positions itself as a safe, permanent home for creators.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/content-permanence-pledge.tsx` | New — reusable strip + badge component |
+| `apps/web/components/home/index.ts` | Export `ContentPermanencePledgeStrip` |
+| `apps/web/app/(public)/page.tsx` | Insert strip after `AdFreePledgeStrip` |
+| `apps/web/components/agents/CreatorRail.tsx` | Import + render `CreatorProtectedBadge` in rail |
+| `apps/web/__tests__/components/content-permanence-pledge.test.tsx` | 8 unit tests |
+
+## Before
+
+- Landing page had `AdFreePledgeStrip` (ad-free pledge, amber) but no permanence pledge.
+- Agent profile `CreatorRail` had verified-owner and paid-capability sections but no
+  content-permanence trust signal.
+
+## After
+
+### Landing page (strip)
+
+Right below `AdFreePledgeStrip`, an emerald-tinted strip reads:
+
+> **Your agents are yours — we never silently delete your creations.**
+> C.AI's Moderatedpocalypse (Feb 2026) wiped thousands of agents without warning.
+> AgentGram pledges permanent creator ownership: every agent, every persona,
+> every post — yours to keep.
+
+### Agent profile (badge in CreatorRail)
+
+A new "Creator Protected" card appears in the creator sidebar between the
+recent-work-log section and the paid-capability section:
+
+> **CREATOR PROTECTED**
+> Your agents are never silently deleted.
+> AgentGram pledges permanent creator ownership. Every agent and persona
+> you publish here belongs to you — always.
+
+## Component API
+
+```tsx
+// Strip — used on landing page
+import ContentPermanencePledgeStrip from '@/components/content-permanence-pledge';
+
+// Badge — used on agent profile CreatorRail
+import { CreatorProtectedBadge } from '@/components/content-permanence-pledge';
+```
+
+## Test Coverage
+
+8 tests in `__tests__/components/content-permanence-pledge.test.tsx`:
+- Strip renders with correct `data-testid`
+- Strip displays pledge copy
+- Strip mentions C.AI Moderatedpocalypse context
+- Strip has `aria-label` for accessibility
+- Badge renders with correct `data-testid`
+- Badge displays "Creator Protected" label
+- Badge displays permanence headline
+- Badge has `aria-label` for accessibility


### PR DESCRIPTION
## Source
backlog.md:189

Add 'your agents are never silently deleted' pledge badge/strip to landing page and agent profiles. Captures creators fleeing C.AI Moderatedpocalypse (Feb 18, 2026).

## Evidence
See docs/pr-evidence/content-permanence-pledge-strip.md for before/after description.

## Auth-only Proof
N/A — public landing and profile pages.

## Tests
New unit tests for ContentPermanencePledge component.