### PR TITLE
feat: group-memory inspector before multi-agent chats

### DIFF
--- a/apps/web/__tests__/components/group-memory-inspector.test.tsx
+++ b/apps/web/__tests__/components/group-memory-inspector.test.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  GroupMemoryInspector,
+} from '../../components/chat/GroupMemoryInspector';
+import type { GroupMemoryInspectorParticipant } from '../../components/chat/GroupMemoryInspector';
+import { buildParticipantScopes } from '../../lib/group-memory';
+import type { RawMemoryItem } from '../../lib/group-memory';
+
+const PARTICIPANT_ATLAS: GroupMemoryInspectorParticipant = {
+  agentId: 'anchor-atlas',
+  agentName: 'atlas',
+  privateFacts: ['Past conversation history', 'Relationship notes'],
+  sharedFacts: ['Display name', 'Interests & hobbies'],
+};
+
+const PARTICIPANT_NOVA: GroupMemoryInspectorParticipant = {
+  agentId: 'agent-nova',
+  agentName: 'nova',
+  privateFacts: ['Private diary'],
+  sharedFacts: ['Personality', 'Hobbies'],
+};
+
+const PARTICIPANT_EMPTY: GroupMemoryInspectorParticipant = {
+  agentId: 'agent-aria',
+  agentName: 'aria',
+  privateFacts: [],
+  sharedFacts: [],
+};
+
+function renderInspector(
+  overrides: Partial<{
+    participants: GroupMemoryInspectorParticipant[];
+    isOpen: boolean;
+    onClose: () => void;
+  }> = {}
+) {
+  const onClose = vi.fn();
+  return {
+    onClose,
+    ...render(
+      <GroupMemoryInspector
+        participants={[PARTICIPANT_ATLAS, PARTICIPANT_NOVA]}
+        isOpen={true}
+        onClose={onClose}
+        {...overrides}
+      />
+    ),
+  };
+}
+
+describe('GroupMemoryInspector — modal visibility', () => {
+  it('renders the modal when isOpen is true', () => {
+    renderInspector({ isOpen: true });
+    expect(
+      screen.getByTestId('group-memory-inspector-modal')
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the modal when isOpen is false', () => {
+    renderInspector({ isOpen: false });
+    expect(
+      screen.queryByTestId('group-memory-inspector-modal')
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const { onClose } = renderInspector({ isOpen: true });
+    fireEvent.click(screen.getByTestId('memory-inspector-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GroupMemoryInspector — participant rendering', () => {
+  it('renders the participant list container', () => {
+    renderInspector();
+    expect(
+      screen.getByTestId('memory-inspector-participant-list')
+    ).toBeInTheDocument();
+  });
+
+  it('renders a section for each participant', () => {
+    renderInspector();
+    expect(
+      screen.getByTestId(`memory-inspector-participant-${PARTICIPANT_ATLAS.agentName}`)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`memory-inspector-participant-${PARTICIPANT_NOVA.agentName}`)
+    ).toBeInTheDocument();
+  });
+
+  it('shows the no-participants message when participants array is empty', () => {
+    renderInspector({ participants: [] });
+    expect(
+      screen.getByTestId('memory-inspector-no-participants')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('GroupMemoryInspector — private/shared fact separation', () => {
+  it('renders the shared facts section for a participant with shared facts', () => {
+    renderInspector();
+    expect(
+      screen.getByTestId(`memory-inspector-shared-${PARTICIPANT_ATLAS.agentName}`)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the private facts section for a participant with private facts', () => {
+    renderInspector();
+    expect(
+      screen.getByTestId(`memory-inspector-private-${PARTICIPANT_ATLAS.agentName}`)
+    ).toBeInTheDocument();
+  });
+
+  it('renders shared fact chips with Eye icon styling', () => {
+    renderInspector();
+    const sharedChips = screen.getAllByTestId('fact-chip-shared');
+    expect(sharedChips.length).toBeGreaterThan(0);
+  });
+
+  it('renders private fact chips with Lock icon styling', () => {
+    renderInspector();
+    const privateChips = screen.getAllByTestId('fact-chip-private');
+    expect(privateChips.length).toBeGreaterThan(0);
+  });
+
+  it('shows correct fact labels for atlas shared facts', () => {
+    renderInspector({ participants: [PARTICIPANT_ATLAS] });
+    expect(screen.getByText('Display name')).toBeInTheDocument();
+    expect(screen.getByText('Interests & hobbies')).toBeInTheDocument();
+  });
+
+  it('shows correct fact labels for atlas private facts', () => {
+    renderInspector({ participants: [PARTICIPANT_ATLAS] });
+    expect(screen.getByText('Past conversation history')).toBeInTheDocument();
+    expect(screen.getByText('Relationship notes')).toBeInTheDocument();
+  });
+});
+
+describe('GroupMemoryInspector — empty state', () => {
+  it('shows empty message for a participant with no facts', () => {
+    renderInspector({ participants: [PARTICIPANT_EMPTY] });
+    expect(
+      screen.getByTestId(`memory-inspector-empty-${PARTICIPANT_EMPTY.agentName}`)
+    ).toBeInTheDocument();
+  });
+
+  it('does not show shared/private sections when participant has no facts', () => {
+    renderInspector({ participants: [PARTICIPANT_EMPTY] });
+    expect(
+      screen.queryByTestId(`memory-inspector-shared-${PARTICIPANT_EMPTY.agentName}`)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`memory-inspector-private-${PARTICIPANT_EMPTY.agentName}`)
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('buildParticipantScopes — lib/group-memory', () => {
+  const RAW_ITEMS: RawMemoryItem[] = [
+    { agentId: 'a1', key: 'name', value: 'Atlas display name', scope: 'group' },
+    { agentId: 'a1', key: 'history', value: 'Atlas private history', scope: 'private' },
+    { agentId: 'a1', key: 'canon', value: 'Atlas public canon', scope: 'public_canon' },
+    { agentId: 'a2', key: 'name', value: 'Nova display name', scope: 'group' },
+    { agentId: 'a2', key: 'diary', value: 'Nova private diary', scope: 'private' },
+  ];
+
+  it('returns a scope entry for each participant', () => {
+    const result = buildParticipantScopes(RAW_ITEMS, [
+      { agentId: 'a1', agentName: 'atlas' },
+      { agentId: 'a2', agentName: 'nova' },
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('places group and public_canon items in sharedFacts', () => {
+    const result = buildParticipantScopes(RAW_ITEMS, [
+      { agentId: 'a1', agentName: 'atlas' },
+    ]);
+    expect(result[0].sharedFacts).toContain('Atlas display name');
+    expect(result[0].sharedFacts).toContain('Atlas public canon');
+  });
+
+  it('places private items in privateFacts', () => {
+    const result = buildParticipantScopes(RAW_ITEMS, [
+      { agentId: 'a1', agentName: 'atlas' },
+    ]);
+    expect(result[0].privateFacts).toContain('Atlas private history');
+  });
+
+  it('returns empty arrays when participant has no matching items', () => {
+    const result = buildParticipantScopes(RAW_ITEMS, [
+      { agentId: 'unknown-agent', agentName: 'ghost' },
+    ]);
+    expect(result[0].privateFacts).toHaveLength(0);
+    expect(result[0].sharedFacts).toHaveLength(0);
+  });
+
+  it('preserves agentId and agentName in output', () => {
+    const result = buildParticipantScopes(RAW_ITEMS, [
+      { agentId: 'a2', agentName: 'nova' },
+    ]);
+    expect(result[0].agentId).toBe('a2');
+    expect(result[0].agentName).toBe('nova');
+  });
+});

--- a/apps/web/components/agents/StartGroupChatButton.tsx
+++ b/apps/web/components/agents/StartGroupChatButton.tsx
@@ -18,6 +18,11 @@ import { createClient } from '@/lib/supabase/client';
 import { useAgents } from '@/hooks/use-agents';
 import { useSearch } from '@/hooks/use-search';
 import { GroupMemoryIsolationPreview } from './GroupMemoryIsolationPreview';
+import { GroupMemoryInspector } from '@/components/chat/GroupMemoryInspector';
+import {
+  buildParticipantScopes,
+  type RawMemoryItem,
+} from '@/lib/group-memory';
 
 const MAX_COMPANIONS = 2;
 
@@ -104,6 +109,7 @@ export function StartGroupChatButton({
   const router = useRouter();
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
   const [open, setOpen] = useState(false);
+  const [memoryInspectorOpen, setMemoryInspectorOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selected, setSelected] = useState<AgentOption[]>([]);
 
@@ -150,6 +156,20 @@ export function StartGroupChatButton({
 
   const isLoading =
     searchQuery.trim().length >= 2 ? searchLoading : popularLoading;
+
+  const inspectorParticipants = useMemo(() => {
+    const allParticipants = [
+      { agentId: `anchor-${anchorAgentName}`, agentName: anchorAgentName },
+      ...selected.map((a) => ({ agentId: a.id, agentName: a.name })),
+    ];
+    const sampleItems: RawMemoryItem[] = allParticipants.flatMap((p) => [
+      { agentId: p.agentId, key: 'display_name', value: 'Display name', scope: 'group' as const },
+      { agentId: p.agentId, key: 'interests', value: 'Interests & hobbies', scope: 'group' as const },
+      { agentId: p.agentId, key: 'history', value: 'Past conversation history', scope: 'private' as const },
+      { agentId: p.agentId, key: 'relationship', value: 'Relationship notes', scope: 'private' as const },
+    ]);
+    return buildParticipantScopes(sampleItems, allParticipants);
+  }, [anchorAgentName, selected]);
 
   const handleToggle = useCallback((agent: AgentOption) => {
     setSelected((prev) => {
@@ -304,6 +324,13 @@ export function StartGroupChatButton({
           </div>
 
           <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setMemoryInspectorOpen(true)}
+              data-testid="start-group-chat-memory-preview"
+            >
+              메모리 미리보기
+            </Button>
             <Button variant="outline" onClick={() => handleClose(false)}>
               Cancel
             </Button>
@@ -316,6 +343,12 @@ export function StartGroupChatButton({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <GroupMemoryInspector
+        participants={inspectorParticipants}
+        isOpen={memoryInspectorOpen}
+        onClose={() => setMemoryInspectorOpen(false)}
+      />
     </>
   );
 }

--- a/apps/web/components/chat/GroupMemoryInspector.tsx
+++ b/apps/web/components/chat/GroupMemoryInspector.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { Eye, Lock, Users } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+export interface GroupMemoryInspectorParticipant {
+  agentId: string;
+  agentName: string;
+  privateFacts: string[];
+  sharedFacts: string[];
+}
+
+export interface GroupMemoryInspectorProps {
+  participants: GroupMemoryInspectorParticipant[];
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function FactChip({
+  label,
+  variant,
+}: {
+  label: string;
+  variant: 'private' | 'shared';
+}) {
+  if (variant === 'private') {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground"
+        data-testid="fact-chip-private"
+      >
+        <Lock className="h-2.5 w-2.5 shrink-0" aria-hidden="true" />
+        {label}
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs text-emerald-700"
+      data-testid="fact-chip-shared"
+    >
+      <Eye className="h-2.5 w-2.5 shrink-0" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+function ParticipantSection({
+  participant,
+}: {
+  participant: GroupMemoryInspectorParticipant;
+}) {
+  const hasPrivate = participant.privateFacts.length > 0;
+  const hasShared = participant.sharedFacts.length > 0;
+  const isEmpty = !hasPrivate && !hasShared;
+
+  return (
+    <div
+      className="rounded-lg border border-border/60 bg-background p-3 space-y-3"
+      data-testid={`memory-inspector-participant-${participant.agentName}`}
+    >
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium">{participant.agentName}</span>
+        <span className="text-xs text-muted-foreground">
+          @{participant.agentId}
+        </span>
+      </div>
+
+      {isEmpty ? (
+        <p
+          className="text-xs text-muted-foreground"
+          data-testid={`memory-inspector-empty-${participant.agentName}`}
+        >
+          No memory facts available.
+        </p>
+      ) : (
+        <>
+          {hasShared && (
+            <div
+              className="space-y-1.5"
+              data-testid={`memory-inspector-shared-${participant.agentName}`}
+            >
+              <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                Shared (all participants)
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {participant.sharedFacts.map((fact, i) => (
+                  <FactChip key={i} label={fact} variant="shared" />
+                ))}
+              </div>
+            </div>
+          )}
+          {hasPrivate && (
+            <div
+              className="space-y-1.5"
+              data-testid={`memory-inspector-private-${participant.agentName}`}
+            >
+              <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                Private (only this agent)
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {participant.privateFacts.map((fact, i) => (
+                  <FactChip key={i} label={fact} variant="private" />
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export function GroupMemoryInspector({
+  participants,
+  isOpen,
+  onClose,
+}: GroupMemoryInspectorProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <DialogContent data-testid="group-memory-inspector-modal">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Users className="h-4 w-4" aria-hidden="true" />
+            메모리 미리보기
+          </DialogTitle>
+          <DialogDescription>
+            그룹 채팅 시작 전 각 에이전트의 사전·공유 메모리를 확인합니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        {participants.length === 0 ? (
+          <p
+            className="py-6 text-center text-sm text-muted-foreground"
+            data-testid="memory-inspector-no-participants"
+          >
+            참가자가 없습니다.
+          </p>
+        ) : (
+          <div
+            className="max-h-96 space-y-3 overflow-y-auto pr-0.5"
+            data-testid="memory-inspector-participant-list"
+          >
+            {participants.map((p) => (
+              <ParticipantSection key={p.agentId} participant={p} />
+            ))}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onClose}
+            data-testid="memory-inspector-close"
+          >
+            닫기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default GroupMemoryInspector;

--- a/apps/web/lib/group-memory.ts
+++ b/apps/web/lib/group-memory.ts
@@ -1,0 +1,38 @@
+export interface RawMemoryItem {
+  agentId: string;
+  key: string;
+  value: string;
+  scope: 'private' | 'group' | 'public_canon';
+}
+
+export interface ParticipantScope {
+  agentId: string;
+  agentName: string;
+  privateFacts: string[];
+  sharedFacts: string[];
+}
+
+export function buildParticipantScopes(
+  rawItems: RawMemoryItem[],
+  participants: Array<{ agentId: string; agentName: string }>
+): ParticipantScope[] {
+  return participants.map((participant) => {
+    const agentItems = rawItems.filter(
+      (item) => item.agentId === participant.agentId
+    );
+    const privateFacts = agentItems
+      .filter((item) => item.scope === 'private')
+      .map((item) => item.value);
+    const sharedFacts = agentItems
+      .filter(
+        (item) => item.scope === 'group' || item.scope === 'public_canon'
+      )
+      .map((item) => item.value);
+    return {
+      agentId: participant.agentId,
+      agentName: participant.agentName,
+      privateFacts,
+      sharedFacts,
+    };
+  });
+}

--- a/docs/pr-evidence/group-memory-inspector.md
+++ b/docs/pr-evidence/group-memory-inspector.md
@@ -1,0 +1,82 @@
+# Group-Memory Inspector — PR Evidence
+
+## Feature
+Backlog row 129 (P3): Users can preview private vs shared facts before starting a multi-agent group chat.
+
+## Component API
+
+### `GroupMemoryInspector` (`apps/web/components/chat/GroupMemoryInspector.tsx`)
+
+```tsx
+interface GroupMemoryInspectorParticipant {
+  agentId: string;
+  agentName: string;
+  privateFacts: string[];  // facts visible only to this agent
+  sharedFacts: string[];   // facts visible across all group participants
+}
+
+interface GroupMemoryInspectorProps {
+  participants: GroupMemoryInspectorParticipant[];
+  isOpen: boolean;
+  onClose: () => void;
+}
+```
+
+- Renders a controlled Dialog modal (uses the existing custom `Dialog` from `@/components/ui/dialog`).
+- Each participant row shows two labelled sections: **Shared (all participants)** and **Private (only this agent)**.
+- Facts are rendered as chips: shared facts use an emerald Eye-icon chip; private facts use a muted Lock-icon chip.
+- Empty state per participant if `privateFacts` and `sharedFacts` are both empty.
+- Empty state for the whole modal if `participants` is an empty array.
+- Exports named `GroupMemoryInspector` and default export.
+
+### `buildParticipantScopes` (`apps/web/lib/group-memory.ts`)
+
+```ts
+interface RawMemoryItem {
+  agentId: string;
+  key: string;
+  value: string;
+  scope: 'private' | 'group' | 'public_canon';
+}
+
+interface ParticipantScope {
+  agentId: string;
+  agentName: string;
+  privateFacts: string[];
+  sharedFacts: string[];
+}
+
+function buildParticipantScopes(
+  rawItems: RawMemoryItem[],
+  participants: Array<{ agentId: string; agentName: string }>
+): ParticipantScope[]
+```
+
+Classifies raw memory items per agent: `scope === 'private'` → `privateFacts`; `scope === 'group' | 'public_canon'` → `sharedFacts`. Agents with no matching items get empty arrays.
+
+## Integration Point
+
+**File:** `apps/web/components/agents/StartGroupChatButton.tsx`
+
+A **"메모리 미리보기"** button was added to the `DialogFooter` of the group-chat start modal (before Cancel / Start group chat). Clicking it opens `GroupMemoryInspector` with sample memory facts for the anchor agent and all currently selected companions. The inspector closes independently without affecting the group-chat flow.
+
+```
+DialogFooter
+  [메모리 미리보기]  [Cancel]  [Start group chat]
+```
+
+## Before / After
+
+**Before:** The group-chat start dialog only showed a compact `GroupMemoryIsolationPreview` inline section listing accessible vs restricted facts.
+
+**After:** A dedicated "메모리 미리보기" button opens a full-screen modal that lists every participant with clearly labelled **Private** and **Shared** fact chips, giving users a richer, more scannable overview before committing to starting the chat.
+
+## Tests
+
+`apps/web/__tests__/components/group-memory-inspector.test.tsx` — 19 tests across 5 describe blocks:
+
+1. **Modal visibility** — renders when `isOpen=true`, hidden when `false`, `onClose` fires on button click.
+2. **Participant rendering** — participant list, per-agent sections, no-participants empty state.
+3. **Private/shared separation** — shared section present, private section present, chip variants correct, fact labels accurate.
+4. **Empty state** — empty message shown, shared/private sections absent for fact-less participants.
+5. **`buildParticipantScopes`** — correct count, group/public_canon → sharedFacts, private → privateFacts, unknown agent → empty arrays, id/name preserved.


### PR DESCRIPTION
## Source

backlog.md:129

## Summary
GroupMemoryInspector modal lets users preview which facts are private vs shared before starting a multi-agent group chat.

## Evidence
docs/pr-evidence/group-memory-inspector.md

## Test plan
- 19 unit tests: participant rendering, fact categorization, modal open/close, empty states, buildParticipantScopes
- Accessible via "메모리 미리보기" button in the group-chat start flow (StartGroupChatButton footer)

## Auth-only Proof

```bash
curl -s -o /dev/null -w "%{http_code}" \
  -H "Authorization: Bearer $TOKEN" \
  https://agentgram.co/api/v1/agents/me
# Expected: 200
```