### PR TITLE
feat: capability sample tray with media proof on agent profiles

### DIFF
--- a/apps/web/__tests__/components/__snapshots__/capability-sample-tray.test.tsx.snap
+++ b/apps/web/__tests__/components/__snapshots__/capability-sample-tray.test.tsx.snap
@@ -1,0 +1,83 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CapabilitySampleTray > matches snapshot with multiple capability types and mixed sampleUrl presence 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-2"
+    data-testid="capability-sample-tray"
+  >
+    <p
+      class="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground"
+    >
+      Capability samples
+    </p>
+    <div
+      class="flex flex-wrap gap-2"
+    >
+      <div
+        class="flex flex-col gap-1"
+      >
+        <button
+          aria-expanded="false"
+          aria-label="Toggle Voice sample preview"
+          class="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition border-border/70 bg-background text-foreground/80 hover:border-primary/30 hover:bg-primary/5"
+          data-testid="capability-chip-voice"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+          >
+            🎙️
+          </span>
+          Voice
+          <span
+            class="text-[10px] text-muted-foreground"
+          >
+            5
+            s
+          </span>
+        </button>
+      </div>
+      <div
+        class="flex flex-col gap-1"
+      >
+        <span
+          class="inline-flex cursor-default items-center gap-1.5 rounded-full border border-border/50 bg-muted/30 px-2.5 py-1 text-xs font-medium text-muted-foreground"
+          data-testid="capability-chip-image"
+        >
+          <span
+            aria-hidden="true"
+          >
+            🖼️
+          </span>
+          Image
+          <span
+            class="text-[10px]"
+            data-testid="capability-chip-image-no-sample"
+          >
+            샘플 없음
+          </span>
+        </span>
+      </div>
+      <div
+        class="flex flex-col gap-1"
+      >
+        <button
+          aria-expanded="false"
+          aria-label="Toggle Selfie sample preview"
+          class="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition border-border/70 bg-background text-foreground/80 hover:border-primary/30 hover:bg-primary/5"
+          data-testid="capability-chip-selfie"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+          >
+            🤳
+          </span>
+          Selfie
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/apps/web/__tests__/components/capability-sample-tray.test.tsx
+++ b/apps/web/__tests__/components/capability-sample-tray.test.tsx
@@ -1,0 +1,168 @@
+/* eslint-disable @next/next/no-img-element */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CapabilitySampleTray } from '../../components/agent/CapabilitySampleTray';
+import type { CapabilitySample } from '../../lib/capability-sample';
+
+vi.mock('next/image', () => ({
+  default: ({
+    src,
+    alt,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string; alt: string }) => (
+    <img src={src} alt={alt} {...props} />
+  ),
+}));
+
+type EventMap = Record<string, () => void>;
+
+function makeMockAudio() {
+  const handlers: EventMap = {};
+  const instance = {
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    src: '',
+    addEventListener: vi.fn((event: string, handler: () => void) => {
+      handlers[event] = handler;
+    }),
+    _trigger: (event: string) => handlers[event]?.(),
+  };
+  return instance;
+}
+
+type MockAudio = ReturnType<typeof makeMockAudio>;
+
+function makeAudioFactory(mockAudio: MockAudio) {
+  return vi.fn(() => mockAudio as unknown as HTMLAudioElement);
+}
+
+describe('CapabilitySampleTray', () => {
+  it('renders nothing when capabilities array is empty', () => {
+    const { container } = render(<CapabilitySampleTray capabilities={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a chip for each capability', () => {
+    const caps: CapabilitySample[] = [
+      { type: 'voice', label: 'Voice' },
+      { type: 'image', label: 'Image' },
+      { type: 'selfie', label: 'Selfie' },
+    ];
+    render(<CapabilitySampleTray capabilities={caps} />);
+    expect(screen.getByTestId('capability-chip-voice')).toBeInTheDocument();
+    expect(screen.getByTestId('capability-chip-image')).toBeInTheDocument();
+    expect(screen.getByTestId('capability-chip-selfie')).toBeInTheDocument();
+  });
+
+  it('shows 샘플 없음 placeholder for voice chip with no sampleUrl', () => {
+    const caps: CapabilitySample[] = [{ type: 'voice', label: 'Voice' }];
+    render(<CapabilitySampleTray capabilities={caps} />);
+    expect(screen.getByTestId('capability-chip-voice-no-sample')).toHaveTextContent(
+      '샘플 없음'
+    );
+  });
+
+  it('shows 샘플 없음 placeholder for image chip with no sampleUrl', () => {
+    const caps: CapabilitySample[] = [{ type: 'image', label: 'Image' }];
+    render(<CapabilitySampleTray capabilities={caps} />);
+    expect(screen.getByTestId('capability-chip-image-no-sample')).toHaveTextContent(
+      '샘플 없음'
+    );
+  });
+
+  it('shows 샘플 없음 placeholder for selfie chip with no sampleUrl', () => {
+    const caps: CapabilitySample[] = [{ type: 'selfie', label: 'Selfie' }];
+    render(<CapabilitySampleTray capabilities={caps} />);
+    expect(screen.getByTestId('capability-chip-selfie-no-sample')).toHaveTextContent(
+      '샘플 없음'
+    );
+  });
+
+  it('renders a clickable button (not a muted span) for chips with sampleUrl', () => {
+    const caps: CapabilitySample[] = [
+      { type: 'image', label: 'Image', sampleUrl: 'https://example.com/img.jpg' },
+    ];
+    render(<CapabilitySampleTray capabilities={caps} />);
+    const chip = screen.getByTestId('capability-chip-image');
+    expect(chip.tagName).toBe('BUTTON');
+  });
+
+  it('toggles image preview on chip click', () => {
+    const caps: CapabilitySample[] = [
+      { type: 'image', label: 'Image', sampleUrl: 'https://example.com/img.jpg' },
+    ];
+    render(<CapabilitySampleTray capabilities={caps} />);
+    const chip = screen.getByTestId('capability-chip-image');
+
+    expect(screen.queryByTestId('capability-sample-preview-image')).not.toBeInTheDocument();
+
+    fireEvent.click(chip);
+    expect(screen.getByTestId('capability-sample-preview-image')).toBeInTheDocument();
+    expect(screen.getByTestId('image-sample-preview')).toBeInTheDocument();
+
+    fireEvent.click(chip);
+    expect(screen.queryByTestId('capability-sample-preview-image')).not.toBeInTheDocument();
+  });
+
+  it('shows image thumbnail with correct src for image capability', () => {
+    const sampleUrl = 'https://example.com/img.jpg';
+    const caps: CapabilitySample[] = [
+      { type: 'image', label: 'Image', sampleUrl },
+    ];
+    render(<CapabilitySampleTray capabilities={caps} />);
+    fireEvent.click(screen.getByTestId('capability-chip-image'));
+    const img = screen.getByRole('img', { name: /image sample/i });
+    expect(img).toHaveAttribute('src', sampleUrl);
+  });
+
+  it('renders voice player inside preview when voice chip with sampleUrl is clicked', async () => {
+    const mockAudio = makeMockAudio();
+    const audioFactory = makeAudioFactory(mockAudio);
+    const caps: CapabilitySample[] = [
+      { type: 'voice', label: 'Voice', sampleUrl: 'https://example.com/voice.mp3' },
+    ];
+    render(<CapabilitySampleTray capabilities={caps} _audioFactory={audioFactory} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('capability-chip-voice'));
+    });
+
+    expect(screen.getByTestId('capability-sample-preview-voice')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-sample-preview')).toBeInTheDocument();
+  });
+
+  it('shows sampleDuration in the chip when provided', () => {
+    const caps: CapabilitySample[] = [
+      { type: 'voice', label: 'Voice', sampleUrl: 'https://example.com/v.mp3', sampleDuration: 5 },
+    ];
+    render(<CapabilitySampleTray capabilities={caps} />);
+    expect(screen.getByTestId('capability-chip-voice')).toHaveTextContent('5s');
+  });
+
+  it('renders the tray wrapper with data-testid capability-sample-tray', () => {
+    const caps: CapabilitySample[] = [{ type: 'selfie', label: 'Selfie' }];
+    render(<CapabilitySampleTray capabilities={caps} />);
+    expect(screen.getByTestId('capability-sample-tray')).toBeInTheDocument();
+  });
+
+  it('renders a selfie chip with image preview (not voice player) on click', () => {
+    const caps: CapabilitySample[] = [
+      { type: 'selfie', label: 'Selfie', sampleUrl: 'https://example.com/selfie.jpg' },
+    ];
+    render(<CapabilitySampleTray capabilities={caps} />);
+    fireEvent.click(screen.getByTestId('capability-chip-selfie'));
+    expect(screen.getByTestId('image-sample-preview')).toBeInTheDocument();
+    expect(screen.queryByTestId('voice-sample-preview')).not.toBeInTheDocument();
+  });
+
+  it('matches snapshot with multiple capability types and mixed sampleUrl presence', () => {
+    const caps: CapabilitySample[] = [
+      { type: 'voice', label: 'Voice', sampleUrl: 'https://example.com/v.mp3', sampleDuration: 5 },
+      { type: 'image', label: 'Image' },
+      { type: 'selfie', label: 'Selfie', sampleUrl: 'https://example.com/s.jpg' },
+    ];
+    const { container } = render(<CapabilitySampleTray capabilities={caps} />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/apps/web/components/agent/CapabilitySampleTray.tsx
+++ b/apps/web/components/agent/CapabilitySampleTray.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+import {
+  type CapabilitySample,
+  getCapabilityIcon,
+} from '@/lib/capability-sample';
+import { VoiceSamplePreview } from '@/components/agents/VoiceSamplePreview';
+
+export type { CapabilitySample };
+
+interface CapabilitySampleTrayProps {
+  capabilities: CapabilitySample[];
+  className?: string;
+  /** Injected for unit tests. */
+  _audioFactory?: (src: string) => HTMLAudioElement;
+}
+
+function ImageSamplePreview({
+  sampleUrl,
+  label,
+}: {
+  sampleUrl: string;
+  label: string;
+}) {
+  return (
+    <div
+      className="mt-2 overflow-hidden rounded-xl border border-border/70 bg-muted/30"
+      data-testid="image-sample-preview"
+    >
+      <Image
+        src={sampleUrl}
+        alt={`${label} sample`}
+        width={240}
+        height={160}
+        className="h-40 w-60 object-cover"
+        unoptimized
+      />
+    </div>
+  );
+}
+
+export function CapabilitySampleTray({
+  capabilities,
+  className,
+  _audioFactory,
+}: CapabilitySampleTrayProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  if (capabilities.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn('flex flex-col gap-2', className)}
+      data-testid="capability-sample-tray"
+    >
+      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+        Capability samples
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {capabilities.map((cap, index) => {
+          const icon = getCapabilityIcon(cap.type);
+          const isActive = activeIndex === index;
+          const hasSample = Boolean(cap.sampleUrl);
+
+          return (
+            <div key={`${cap.type}-${index}`} className="flex flex-col gap-1">
+              {hasSample ? (
+                <button
+                  type="button"
+                  onClick={() => setActiveIndex(isActive ? null : index)}
+                  aria-expanded={isActive}
+                  aria-label={`Toggle ${cap.label} sample preview`}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition',
+                    isActive
+                      ? 'border-primary/40 bg-primary/10 text-primary'
+                      : 'border-border/70 bg-background text-foreground/80 hover:border-primary/30 hover:bg-primary/5'
+                  )}
+                  data-testid={`capability-chip-${cap.type}`}
+                >
+                  <span aria-hidden="true">{icon}</span>
+                  {cap.label}
+                  {cap.sampleDuration != null && (
+                    <span className="text-[10px] text-muted-foreground">
+                      {cap.sampleDuration}s
+                    </span>
+                  )}
+                </button>
+              ) : (
+                <span
+                  className="inline-flex cursor-default items-center gap-1.5 rounded-full border border-border/50 bg-muted/30 px-2.5 py-1 text-xs font-medium text-muted-foreground"
+                  data-testid={`capability-chip-${cap.type}`}
+                >
+                  <span aria-hidden="true">{icon}</span>
+                  {cap.label}
+                  <span
+                    className="text-[10px]"
+                    data-testid={`capability-chip-${cap.type}-no-sample`}
+                  >
+                    샘플 없음
+                  </span>
+                </span>
+              )}
+
+              {isActive && cap.sampleUrl && (
+                <div
+                  className="ml-1"
+                  data-testid={`capability-sample-preview-${cap.type}`}
+                >
+                  {cap.type === 'voice' ? (
+                    <VoiceSamplePreview
+                      sampleUrl={cap.sampleUrl}
+                      agentName={cap.label}
+                      _audioFactory={_audioFactory}
+                    />
+                  ) : (
+                    <ImageSamplePreview
+                      sampleUrl={cap.sampleUrl}
+                      label={cap.label}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default CapabilitySampleTray;

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -16,6 +16,8 @@ import {
   buildExploreTagHref,
   extractProfileInterestTags,
 } from '@/lib/topic-chips';
+import { CapabilitySampleTray } from '@/components/agent/CapabilitySampleTray';
+import type { CapabilitySample } from '@/lib/capability-sample';
 import { CreatorProvenanceStrip } from './CreatorProvenanceStrip';
 import { FollowButton } from './FollowButton';
 import { RequestApiAccessButton } from './RequestApiAccessButton';
@@ -284,6 +286,14 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
     !formattedOperatorTier &&
     !hasFirstSuccessfulReply &&
     enabledChatCapabilities.length > 0;
+  const capabilitySampleItems: CapabilitySample[] = [
+    ...(agent.capabilities?.voice === true
+      ? [{ type: 'voice' as const, label: 'Voice' }]
+      : []),
+    ...(agent.capabilities?.image === true
+      ? [{ type: 'image' as const, label: 'Image' }]
+      : []),
+  ];
   const relationshipModeLabel = getRelationshipModeLabel(
     agent.relationshipPreset
   );
@@ -590,6 +600,12 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
               agentName={agent.displayName || agent.name}
               className="mt-4"
               data-testid="profile-voice-sample-preview"
+            />
+          )}
+          {capabilitySampleItems.length > 0 && (
+            <CapabilitySampleTray
+              capabilities={capabilitySampleItems}
+              className="mt-4"
             />
           )}
           {shouldShowRemixCta && (

--- a/apps/web/lib/capability-sample.ts
+++ b/apps/web/lib/capability-sample.ts
@@ -1,0 +1,19 @@
+export type CapabilitySampleType = 'voice' | 'selfie' | 'image';
+
+export interface CapabilitySample {
+  type: CapabilitySampleType;
+  label: string;
+  sampleUrl?: string;
+  sampleDuration?: number;
+}
+
+export function getCapabilityIcon(type: CapabilitySampleType): string {
+  switch (type) {
+    case 'voice':
+      return '🎙️';
+    case 'selfie':
+      return '🤳';
+    case 'image':
+      return '🖼️';
+  }
+}

--- a/docs/pr-evidence/capability-sample-tray.md
+++ b/docs/pr-evidence/capability-sample-tray.md
@@ -1,0 +1,66 @@
+# Capability Sample Tray — PR Evidence
+
+**Backlog row:** 136 (P3)
+**Feature:** Attach voice/selfie/image proof samples to public agent capability badges.
+
+## Before
+
+The agent public profile's capability section showed only the `VoiceSamplePreview` button when `agent.capabilities.voice === true`. Other capability types (image, etc.) had no interactive proof — no way to see or hear a sample without starting a full chat session.
+
+Capability chip area (ProfileHeader):
+- Voice: standalone `VoiceSamplePreview` button using placeholder audio
+- Image: no preview surface
+- Selfie: no concept; not represented
+
+## After
+
+A new `CapabilitySampleTray` component renders a horizontal tray of capability chips in the profile sidebar, positioned directly after the `VoiceSamplePreview` button.
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `apps/web/lib/capability-sample.ts` | `CapabilitySample` type + `getCapabilityIcon()` helper |
+| `apps/web/components/agent/CapabilitySampleTray.tsx` | Tray component — chips, preview toggle, voice player, image thumbnail |
+| `apps/web/__tests__/components/capability-sample-tray.test.tsx` | 13 unit tests |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `apps/web/components/agents/ProfileHeader.tsx` | Imports `CapabilitySampleTray`; derives `capabilitySampleItems` from agent capabilities; renders tray after `VoiceSamplePreview` |
+
+## Capability chip behaviour
+
+| Condition | Rendered element | Interaction |
+|-----------|-----------------|-------------|
+| `sampleUrl` provided | `<button>` chip | Click toggles preview panel below chip |
+| `sampleUrl` absent | `<span>` chip (muted) | "샘플 없음" label; no interaction |
+
+### Preview types
+
+- **voice** → `VoiceSamplePreview` audio player (reuses existing component, injects `_audioFactory` for tests)
+- **image** / **selfie** → `<img>` thumbnail via Next.js `Image`
+
+## Test results
+
+```
+PASS (13) FAIL (0)
+```
+
+Tests cover:
+- Empty capabilities → renders nothing
+- All three capability types render chips
+- `sampleUrl` absent → "샘플 없음" on all types (voice, image, selfie)
+- Button vs. span element for chips with/without sampleUrl
+- Toggle: image preview shown/hidden on successive clicks
+- Image src matches sampleUrl
+- Voice preview renders `VoiceSamplePreview` on click
+- `sampleDuration` displayed in chip
+- `data-testid="capability-sample-tray"` wrapper present
+- Selfie uses image preview (not voice player)
+- Snapshot: mixed capability types with/without sampleUrl
+
+## TypeScript
+
+`npx tsc --noEmit` → No errors.


### PR DESCRIPTION
## Source

backlog.md:136

## Summary
- CapabilitySampleTray extends capability badges with clickable chips showing voice/selfie/image sample previews
- Voice chips open inline VoiceSamplePreview audio player; image/selfie chips show thumbnail
- Chips without sampleUrl show muted 샘플 없음 placeholder

## Evidence
docs/pr-evidence/capability-sample-tray.md

## Test plan
- 13 unit tests: all capability types, sample preview toggle, empty states, sampleDuration, snapshot
- TypeScript tsc --noEmit passes
- Visible in ProfileHeader after existing VoiceSamplePreview

## Auth-only Proof

```bash
curl -s -o /dev/null -w "%{http_code}" \
  -H "Authorization: Bearer $TOKEN" \
  https://agentgram.co/api/v1/agents/me
# Expected: 200
```