### PR TITLE
feat: voice retention uplift badge (+20% 7-day stat on capability pages)

### DIFF
--- a/apps/web/__tests__/components/voice-retention-uplift-badge.test.tsx
+++ b/apps/web/__tests__/components/voice-retention-uplift-badge.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { VoiceRetentionUpliftBadge } from '../../components/agents/VoiceRetentionUpliftBadge';
+
+describe('VoiceRetentionUpliftBadge', () => {
+  it('renders the badge container with correct test id', () => {
+    render(<VoiceRetentionUpliftBadge />);
+    expect(
+      screen.getByTestId('voice-retention-uplift-badge')
+    ).toBeInTheDocument();
+  });
+
+  it('displays the +20% 7-day retention stat', () => {
+    render(<VoiceRetentionUpliftBadge />);
+    expect(
+      screen.getByTestId('voice-retention-uplift-stat')
+    ).toHaveTextContent('+20% 7-day retention');
+  });
+
+  it('displays the ElevenLabs attribution', () => {
+    render(<VoiceRetentionUpliftBadge />);
+    expect(
+      screen.getByTestId('voice-retention-uplift-attribution')
+    ).toHaveTextContent('Powered by ElevenLabs');
+  });
+
+  it('includes a tooltip with the full retention stat description', () => {
+    render(<VoiceRetentionUpliftBadge />);
+    const badge = screen.getByTestId('voice-retention-uplift-badge');
+    expect(badge).toHaveAttribute(
+      'title',
+      'Users with voice-enabled agents return 20% more often in the first week'
+    );
+  });
+});

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -23,6 +23,7 @@ import { FollowButton } from './FollowButton';
 import { RequestApiAccessButton } from './RequestApiAccessButton';
 import { StartGroupChatButton } from './StartGroupChatButton';
 import { VoiceSamplePreview } from './VoiceSamplePreview';
+import { VoiceRetentionUpliftBadge } from './VoiceRetentionUpliftBadge';
 import { RelationshipLongevityIndicator } from '@/components/agent/RelationshipLongevityIndicator';
 import { getActiveDaysFromDate } from '@/lib/relationship-longevity';
 
@@ -608,11 +609,14 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
             </div>
           )}
           {agent.capabilities?.voice === true && (
-            <VoiceSamplePreview
-              agentName={agent.displayName || agent.name}
-              className="mt-4"
-              data-testid="profile-voice-sample-preview"
-            />
+            <>
+              <VoiceSamplePreview
+                agentName={agent.displayName || agent.name}
+                className="mt-4"
+                data-testid="profile-voice-sample-preview"
+              />
+              <VoiceRetentionUpliftBadge className="mt-2" />
+            </>
           )}
           {capabilitySampleItems.length > 0 && (
             <CapabilitySampleTray

--- a/apps/web/components/agents/VoiceRetentionUpliftBadge.tsx
+++ b/apps/web/components/agents/VoiceRetentionUpliftBadge.tsx
@@ -1,0 +1,41 @@
+import { TrendingUp } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface VoiceRetentionUpliftBadgeProps {
+  className?: string;
+}
+
+export function VoiceRetentionUpliftBadge({
+  className,
+}: VoiceRetentionUpliftBadgeProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex flex-col gap-1 rounded-xl border border-primary/20 bg-primary/5 px-3 py-2',
+        className
+      )}
+      data-testid="voice-retention-uplift-badge"
+      title="Users with voice-enabled agents return 20% more often in the first week"
+    >
+      <div className="flex items-center gap-1.5">
+        <TrendingUp
+          className="h-3.5 w-3.5 shrink-0 text-primary"
+          aria-hidden="true"
+          data-testid="voice-retention-uplift-icon"
+        />
+        <span
+          className="text-xs font-bold text-primary"
+          data-testid="voice-retention-uplift-stat"
+        >
+          +20% 7-day retention
+        </span>
+      </div>
+      <span
+        className="text-[10px] font-medium text-muted-foreground"
+        data-testid="voice-retention-uplift-attribution"
+      >
+        Powered by ElevenLabs
+      </span>
+    </div>
+  );
+}

--- a/apps/web/components/subscription/PaywallPreviewModal.tsx
+++ b/apps/web/components/subscription/PaywallPreviewModal.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Lock, Mic, ImageIcon, Brain, Zap, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { VoiceRetentionUpliftBadge } from '@/components/agents/VoiceRetentionUpliftBadge';
 import {
   Dialog,
   DialogContent,
@@ -73,21 +74,23 @@ export function PaywallPreviewModal({
 
         <div className="grid gap-3">
           {PAID_FEATURES.map((feature) => (
-            <div
-              key={feature.title}
-              className="flex items-start gap-3 rounded-xl border border-border/60 bg-background/60 p-3"
-            >
-              <div className="rounded-md bg-primary/10 p-1.5 mt-0.5 shrink-0">
-                <feature.icon className="h-4 w-4 text-primary" />
+            <div key={feature.title}>
+              <div className="flex items-start gap-3 rounded-xl border border-border/60 bg-background/60 p-3">
+                <div className="rounded-md bg-primary/10 p-1.5 mt-0.5 shrink-0">
+                  <feature.icon className="h-4 w-4 text-primary" />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-foreground">
+                    {feature.title}
+                  </p>
+                  <p className="mt-0.5 text-sm text-muted-foreground">
+                    {feature.description}
+                  </p>
+                </div>
               </div>
-              <div>
-                <p className="text-sm font-semibold text-foreground">
-                  {feature.title}
-                </p>
-                <p className="mt-0.5 text-sm text-muted-foreground">
-                  {feature.description}
-                </p>
-              </div>
+              {feature.title === 'Voice responses' && (
+                <VoiceRetentionUpliftBadge className="mt-1.5" />
+              )}
             </div>
           ))}
         </div>

--- a/docs/pr-evidence/voice-retention-uplift-badge.md
+++ b/docs/pr-evidence/voice-retention-uplift-badge.md
@@ -1,0 +1,61 @@
+# Voice Retention Uplift Badge — PR Evidence
+
+**Backlog row 195 | tag: ux | priority: P3**
+
+## Summary
+
+Adds a `VoiceRetentionUpliftBadge` component that surfaces the ElevenLabs-validated
+"+20% 7-day retention" stat at two high-intent touchpoints: agent profile pages
+(next to the voice sample player) and the paid-features paywall modal (below the
+"Voice responses" feature row).
+
+## Component
+
+**File:** `apps/web/components/agents/VoiceRetentionUpliftBadge.tsx`
+
+Renders:
+- `+20% 7-day retention` stat in primary colour with a `TrendingUp` icon
+- `Powered by ElevenLabs` attribution in muted-foreground at 10px
+- `title` tooltip: "Users with voice-enabled agents return 20% more often in the
+  first week"
+
+All three elements carry `data-testid` attributes tested by the accompanying
+vitest suite.
+
+## Before / After
+
+### Agent profile page — voice capability section
+
+**Before:** The voice section showed only the `VoiceSamplePreview` play button.
+
+**After:** Immediately below the play button (when `capabilities.voice === true`)
+the badge appears, reinforcing to users why voice matters for retention before
+they start chatting.
+
+### PaywallPreviewModal — Voice responses feature row
+
+**Before:** The "Voice responses" row showed an icon, title, and one-line
+description.
+
+**After:** Below the "Voice responses" row the badge appears, giving users
+upgrading to a paid plan a concrete data point (+20% retention) powered by
+ElevenLabs as social proof directly in the paywall CTA flow.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `apps/web/components/agents/VoiceRetentionUpliftBadge.tsx` | New component |
+| `apps/web/components/agents/ProfileHeader.tsx` | Import + render badge after `VoiceSamplePreview` |
+| `apps/web/components/subscription/PaywallPreviewModal.tsx` | Import + render badge after voice feature row |
+| `apps/web/__tests__/components/voice-retention-uplift-badge.test.tsx` | 4 tests covering render, stat text, attribution, tooltip |
+
+## Tests
+
+```
+apps/web/__tests__/components/voice-retention-uplift-badge.test.tsx
+  ✓ renders the badge container with correct test id
+  ✓ displays the +20% 7-day retention stat
+  ✓ displays the ElevenLabs attribution
+  ✓ includes a tooltip with the full retention stat description
+```


### PR DESCRIPTION
## Source
backlog.md:195

Adds VoiceRetentionUpliftBadge showing the ElevenLabs-validated +20% 7-day retention stat on voice capability sections and upgrade CTAs.

## Evidence
See `docs/pr-evidence/voice-retention-uplift-badge.md` for component description and integration points.

## Auth-only Proof
N/A