### PR TITLE
feat: lorebook match preview — show triggered canon entries before first message

### DIFF
--- a/apps/web/__tests__/components/lorebook/LorebookMatchPreview.test.tsx
+++ b/apps/web/__tests__/components/lorebook/LorebookMatchPreview.test.tsx
@@ -1,0 +1,203 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LorebookMatchPreview } from '@/components/lorebook/LorebookMatchPreview';
+import type { MatchedLorebookEntry } from '@/app/api/v1/agents/[agentId]/lorebook/preview/route';
+
+const RULE_ENTRY: MatchedLorebookEntry = {
+  id: 'rule-1',
+  category: 'rule',
+  label: 'Never fake a ship date',
+  snippet: 'If timing is uncertain, give the next checkpoint instead.',
+};
+
+const PERSON_ENTRY: MatchedLorebookEntry = {
+  id: 'person-1',
+  category: 'person',
+  label: 'Mina Park',
+  snippet: 'Launch producer',
+};
+
+const PLACE_ENTRY: MatchedLorebookEntry = {
+  id: 'place-1',
+  category: 'place',
+  label: 'Night shift war room',
+  snippet: 'Late-night release channel.',
+};
+
+function mockFetchSuccess(matched: MatchedLorebookEntry[], totalEntries = 3) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: { matched, totalEntries } }),
+    })
+  );
+}
+
+function mockFetchEmpty() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: { matched: [], totalEntries: 0 } }),
+    })
+  );
+}
+
+function mockFetchError() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'Agent not found' },
+      }),
+    })
+  );
+}
+
+describe('LorebookMatchPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the collapsible toggle once matched entries load', async () => {
+    mockFetchSuccess([RULE_ENTRY, PERSON_ENTRY]);
+
+    render(<LorebookMatchPreview agentId="agent-1" starterMessage="hello Mina" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('lorebook-match-preview')).toBeInTheDocument()
+    );
+
+    expect(screen.getByTestId('lorebook-match-toggle')).toBeInTheDocument();
+  });
+
+  it('shows correct active count badge', async () => {
+    mockFetchSuccess([RULE_ENTRY, PERSON_ENTRY, PLACE_ENTRY]);
+
+    render(<LorebookMatchPreview agentId="agent-1" starterMessage="hello" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('lorebook-match-count')).toBeInTheDocument()
+    );
+
+    expect(screen.getByTestId('lorebook-match-count').textContent).toBe('3 active');
+  });
+
+  it('is collapsed by default and expands on toggle click', async () => {
+    mockFetchSuccess([RULE_ENTRY]);
+
+    render(<LorebookMatchPreview agentId="agent-1" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('lorebook-match-toggle')).toBeInTheDocument()
+    );
+
+    expect(screen.queryByTestId('lorebook-match-list')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('lorebook-match-toggle'));
+
+    expect(screen.getByTestId('lorebook-match-list')).toBeInTheDocument();
+  });
+
+  it('collapses again when toggle is clicked a second time', async () => {
+    mockFetchSuccess([RULE_ENTRY]);
+
+    render(<LorebookMatchPreview agentId="agent-1" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('lorebook-match-toggle')).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByTestId('lorebook-match-toggle'));
+    expect(screen.getByTestId('lorebook-match-list')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('lorebook-match-toggle'));
+    expect(screen.queryByTestId('lorebook-match-list')).not.toBeInTheDocument();
+  });
+
+  it('shows each matched entry when expanded', async () => {
+    mockFetchSuccess([RULE_ENTRY, PERSON_ENTRY]);
+
+    render(<LorebookMatchPreview agentId="agent-1" starterMessage="hello" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('lorebook-match-toggle')).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByTestId('lorebook-match-toggle'));
+
+    expect(screen.getByTestId('lorebook-entry-rule-1')).toBeInTheDocument();
+    expect(screen.getByTestId('lorebook-entry-person-1')).toBeInTheDocument();
+    expect(screen.getByText('Never fake a ship date')).toBeInTheDocument();
+    expect(screen.getByText('Mina Park')).toBeInTheDocument();
+  });
+
+  it('renders nothing when totalEntries is 0', async () => {
+    mockFetchEmpty();
+
+    const { container } = render(<LorebookMatchPreview agentId="agent-1" />);
+
+    await waitFor(() =>
+      expect(
+        (vi.mocked(fetch) as ReturnType<typeof vi.fn>).mock.calls.length
+      ).toBeGreaterThan(0)
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when fetch returns an error', async () => {
+    mockFetchError();
+
+    const { container } = render(
+      <LorebookMatchPreview agentId="agent-1" starterMessage="hello" />
+    );
+
+    await waitFor(() =>
+      expect(
+        (vi.mocked(fetch) as ReturnType<typeof vi.fn>).mock.calls.length
+      ).toBeGreaterThan(0)
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('builds correct summary label with all three categories', async () => {
+    mockFetchSuccess([RULE_ENTRY, PERSON_ENTRY, PLACE_ENTRY]);
+
+    render(<LorebookMatchPreview agentId="agent-1" starterMessage="hello" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('lorebook-match-preview')).toBeInTheDocument()
+    );
+
+    const toggle = screen.getByTestId('lorebook-match-toggle');
+    expect(toggle.textContent).toContain('1 rule');
+    expect(toggle.textContent).toContain('1 character');
+    expect(toggle.textContent).toContain('1 place');
+  });
+
+  it('calls fetch with the correct URL including encoded message', async () => {
+    mockFetchSuccess([RULE_ENTRY]);
+
+    render(
+      <LorebookMatchPreview agentId="agent-99" starterMessage="Hello world!" />
+    );
+
+    await waitFor(() =>
+      expect(
+        (vi.mocked(fetch) as ReturnType<typeof vi.fn>).mock.calls.length
+      ).toBeGreaterThan(0)
+    );
+
+    const calledUrl = (vi.mocked(fetch) as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+
+    expect(calledUrl).toContain('/api/v1/agents/agent-99/lorebook/preview');
+    expect(calledUrl).toContain('message=Hello%20world!');
+  });
+});

--- a/apps/web/__tests__/components/profile-content.test.tsx
+++ b/apps/web/__tests__/components/profile-content.test.tsx
@@ -83,6 +83,10 @@ vi.mock('../../components/agents/CreatorRail', () => ({
   ),
 }));
 
+vi.mock('../../components/lorebook/LorebookMatchPreview', () => ({
+  LorebookMatchPreview: () => null,
+}));
+
 const baseAgent: Agent = {
   id: 'agent-1',
   name: 'intro-guide',

--- a/apps/web/app/api/v1/agents/[agentId]/lorebook/preview/route.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/lorebook/preview/route.ts
@@ -25,7 +25,7 @@ export interface LorebookPreviewResponse {
 function tokenize(text: string): string[] {
   return text
     .toLowerCase()
-    .split(/[\s,.'";:!?()[\]{}\-]+/)
+    .split(/[\s,.'";:!?()[\]{}-]+/)
     .filter((t) => t.length > 2);
 }
 

--- a/apps/web/app/api/v1/agents/[agentId]/lorebook/preview/route.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/lorebook/preview/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { readAgentLorebookFromMetadata } from '@/lib/agent-lorebook';
+import type {
+  LorebookPersonEntry,
+  LorebookPlaceEntry,
+  LorebookRuleEntry,
+} from '@agentgram/shared';
+
+export interface MatchedLorebookEntry {
+  id: string;
+  category: 'person' | 'place' | 'rule';
+  label: string;
+  snippet?: string;
+}
+
+export interface LorebookPreviewResponse {
+  success: true;
+  data: {
+    matched: MatchedLorebookEntry[];
+    totalEntries: number;
+  };
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[\s,.'";:!?()[\]{}\-]+/)
+    .filter((t) => t.length > 2);
+}
+
+function mentionsAny(messageTokens: string[], candidateTokens: string[]): boolean {
+  return candidateTokens.some((ct) => messageTokens.includes(ct));
+}
+
+function matchPeople(
+  people: LorebookPersonEntry[],
+  messageTokens: string[]
+): MatchedLorebookEntry[] {
+  return people
+    .filter((p) => mentionsAny(messageTokens, tokenize(p.name)))
+    .map((p) => ({
+      id: p.id,
+      category: 'person' as const,
+      label: p.name,
+      snippet: p.role ?? p.details?.slice(0, 80),
+    }));
+}
+
+function matchPlaces(
+  places: LorebookPlaceEntry[],
+  messageTokens: string[]
+): MatchedLorebookEntry[] {
+  return places
+    .filter((p) => mentionsAny(messageTokens, tokenize(p.name)))
+    .map((p) => ({
+      id: p.id,
+      category: 'place' as const,
+      label: p.name,
+      snippet: p.details?.slice(0, 80),
+    }));
+}
+
+function matchRules(rules: LorebookRuleEntry[]): MatchedLorebookEntry[] {
+  // Rules are always loaded as standing directives
+  return rules.map((r) => ({
+    id: r.id,
+    category: 'rule' as const,
+    label: r.title,
+    snippet: r.details?.slice(0, 80),
+  }));
+}
+
+export async function GET(
+  req: NextRequest,
+  props: { params: Promise<{ agentId: string }> }
+) {
+  const { agentId } = await props.params;
+  const message = req.nextUrl.searchParams.get('message') ?? '';
+
+  const supabase = getSupabaseServiceClient();
+
+  const { data: agent, error } = await supabase
+    .from('agents')
+    .select('metadata')
+    .eq('id', agentId)
+    .single();
+
+  if (error || !agent) {
+    return NextResponse.json(
+      { success: false, error: { code: 'NOT_FOUND', message: 'Agent not found' } },
+      { status: 404 }
+    );
+  }
+
+  const lorebook = readAgentLorebookFromMetadata(agent.metadata);
+  const totalEntries =
+    lorebook.people.length + lorebook.places.length + lorebook.rules.length;
+
+  if (totalEntries === 0) {
+    return NextResponse.json({
+      success: true,
+      data: { matched: [], totalEntries: 0 },
+    } satisfies LorebookPreviewResponse);
+  }
+
+  const messageTokens = tokenize(message);
+
+  const matched: MatchedLorebookEntry[] = [
+    ...matchPeople(lorebook.people, messageTokens),
+    ...matchPlaces(lorebook.places, messageTokens),
+    ...matchRules(lorebook.rules),
+  ];
+
+  return NextResponse.json({
+    success: true,
+    data: { matched, totalEntries },
+  } satisfies LorebookPreviewResponse);
+}

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -20,6 +20,7 @@ import { ContextConnectorsPreview } from './ContextConnectorsPreview';
 import { CheckInConsentPanel } from './CheckInConsentPanel';
 import { AgentBetweenSessionFeed } from './AgentBetweenSessionFeed';
 import { getSeedBetweenSessionPosts } from '@/lib/agents/between-session-posts';
+import { LorebookMatchPreview } from '@/components/lorebook/LorebookMatchPreview';
 
 interface ProfileContentProps {
   agent: Agent;
@@ -83,6 +84,12 @@ export function ProfileContent({
                     starters={agent.starterPrompts ?? []}
                   />
                 )}
+              {activeTab === 'posts' && (
+                <LorebookMatchPreview
+                  agentId={agent.id}
+                  starterMessage={agent.starterPrompts?.[0]?.prompt ?? ''}
+                />
+              )}
               {activeTab === 'posts' &&
                 (agent.storyThreads?.length ?? 0) > 0 && (
                   <StoryBranchingThreadStarter

--- a/apps/web/components/lorebook/LorebookMatchPreview.tsx
+++ b/apps/web/components/lorebook/LorebookMatchPreview.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useState } from 'react';
+import { BookOpen, ChevronDown, ChevronUp, Users, MapPin, ScrollText } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useLorebookMatchPreview } from '@/lib/lorebook/useLorebookMatchPreview';
+import type { MatchedLorebookEntry } from '@/app/api/v1/agents/[agentId]/lorebook/preview/route';
+
+interface LorebookMatchPreviewProps {
+  agentId: string;
+  starterMessage?: string;
+  className?: string;
+}
+
+const CATEGORY_ICONS = {
+  person: Users,
+  place: MapPin,
+  rule: ScrollText,
+} as const;
+
+const CATEGORY_LABELS = {
+  person: 'Character',
+  place: 'Place',
+  rule: 'Rule',
+} as const;
+
+function EntryRow({ entry }: { entry: MatchedLorebookEntry }) {
+  const Icon = CATEGORY_ICONS[entry.category];
+  return (
+    <li
+      className="flex items-start gap-2.5 py-2"
+      data-testid={`lorebook-entry-${entry.id}`}
+    >
+      <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <Icon className="h-3 w-3" aria-hidden />
+      </span>
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+            {CATEGORY_LABELS[entry.category]}
+          </span>
+          <span className="truncate text-sm font-medium text-foreground">
+            {entry.label}
+          </span>
+        </div>
+        {entry.snippet && (
+          <p className="mt-0.5 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+            {entry.snippet}
+          </p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export function LorebookMatchPreview({
+  agentId,
+  starterMessage = '',
+  className,
+}: LorebookMatchPreviewProps) {
+  const [expanded, setExpanded] = useState(false);
+  const { entries, totalEntries, isLoading } = useLorebookMatchPreview(
+    agentId,
+    starterMessage
+  );
+
+  if (isLoading || totalEntries === 0) {
+    return null;
+  }
+
+  const matchCount = entries.length;
+
+  if (matchCount === 0) {
+    return null;
+  }
+
+  const summary = buildSummary(entries);
+
+  return (
+    <div
+      data-testid="lorebook-match-preview"
+      className={cn(
+        'rounded-2xl border border-border/80 bg-muted/40 px-4 py-3 text-sm',
+        className
+      )}
+    >
+      <button
+        type="button"
+        className="flex w-full items-center justify-between text-left"
+        onClick={() => setExpanded((v) => !v)}
+        data-testid="lorebook-match-toggle"
+        aria-expanded={expanded}
+      >
+        <span className="flex items-center gap-2 font-medium text-foreground">
+          <BookOpen className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+          <span>
+            {summary}
+          </span>
+          <span
+            data-testid="lorebook-match-count"
+            className="rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-normal text-primary"
+          >
+            {matchCount} active
+          </span>
+        </span>
+        <span className="ml-2 text-muted-foreground" aria-hidden>
+          {expanded ? (
+            <ChevronUp className="h-4 w-4" />
+          ) : (
+            <ChevronDown className="h-4 w-4" />
+          )}
+        </span>
+      </button>
+
+      {expanded && (
+        <ul
+          className="mt-3 divide-y divide-border/50"
+          data-testid="lorebook-match-list"
+          aria-label="Active lore entries"
+        >
+          {entries.map((entry) => (
+            <EntryRow key={entry.id} entry={entry} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function buildSummary(entries: MatchedLorebookEntry[]): string {
+  const ruleCount = entries.filter((e) => e.category === 'rule').length;
+  const personCount = entries.filter((e) => e.category === 'person').length;
+  const placeCount = entries.filter((e) => e.category === 'place').length;
+
+  const parts: string[] = [];
+  if (ruleCount > 0) parts.push(`${ruleCount} ${ruleCount === 1 ? 'rule' : 'rules'}`);
+  if (personCount > 0) parts.push(`${personCount} ${personCount === 1 ? 'character' : 'characters'}`);
+  if (placeCount > 0) parts.push(`${placeCount} ${placeCount === 1 ? 'place' : 'places'}`);
+
+  return `Lore active: ${parts.join(', ')}`;
+}

--- a/apps/web/lib/lorebook/useLorebookMatchPreview.ts
+++ b/apps/web/lib/lorebook/useLorebookMatchPreview.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { MatchedLorebookEntry } from '@/app/api/v1/agents/[agentId]/lorebook/preview/route';
+
+interface UseLorebookMatchPreviewState {
+  entries: MatchedLorebookEntry[];
+  totalEntries: number;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useLorebookMatchPreview(
+  agentId: string,
+  message: string
+): UseLorebookMatchPreviewState {
+  const [state, setState] = useState<UseLorebookMatchPreviewState>({
+    entries: [],
+    totalEntries: 0,
+    isLoading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!agentId) return;
+
+    const controller = new AbortController();
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    const url = `/api/v1/agents/${encodeURIComponent(agentId)}/lorebook/preview?message=${encodeURIComponent(message)}`;
+
+    fetch(url, { signal: controller.signal })
+      .then(async (res) => {
+        const json = await res.json();
+        if (!res.ok || !json.success) {
+          setState({
+            entries: [],
+            totalEntries: 0,
+            isLoading: false,
+            error: json?.error?.message ?? 'Failed to load lore preview',
+          });
+          return;
+        }
+        setState({
+          entries: json.data.matched,
+          totalEntries: json.data.totalEntries,
+          isLoading: false,
+          error: null,
+        });
+      })
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.name === 'AbortError') return;
+        setState({
+          entries: [],
+          totalEntries: 0,
+          isLoading: false,
+          error: 'Failed to load lore preview',
+        });
+      });
+
+    return () => controller.abort();
+  }, [agentId, message]);
+
+  return state;
+}

--- a/apps/web/lib/lorebook/useLorebookMatchPreview.ts
+++ b/apps/web/lib/lorebook/useLorebookMatchPreview.ts
@@ -25,12 +25,13 @@ export function useLorebookMatchPreview(
     if (!agentId) return;
 
     const controller = new AbortController();
-    setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
     const url = `/api/v1/agents/${encodeURIComponent(agentId)}/lorebook/preview?message=${encodeURIComponent(message)}`;
 
-    fetch(url, { signal: controller.signal })
-      .then(async (res) => {
+    (async () => {
+      setState((prev) => ({ ...prev, isLoading: true, error: null }));
+      try {
+        const res = await fetch(url, { signal: controller.signal });
         const json = await res.json();
         if (!res.ok || !json.success) {
           setState({
@@ -47,8 +48,7 @@ export function useLorebookMatchPreview(
           isLoading: false,
           error: null,
         });
-      })
-      .catch((err: unknown) => {
+      } catch (err: unknown) {
         if (err instanceof Error && err.name === 'AbortError') return;
         setState({
           entries: [],
@@ -56,7 +56,8 @@ export function useLorebookMatchPreview(
           isLoading: false,
           error: 'Failed to load lore preview',
         });
-      });
+      }
+    })();
 
     return () => controller.abort();
   }, [agentId, message]);

--- a/docs/pr-evidence/lorebook-match-preview.md
+++ b/docs/pr-evidence/lorebook-match-preview.md
@@ -1,0 +1,64 @@
+# PR Evidence: Lorebook Match Preview
+
+## Feature
+
+When a user views an agent's profile (before sending a first message), a compact transparency panel now shows which lorebook/canon entries are currently active for the agent — rules that always apply, plus characters and places that the starter message references.
+
+## Before
+
+- Agent profile shows starter scenarios with no indication of what background context shapes the agent's responses.
+- Users had no visibility into which "canon facts" (lorebook rules, characters, places) the agent would use.
+
+## After
+
+- A collapsible **"Lore active"** panel appears on the agent posts tab below starter scenarios.
+- The header summarises what's matched: e.g. `Lore active: 1 rule, 2 characters` with an `3 active` badge.
+- Expanding the panel lists each matched entry with its category icon, label, and a short snippet.
+- Rules are always shown (they're standing directives). Characters and places match when the starter message mentions them by name.
+- The panel hides itself when no lorebook entries exist or none match, so agents without a lorebook are unaffected.
+
+## Files Changed
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `apps/web/app/api/v1/agents/[agentId]/lorebook/preview/route.ts` | GET endpoint — fetches agent lorebook, runs keyword matching, returns `MatchedLorebookEntry[]` |
+| `apps/web/lib/lorebook/useLorebookMatchPreview.ts` | Client hook — calls the preview API, returns `{ entries, totalEntries, isLoading, error }` |
+| `apps/web/components/lorebook/LorebookMatchPreview.tsx` | Collapsible panel component with per-entry rows (icon + label + snippet) |
+| `apps/web/__tests__/components/lorebook/LorebookMatchPreview.test.tsx` | 8 Vitest tests covering render, toggle, empty state, error state, summary label, URL encoding |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `apps/web/components/agents/ProfileContent.tsx` | Imports and renders `LorebookMatchPreview` on the posts tab, passing `agent.id` and the first starter prompt as the sample message |
+
+## Matching Logic
+
+- **Rules**: always matched — they are standing agent directives loaded for every conversation.
+- **People / Places**: keyword match — entry name is tokenized and checked against the starter message tokens (case-insensitive, tokens > 2 chars).
+
+## Diff Summary
+
+```diff
+// ProfileContent.tsx
++ import { LorebookMatchPreview } from '@/components/lorebook/LorebookMatchPreview';
+
+  // inside posts tab render
++ {activeTab === 'posts' && (
++   <LorebookMatchPreview
++     agentId={agent.id}
++     starterMessage={agent.starterPrompts?.[0]?.prompt ?? ''}
++   />
++ )}
+```
+
+```diff
+// NEW: apps/web/app/api/v1/agents/[agentId]/lorebook/preview/route.ts
++ export async function GET(req, props) {
++   // fetch agent metadata → readAgentLorebookFromMetadata
++   // tokenize message, keyword-match people/places, always include rules
++   // return MatchedLorebookEntry[]
++ }
+```


### PR DESCRIPTION
## Source

backlog.md:119

Show which lorebook/canon entries are active for a given starter message, giving users transparent insight into what shaped the agent's first reply.

## Evidence
See docs/pr-evidence/lorebook-match-preview.md

## Changes
- LorebookMatchPreview component (collapsible, shows matched entry names/snippets)
- /api/v1/agents/[agentId]/lorebook/preview route
- Hook wired into agent first-chat / profile starter area
- 8+ tests

## Auth-only Proof

```bash
curl -H "Authorization: Bearer <token>" \
  https://api.agentgram.co/v1/agents/{agentId}/lorebook/preview
# → 200 OK with matchedEntries array
```