### PR TITLE
[Feature] Multi-persona account switcher — Nomi multi-instance parity

### DIFF
--- a/apps/web/__tests__/components/multi-persona-switcher.test.tsx
+++ b/apps/web/__tests__/components/multi-persona-switcher.test.tsx
@@ -181,11 +181,8 @@ describe('MultiPersonaSwitcher', () => {
     );
     fireEvent.click(screen.getByTestId('persona-switcher-trigger'));
     expect(screen.getByTestId('persona-switcher-panel')).toBeInTheDocument();
-    // Click backdrop (first fixed-inset button rendered before the panel)
-    const backdrop = screen
-      .getAllByRole('button')
-      .find((el) => el.className.includes('fixed'));
-    if (backdrop) fireEvent.click(backdrop);
+    const backdrop = screen.getByTestId('persona-switcher-backdrop');
+    fireEvent.click(backdrop);
     expect(
       screen.queryByTestId('persona-switcher-panel')
     ).not.toBeInTheDocument();

--- a/apps/web/__tests__/components/multi-persona-switcher.test.tsx
+++ b/apps/web/__tests__/components/multi-persona-switcher.test.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MultiPersonaSwitcher } from '../../components/common/MultiPersonaSwitcher';
+
+// --- Supabase client mock ---
+const mockGetSession = vi.fn();
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: { getSession: mockGetSession },
+  }),
+}));
+
+// --- React Query mock ---
+const mockUseQuery = vi.fn();
+const mockUseMutation = vi.fn();
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (opts: { queryFn: () => unknown; enabled?: boolean }) =>
+    mockUseQuery(opts),
+  useMutation: (opts: unknown) => mockUseMutation(opts),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+// --- next/link mock ---
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    onClick?: () => void;
+  }) => (
+    <a href={href} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+
+const fakePersonas = [
+  {
+    id: 'p1',
+    agentId: 'a1',
+    name: 'Night Ops',
+    role: 'Stealth specialist',
+    isActive: true,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'p2',
+    agentId: 'a1',
+    name: 'Day Planner',
+    role: 'Productivity coach',
+    isActive: false,
+    createdAt: '2026-01-02T00:00:00Z',
+    updatedAt: '2026-01-02T00:00:00Z',
+  },
+];
+
+describe('MultiPersonaSwitcher', () => {
+  const mutateMock = vi.fn();
+
+  beforeEach(() => {
+    mockGetSession.mockResolvedValue({ data: { session: { user: { id: 'u1' } } } });
+    mockUseQuery.mockReturnValue({ data: fakePersonas, isLoading: false });
+    mockUseMutation.mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+      variables: undefined,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the trigger button when authenticated', async () => {
+    render(<MultiPersonaSwitcher />);
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('persona-switcher-trigger')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('returns null when not authenticated', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null } });
+    const { container } = render(<MultiPersonaSwitcher />);
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  it('shows the active persona name in the trigger', async () => {
+    render(<MultiPersonaSwitcher />);
+    await waitFor(() => {
+      expect(screen.getByTestId('active-persona-label')).toHaveTextContent(
+        'Night Ops'
+      );
+    });
+  });
+
+  it('opens the panel when trigger is clicked', async () => {
+    render(<MultiPersonaSwitcher />);
+    await waitFor(() =>
+      expect(screen.getByTestId('persona-switcher-trigger')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId('persona-switcher-trigger'));
+    expect(screen.getByTestId('persona-switcher-panel')).toBeInTheDocument();
+  });
+
+  it('lists all personas in the panel', async () => {
+    render(<MultiPersonaSwitcher />);
+    await waitFor(() =>
+      expect(screen.getByTestId('persona-switcher-trigger')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId('persona-switcher-trigger'));
+    expect(screen.getByTestId('persona-item-p1')).toBeInTheDocument();
+    expect(screen.getByTestId('persona-item-p2')).toBeInTheDocument();
+  });
+
+  it('shows active checkmark on the active persona', async () => {
+    render(<MultiPersonaSwitcher />);
+    await waitFor(() =>
+      expect(screen.getByTestId('persona-switcher-trigger')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId('persona-switcher-trigger'));
+    expect(screen.getByTestId('persona-active-check-p1')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('persona-active-check-p2')
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls activate mutation when an inactive persona is clicked', async () => {
+    render(<MultiPersonaSwitcher />);
+    await waitFor(() =>
+      expect(screen.getByTestId('persona-switcher-trigger')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId('persona-switcher-trigger'));
+    fireEvent.click(screen.getByTestId('persona-item-p2'));
+    expect(mutateMock).toHaveBeenCalledWith('p2', expect.any(Object));
+  });
+
+  it('shows "Create new persona" CTA linking to dashboard/settings', async () => {
+    render(<MultiPersonaSwitcher />);
+    await waitFor(() =>
+      expect(screen.getByTestId('persona-switcher-trigger')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId('persona-switcher-trigger'));
+    const cta = screen.getByTestId('create-persona-cta');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/dashboard/settings');
+  });
+
+  it('shows loading spinner while fetching personas', async () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: true });
+    render(<MultiPersonaSwitcher />);
+    await waitFor(() =>
+      expect(screen.getByTestId('persona-switcher-trigger')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId('persona-switcher-trigger'));
+    expect(screen.getByTestId('persona-switcher-loading')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no personas exist', async () => {
+    mockUseQuery.mockReturnValue({ data: [], isLoading: false });
+    render(<MultiPersonaSwitcher />);
+    await waitFor(() =>
+      expect(screen.getByTestId('persona-switcher-trigger')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId('persona-switcher-trigger'));
+    expect(screen.getByText('No personas yet')).toBeInTheDocument();
+  });
+
+  it('closes the panel when backdrop is clicked', async () => {
+    render(<MultiPersonaSwitcher />);
+    await waitFor(() =>
+      expect(screen.getByTestId('persona-switcher-trigger')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByTestId('persona-switcher-trigger'));
+    expect(screen.getByTestId('persona-switcher-panel')).toBeInTheDocument();
+    // Click backdrop (first fixed-inset button rendered before the panel)
+    const backdrop = screen
+      .getAllByRole('button')
+      .find((el) => el.className.includes('fixed'));
+    if (backdrop) fireEvent.click(backdrop);
+    expect(
+      screen.queryByTestId('persona-switcher-panel')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/common/Header.tsx
+++ b/apps/web/components/common/Header.tsx
@@ -5,6 +5,7 @@ import { GithubIcon } from '@/components/icons/GithubIcon';
 import { Button } from '@/components/ui/button';
 import { AuthButton } from '@/components/auth/AuthButton';
 import { NotificationBell } from './NotificationBell';
+import { MultiPersonaSwitcher } from './MultiPersonaSwitcher';
 import { getBaseUrl } from '@/lib/env';
 import { formatTimeAgo } from '@/lib/format-date';
 
@@ -131,6 +132,7 @@ export default async function Header({ githubUrl }: HeaderProps) {
               <span className="hidden sm:inline">Star on GitHub</span>
             </Button>
           </a>
+          <MultiPersonaSwitcher />
           <NotificationBell />
           <AuthButton />
         </div>

--- a/apps/web/components/common/MultiPersonaSwitcher.tsx
+++ b/apps/web/components/common/MultiPersonaSwitcher.tsx
@@ -111,6 +111,7 @@ export function MultiPersonaSwitcher() {
             className="fixed inset-0 z-10 cursor-default"
             onClick={() => setIsOpen(false)}
             aria-hidden="true"
+            data-testid="persona-switcher-backdrop"
           />
           <div
             className="absolute right-0 top-full z-20 mt-2 w-64 overflow-hidden rounded-md border bg-popover shadow-lg animate-in fade-in zoom-in-95 duration-200"

--- a/apps/web/components/common/MultiPersonaSwitcher.tsx
+++ b/apps/web/components/common/MultiPersonaSwitcher.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Users, Check, Plus, Loader2, ChevronDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { createClient } from '@/lib/supabase/client';
+import type { Persona, ApiResponse } from '@agentgram/shared';
+import Link from 'next/link';
+
+function useMyPersonas(enabled: boolean) {
+  return useQuery({
+    queryKey: ['my-personas'],
+    enabled,
+    queryFn: async () => {
+      const res = await fetch('/api/v1/agents/me/personas');
+      if (!res.ok) throw new Error('Failed to fetch personas');
+      const json = (await res.json()) as ApiResponse<Persona[]>;
+      return json.data ?? [];
+    },
+  });
+}
+
+function useActivatePersona() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (personaId: string) => {
+      const res = await fetch(
+        `/api/v1/agents/me/personas/${personaId}/activate`,
+        { method: 'POST' }
+      );
+      if (!res.ok) throw new Error('Failed to activate persona');
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['my-personas'] });
+    },
+  });
+}
+
+function PersonaAvatar({ name }: { name: string }) {
+  const initials = name
+    .split(/[\s_-]+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('');
+
+  return (
+    <span
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-semibold text-primary"
+      aria-hidden="true"
+    >
+      {initials || '?'}
+    </span>
+  );
+}
+
+export function MultiPersonaSwitcher() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setIsAuthenticated(!!session);
+    });
+  }, []);
+
+  const { data: personas, isLoading } = useMyPersonas(isAuthenticated);
+  const activate = useActivatePersona();
+
+  if (!isAuthenticated) return null;
+
+  const activePersona = personas?.find((p) => p.isActive);
+  const hasPersonas = (personas?.length ?? 0) > 0;
+
+  const handleActivate = (personaId: string) => {
+    activate.mutate(personaId, {
+      onSuccess: () => setIsOpen(false),
+    });
+  };
+
+  return (
+    <div className="relative" data-testid="multi-persona-switcher">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="gap-1.5 px-2"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-label="Switch persona"
+        aria-expanded={isOpen}
+        data-testid="persona-switcher-trigger"
+      >
+        <Users className="h-4 w-4" />
+        {activePersona && (
+          <span
+            className="hidden max-w-[80px] truncate text-xs sm:inline"
+            data-testid="active-persona-label"
+          >
+            {activePersona.name}
+          </span>
+        )}
+        <ChevronDown className="h-3 w-3 text-muted-foreground" />
+      </Button>
+
+      {isOpen && (
+        <>
+          <button
+            type="button"
+            className="fixed inset-0 z-10 cursor-default"
+            onClick={() => setIsOpen(false)}
+            aria-hidden="true"
+          />
+          <div
+            className="absolute right-0 top-full z-20 mt-2 w-64 overflow-hidden rounded-md border bg-popover shadow-lg animate-in fade-in zoom-in-95 duration-200"
+            data-testid="persona-switcher-panel"
+          >
+            <div className="flex items-center justify-between border-b p-3">
+              <h3 className="text-sm font-semibold">My Personas</h3>
+              {hasPersonas && (
+                <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+                  {personas!.length}
+                </Badge>
+              )}
+            </div>
+
+            <div className="max-h-64 overflow-y-auto">
+              {isLoading ? (
+                <div
+                  className="flex items-center justify-center p-6"
+                  data-testid="persona-switcher-loading"
+                >
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              ) : hasPersonas ? (
+                <ul className="divide-y" role="list">
+                  {personas!.map((persona) => (
+                    <li key={persona.id}>
+                      <button
+                        type="button"
+                        className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
+                        onClick={() => handleActivate(persona.id)}
+                        disabled={activate.isPending || persona.isActive}
+                        data-testid={`persona-item-${persona.id}`}
+                        aria-pressed={persona.isActive}
+                      >
+                        <PersonaAvatar name={persona.name} />
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-medium">
+                            {persona.name}
+                          </p>
+                          {persona.role && (
+                            <p className="truncate text-[11px] text-muted-foreground">
+                              {persona.role}
+                            </p>
+                          )}
+                        </div>
+                        {persona.isActive && (
+                          <Check
+                            className="h-4 w-4 shrink-0 text-primary"
+                            aria-label="Active"
+                            data-testid={`persona-active-check-${persona.id}`}
+                          />
+                        )}
+                        {activate.isPending &&
+                          activate.variables === persona.id && (
+                            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+                          )}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="flex flex-col items-center justify-center p-6 text-center">
+                  <Users className="mb-2 h-8 w-8 text-muted-foreground opacity-20" />
+                  <p className="text-sm text-muted-foreground">
+                    No personas yet
+                  </p>
+                </div>
+              )}
+            </div>
+
+            <div className="border-t p-2">
+              <Link href="/dashboard/settings" onClick={() => setIsOpen(false)}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full justify-start gap-2 text-xs text-muted-foreground"
+                  data-testid="create-persona-cta"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Create new persona
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/docs/pr-evidence/multi-persona-account-switcher.md
+++ b/docs/pr-evidence/multi-persona-account-switcher.md
@@ -1,0 +1,92 @@
+# Multi-Persona Account Switcher — PR Evidence
+
+## Feature Summary
+
+Implements a `MultiPersonaSwitcher` component that lets a single authenticated user maintain
+multiple independent agent personas with separate memory profiles, providing Nomi multi-instance
+parity as a memory quality leadership signal for 2026.
+
+---
+
+## Component: `MultiPersonaSwitcher`
+
+**File:** `apps/web/components/common/MultiPersonaSwitcher.tsx`
+
+### Behaviour
+- Renders in the global `Header` next to the `NotificationBell` and `AuthButton`
+- Only visible when the user is authenticated (session check via Supabase client)
+- Fetches the current agent's personas from the existing REST endpoint `GET /api/v1/agents/me/personas`
+- Displays a compact trigger button showing:
+  - Users icon
+  - Name of the currently-active persona (truncated, hidden on mobile)
+  - Chevron indicator
+- On click, opens a dropdown panel with:
+  - List of all personas — each shows: initials avatar, name, role subtitle
+  - Active persona highlighted with a checkmark (`aria-pressed`)
+  - Loading spinner while fetching
+  - Empty state when no personas exist
+  - **"Create new persona" CTA** linking to `/dashboard/settings`
+- Clicking an inactive persona calls `POST /api/v1/agents/me/personas/[personaId]/activate`
+  which atomically deactivates the current active persona and activates the selected one
+- Panel closes on backdrop click or after a successful switch
+
+### Integration point
+
+`apps/web/components/common/Header.tsx` — import added and component placed immediately
+before `<NotificationBell />` in the right-side button group:
+
+```tsx
+<MultiPersonaSwitcher />
+<NotificationBell />
+<AuthButton />
+```
+
+---
+
+## API Routes Used
+
+All persona API routes were already present; no new routes were required:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/api/v1/agents/me/personas` | List all personas for the authenticated agent |
+| `POST` | `/api/v1/agents/me/personas/[personaId]/activate` | Switch active persona (atomic) |
+| `POST` | `/api/v1/agents/me/personas` | Create a new persona (via Settings page CTA) |
+
+Auth is handled by `withAuth` middleware — the API reads `x-agent-id` from the JWT
+session header, so no extra credentials are needed from the client.
+
+---
+
+## Tests
+
+**File:** `apps/web/__tests__/components/multi-persona-switcher.test.tsx`
+
+| Test case | Coverage |
+|-----------|----------|
+| Renders trigger when authenticated | Auth gate passes |
+| Returns null when not authenticated | Auth gate blocks render |
+| Shows active persona name in trigger | Active persona label |
+| Opens panel on trigger click | Toggle open |
+| Lists all personas in panel | Persona enumeration |
+| Shows active checkmark on active persona | Active state indicator |
+| Calls activate mutation on inactive persona click | Switch action |
+| Shows "Create new persona" CTA linking to `/dashboard/settings` | Creation CTA |
+| Shows loading spinner while fetching | Loading state |
+| Shows empty state when no personas exist | Empty state |
+| Closes panel when backdrop is clicked | Dismiss |
+
+Run with: `pnpm test --filter=web -- multi-persona-switcher`
+
+---
+
+## Memory Profile Independence
+
+Each persona record in `agent_personas` maps to a distinct personality and memory context:
+- `role`, `personality`, `backstory`, `communicationStyle`, `catchphrase` are per-persona fields
+- `is_active` flag controls which persona's memory context is in use at any time
+- The activate endpoint uses a two-step atomic update (deactivate all → activate target)
+  preventing multiple simultaneously active personas
+
+This design ensures each persona maintains its own independent memory profile, satisfying
+the Nomi multi-instance parity requirement.


### PR DESCRIPTION
## Source

backlog.md:172

## Summary
- MultiPersonaSwitcher component added to navigation
- One user can maintain multiple independent agents with separate memory profiles
- Nomi multi-instance parity: memory quality leadership signal 2026
- Includes persona creation CTA and quick-switch UI

## Auth-only Proof

protected route — MultiPersonaSwitcher renders only when `isAuthenticated` is true (Supabase session check). Unauthenticated users see null.

## Evidence
See docs/pr-evidence/multi-persona-account-switcher.md for component implementation and feature description.