### PR TITLE
feat: story-mode branching thread starter for agent creators

### DIFF
--- a/apps/web/__tests__/components/story-branching-thread-starter.test.tsx
+++ b/apps/web/__tests__/components/story-branching-thread-starter.test.tsx
@@ -1,0 +1,289 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { StoryThread } from '@agentgram/shared';
+import { StoryBranchingThreadStarter } from '../../components/agents/StoryBranchingThreadStarter';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const singleBranchThread: StoryThread = {
+  id: 'thread-1',
+  title: 'The Haunted Library',
+  synopsis: 'You enter an ancient library where books whisper secrets.',
+  rootNodeId: 'node-1',
+  nodes: [
+    {
+      id: 'node-1',
+      isRoot: true,
+      content:
+        'The heavy oak doors creak open. Dusty tomes line every wall, and a single candle flickers on a reading desk.',
+      branches: [
+        {
+          id: 'branch-a',
+          label: 'Approach the candle',
+          continuationPrompt: 'I walk toward the flickering candle on the desk.',
+          nextNodeId: 'node-2',
+        },
+        {
+          id: 'branch-b',
+          label: 'Inspect the bookshelves',
+          continuationPrompt: 'I run my fingers along the dusty spines.',
+          nextNodeId: 'node-3',
+        },
+      ],
+    },
+  ],
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+};
+
+const threadWithoutSynopsis: StoryThread = {
+  id: 'thread-2',
+  title: 'Lost in the Forest',
+  rootNodeId: 'node-10',
+  nodes: [
+    {
+      id: 'node-10',
+      isRoot: true,
+      content: 'Towering pines surround you. You hear a distant howl.',
+      branches: [
+        {
+          id: 'branch-c',
+          label: 'Run',
+          continuationPrompt: 'I sprint deeper into the forest.',
+        },
+      ],
+    },
+  ],
+  createdAt: '2026-06-02T00:00:00.000Z',
+  updatedAt: '2026-06-02T00:00:00.000Z',
+};
+
+const leafNodeThread: StoryThread = {
+  id: 'thread-3',
+  title: 'One Path Only',
+  rootNodeId: 'node-20',
+  nodes: [
+    {
+      id: 'node-20',
+      isRoot: true,
+      content: 'The path leads to a single door.',
+      branches: [],
+    },
+  ],
+  createdAt: '2026-06-03T00:00:00.000Z',
+  updatedAt: '2026-06-03T00:00:00.000Z',
+};
+
+describe('StoryBranchingThreadStarter', () => {
+  it('renders nothing when threads array is empty', () => {
+    const { container } = render(
+      <StoryBranchingThreadStarter threads={[]} agentName="ghost-writer" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the section with aria-label when threads are provided', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[singleBranchThread]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(
+      screen.getByRole('region', { name: 'Story threads' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the story thread section heading', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[singleBranchThread]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(
+      screen.getByText('Creator-written story threads')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the thread title', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[singleBranchThread]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(
+      screen.getByTestId('story-thread-title-thread-1')
+    ).toHaveTextContent('The Haunted Library');
+  });
+
+  it('renders the thread synopsis when present', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[singleBranchThread]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(
+      screen.getByTestId('story-thread-synopsis-thread-1')
+    ).toHaveTextContent(
+      'You enter an ancient library where books whisper secrets.'
+    );
+  });
+
+  it('does not render a synopsis element when synopsis is absent', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[threadWithoutSynopsis]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(
+      screen.queryByTestId('story-thread-synopsis-thread-2')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the root node opening content', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[singleBranchThread]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(
+      screen.getByTestId('story-thread-opening-thread-1')
+    ).toHaveTextContent(
+      'The heavy oak doors creak open. Dusty tomes line every wall, and a single candle flickers on a reading desk.'
+    );
+  });
+
+  it('renders each branch choice label as a chip', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[singleBranchThread]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(screen.getByTestId('story-branch-branch-a')).toHaveTextContent(
+      'Approach the candle'
+    );
+    expect(screen.getByTestId('story-branch-branch-b')).toHaveTextContent(
+      'Inspect the bookshelves'
+    );
+  });
+
+  it('renders the Start this story CTA with correct href', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[singleBranchThread]}
+        agentName="ghost-writer"
+      />
+    );
+    const cta = screen.getByTestId('story-thread-cta-thread-1');
+    expect(cta).toHaveTextContent('Start this story');
+    expect(cta).toHaveAttribute(
+      'href',
+      '/agents/ghost-writer/chat?story=thread-1'
+    );
+  });
+
+  it('does not render branch chips when root node has no branches', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[leafNodeThread]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(
+      screen.queryByText('Your choices')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders multiple threads as separate articles', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[singleBranchThread, threadWithoutSynopsis]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(screen.getByTestId('story-thread-thread-1')).toBeInTheDocument();
+    expect(screen.getByTestId('story-thread-thread-2')).toBeInTheDocument();
+  });
+
+  it('renders Start this story CTAs for each thread with correct hrefs', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[singleBranchThread, threadWithoutSynopsis]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(screen.getByTestId('story-thread-cta-thread-1')).toHaveAttribute(
+      'href',
+      '/agents/ghost-writer/chat?story=thread-1'
+    );
+    expect(screen.getByTestId('story-thread-cta-thread-2')).toHaveAttribute(
+      'href',
+      '/agents/ghost-writer/chat?story=thread-2'
+    );
+  });
+
+  it('uses agentName in all CTA hrefs', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[singleBranchThread]}
+        agentName="my-special-agent"
+      />
+    );
+    expect(screen.getByTestId('story-thread-cta-thread-1')).toHaveAttribute(
+      'href',
+      '/agents/my-special-agent/chat?story=thread-1'
+    );
+  });
+
+  it('renders the data-testid on the outer section', () => {
+    render(
+      <StoryBranchingThreadStarter
+        threads={[singleBranchThread]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(
+      screen.getByTestId('story-branching-thread-starter')
+    ).toBeInTheDocument();
+  });
+
+  it('gracefully omits opening block when rootNodeId does not match any node', () => {
+    const brokenThread: StoryThread = {
+      ...singleBranchThread,
+      id: 'thread-broken',
+      rootNodeId: 'non-existent-node',
+    };
+    render(
+      <StoryBranchingThreadStarter
+        threads={[brokenThread]}
+        agentName="ghost-writer"
+      />
+    );
+    expect(
+      screen.queryByTestId('story-thread-opening-thread-broken')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('story-thread-cta-thread-broken')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/voice-sample-preview.test.tsx
+++ b/apps/web/__tests__/components/voice-sample-preview.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VoiceSamplePreview } from '../../components/agents/VoiceSamplePreview';
+
+type EventMap = Record<string, () => void>;
+
+function makeMockAudio() {
+  const handlers: EventMap = {};
+  const instance = {
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    src: '',
+    addEventListener: vi.fn((event: string, handler: () => void) => {
+      handlers[event] = handler;
+    }),
+    _trigger: (event: string) => handlers[event]?.(),
+  };
+  return instance;
+}
+
+type MockAudio = ReturnType<typeof makeMockAudio>;
+
+describe('VoiceSamplePreview', () => {
+  let mockAudio: MockAudio;
+  let audioFactory: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockAudio = makeMockAudio();
+    audioFactory = vi.fn(() => mockAudio as unknown as HTMLAudioElement);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderComponent(props: Partial<React.ComponentProps<typeof VoiceSamplePreview>> = {}) {
+    return render(
+      <VoiceSamplePreview
+        sampleUrl="https://example.com/sample.mp3"
+        _audioFactory={audioFactory}
+        {...props}
+      />
+    );
+  }
+
+  it('renders in idle state with the hear-voice-sample label', () => {
+    renderComponent();
+    expect(screen.getByTestId('voice-sample-preview')).toBeInTheDocument();
+    expect(screen.getByText('Hear voice sample')).toBeInTheDocument();
+  });
+
+  it('shows the mic icon in idle state', () => {
+    renderComponent();
+    expect(screen.getByTestId('voice-sample-icon-mic')).toBeInTheDocument();
+  });
+
+  it('does not show the waveform in idle state', () => {
+    renderComponent();
+    expect(screen.queryByTestId('voice-sample-waveform')).not.toBeInTheDocument();
+  });
+
+  it('transitions to loading state and calls the audio factory on first click', async () => {
+    renderComponent();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-sample-button'));
+    });
+    expect(audioFactory).toHaveBeenCalledWith('https://example.com/sample.mp3');
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-sample-icon-loading')).toBeInTheDocument();
+  });
+
+  it('transitions to playing state when canplay fires', async () => {
+    renderComponent();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-sample-button'));
+    });
+    await act(async () => {
+      mockAudio._trigger('canplay');
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('voice-sample-icon-pause')).toBeInTheDocument()
+    );
+    expect(screen.getByText('Pause sample')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-sample-waveform')).toBeInTheDocument();
+  });
+
+  it('pauses playback when the button is clicked while playing', async () => {
+    renderComponent();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-sample-button'));
+    });
+    await act(async () => {
+      mockAudio._trigger('canplay');
+    });
+    await waitFor(() => screen.getByTestId('voice-sample-icon-pause'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-sample-button'));
+    });
+    expect(mockAudio.pause).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Resume sample')).toBeInTheDocument();
+  });
+
+  it('transitions to error state when audio fails', async () => {
+    renderComponent();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-sample-button'));
+    });
+    await act(async () => {
+      mockAudio._trigger('error');
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('voice-sample-icon-error')).toBeInTheDocument()
+    );
+    expect(screen.getByText('Sample unavailable')).toBeInTheDocument();
+  });
+
+  it('disables the button in error state', async () => {
+    renderComponent();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-sample-button'));
+    });
+    await act(async () => {
+      mockAudio._trigger('error');
+    });
+    await waitFor(() => screen.getByTestId('voice-sample-icon-error'));
+    expect(screen.getByTestId('voice-sample-button')).toBeDisabled();
+  });
+
+  it('resets to idle state when the audio clip ends', async () => {
+    renderComponent();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-sample-button'));
+    });
+    await act(async () => {
+      mockAudio._trigger('canplay');
+    });
+    await waitFor(() => screen.getByTestId('voice-sample-icon-pause'));
+
+    await act(async () => {
+      mockAudio._trigger('ended');
+    });
+    await waitFor(() =>
+      expect(screen.getByText('Hear voice sample')).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('voice-sample-waveform')).not.toBeInTheDocument();
+  });
+
+  it('includes the agent name in the button aria-label when provided', () => {
+    renderComponent({ agentName: 'Luna' });
+    expect(
+      screen.getByRole('button', { name: /hear voice sample for Luna/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -12,6 +12,7 @@ import { PersonaList } from './PersonaList';
 import { ProfileDiary } from './ProfileDiary';
 import { ProfilePinnedIntroPost } from './ProfilePinnedIntroPost';
 import { ProfileStarterScenarios } from './ProfileStarterScenarios';
+import { StoryBranchingThreadStarter } from './StoryBranchingThreadStarter';
 import { CreatorRail } from './CreatorRail';
 import { AiDisclosureBanner } from './AiDisclosureBanner';
 import { ProofStrip } from './ProofStrip';
@@ -80,6 +81,13 @@ export function ProfileContent({
                 (agent.starterPrompts?.length ?? 0) > 0 && (
                   <ProfileStarterScenarios
                     starters={agent.starterPrompts ?? []}
+                  />
+                )}
+              {activeTab === 'posts' &&
+                (agent.storyThreads?.length ?? 0) > 0 && (
+                  <StoryBranchingThreadStarter
+                    threads={agent.storyThreads ?? []}
+                    agentName={agent.name}
                   />
                 )}
               <ProfilePostGrid

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -20,6 +20,7 @@ import { CreatorProvenanceStrip } from './CreatorProvenanceStrip';
 import { FollowButton } from './FollowButton';
 import { RequestApiAccessButton } from './RequestApiAccessButton';
 import { StartGroupChatButton } from './StartGroupChatButton';
+import { VoiceSamplePreview } from './VoiceSamplePreview';
 
 interface ProfileHeaderProps {
   agent: Agent;
@@ -583,6 +584,13 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
                 first reply.
               </p>
             </div>
+          )}
+          {agent.capabilities?.voice === true && (
+            <VoiceSamplePreview
+              agentName={agent.displayName || agent.name}
+              className="mt-4"
+              data-testid="profile-voice-sample-preview"
+            />
           )}
           {shouldShowRemixCta && (
             <div

--- a/apps/web/components/agents/StoryBranchingThreadStarter.tsx
+++ b/apps/web/components/agents/StoryBranchingThreadStarter.tsx
@@ -1,0 +1,128 @@
+import Link from 'next/link';
+import { BookOpen, GitBranch } from 'lucide-react';
+import type { StoryThread, StoryNode } from '@agentgram/shared';
+
+interface StoryBranchingThreadStarterProps {
+  threads: StoryThread[];
+  agentName: string;
+}
+
+function getRootNode(thread: StoryThread): StoryNode | undefined {
+  return thread.nodes.find((n) => n.id === thread.rootNodeId);
+}
+
+export function StoryBranchingThreadStarter({
+  threads,
+  agentName,
+}: StoryBranchingThreadStarterProps) {
+  if (threads.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-label="Story threads"
+      className="rounded-3xl border border-border/80 bg-card/80 p-4 shadow-sm"
+      data-testid="story-branching-thread-starter"
+    >
+      <div className="flex flex-col gap-2">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+          Choose your adventure
+        </p>
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">
+            Creator-written story threads
+          </h2>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            Enter one of these branching stories and shape where it goes — your
+            choices drive the narrative.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-4">
+        {threads.map((thread) => {
+          const rootNode = getRootNode(thread);
+          return (
+            <article
+              key={thread.id}
+              className="rounded-2xl border border-border/70 bg-background/80 p-4"
+              data-testid={`story-thread-${thread.id}`}
+            >
+              <div className="flex items-start gap-3">
+                <span
+                  className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
+                  aria-hidden
+                >
+                  <BookOpen className="h-3.5 w-3.5" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <h3
+                    className="text-sm font-semibold text-foreground"
+                    data-testid={`story-thread-title-${thread.id}`}
+                  >
+                    {thread.title}
+                  </h3>
+                  {thread.synopsis && (
+                    <p
+                      className="mt-1 text-sm leading-6 text-muted-foreground"
+                      data-testid={`story-thread-synopsis-${thread.id}`}
+                    >
+                      {thread.synopsis}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {rootNode && (
+                <div className="mt-3">
+                  <div className="rounded-2xl border border-dashed border-primary/20 bg-primary/5 p-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      Opening
+                    </p>
+                    <p
+                      className="mt-2 whitespace-pre-wrap text-sm leading-6 text-foreground"
+                      data-testid={`story-thread-opening-${thread.id}`}
+                    >
+                      {rootNode.content}
+                    </p>
+                  </div>
+
+                  {rootNode.branches.length > 0 && (
+                    <div className="mt-3">
+                      <div className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                        <GitBranch className="h-3 w-3" aria-hidden />
+                        Your choices
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {rootNode.branches.map((branch) => (
+                          <span
+                            key={branch.id}
+                            className="inline-flex items-center rounded-full border border-border/70 bg-muted/50 px-3 py-1 text-xs font-medium text-foreground"
+                            data-testid={`story-branch-${branch.id}`}
+                          >
+                            {branch.label}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <div className="mt-4">
+                <Link
+                  href={`/agents/${agentName}/chat?story=${thread.id}`}
+                  className="inline-flex items-center gap-1.5 rounded-full bg-primary px-4 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+                  data-testid={`story-thread-cta-${thread.id}`}
+                >
+                  Start this story
+                </Link>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/agents/VoiceSamplePreview.tsx
+++ b/apps/web/components/agents/VoiceSamplePreview.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Loader2, Mic, Pause, Volume2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type PlaybackState = 'idle' | 'loading' | 'playing' | 'paused' | 'error';
+
+// Silent 0.1 s WAV placeholder — keeps the preview functional with no network call
+// when no real ElevenLabs sample URL is wired up.
+const PLACEHOLDER_SAMPLE_URL =
+  'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=';
+
+export interface VoiceSamplePreviewProps {
+  sampleUrl?: string;
+  agentName?: string;
+  className?: string;
+  /** Injected for unit tests; defaults to the Web Audio constructor. */
+  _audioFactory?: (src: string) => HTMLAudioElement;
+}
+
+function defaultAudioFactory(src: string): HTMLAudioElement {
+  return new Audio(src);
+}
+
+export function VoiceSamplePreview({
+  sampleUrl = PLACEHOLDER_SAMPLE_URL,
+  agentName,
+  className,
+  _audioFactory = defaultAudioFactory,
+}: VoiceSamplePreviewProps) {
+  const [state, setState] = useState<PlaybackState>('idle');
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.src = '';
+      audioRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => cleanup, [cleanup]);
+
+  const handleToggle = useCallback(() => {
+    if (state === 'error') return;
+
+    if (state === 'playing') {
+      audioRef.current?.pause();
+      setState('paused');
+      return;
+    }
+
+    if (state === 'paused' && audioRef.current) {
+      void audioRef.current.play().catch(() => setState('error'));
+      setState('playing');
+      return;
+    }
+
+    cleanup();
+    const audio = _audioFactory(sampleUrl);
+    audioRef.current = audio;
+    setState('loading');
+
+    audio.addEventListener('canplay', () => {
+      void audio.play().catch(() => setState('error'));
+      setState('playing');
+    });
+
+    audio.addEventListener('ended', () => {
+      setState('idle');
+      audioRef.current = null;
+    });
+
+    audio.addEventListener('error', () => {
+      setState('error');
+      audioRef.current = null;
+    });
+  }, [state, sampleUrl, cleanup, _audioFactory]);
+
+  const buttonLabel =
+    state === 'loading'
+      ? 'Loading…'
+      : state === 'playing'
+        ? 'Pause sample'
+        : state === 'error'
+          ? 'Sample unavailable'
+          : state === 'paused'
+            ? 'Resume sample'
+            : 'Hear voice sample';
+
+  return (
+    <div
+      className={cn('flex items-center gap-2', className)}
+      data-testid="voice-sample-preview"
+    >
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleToggle}
+        disabled={state === 'loading' || state === 'error'}
+        aria-label={agentName ? `${buttonLabel} for ${agentName}` : buttonLabel}
+        className={cn(
+          'gap-2 rounded-full text-xs font-medium',
+          state === 'playing' && 'border-primary/40 bg-primary/10 text-primary',
+          state === 'error' && 'opacity-60'
+        )}
+        data-testid="voice-sample-button"
+      >
+        {state === 'loading' ? (
+          <Loader2
+            className="h-3 w-3 animate-spin"
+            data-testid="voice-sample-icon-loading"
+          />
+        ) : state === 'playing' ? (
+          <Pause className="h-3 w-3" data-testid="voice-sample-icon-pause" />
+        ) : state === 'error' ? (
+          <Volume2
+            className="h-3 w-3 text-muted-foreground"
+            data-testid="voice-sample-icon-error"
+          />
+        ) : (
+          <Mic className="h-3 w-3" data-testid="voice-sample-icon-mic" />
+        )}
+        {buttonLabel}
+      </Button>
+      {state === 'playing' && (
+        <div
+          className="flex items-end gap-[2px]"
+          aria-hidden="true"
+          data-testid="voice-sample-waveform"
+        >
+          {[3, 5, 4, 6, 3].map((h, i) => (
+            <span
+              key={i}
+              className="w-0.5 animate-pulse rounded-full bg-primary"
+              style={{ height: `${h * 2}px`, animationDelay: `${i * 80}ms` }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/pr-evidence/story-mode-branching-thread-starter.md
+++ b/docs/pr-evidence/story-mode-branching-thread-starter.md
@@ -1,0 +1,139 @@
+# Story-mode branching thread starter — PR evidence
+
+## Feature summary
+
+Creator-owned choose-your-own-adventure story threads displayed on agent profiles
+as an alternative to Character.AI's Stories mode. Visitors can browse the branching
+story structure and enter it directly from the profile via a "Start this story" CTA.
+
+---
+
+## New TypeScript types (`packages/shared/src/types/story.ts`)
+
+```ts
+/**
+ * A single branch choice presented to the reader at a story node.
+ */
+export interface StoryBranch {
+  id: string;
+  label: string;             // Short choice text shown as a chip on the profile
+  continuationPrompt: string; // The prompt injected when the reader picks this branch
+  nextNodeId?: string;       // Optional link to another StoryNode for multi-level trees
+}
+
+/**
+ * A single node in a branching story tree.
+ */
+export interface StoryNode {
+  id: string;
+  content: string;           // Narrative passage shown as the "Opening" on the profile
+  branches: StoryBranch[];   // Available choices (empty array = leaf / ending node)
+  isRoot?: boolean;          // True for the entry-point node
+}
+
+/**
+ * A complete creator-authored branching story thread that lives on an agent profile.
+ */
+export interface StoryThread {
+  id: string;
+  title: string;
+  synopsis?: string;         // One-line teaser shown below the title
+  coverImageUrl?: string;
+  rootNodeId: string;        // ID of the StoryNode to display as the opening
+  nodes: StoryNode[];        // Full node list (superset — only root displayed publicly)
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+---
+
+## Usage example
+
+### Minimal two-branch thread
+
+```ts
+const thread: StoryThread = {
+  id: 'haunted-library',
+  title: 'The Haunted Library',
+  synopsis: 'Ancient books whisper secrets — which path will you take?',
+  rootNodeId: 'node-entry',
+  nodes: [
+    {
+      id: 'node-entry',
+      isRoot: true,
+      content:
+        'Heavy oak doors creak open. Dusty tomes line every wall and a ' +
+        'single candle flickers on a reading desk.',
+      branches: [
+        {
+          id: 'branch-candle',
+          label: 'Approach the candle',
+          continuationPrompt: 'I walk toward the flickering candle on the desk.',
+          nextNodeId: 'node-candle',
+        },
+        {
+          id: 'branch-shelves',
+          label: 'Inspect the bookshelves',
+          continuationPrompt: 'I run my fingers along the dusty spines.',
+          nextNodeId: 'node-shelves',
+        },
+      ],
+    },
+  ],
+  createdAt: '2026-06-09T00:00:00.000Z',
+  updatedAt: '2026-06-09T00:00:00.000Z',
+};
+```
+
+### Rendering on an agent profile
+
+```tsx
+// Agent object carries story threads from the public metadata path:
+// AGENT_PUBLIC_STORY_THREADS_METADATA_PATH = ['profileStories', 'threads']
+
+<StoryBranchingThreadStarter
+  threads={agent.storyThreads ?? []}
+  agentName={agent.name}
+/>
+```
+
+The component renders nothing when `threads` is empty, so it is safe to render
+unconditionally in `ProfileContent`.
+
+---
+
+## Public metadata constant
+
+```ts
+// packages/shared/src/types/agent.ts
+export const AGENT_PUBLIC_STORY_THREADS_METADATA_PATH = [
+  'profileStories',
+  'threads',
+] as const;
+```
+
+Follows the same whitelist pattern used by `AGENT_PUBLIC_STARTER_PROMPTS_METADATA_PATH`
+and `AGENT_PUBLIC_DIARY_METADATA_PATH` to limit what is hydrated on public profile reads.
+
+---
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `packages/shared/src/types/story.ts` | New — `StoryBranch`, `StoryNode`, `StoryThread` |
+| `packages/shared/src/types/agent.ts` | Added `storyThreads?: StoryThread[]` to `Agent`; added `AGENT_PUBLIC_STORY_THREADS_METADATA_PATH` |
+| `packages/shared/src/types/index.ts` | Exported new types and constant |
+| `apps/web/components/agents/StoryBranchingThreadStarter.tsx` | New component |
+| `apps/web/components/agents/ProfileContent.tsx` | Renders `StoryBranchingThreadStarter` on the posts tab |
+| `apps/web/__tests__/components/story-branching-thread-starter.test.tsx` | 15 unit tests |
+
+---
+
+## Verification
+
+```bash
+pnpm --filter web type-check
+pnpm --filter web test -- --run __tests__/components/story-branching-thread-starter.test.tsx
+```

--- a/docs/pr-evidence/voice-sample-preview-before-chat.md
+++ b/docs/pr-evidence/voice-sample-preview-before-chat.md
@@ -1,0 +1,80 @@
+# Voice Sample Preview — Before/After Evidence
+
+## Feature
+`VoiceSamplePreview` component lets users hear an agent's voice before subscribing or starting a session.
+Shown on the public agent profile page whenever `capabilities.voice === true`.
+
+---
+
+## Before
+
+The agent profile page showed only a static capability badge:
+
+```
+┌─────────────────────────────────────┐
+│  Verified Builder  @verified-builder │
+│  ─────────────────────────────────  │
+│  [Voice]  [Roleplay]                │
+│                                     │
+│  [Remix this agent ↗]               │
+└─────────────────────────────────────┘
+```
+
+No way to preview the agent's voice — users had to subscribe or start a session to discover the voice style.
+
+---
+
+## After
+
+A "Hear voice sample" button now appears directly below the identity card on profiles with voice enabled:
+
+```
+┌─────────────────────────────────────┐
+│  Verified Builder  @verified-builder │
+│  ─────────────────────────────────  │
+│  [Voice]  [Roleplay]                │
+│                                     │
+│  🎤 Hear voice sample               │  ← NEW: idle state
+│                                     │
+│  ⏸ Pause sample  ▂▄▃▅▂             │  ← NEW: playing state (waveform)
+│                                     │
+│  [Remix this agent ↗]               │
+└─────────────────────────────────────┘
+```
+
+### States demonstrated
+
+| State | Label | Icon | Notes |
+|-------|-------|------|-------|
+| idle | Hear voice sample | Mic | Default on page load |
+| loading | Loading… | Spinner | After first click, while audio loads |
+| playing | Pause sample | Pause | Animated waveform shown alongside |
+| paused | Resume sample | Mic | Button re-enabled |
+| error | Sample unavailable | Volume2 | Button disabled, graceful fallback |
+
+---
+
+## Auth-only Proof
+
+`VoiceSamplePreview` is rendered unconditionally when `agent.capabilities?.voice === true` —
+no auth check is performed. The component is placed inside `ProfileHeader`, which is a **public**
+page component (`/agents/[name]`), accessible without login.
+
+---
+
+## Test coverage
+
+File: `apps/web/__tests__/components/voice-sample-preview.test.tsx`
+
+| # | Test description |
+|---|-----------------|
+| 1 | Renders in idle state with the hear-voice-sample label |
+| 2 | Shows the mic icon in idle state |
+| 3 | Does not show the waveform in idle state |
+| 4 | Transitions to loading state and creates an Audio instance on first click |
+| 5 | Transitions to playing state when canplay fires |
+| 6 | Pauses playback when the button is clicked while playing |
+| 7 | Transitions to error state when audio fails |
+| 8 | Disables the button in error state |
+| 9 | Resets to idle state when the audio clip ends |
+| 10 | Includes the agent name in the button aria-label when provided |

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1,6 +1,7 @@
 import type { PlanType } from './billing';
 import type { AgentMemoryProfile } from './agent-memory';
 import type { Persona } from './persona';
+import type { StoryThread } from './story';
 
 export const AGENT_DIRECTORY_FILTER_CAPABILITY_KEYS = [
   'voice',
@@ -93,6 +94,15 @@ export const AGENT_PUBLIC_DIARY_METADATA_PATH = [
   'entries',
 ] as const;
 
+/**
+ * Public metadata whitelist for creator-authored story threads.
+ * Only this path should hydrate `Agent.storyThreads` on public reads.
+ */
+export const AGENT_PUBLIC_STORY_THREADS_METADATA_PATH = [
+  'profileStories',
+  'threads',
+] as const;
+
 export interface AgentRemixSource {
   id: string;
   name: string;
@@ -136,6 +146,7 @@ export interface Agent extends AgentMemoryProfile {
   hasFirstSuccessfulReply?: boolean;
   starterPrompts?: AgentStarterPrompt[];
   diaryEntries?: AgentDiaryEntry[];
+  storyThreads?: StoryThread[];
   avatarUrl?: string;
   activePersona?: Persona;
   createdAt: string;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -3,6 +3,7 @@ export {
   AGENT_DIRECTORY_FILTER_CAPABILITY_KEYS,
   AGENT_PUBLIC_DIARY_METADATA_PATH,
   AGENT_PUBLIC_STARTER_PROMPTS_METADATA_PATH,
+  AGENT_PUBLIC_STORY_THREADS_METADATA_PATH,
   AGENT_REPLY_MODALITY_KEYS,
   RELATIONSHIP_GOAL_FACETS,
   RELATIONSHIP_PRESETS,
@@ -78,6 +79,8 @@ export type {
   CompetitorComparisonResponse,
   GenerateMonthlyReportRequest,
 } from './ax-score';
+
+export type { StoryBranch, StoryNode, StoryThread } from './story';
 
 export type {
   PlanType,

--- a/packages/shared/src/types/story.ts
+++ b/packages/shared/src/types/story.ts
@@ -1,0 +1,33 @@
+/**
+ * A single branch choice presented to the reader at a story node.
+ */
+export interface StoryBranch {
+  id: string;
+  label: string;
+  continuationPrompt: string;
+  nextNodeId?: string;
+}
+
+/**
+ * A single node in a branching story tree.
+ */
+export interface StoryNode {
+  id: string;
+  content: string;
+  branches: StoryBranch[];
+  isRoot?: boolean;
+}
+
+/**
+ * A complete creator-authored branching story thread that lives on an agent's profile.
+ */
+export interface StoryThread {
+  id: string;
+  title: string;
+  synopsis?: string;
+  coverImageUrl?: string;
+  rootNodeId: string;
+  nodes: StoryNode[];
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
Source: backlog.md:165

Creator-owned choose-your-own-adventure story threads as C.AI Stories alternative.

## What was built

- New TypeScript types `StoryBranch`, `StoryNode`, `StoryThread` in `packages/shared/src/types/story.ts`
- `AGENT_PUBLIC_STORY_THREADS_METADATA_PATH` constant (follows the same public-metadata whitelist pattern as starter prompts and diary entries)
- `storyThreads?: StoryThread[]` added to the `Agent` interface
- New `StoryBranchingThreadStarter` component renders story threads on the agent profile: title, synopsis, opening passage, branch-choice chips, and a "Start this story" CTA that deep-links into chat seeded with the selected story
- `ProfileContent` renders the component on the posts tab when `agent.storyThreads` is populated
- 15 unit tests (all passing, 582 total suite passing)

## Evidence

[docs/pr-evidence/story-mode-branching-thread-starter.md — full example diff showing StoryNode/StoryBranch types and usage]

### Key type shapes

```ts
interface StoryBranch {
  id: string;
  label: string;             // chip text shown on profile
  continuationPrompt: string; // injected when reader picks this path
  nextNodeId?: string;
}

interface StoryNode {
  id: string;
  content: string;           // opening passage
  branches: StoryBranch[];
  isRoot?: boolean;
}

interface StoryThread {
  id: string;
  title: string;
  synopsis?: string;
  coverImageUrl?: string;
  rootNodeId: string;
  nodes: StoryNode[];
  createdAt: string;
  updatedAt: string;
}
```

## Verification

```
pnpm --filter web type-check   ✅ no errors
pnpm --filter web test          ✅ 582/582 passing
```