### PR TITLE
[UX] Voice latency indicator badge on agent capability cards

### DIFF
--- a/apps/web/__tests__/components/voice-latency-badge.test.tsx
+++ b/apps/web/__tests__/components/voice-latency-badge.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  VoiceLatencyBadge,
+  getVoiceLatencyTier,
+  getVoiceLatencyLabel,
+} from '../../components/agents/VoiceLatencyBadge';
+
+describe('getVoiceLatencyTier', () => {
+  it('returns fast for latencyMs < 2000', () => {
+    expect(getVoiceLatencyTier(0)).toBe('fast');
+    expect(getVoiceLatencyTier(1999)).toBe('fast');
+    expect(getVoiceLatencyTier(1500)).toBe('fast');
+  });
+
+  it('returns medium for latencyMs in [2000, 5000]', () => {
+    expect(getVoiceLatencyTier(2000)).toBe('medium');
+    expect(getVoiceLatencyTier(3500)).toBe('medium');
+    expect(getVoiceLatencyTier(5000)).toBe('medium');
+  });
+
+  it('returns slow for latencyMs > 5000', () => {
+    expect(getVoiceLatencyTier(5001)).toBe('slow');
+    expect(getVoiceLatencyTier(10000)).toBe('slow');
+  });
+});
+
+describe('getVoiceLatencyLabel', () => {
+  it('returns "<2s" for fast tier', () => {
+    expect(getVoiceLatencyLabel(1800)).toBe('<2s');
+  });
+
+  it('returns "2–5s" for medium tier', () => {
+    expect(getVoiceLatencyLabel(2000)).toBe('2–5s');
+    expect(getVoiceLatencyLabel(4000)).toBe('2–5s');
+  });
+
+  it('returns ">5s" for slow tier', () => {
+    expect(getVoiceLatencyLabel(6000)).toBe('>5s');
+  });
+});
+
+describe('VoiceLatencyBadge', () => {
+  it('renders with data-testid', () => {
+    render(<VoiceLatencyBadge latencyMs={1500} />);
+    expect(screen.getByTestId('voice-latency-badge')).toBeInTheDocument();
+  });
+
+  it('shows "<2s" label for fast latency', () => {
+    render(<VoiceLatencyBadge latencyMs={1500} />);
+    expect(screen.getByTestId('voice-latency-badge')).toHaveTextContent('<2s');
+  });
+
+  it('shows "2–5s" label for medium latency', () => {
+    render(<VoiceLatencyBadge latencyMs={3000} />);
+    expect(screen.getByTestId('voice-latency-badge')).toHaveTextContent('2–5s');
+  });
+
+  it('shows ">5s" label for slow latency', () => {
+    render(<VoiceLatencyBadge latencyMs={7000} />);
+    expect(screen.getByTestId('voice-latency-badge')).toHaveTextContent('>5s');
+  });
+
+  it('sets data-latency-tier="fast" for latencyMs < 2000', () => {
+    render(<VoiceLatencyBadge latencyMs={1800} />);
+    expect(screen.getByTestId('voice-latency-badge')).toHaveAttribute(
+      'data-latency-tier',
+      'fast'
+    );
+  });
+
+  it('sets data-latency-tier="medium" for latencyMs in [2000, 5000]', () => {
+    render(<VoiceLatencyBadge latencyMs={3500} />);
+    expect(screen.getByTestId('voice-latency-badge')).toHaveAttribute(
+      'data-latency-tier',
+      'medium'
+    );
+  });
+
+  it('sets data-latency-tier="slow" for latencyMs > 5000', () => {
+    render(<VoiceLatencyBadge latencyMs={6000} />);
+    expect(screen.getByTestId('voice-latency-badge')).toHaveAttribute(
+      'data-latency-tier',
+      'slow'
+    );
+  });
+
+  it('includes the Nomi benchmark reference in the title', () => {
+    render(<VoiceLatencyBadge latencyMs={1500} />);
+    const badge = screen.getByTestId('voice-latency-badge');
+    expect(badge).toHaveAttribute('title', expect.stringContaining('Nomi benchmark'));
+  });
+
+  it('accepts an optional className prop', () => {
+    render(<VoiceLatencyBadge latencyMs={1500} className="extra-class" />);
+    expect(screen.getByTestId('voice-latency-badge')).toHaveClass('extra-class');
+  });
+
+  it('boundary: latencyMs exactly 2000 is medium', () => {
+    render(<VoiceLatencyBadge latencyMs={2000} />);
+    expect(screen.getByTestId('voice-latency-badge')).toHaveAttribute(
+      'data-latency-tier',
+      'medium'
+    );
+  });
+
+  it('boundary: latencyMs exactly 5000 is medium', () => {
+    render(<VoiceLatencyBadge latencyMs={5000} />);
+    expect(screen.getByTestId('voice-latency-badge')).toHaveAttribute(
+      'data-latency-tier',
+      'medium'
+    );
+  });
+});

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/lib/agents/capabilities';
 import { CreatorProvenanceStrip } from './CreatorProvenanceStrip';
 import { CreatorVoiceCallPreview } from './CreatorVoiceCallPreview';
+import { VoiceLatencyBadge } from './VoiceLatencyBadge';
 
 type AgentCardAgent = {
   id: string;
@@ -74,6 +75,7 @@ type AgentCardAgent = {
   } | null;
   creatorHandle?: string | null;
   voiceSampleUrl?: string | null;
+  voiceLatencyMs?: number | null;
 };
 
 const AGENTGRAM_PUBLIC_ORIGIN = 'https://agentgram.ai';
@@ -442,6 +444,10 @@ export function AgentCard({
               </Badge>
             );
           })}
+          {agent.capabilities?.voice === true &&
+            agent.voiceLatencyMs != null && (
+              <VoiceLatencyBadge latencyMs={agent.voiceLatencyMs} />
+            )}
         </div>
       )}
 

--- a/apps/web/components/agents/VoiceLatencyBadge.tsx
+++ b/apps/web/components/agents/VoiceLatencyBadge.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Zap } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+export type VoiceLatencyTier = 'fast' | 'medium' | 'slow';
+
+export interface VoiceLatencyBadgeProps {
+  latencyMs: number;
+  className?: string;
+}
+
+export function getVoiceLatencyTier(latencyMs: number): VoiceLatencyTier {
+  if (latencyMs < 2000) return 'fast';
+  if (latencyMs <= 5000) return 'medium';
+  return 'slow';
+}
+
+export function getVoiceLatencyLabel(latencyMs: number): string {
+  if (latencyMs < 2000) return '<2s';
+  if (latencyMs <= 5000) return '2–5s';
+  return '>5s';
+}
+
+const TIER_CLASS: Record<VoiceLatencyTier, string> = {
+  fast: 'border-green-500/20 bg-green-500/10 text-green-700 dark:text-green-300',
+  medium:
+    'border-yellow-500/20 bg-yellow-500/10 text-yellow-700 dark:text-yellow-300',
+  slow: 'border-border/70 bg-muted/40 text-muted-foreground',
+};
+
+export function VoiceLatencyBadge({ latencyMs, className }: VoiceLatencyBadgeProps) {
+  const tier = getVoiceLatencyTier(latencyMs);
+  const label = getVoiceLatencyLabel(latencyMs);
+
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        'gap-1 border text-[10px] font-semibold',
+        TIER_CLASS[tier],
+        className
+      )}
+      data-testid="voice-latency-badge"
+      data-latency-tier={tier}
+      title={`Voice latency: ${label} (Nomi benchmark: <2s)`}
+    >
+      <Zap className="h-3 w-3" />
+      {label}
+    </Badge>
+  );
+}

--- a/docs/pr-evidence/voice-latency-indicator-badge.md
+++ b/docs/pr-evidence/voice-latency-indicator-badge.md
@@ -1,0 +1,74 @@
+# Voice Latency Indicator Badge — PR Evidence
+
+**Backlog row:** 159
+**Feature:** Display measured voice response latency on agent capability cards with Nomi's <2s (Jan 2026) as market reference benchmark.
+
+## Before
+
+Agent capability cards in the directory listing showed voice modality ("Replies with Voice") but gave no indication of how fast the voice response was. Users had no way to compare voice responsiveness between agents or understand where an agent stood relative to market leaders like Nomi (<2s as of Jan 2026).
+
+Modality badges section (AgentCard):
+- Voice: "Replies with 🎤 Voice" badge only — no latency signal
+- No tier differentiation between fast and slow voice agents
+
+## After
+
+A new `VoiceLatencyBadge` component renders a color-coded latency badge alongside the voice modality badge in the "Replies with" row of the agent capability card. The badge is only shown when `voiceLatencyMs` is provided and voice capability is enabled.
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `apps/web/components/agents/VoiceLatencyBadge.tsx` | Badge component — tier classification, label formatting, color-coded rendering |
+| `apps/web/__tests__/components/voice-latency-badge.test.tsx` | 17 unit tests covering tier logic, label display, data attributes, boundary conditions |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `apps/web/components/agents/AgentCard.tsx` | Added `voiceLatencyMs?: number \| null` to `AgentCardAgent`; imports `VoiceLatencyBadge`; renders badge after modality badges when voice is enabled and `voiceLatencyMs` is present |
+| `packages/shared/src/types/agent.ts` | Added `voiceLatencyMs?: number` to the `Agent` interface |
+
+## Color-coding tiers
+
+| Latency range | Tier | Color | Rationale |
+|---------------|------|-------|-----------|
+| < 2000ms | fast | Green | At or below Nomi Jan 2026 benchmark (<2s) |
+| 2000–5000ms | medium | Yellow | Noticeable but acceptable voice delay |
+| > 5000ms | slow | Gray/muted | High-latency — may impact conversational feel |
+
+### Badge label display
+
+| Tier | Label |
+|------|-------|
+| fast | `<2s` |
+| medium | `2–5s` |
+| slow | `>5s` |
+
+### Integration behavior
+
+- Badge is rendered inside the `agent-card-modality-badges` row, immediately after the modality badge map
+- Only rendered when `agent.capabilities?.voice === true` **and** `agent.voiceLatencyMs != null`
+- `data-testid="voice-latency-badge"` for test selection
+- `data-latency-tier` attribute exposes tier for targeted CSS/test assertions
+- `title` tooltip includes the Nomi benchmark reference: `Voice latency: <2s (Nomi benchmark: <2s)`
+
+## Test results
+
+```
+PASS (17) FAIL (0)
+```
+
+Tests cover:
+- `getVoiceLatencyTier`: fast/medium/slow for all boundary values (0, 1999, 2000, 3500, 5000, 5001)
+- `getVoiceLatencyLabel`: correct label strings for each tier
+- `VoiceLatencyBadge` renders with `data-testid`
+- Correct label text for each tier
+- `data-latency-tier` attribute set correctly for each tier
+- Title includes "Nomi benchmark" reference string
+- `className` prop forwarded correctly
+- Boundary conditions: exactly 2000ms = medium, exactly 5000ms = medium
+
+## TypeScript
+
+`npx tsc --noEmit` → No errors.

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -154,6 +154,7 @@ export interface Agent extends AgentMemoryProfile {
   starterPrompts?: AgentStarterPrompt[];
   diaryEntries?: AgentDiaryEntry[];
   storyThreads?: StoryThread[];
+  voiceLatencyMs?: number;
   avatarUrl?: string;
   activePersona?: Persona;
   createdAt: string;


### PR DESCRIPTION
## Source

backlog.md:159

## Summary
- VoiceLatencyBadge component added to agent capability cards
- Color-coded latency indicator: green <2s (Nomi Jan 2026 benchmark), yellow 2-5s, gray >5s
- Market reference positioning vs Nomi <2s voice quality leadership signal

## Auth-only Proof

N/A — public route. Agent cards are rendered on the public explore page (`/explore`), no authentication required.

## Data Source

`voiceLatencyMs` is defined as optional in `packages/shared/src/types/agent.ts`. DB column (`voice_latency_ms`) is not yet migrated — badge renders only when the field is non-null. Data supply path: once column is added and populated via agent profile API, badge activates automatically. Current state: badge hidden until DB column is wired.

## Evidence
See docs/pr-evidence/voice-latency-indicator-badge.md for component implementation and before/after description.