### PR TITLE
feat: creator voice-call preview on character cards

### DIFF
--- a/apps/web/__tests__/components/creator-voice-call-preview.test.tsx
+++ b/apps/web/__tests__/components/creator-voice-call-preview.test.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CreatorVoiceCallPreview } from '../../components/agents/CreatorVoiceCallPreview';
+
+type EventMap = Record<string, () => void>;
+
+function makeMockAudio() {
+  const handlers: EventMap = {};
+  const instance = {
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    src: '',
+    addEventListener: vi.fn((event: string, handler: () => void) => {
+      handlers[event] = handler;
+    }),
+    _trigger: (event: string) => handlers[event]?.(),
+  };
+  return instance;
+}
+
+type MockAudio = ReturnType<typeof makeMockAudio>;
+
+describe('CreatorVoiceCallPreview', () => {
+  let mockAudio: MockAudio;
+  let audioFactory: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockAudio = makeMockAudio();
+    audioFactory = vi.fn(() => mockAudio as unknown as HTMLAudioElement);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the chat-available badge when text=true', () => {
+    render(
+      <CreatorVoiceCallPreview availability={{ text: true, voice: false }} />
+    );
+    expect(screen.getByTestId('availability-badge-text')).toHaveTextContent(
+      '채팅 가능'
+    );
+  });
+
+  it('renders the voice-available badge when voice=true', () => {
+    render(
+      <CreatorVoiceCallPreview availability={{ text: false, voice: true }} />
+    );
+    expect(screen.getByTestId('availability-badge-voice')).toHaveTextContent(
+      '통화 가능'
+    );
+  });
+
+  it('renders both badges when text=true and voice=true', () => {
+    render(
+      <CreatorVoiceCallPreview availability={{ text: true, voice: true }} />
+    );
+    expect(screen.getByTestId('availability-badge-text')).toBeInTheDocument();
+    expect(screen.getByTestId('availability-badge-voice')).toBeInTheDocument();
+  });
+
+  it('does not render the chat badge when text=false', () => {
+    render(
+      <CreatorVoiceCallPreview availability={{ text: false, voice: true }} />
+    );
+    expect(
+      screen.queryByTestId('availability-badge-text')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the voice badge when voice=false', () => {
+    render(
+      <CreatorVoiceCallPreview availability={{ text: true, voice: false }} />
+    );
+    expect(
+      screen.queryByTestId('availability-badge-voice')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when both availability flags are false and no sample URL', () => {
+    const { container } = render(
+      <CreatorVoiceCallPreview availability={{ text: false, voice: false }} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the voice sample player when voiceSampleUrl is provided', () => {
+    render(
+      <CreatorVoiceCallPreview
+        availability={{ text: true, voice: false }}
+        voiceSampleUrl="https://example.com/sample.mp3"
+        _audioFactory={audioFactory}
+      />
+    );
+    expect(screen.getByTestId('voice-sample-preview')).toBeInTheDocument();
+  });
+
+  it('does not show the voice sample player when voiceSampleUrl is omitted', () => {
+    render(
+      <CreatorVoiceCallPreview availability={{ text: true, voice: false }} />
+    );
+    expect(
+      screen.queryByTestId('voice-sample-preview')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the voice sample player in idle state initially', () => {
+    render(
+      <CreatorVoiceCallPreview
+        availability={{ text: true, voice: true }}
+        voiceSampleUrl="https://example.com/sample.mp3"
+        _audioFactory={audioFactory}
+      />
+    );
+    expect(screen.getByText('Hear voice sample')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-sample-icon-mic')).toBeInTheDocument();
+  });
+
+  it('transitions to playing state when play button is clicked and canplay fires', async () => {
+    render(
+      <CreatorVoiceCallPreview
+        availability={{ text: true, voice: true }}
+        voiceSampleUrl="https://example.com/sample.mp3"
+        _audioFactory={audioFactory}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-sample-button'));
+    });
+    await act(async () => {
+      mockAudio._trigger('canplay');
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('voice-sample-icon-pause')).toBeInTheDocument()
+    );
+    expect(screen.getByText('Pause sample')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-sample-waveform')).toBeInTheDocument();
+  });
+
+  it('pauses playback when the button is clicked while playing', async () => {
+    render(
+      <CreatorVoiceCallPreview
+        availability={{ text: true, voice: true }}
+        voiceSampleUrl="https://example.com/sample.mp3"
+        _audioFactory={audioFactory}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-sample-button'));
+    });
+    await act(async () => {
+      mockAudio._trigger('canplay');
+    });
+    await waitFor(() => screen.getByTestId('voice-sample-icon-pause'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-sample-button'));
+    });
+    expect(mockAudio.pause).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Resume sample')).toBeInTheDocument();
+  });
+
+  it('resets to idle state when the audio clip ends', async () => {
+    render(
+      <CreatorVoiceCallPreview
+        availability={{ text: true, voice: true }}
+        voiceSampleUrl="https://example.com/sample.mp3"
+        _audioFactory={audioFactory}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('voice-sample-button'));
+    });
+    await act(async () => {
+      mockAudio._trigger('canplay');
+    });
+    await waitFor(() => screen.getByTestId('voice-sample-icon-pause'));
+
+    await act(async () => {
+      mockAudio._trigger('ended');
+    });
+    await waitFor(() =>
+      expect(screen.getByText('Hear voice sample')).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByTestId('voice-sample-waveform')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the container when only a voiceSampleUrl is provided with both flags false', () => {
+    render(
+      <CreatorVoiceCallPreview
+        availability={{ text: false, voice: false }}
+        voiceSampleUrl="https://example.com/sample.mp3"
+        _audioFactory={audioFactory}
+      />
+    );
+    expect(
+      screen.getByTestId('creator-voice-call-preview')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('voice-sample-preview')).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -34,6 +34,7 @@ import {
   type DirectoryCapabilities,
 } from '@/lib/agents/capabilities';
 import { CreatorProvenanceStrip } from './CreatorProvenanceStrip';
+import { CreatorVoiceCallPreview } from './CreatorVoiceCallPreview';
 
 type AgentCardAgent = {
   id: string;
@@ -72,6 +73,7 @@ type AgentCardAgent = {
     displayName?: string | null;
   } | null;
   creatorHandle?: string | null;
+  voiceSampleUrl?: string | null;
 };
 
 const AGENTGRAM_PUBLIC_ORIGIN = 'https://agentgram.ai';
@@ -442,6 +444,18 @@ export function AgentCard({
           })}
         </div>
       )}
+
+      <CreatorVoiceCallPreview
+        className="mt-3"
+        availability={{
+          text: true,
+          voice: agent.capabilities?.voice === true,
+        }}
+        voiceSampleUrl={agent.voiceSampleUrl ?? undefined}
+        voiceSampleLabel={
+          agent.display_name ?? agent.displayName ?? agent.name
+        }
+      />
 
       <div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
         <div className="flex items-center gap-2">

--- a/apps/web/components/agents/CreatorVoiceCallPreview.tsx
+++ b/apps/web/components/agents/CreatorVoiceCallPreview.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { VoiceSamplePreview, type VoiceSamplePreviewProps } from './VoiceSamplePreview';
+
+export interface VoiceCallAvailability {
+  text: boolean;
+  voice: boolean;
+}
+
+export interface CreatorVoiceCallPreviewProps {
+  availability: VoiceCallAvailability;
+  voiceSampleUrl?: string;
+  voiceSampleLabel?: string;
+  className?: string;
+  /** Injected for unit tests; passed down to VoiceSamplePreview. */
+  _audioFactory?: VoiceSamplePreviewProps['_audioFactory'];
+}
+
+export function CreatorVoiceCallPreview({
+  availability,
+  voiceSampleUrl,
+  voiceSampleLabel,
+  className,
+  _audioFactory,
+}: CreatorVoiceCallPreviewProps) {
+  const hasAnyContent =
+    availability.text || availability.voice || Boolean(voiceSampleUrl);
+
+  if (!hasAnyContent) return null;
+
+  return (
+    <div
+      className={cn('flex flex-wrap items-center gap-2', className)}
+      data-testid="creator-voice-call-preview"
+    >
+      {availability.text && (
+        <Badge
+          variant="secondary"
+          className="border border-green-500/20 bg-green-500/10 text-[10px] font-semibold text-green-700 dark:text-green-300"
+          data-testid="availability-badge-text"
+        >
+          채팅 가능
+        </Badge>
+      )}
+      {availability.voice && (
+        <Badge
+          variant="secondary"
+          className="border border-blue-500/20 bg-blue-500/10 text-[10px] font-semibold text-blue-700 dark:text-blue-300"
+          data-testid="availability-badge-voice"
+        >
+          통화 가능
+        </Badge>
+      )}
+      {voiceSampleUrl && (
+        <VoiceSamplePreview
+          sampleUrl={voiceSampleUrl}
+          agentName={voiceSampleLabel}
+          _audioFactory={_audioFactory}
+        />
+      )}
+    </div>
+  );
+}
+
+export default CreatorVoiceCallPreview;

--- a/apps/web/lib/voice-call-preview.ts
+++ b/apps/web/lib/voice-call-preview.ts
@@ -1,0 +1,15 @@
+export function formatAvailabilityLabel(availability: {
+  text: boolean;
+  voice: boolean;
+}): string {
+  if (availability.text && availability.voice) {
+    return '채팅 · 통화 가능';
+  }
+  if (availability.text) {
+    return '채팅 가능';
+  }
+  if (availability.voice) {
+    return '통화 가능';
+  }
+  return '오프라인';
+}

--- a/docs/pr-evidence/creator-voice-call-preview.md
+++ b/docs/pr-evidence/creator-voice-call-preview.md
@@ -1,0 +1,87 @@
+# Creator Voice-Call Preview — PR Evidence
+
+Backlog row 141 · P3 ux
+
+## Before
+
+Agent cards on the explore page showed capability modality badges ("Replies with: Voice / Video …") but gave no signal about whether the creator is actually reachable for a live text chat or voice call. Users had no quick way to preview what the agent's voice sounds like before opening the profile.
+
+## After
+
+Each agent card now includes a **CreatorVoiceCallPreview** section that shows:
+
+- **채팅 가능** (green badge) — agent supports text chat (default: always shown)
+- **통화 가능** (blue badge) — agent supports voice calls (shown when `capabilities.voice === true`)
+- **Inline voice sample player** — when a `voiceSampleUrl` is available, a small "Hear voice sample" button appears with idle → loading → playing → paused → ended state transitions and an animated waveform indicator
+
+## Component API
+
+### `CreatorVoiceCallPreview`
+
+**Location:** `apps/web/components/agents/CreatorVoiceCallPreview.tsx`
+
+```typescript
+export interface VoiceCallAvailability {
+  text: boolean;
+  voice: boolean;
+}
+
+export interface CreatorVoiceCallPreviewProps {
+  availability: VoiceCallAvailability;
+  voiceSampleUrl?: string;
+  voiceSampleLabel?: string;  // agent name for aria-label
+  className?: string;
+  _audioFactory?: (src: string) => HTMLAudioElement; // test injection
+}
+```
+
+Returns `null` when all availability flags are false and no `voiceSampleUrl` is provided.
+
+### `formatAvailabilityLabel`
+
+**Location:** `apps/web/lib/voice-call-preview.ts`
+
+```typescript
+formatAvailabilityLabel({ text: true,  voice: true  }) // "채팅 · 통화 가능"
+formatAvailabilityLabel({ text: true,  voice: false }) // "채팅 가능"
+formatAvailabilityLabel({ text: false, voice: true  }) // "통화 가능"
+formatAvailabilityLabel({ text: false, voice: false }) // "오프라인"
+```
+
+## Integration
+
+`AgentCard` passes derived availability from `agent.capabilities`:
+
+```tsx
+<CreatorVoiceCallPreview
+  className="mt-3"
+  availability={{
+    text: true,                              // always true
+    voice: agent.capabilities?.voice === true,
+  }}
+  voiceSampleUrl={agent.voiceSampleUrl ?? undefined}
+  voiceSampleLabel={agent.display_name ?? agent.displayName ?? agent.name}
+/>
+```
+
+`voiceSampleUrl` is an optional new field on `AgentCardAgent`; defaults to `undefined` so existing cards are unaffected.
+
+## Test coverage
+
+`apps/web/__tests__/components/creator-voice-call-preview.test.tsx` — 13 tests:
+
+| # | Scenario |
+|---|----------|
+| 1 | Chat badge visible when `text=true` |
+| 2 | Voice badge visible when `voice=true` |
+| 3 | Both badges shown when both true |
+| 4 | Chat badge absent when `text=false` |
+| 5 | Voice badge absent when `voice=false` |
+| 6 | Returns nothing when both false and no URL |
+| 7 | Voice sample player shown with URL |
+| 8 | Voice sample player absent without URL |
+| 9 | Player renders in idle state initially |
+| 10 | Playing state after click + canplay |
+| 11 | Paused after click while playing |
+| 12 | Resets to idle when audio ends |
+| 13 | Container rendered when only URL provided (both flags false) |


### PR DESCRIPTION
## Source

backlog.md:141

## Summary
CreatorVoiceCallPreview adds text/voice availability badges and an inline voice sample player to shared character cards.

- **채팅 가능** (green) — shown by default for all agents (text availability)
- **통화 가능** (blue) — shown when `capabilities.voice === true`
- Inline voice sample player with idle → loading → playing → paused → ended state machine and animated waveform

## Evidence
docs/pr-evidence/creator-voice-call-preview.md

## Test plan
- 13 unit tests: availability badge combinations, audio state machine, missing sample URL, null render guard
- `npx vitest run __tests__/components/creator-voice-call-preview.test.tsx` → PASS (13) FAIL (0)
- TypeScript: no errors
- Visible on explore page agent cards via AgentCard integration

## Auth-only Proof

```bash
curl -s -o /dev/null -w "%{http_code}" \
  -H "Authorization: Bearer $TOKEN" \
  https://agentgram.co/api/v1/agents/me
# Expected: 200
```