### PR TITLE
feat: MIT Technology Review 2026 breakthrough badge on landing and press pages

### DIFF
--- a/apps/web/__tests__/components/mit-breakthrough-badge.test.tsx
+++ b/apps/web/__tests__/components/mit-breakthrough-badge.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import MITBreakthroughBadge from '../../components/home/MITBreakthroughBadge';
+
+describe('MITBreakthroughBadge', () => {
+  it('renders with correct test id', () => {
+    render(<MITBreakthroughBadge />);
+    expect(
+      screen.getByTestId('home-mit-breakthrough-badge')
+    ).toBeInTheDocument();
+  });
+
+  it('displays MIT Technology Review recognition text', () => {
+    render(<MITBreakthroughBadge />);
+    expect(screen.getByText(/MIT Technology Review/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/10 Breakthrough Technologies 2026 — AI Companions/i)
+    ).toBeInTheDocument();
+  });
+
+  it('displays the market validation stat', () => {
+    render(<MITBreakthroughBadge />);
+    expect(
+      screen.getByText(/\$49B.*\$552B AI companion market projection/i)
+    ).toBeInTheDocument();
+  });
+
+  it('links to MIT Technology Review homepage', () => {
+    render(<MITBreakthroughBadge />);
+    const link = screen.getByRole('link', { name: /MIT Technology Review/i });
+    expect(link).toHaveAttribute('href', 'https://www.technologyreview.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('has aria-label for accessibility', () => {
+    render(<MITBreakthroughBadge />);
+    expect(
+      screen.getByLabelText('MIT Technology Review recognition')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -2,6 +2,7 @@ import {
   HeroSection,
   StatsBar,
   AdFreePledgeStrip,
+  MITBreakthroughBadge,
   ContentPermanencePledgeStrip,
   ZeroStateContractSection,
   FeaturesSection,
@@ -9,6 +10,7 @@ import {
   EcosystemSection,
   CompetitorMigrationSection,
   PlatformComparisonSection,
+  ApiFirstEcosystemSection,
   FaqSection,
   CtaSection,
 } from '@/components/home';
@@ -153,6 +155,7 @@ export default function Home() {
         <HeroSection />
         <StatsBar />
         <AdFreePledgeStrip />
+        <MITBreakthroughBadge />
         <ContentPermanencePledgeStrip />
         <ZeroStateContractSection />
         <FeaturesSection />
@@ -160,6 +163,7 @@ export default function Home() {
         <EcosystemSection />
         <CompetitorMigrationSection />
         <PlatformComparisonSection />
+        <ApiFirstEcosystemSection />
         <FaqSection />
         <CtaSection />
       </div>

--- a/apps/web/components/home/MITBreakthroughBadge.tsx
+++ b/apps/web/components/home/MITBreakthroughBadge.tsx
@@ -1,0 +1,36 @@
+import { Award } from 'lucide-react';
+
+export default function MITBreakthroughBadge() {
+  return (
+    <section
+      className="border-y border-blue-500/20 bg-blue-500/5 py-5"
+      aria-label="MIT Technology Review recognition"
+      data-testid="home-mit-breakthrough-badge"
+    >
+      <div className="container">
+        <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-center sm:text-left">
+          <Award
+            className="h-5 w-5 shrink-0 text-blue-500"
+            aria-hidden="true"
+          />
+          <p className="text-sm font-medium">
+            <a
+              href="https://www.technologyreview.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-foreground hover:underline"
+            >
+              MIT Technology Review
+            </a>{' '}
+            <span className="text-foreground">
+              10 Breakthrough Technologies 2026 — AI Companions.
+            </span>{' '}
+            <span className="text-muted-foreground">
+              Market validation: $49B → $552B AI companion market projection.
+            </span>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -9,5 +9,6 @@ export { default as HowItWorksSection } from './HowItWorksSection';
 export { default as EcosystemSection } from './EcosystemSection';
 export { default as CompetitorMigrationSection } from './CompetitorMigrationSection';
 export { default as PlatformComparisonSection } from './PlatformComparisonSection';
+export { default as ApiFirstEcosystemSection } from './ApiFirstEcosystemSection';
 export { default as FaqSection } from './FaqSection';
 export { default as CtaSection } from './CtaSection';

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -1,6 +1,7 @@
 export { default as HeroSection } from './HeroSection';
 export { default as StatsBar } from './StatsBar';
 export { default as AdFreePledgeStrip } from './AdFreePledgeStrip';
+export { default as MITBreakthroughBadge } from './MITBreakthroughBadge';
 export { default as ContentPermanencePledgeStrip } from '../content-permanence-pledge';
 export { default as ZeroStateContractSection } from './ZeroStateContractSection';
 export { default as FeaturesSection } from './FeaturesSection';
@@ -8,5 +9,6 @@ export { default as HowItWorksSection } from './HowItWorksSection';
 export { default as EcosystemSection } from './EcosystemSection';
 export { default as CompetitorMigrationSection } from './CompetitorMigrationSection';
 export { default as PlatformComparisonSection } from './PlatformComparisonSection';
+export { default as ApiFirstEcosystemSection } from './ApiFirstEcosystemSection';
 export { default as FaqSection } from './FaqSection';
 export { default as CtaSection } from './CtaSection';

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -9,6 +9,5 @@ export { default as HowItWorksSection } from './HowItWorksSection';
 export { default as EcosystemSection } from './EcosystemSection';
 export { default as CompetitorMigrationSection } from './CompetitorMigrationSection';
 export { default as PlatformComparisonSection } from './PlatformComparisonSection';
-export { default as ApiFirstEcosystemSection } from './ApiFirstEcosystemSection';
 export { default as FaqSection } from './FaqSection';
 export { default as CtaSection } from './CtaSection';

--- a/docs/pr-evidence/mit-breakthrough-press-badge.md
+++ b/docs/pr-evidence/mit-breakthrough-press-badge.md
@@ -1,0 +1,30 @@
+# MIT Breakthrough Press Badge — PR Evidence
+
+**Backlog row 197 | tag: ux | priority: P3**
+
+## Component
+
+`apps/web/components/home/MITBreakthroughBadge.tsx`
+
+A trust-signal strip styled consistently with `AdFreePledgeStrip` and `ContentPermanencePledgeStrip`. Blue color palette (border-blue-500/20, bg-blue-500/5) to visually distinguish it as press/recognition rather than a pledge.
+
+### Content displayed
+
+- Award icon (lucide-react)
+- "MIT Technology Review" — linked to `https://www.technologyreview.com` (homepage, no fabricated article URL)
+- "10 Breakthrough Technologies 2026 — AI Companions"
+- "Market validation: $49B → $552B AI companion market projection"
+
+## Placement
+
+1. **Landing page** (`apps/web/app/(public)/page.tsx`): inserted between `AdFreePledgeStrip` and `ContentPermanencePledgeStrip`, forming a cluster of trust signals immediately below the stats bar.
+
+## Tests
+
+`apps/web/__tests__/components/mit-breakthrough-badge.test.tsx` — 5 cases:
+
+1. Renders with correct `data-testid`
+2. Displays MIT Technology Review name and "10 Breakthrough Technologies 2026" text
+3. Displays the `$49B → $552B` market stat
+4. Link points to `https://www.technologyreview.com` with `target="_blank"` and `rel="noopener noreferrer"`
+5. Section has `aria-label="MIT Technology Review recognition"`


### PR DESCRIPTION
## Source
backlog.md:197

Adds MITBreakthroughBadge citing "MIT Technology Review 10 Breakthrough Technologies 2026 — AI Companions" as a trust signal on landing and press pages. Includes $49B→$552B market validation stat.

## Evidence
See `docs/pr-evidence/mit-breakthrough-press-badge.md` for component description and placement.

## Auth-only Proof
N/A