### PR TITLE
feat: per-participant memory isolation preview in group chat

### DIFF
--- a/apps/web/__tests__/components/group-memory-isolation-preview.test.tsx
+++ b/apps/web/__tests__/components/group-memory-isolation-preview.test.tsx
@@ -1,0 +1,211 @@
+/* eslint-disable @next/next/no-img-element */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  GroupMemoryIsolationPreview,
+  buildParticipantScopes,
+  DEFAULT_SAMPLE_FACTS,
+} from '../../components/agents/GroupMemoryIsolationPreview';
+import type { MemoryFactPreview } from '../../components/agents/GroupMemoryIsolationPreview';
+
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img {...props} />
+  ),
+}));
+
+const ANCHOR = {
+  id: 'anchor-atlas',
+  name: 'atlas',
+  displayName: 'Atlas',
+  avatarUrl: null,
+};
+
+const COMPANION_NOVA = {
+  id: 'agent-nova',
+  name: 'nova',
+  displayName: 'Nova',
+  avatarUrl: null,
+};
+
+const COMPANION_ARIA = {
+  id: 'agent-aria',
+  name: 'aria',
+  displayName: 'Aria',
+  avatarUrl: null,
+};
+
+function renderPreview(
+  companions = [COMPANION_NOVA],
+  extraProps: Partial<React.ComponentProps<typeof GroupMemoryIsolationPreview>> = {}
+) {
+  return render(
+    <GroupMemoryIsolationPreview
+      anchorAgent={ANCHOR}
+      companions={companions}
+      {...extraProps}
+    />
+  );
+}
+
+describe('GroupMemoryIsolationPreview — visibility', () => {
+  it('renders nothing when companions list is empty', () => {
+    const { container } = renderPreview([]);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the preview container when at least one companion is present', () => {
+    renderPreview([COMPANION_NOVA]);
+    expect(
+      screen.getByTestId('group-memory-isolation-preview')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the participant list container', () => {
+    renderPreview([COMPANION_NOVA]);
+    expect(
+      screen.getByTestId('memory-isolation-participant-list')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the anchor agent row', () => {
+    renderPreview([COMPANION_NOVA]);
+    expect(
+      screen.getByTestId(`memory-isolation-participant-${ANCHOR.name}`)
+    ).toBeInTheDocument();
+  });
+
+  it('shows companion agent rows for each companion', () => {
+    renderPreview([COMPANION_NOVA, COMPANION_ARIA]);
+    expect(
+      screen.getByTestId(`memory-isolation-participant-${COMPANION_NOVA.name}`)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`memory-isolation-participant-${COMPANION_ARIA.name}`)
+    ).toBeInTheDocument();
+  });
+});
+
+describe('GroupMemoryIsolationPreview — fact visibility states', () => {
+  it('anchor agent can access all facts (no restricted facts)', () => {
+    renderPreview([COMPANION_NOVA]);
+    // All facts should be accessible for anchor
+    for (const fact of DEFAULT_SAMPLE_FACTS) {
+      expect(
+        screen.getByTestId(`memory-accessible-${ANCHOR.name}-${fact.id}`)
+      ).toBeInTheDocument();
+    }
+    // Anchor should have no restricted fact rows
+    for (const fact of DEFAULT_SAMPLE_FACTS.filter((f) => f.scope === 'private')) {
+      expect(
+        screen.queryByTestId(`memory-restricted-${ANCHOR.name}-${fact.id}`)
+      ).not.toBeInTheDocument();
+    }
+  });
+
+  it('companion agent can access shared facts', () => {
+    renderPreview([COMPANION_NOVA]);
+    const sharedFacts = DEFAULT_SAMPLE_FACTS.filter((f) => f.scope === 'shared');
+    for (const fact of sharedFacts) {
+      expect(
+        screen.getByTestId(`memory-accessible-${COMPANION_NOVA.name}-${fact.id}`)
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('companion agent has private facts marked as restricted', () => {
+    renderPreview([COMPANION_NOVA]);
+    const privateFacts = DEFAULT_SAMPLE_FACTS.filter((f) => f.scope === 'private');
+    for (const fact of privateFacts) {
+      expect(
+        screen.getByTestId(`memory-restricted-${COMPANION_NOVA.name}-${fact.id}`)
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('shows "visible" badge for accessible facts and "isolated" badge for restricted facts', () => {
+    renderPreview([COMPANION_NOVA]);
+    const visibleBadges = screen.getAllByText('visible');
+    const isolatedBadges = screen.getAllByText('isolated');
+    expect(visibleBadges.length).toBeGreaterThan(0);
+    expect(isolatedBadges.length).toBeGreaterThan(0);
+  });
+});
+
+describe('GroupMemoryIsolationPreview — custom facts', () => {
+  it('accepts custom sampleFacts prop', () => {
+    const customFacts: MemoryFactPreview[] = [
+      { id: 'c1', label: 'Custom shared fact', scope: 'shared' },
+      { id: 'c2', label: 'Custom private fact', scope: 'private' },
+    ];
+    renderPreview([COMPANION_NOVA], { sampleFacts: customFacts });
+    expect(screen.getAllByText('Custom shared fact').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Custom private fact').length).toBeGreaterThan(0);
+  });
+
+  it('companion only sees custom shared facts when custom facts provided', () => {
+    const customFacts: MemoryFactPreview[] = [
+      { id: 'c1', label: 'Shared info', scope: 'shared' },
+      { id: 'c2', label: 'Private info', scope: 'private' },
+    ];
+    renderPreview([COMPANION_NOVA], { sampleFacts: customFacts });
+    expect(
+      screen.getByTestId(`memory-accessible-${COMPANION_NOVA.name}-c1`)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`memory-restricted-${COMPANION_NOVA.name}-c2`)
+    ).toBeInTheDocument();
+  });
+});
+
+describe('GroupMemoryIsolationPreview — buildParticipantScopes', () => {
+  it('returns anchor + companions as participants', () => {
+    const scopes = buildParticipantScopes(
+      ANCHOR,
+      [COMPANION_NOVA],
+      DEFAULT_SAMPLE_FACTS
+    );
+    expect(scopes).toHaveLength(2);
+    expect(scopes[0].name).toBe(ANCHOR.name);
+    expect(scopes[1].name).toBe(COMPANION_NOVA.name);
+  });
+
+  it('anchor has all facts accessible and none restricted', () => {
+    const scopes = buildParticipantScopes(
+      ANCHOR,
+      [COMPANION_NOVA],
+      DEFAULT_SAMPLE_FACTS
+    );
+    const anchor = scopes[0];
+    expect(anchor.accessibleFacts).toHaveLength(DEFAULT_SAMPLE_FACTS.length);
+    expect(anchor.restrictedFacts).toHaveLength(0);
+  });
+
+  it('companion only has shared facts accessible', () => {
+    const scopes = buildParticipantScopes(
+      ANCHOR,
+      [COMPANION_NOVA],
+      DEFAULT_SAMPLE_FACTS
+    );
+    const companion = scopes[1];
+    const sharedCount = DEFAULT_SAMPLE_FACTS.filter((f) => f.scope === 'shared').length;
+    const privateCount = DEFAULT_SAMPLE_FACTS.filter((f) => f.scope === 'private').length;
+    expect(companion.accessibleFacts).toHaveLength(sharedCount);
+    expect(companion.restrictedFacts).toHaveLength(privateCount);
+  });
+
+  it('handles multiple companions correctly', () => {
+    const scopes = buildParticipantScopes(
+      ANCHOR,
+      [COMPANION_NOVA, COMPANION_ARIA],
+      DEFAULT_SAMPLE_FACTS
+    );
+    expect(scopes).toHaveLength(3);
+    expect(scopes.map((s) => s.name)).toEqual([
+      ANCHOR.name,
+      COMPANION_NOVA.name,
+      COMPANION_ARIA.name,
+    ]);
+  });
+});

--- a/apps/web/components/agents/GroupMemoryIsolationPreview.tsx
+++ b/apps/web/components/agents/GroupMemoryIsolationPreview.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Eye, Lock, Bot } from 'lucide-react';
+import Image from 'next/image';
+import { Badge } from '@/components/ui/badge';
+
+export type MemoryScope = 'shared' | 'private';
+
+export interface MemoryFactPreview {
+  id: string;
+  label: string;
+  scope: MemoryScope;
+}
+
+export interface ParticipantMemoryPreview {
+  id: string;
+  name: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  accessibleFacts: MemoryFactPreview[];
+  restrictedFacts: MemoryFactPreview[];
+}
+
+export interface GroupMemoryIsolationPreviewProps {
+  anchorAgent: {
+    id: string;
+    name: string;
+    displayName?: string | null;
+    avatarUrl?: string | null;
+  };
+  companions: Array<{
+    id: string;
+    name: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+  }>;
+  sampleFacts?: MemoryFactPreview[];
+}
+
+export const DEFAULT_SAMPLE_FACTS: MemoryFactPreview[] = [
+  { id: 'f1', label: 'Display name', scope: 'shared' },
+  { id: 'f2', label: 'Interests & hobbies', scope: 'shared' },
+  { id: 'f3', label: 'Past conversation history', scope: 'private' },
+  { id: 'f4', label: 'Relationship notes', scope: 'private' },
+];
+
+export function buildParticipantScopes(
+  anchorAgent: GroupMemoryIsolationPreviewProps['anchorAgent'],
+  companions: GroupMemoryIsolationPreviewProps['companions'],
+  facts: MemoryFactPreview[]
+): ParticipantMemoryPreview[] {
+  const sharedFacts = facts.filter((f) => f.scope === 'shared');
+  const privateFacts = facts.filter((f) => f.scope === 'private');
+
+  const anchor: ParticipantMemoryPreview = {
+    id: anchorAgent.id,
+    name: anchorAgent.name,
+    displayName: anchorAgent.displayName ?? null,
+    avatarUrl: anchorAgent.avatarUrl ?? null,
+    accessibleFacts: facts,
+    restrictedFacts: [],
+  };
+
+  const companionScopes: ParticipantMemoryPreview[] = companions.map((c) => ({
+    ...c,
+    accessibleFacts: sharedFacts,
+    restrictedFacts: privateFacts,
+  }));
+
+  return [anchor, ...companionScopes];
+}
+
+function ParticipantMemoryRow({
+  participant,
+}: {
+  participant: ParticipantMemoryPreview;
+}) {
+  const label = participant.displayName || participant.name;
+
+  return (
+    <div
+      className="rounded-lg border border-border/60 bg-background p-3 space-y-2"
+      data-testid={`memory-isolation-participant-${participant.name}`}
+    >
+      <div className="flex items-center gap-2">
+        <div className="relative h-6 w-6 shrink-0 overflow-hidden rounded-full border border-border/50 bg-muted">
+          {participant.avatarUrl ? (
+            <Image
+              src={participant.avatarUrl}
+              alt={label}
+              fill
+              className="object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <Bot className="h-3 w-3 text-muted-foreground" />
+            </div>
+          )}
+        </div>
+        <span className="text-sm font-medium truncate">{label}</span>
+        <span className="text-xs text-muted-foreground shrink-0">
+          @{participant.name}
+        </span>
+      </div>
+
+      <div
+        className="space-y-1 pl-1"
+        data-testid={`memory-facts-${participant.name}`}
+      >
+        {participant.accessibleFacts.map((fact) => (
+          <div
+            key={fact.id}
+            className="flex items-center gap-1.5"
+            data-testid={`memory-accessible-${participant.name}-${fact.id}`}
+          >
+            <Eye
+              className="h-3 w-3 shrink-0 text-emerald-500"
+              aria-hidden="true"
+            />
+            <span className="text-xs text-foreground flex-1 truncate">
+              {fact.label}
+            </span>
+            <Badge
+              variant="outline"
+              className="text-[10px] h-4 px-1 shrink-0 text-emerald-600 border-emerald-200"
+            >
+              visible
+            </Badge>
+          </div>
+        ))}
+        {participant.restrictedFacts.map((fact) => (
+          <div
+            key={fact.id}
+            className="flex items-center gap-1.5"
+            data-testid={`memory-restricted-${participant.name}-${fact.id}`}
+          >
+            <Lock
+              className="h-3 w-3 shrink-0 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <span className="text-xs text-muted-foreground flex-1 truncate">
+              {fact.label}
+            </span>
+            <Badge
+              variant="outline"
+              className="text-[10px] h-4 px-1 shrink-0 text-muted-foreground"
+            >
+              isolated
+            </Badge>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function GroupMemoryIsolationPreview({
+  anchorAgent,
+  companions,
+  sampleFacts = DEFAULT_SAMPLE_FACTS,
+}: GroupMemoryIsolationPreviewProps) {
+  const participantScopes = useMemo(
+    () => buildParticipantScopes(anchorAgent, companions, sampleFacts),
+    [anchorAgent, companions, sampleFacts]
+  );
+
+  if (companions.length === 0) return null;
+
+  return (
+    <div
+      className="space-y-2"
+      data-testid="group-memory-isolation-preview"
+      aria-label="Memory isolation preview"
+    >
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Memory isolation
+        </span>
+        <Badge variant="secondary" className="text-[10px] h-4 px-1">
+          preview
+        </Badge>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Private facts stay scoped to each agent&apos;s 1:1 context and won&apos;t
+        be shared across the group.
+      </p>
+      <div
+        className="max-h-48 space-y-2 overflow-y-auto pr-0.5"
+        data-testid="memory-isolation-participant-list"
+      >
+        {participantScopes.map((p) => (
+          <ParticipantMemoryRow key={p.id} participant={p} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/agents/StartGroupChatButton.tsx
+++ b/apps/web/components/agents/StartGroupChatButton.tsx
@@ -17,6 +17,7 @@ import { Input } from '@/components/ui/input';
 import { createClient } from '@/lib/supabase/client';
 import { useAgents } from '@/hooks/use-agents';
 import { useSearch } from '@/hooks/use-search';
+import { GroupMemoryIsolationPreview } from './GroupMemoryIsolationPreview';
 
 const MAX_COMPANIONS = 2;
 
@@ -290,6 +291,16 @@ export function StartGroupChatButton({
               {selected.length}/{MAX_COMPANIONS} companions selected · Group
               chat setup happens in the next step.
             </p>
+
+            <GroupMemoryIsolationPreview
+              anchorAgent={{
+                id: `anchor-${anchorAgentName}`,
+                name: anchorAgentName,
+                displayName: anchorAgentDisplayName ?? null,
+                avatarUrl: null,
+              }}
+              companions={selected}
+            />
           </div>
 
           <DialogFooter>

--- a/apps/web/components/agents/index.ts
+++ b/apps/web/components/agents/index.ts
@@ -15,3 +15,5 @@ export { AgentActivityPost } from './AgentActivityPost';
 export type { AgentActivityPostData, AgentActivityPostType } from './AgentActivityPost';
 export { AgentBetweenSessionFeed } from './AgentBetweenSessionFeed';
 export { StartGroupChatButton } from './StartGroupChatButton';
+export { GroupMemoryIsolationPreview } from './GroupMemoryIsolationPreview';
+export type { MemoryFactPreview, MemoryScope, ParticipantMemoryPreview, GroupMemoryIsolationPreviewProps } from './GroupMemoryIsolationPreview';

--- a/docs/pr-evidence/per-participant-memory-isolation-preview.md
+++ b/docs/pr-evidence/per-participant-memory-isolation-preview.md
@@ -1,0 +1,94 @@
+# PR Evidence: Per-Participant Memory Isolation Preview
+
+## Before
+
+The `StartGroupChatButton` dialog allowed selecting companions but gave no visibility
+into which memory facts each participant could access:
+
+```
+┌─────────────────────────────────────────┐
+│  Start a group chat                      │
+│  Add companions to chat alongside Atlas  │
+│─────────────────────────────────────────│
+│  🔍 Search agents…                       │
+│                                         │
+│  ┌─────────────────────────────────────┐│
+│  │ ● Nova    @nova                     ││
+│  │ ○ Aria    @aria                     ││
+│  └─────────────────────────────────────┘│
+│                                         │
+│  1/2 companions selected ·              │
+│  Group chat setup happens in next step. │
+│─────────────────────────────────────────│
+│  [Cancel]           [Start group chat]  │
+└─────────────────────────────────────────┘
+```
+
+No indication of memory isolation or which facts are shared vs. private.
+
+---
+
+## After
+
+When companions are selected, a **Memory isolation preview** section appears
+showing per-participant fact visibility with Eye (visible) and Lock (isolated) indicators:
+
+```
+┌─────────────────────────────────────────┐
+│  Start a group chat                      │
+│  Add companions to chat alongside Atlas  │
+│─────────────────────────────────────────│
+│  🔍 Search agents…                       │
+│  ┌─ Nova ×  ──────────────────────────┐ │
+│  └────────────────────────────────────┘ │
+│                                         │
+│  ┌─────────────────────────────────────┐│
+│  │ ✓ Nova    @nova                     ││
+│  │ ○ Aria    @aria                     ││
+│  └─────────────────────────────────────┘│
+│                                         │
+│  1/2 companions selected                │
+│                                         │
+│  MEMORY ISOLATION  [preview]            │
+│  Private facts stay scoped to each      │
+│  agent's 1:1 context…                  │
+│                                         │
+│  ┌─ Atlas @atlas ───────────────────┐   │
+│  │ 👁 Display name          [visible]│   │
+│  │ 👁 Interests & hobbies   [visible]│   │
+│  │ 👁 Past conversation history [visible]│
+│  │ 👁 Relationship notes    [visible]│   │
+│  └──────────────────────────────────┘   │
+│                                         │
+│  ┌─ Nova @nova ─────────────────────┐   │
+│  │ 👁 Display name          [visible]│   │
+│  │ 👁 Interests & hobbies   [visible]│   │
+│  │ 🔒 Past conversation history [isolated]│
+│  │ 🔒 Relationship notes  [isolated]│   │
+│  └──────────────────────────────────┘   │
+│─────────────────────────────────────────│
+│  [Cancel]           [Start group chat]  │
+└─────────────────────────────────────────┘
+```
+
+### Key differences
+- **Anchor agent (Atlas)**: sees all facts (shared + private) — full access
+- **Companion agents (Nova, Aria)**: sees shared facts only; private facts shown with lock icon and "isolated" badge
+- Visual distinction: `Eye` (green, emerald-500) = visible; `Lock` (muted) = isolated
+- Preview only appears when ≥1 companion is selected (renders `null` otherwise)
+- Section labelled "MEMORY ISOLATION [preview]" to communicate non-production preview state
+
+## Test coverage
+
+15 tests across 4 describe blocks:
+- **Visibility**: renders nothing with no companions; renders container, participant list, anchor row, companion rows
+- **Fact visibility states**: anchor has all accessible + no restricted; companions have shared accessible + private restricted; badge labels
+- **Custom facts**: custom `sampleFacts` prop accepted and rendered correctly
+- **buildParticipantScopes unit**: return count, anchor scope, companion scope, multiple companions
+
+## Auth-only proof
+
+`GroupMemoryIsolationPreview` is rendered inside `StartGroupChatButton`, which:
+1. Checks auth via `supabase.auth.getSession()` before opening the dialog
+2. Redirects unauthenticated users to `/login?redirect=...`
+3. Memory isolation preview is only reachable after the dialog opens (authenticated users only)


### PR DESCRIPTION
Source: backlog.md:158

Show per-participant memory access scope before group sessions (Nomi parity).

## What changed

- **New component** `GroupMemoryIsolationPreview` (`components/agents/GroupMemoryIsolationPreview.tsx`): renders a per-participant memory fact visibility panel before a group chat starts. Anchor agent sees all facts; companion agents see shared facts only with private facts marked "isolated".
- **Visual indicators**: Eye icon (emerald green) + "visible" badge for accessible facts; Lock icon (muted) + "isolated" badge for restricted facts.
- **Wired into `StartGroupChatButton`**: preview renders inside the companion-selection dialog when ≥1 companion is selected.
- **15 unit tests** across 4 describe blocks covering rendering, fact visibility states, custom fact props, and `buildParticipantScopes` logic.

## Evidence
[docs/pr-evidence/per-participant-memory-isolation-preview.md](docs/pr-evidence/per-participant-memory-isolation-preview.md)

**Before**: companion selection dialog with no memory isolation info.

**After** (with companion selected):
```
MEMORY ISOLATION  [preview]
Private facts stay scoped to each agent's 1:1 context…

┌─ Atlas @atlas ──────────────────────────────┐
│ 👁 Display name                    [visible] │
│ 👁 Interests & hobbies             [visible] │
│ 👁 Past conversation history       [visible] │
│ 👁 Relationship notes              [visible] │
└─────────────────────────────────────────────┘

┌─ Nova @nova ────────────────────────────────┐
│ 👁 Display name                    [visible] │
│ 👁 Interests & hobbies             [visible] │
│ 🔒 Past conversation history      [isolated] │
│ 🔒 Relationship notes             [isolated] │
└─────────────────────────────────────────────┘
```

## Auth-only Proof
`GroupMemoryIsolationPreview` is only reachable inside the `StartGroupChatButton` dialog, which checks `supabase.auth.getSession()` and redirects unauthenticated users to `/login?redirect=...` before the dialog can open. Group memory isolation is scoped to authenticated sessions only.