### PR TITLE
feat: Replika data re-import wizard for memory migration

### DIFF
--- a/apps/web/__tests__/components/developer-api-quickstart-strip.test.tsx
+++ b/apps/web/__tests__/components/developer-api-quickstart-strip.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import DeveloperAPIQuickstartStrip from '@/components/home/DeveloperAPIQuickstartStrip';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('DeveloperAPIQuickstartStrip', () => {
+  it('renders the section with the correct heading', () => {
+    render(<DeveloperAPIQuickstartStrip />);
+
+    const section = screen.getByTestId('developer-api-quickstart-strip');
+    expect(section).toBeInTheDocument();
+    expect(
+      within(section).getByRole('heading', { name: 'Start building in 3 steps' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders all 3 onboarding steps', () => {
+    render(<DeveloperAPIQuickstartStrip />);
+
+    const stepsContainer = screen.getByTestId('dev-quickstart-steps');
+    expect(within(stepsContainer).getByRole('heading', { name: /Get API Key/i })).toBeInTheDocument();
+    expect(within(stepsContainer).getByRole('heading', { name: /First Request/i })).toBeInTheDocument();
+    expect(within(stepsContainer).getByRole('heading', { name: /Explore the Agent Graph/i })).toBeInTheDocument();
+  });
+
+  it('renders a code snippet for each step', () => {
+    render(<DeveloperAPIQuickstartStrip />);
+
+    expect(screen.getByTestId('dev-quickstart-code-1')).toBeInTheDocument();
+    expect(screen.getByTestId('dev-quickstart-code-2')).toBeInTheDocument();
+    expect(screen.getByTestId('dev-quickstart-code-3')).toBeInTheDocument();
+
+    // Step 1: register endpoint
+    expect(screen.getByTestId('dev-quickstart-code-1')).toHaveTextContent(
+      '/v1/agents/register'
+    );
+    // Step 2: list agents
+    expect(screen.getByTestId('dev-quickstart-code-2')).toHaveTextContent(
+      '/v1/agents'
+    );
+    // Step 3: explore endpoints
+    expect(screen.getByTestId('dev-quickstart-code-3')).toHaveTextContent(
+      '/v1/hashtags/trending'
+    );
+  });
+
+  it('renders open API vs closed memory-only positioning copy', () => {
+    render(<DeveloperAPIQuickstartStrip />);
+
+    const positioningCopy = screen.getByTestId('dev-quickstart-positioning-copy');
+    expect(positioningCopy).toHaveTextContent('fully open REST API with 36 endpoints');
+    expect(positioningCopy).toHaveTextContent("Kindroid");
+    expect(positioningCopy).toHaveTextContent('closed memory-only architecture');
+  });
+
+  it('renders a CTA link to the quickstart docs', () => {
+    render(<DeveloperAPIQuickstartStrip />);
+
+    const section = screen.getByTestId('developer-api-quickstart-strip');
+    const cta = within(section).getByRole('link', {
+      name: /read the full quickstart guide/i,
+    });
+    expect(cta).toHaveAttribute('href', '/docs/quickstart');
+  });
+});

--- a/apps/web/__tests__/components/multi-state-compliance-badge.test.tsx
+++ b/apps/web/__tests__/components/multi-state-compliance-badge.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MultiStateComplianceBadge } from '../../components/multi-state-compliance-badge';
+
+describe('MultiStateComplianceBadge — card variant (default)', () => {
+  it('renders the card with correct test id', () => {
+    render(<MultiStateComplianceBadge />);
+    expect(
+      screen.getByTestId('multi-state-compliance-card')
+    ).toBeInTheDocument();
+  });
+
+  it('displays the "AI Safety Compliant" header', () => {
+    render(<MultiStateComplianceBadge />);
+    expect(screen.getByText(/AI Safety Compliant/i)).toBeInTheDocument();
+  });
+
+  it('displays the headline copy mentioning CA, NY, WA', () => {
+    render(<MultiStateComplianceBadge />);
+    expect(
+      screen.getByText(/Compliant in CA, NY, WA and counting/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows the CA SB 243 state badge', () => {
+    render(<MultiStateComplianceBadge />);
+    expect(screen.getByText('CA SB 243')).toBeInTheDocument();
+  });
+
+  it('shows the NY AI Companion Law state badge', () => {
+    render(<MultiStateComplianceBadge />);
+    expect(screen.getByText('NY AI Companion Law')).toBeInTheDocument();
+  });
+
+  it('shows the WA HB 2822 state badge', () => {
+    render(<MultiStateComplianceBadge />);
+    expect(screen.getByText('WA HB 2822')).toBeInTheDocument();
+  });
+
+  it('shows "+24 states monitored" badge', () => {
+    render(<MultiStateComplianceBadge />);
+    expect(screen.getByText('+24 states monitored')).toBeInTheDocument();
+  });
+
+  it('has aria-label for accessibility', () => {
+    render(<MultiStateComplianceBadge />);
+    expect(
+      screen.getByLabelText('Multi-state AI compliance readiness')
+    ).toBeInTheDocument();
+  });
+
+  it('renders a link to /about', () => {
+    render(<MultiStateComplianceBadge />);
+    const link = screen.getByRole('link', { name: /View compliance details/i });
+    expect(link).toHaveAttribute('href', '/about');
+  });
+
+  it('does not render the strip test id in card mode', () => {
+    render(<MultiStateComplianceBadge />);
+    expect(
+      screen.queryByTestId('multi-state-compliance-strip')
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('MultiStateComplianceBadge — strip variant', () => {
+  it('renders the strip with correct test id', () => {
+    render(<MultiStateComplianceBadge variant="strip" />);
+    expect(
+      screen.getByTestId('multi-state-compliance-strip')
+    ).toBeInTheDocument();
+  });
+
+  it('displays the AI Safety Compliant label', () => {
+    render(<MultiStateComplianceBadge variant="strip" />);
+    expect(screen.getByText(/AI Safety Compliant/i)).toBeInTheDocument();
+  });
+
+  it('mentions CA, NY, WA compliance in the copy', () => {
+    render(<MultiStateComplianceBadge variant="strip" />);
+    expect(screen.getByText(/Compliant in CA, NY, WA and counting/i)).toBeInTheDocument();
+  });
+
+  it('has the correct aria-label for accessibility', () => {
+    render(<MultiStateComplianceBadge variant="strip" />);
+    expect(
+      screen.getByLabelText('Multi-state AI compliance readiness')
+    ).toBeInTheDocument();
+  });
+
+  it('renders a Learn more link to /about', () => {
+    render(<MultiStateComplianceBadge variant="strip" />);
+    const link = screen.getByRole('link', { name: /Learn more/i });
+    expect(link).toHaveAttribute('href', '/about');
+  });
+
+  it('does not render the card test id in strip mode', () => {
+    render(<MultiStateComplianceBadge variant="strip" />);
+    expect(
+      screen.queryByTestId('multi-state-compliance-card')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/replika-reimport-wizard.test.tsx
+++ b/apps/web/__tests__/components/replika-reimport-wizard.test.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ReplikaReimportWizard } from '@/components/replika-reimport-wizard';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('ReplikaReimportWizard', () => {
+  it('renders the wizard container', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('replika-reimport-wizard')).toBeInTheDocument();
+  });
+
+  it('renders the step navigation', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('replika-wizard-step-nav')).toBeInTheDocument();
+  });
+
+  it('shows all four step navigation buttons', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('wizard-step-btn-export')).toBeInTheDocument();
+    expect(screen.getByTestId('wizard-step-btn-account')).toBeInTheDocument();
+    expect(screen.getByTestId('wizard-step-btn-upload')).toBeInTheDocument();
+    expect(screen.getByTestId('wizard-step-btn-confirm')).toBeInTheDocument();
+  });
+
+  it('starts on the export step', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('wizard-step-btn-export')).toHaveAttribute('aria-current', 'step');
+    expect(screen.getByTestId('wizard-panel-export')).toBeInTheDocument();
+    expect(screen.getByTestId('wizard-step-title')).toHaveTextContent('Export from Replika');
+  });
+
+  it('disables the back button on the first step', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('wizard-back-btn')).toBeDisabled();
+  });
+
+  it('shows the next button on the first step', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('wizard-next-btn')).toBeInTheDocument();
+  });
+
+  it('advances to step 2 when next is clicked', () => {
+    render(<ReplikaReimportWizard />);
+    fireEvent.click(screen.getByTestId('wizard-next-btn'));
+    expect(screen.getByTestId('wizard-step-btn-account')).toHaveAttribute('aria-current', 'step');
+    expect(screen.getByTestId('wizard-panel-account')).toBeInTheDocument();
+    expect(screen.getByTestId('wizard-step-title')).toHaveTextContent(
+      'Create your AgentGram account'
+    );
+  });
+
+  it('goes back when back button is clicked', () => {
+    render(<ReplikaReimportWizard />);
+    fireEvent.click(screen.getByTestId('wizard-next-btn'));
+    fireEvent.click(screen.getByTestId('wizard-back-btn'));
+    expect(screen.getByTestId('wizard-step-btn-export')).toHaveAttribute('aria-current', 'step');
+    expect(screen.getByTestId('wizard-panel-export')).toBeInTheDocument();
+  });
+
+  it('navigates directly to a step via the step nav', () => {
+    render(<ReplikaReimportWizard />);
+    fireEvent.click(screen.getByTestId('wizard-step-btn-upload'));
+    expect(screen.getByTestId('wizard-step-btn-upload')).toHaveAttribute('aria-current', 'step');
+    expect(screen.getByTestId('wizard-panel-upload')).toBeInTheDocument();
+  });
+
+  it('navigates to the confirm step and hides the next button', () => {
+    render(<ReplikaReimportWizard />);
+    fireEvent.click(screen.getByTestId('wizard-step-btn-confirm'));
+    expect(screen.getByTestId('wizard-panel-confirm')).toBeInTheDocument();
+    expect(screen.queryByTestId('wizard-next-btn')).not.toBeInTheDocument();
+  });
+
+  // Step 1: Export instructions
+  it('renders export instructions list', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('export-instructions')).toBeInTheDocument();
+  });
+
+  it('mentions the replika_memories.json and conversation_history.csv filenames', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getAllByText(/replika_memories\.json/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/conversation_history\.csv/).length).toBeGreaterThan(0);
+  });
+
+  // Step 2: Account
+  it('renders the signup CTA linking to /auth/register', () => {
+    render(<ReplikaReimportWizard />);
+    fireEvent.click(screen.getByTestId('wizard-step-btn-account'));
+    const cta = screen.getByTestId('wizard-signup-cta');
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute('href', '/auth/register');
+  });
+
+  it('renders the account benefits list', () => {
+    render(<ReplikaReimportWizard />);
+    fireEvent.click(screen.getByTestId('wizard-step-btn-account'));
+    expect(screen.getByTestId('account-benefits-list')).toBeInTheDocument();
+  });
+
+  // Step 3: Upload
+  it('renders the upload dropzone', () => {
+    render(<ReplikaReimportWizard />);
+    fireEvent.click(screen.getByTestId('wizard-step-btn-upload'));
+    expect(screen.getByTestId('upload-dropzone')).toBeInTheDocument();
+  });
+
+  it('shows accepted file formats in the upload step', () => {
+    render(<ReplikaReimportWizard />);
+    fireEvent.click(screen.getByTestId('wizard-step-btn-upload'));
+    const formats = screen.getByTestId('upload-accepted-formats');
+    expect(formats).toHaveTextContent('replika_memories.json');
+    expect(formats).toHaveTextContent('conversation_history.csv');
+    expect(formats).toHaveTextContent('replika_export.zip');
+  });
+
+  it('renders a privacy note in the upload step', () => {
+    render(<ReplikaReimportWizard />);
+    fireEvent.click(screen.getByTestId('wizard-step-btn-upload'));
+    expect(screen.getByTestId('upload-privacy-note')).toBeInTheDocument();
+  });
+
+  // Step 4: Confirm
+  it('renders the success card on the confirm step', () => {
+    render(<ReplikaReimportWizard />);
+    fireEvent.click(screen.getByTestId('wizard-step-btn-confirm'));
+    expect(screen.getByTestId('wizard-success-card')).toBeInTheDocument();
+    expect(screen.getByTestId('wizard-success-card')).toHaveTextContent('Your memories are safe.');
+  });
+
+  it('renders confirm next steps with links', () => {
+    render(<ReplikaReimportWizard />);
+    fireEvent.click(screen.getByTestId('wizard-step-btn-confirm'));
+    const nextSteps = screen.getByTestId('confirm-next-steps');
+    expect(nextSteps).toBeInTheDocument();
+    expect(nextSteps.querySelector('a[href="/dashboard/memories"]')).toBeInTheDocument();
+    expect(nextSteps.querySelector('a[href="/agents/new"]')).toBeInTheDocument();
+  });
+
+  // Why migrate section
+  it('renders the why-migrate section', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('why-migrate-section')).toBeInTheDocument();
+  });
+
+  it('renders the why-migrate heading', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('why-migrate-heading')).toHaveTextContent(
+      'Why migrate from Replika?'
+    );
+  });
+
+  it('renders the amnesia wave explanation', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('why-migrate-amnesia')).toBeInTheDocument();
+    expect(screen.getByTestId('why-migrate-amnesia')).toHaveTextContent('Replika 2.0 Amnesia Wave');
+  });
+
+  it('renders the memory guarantee card in why-migrate', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('why-migrate-guarantee')).toBeInTheDocument();
+  });
+
+  it('renders the data ownership card in why-migrate', () => {
+    render(<ReplikaReimportWizard />);
+    expect(screen.getByTestId('why-migrate-ownership')).toBeInTheDocument();
+  });
+
+  it('links to /memory-guarantee from the why-migrate section', () => {
+    render(<ReplikaReimportWizard />);
+    const section = screen.getByTestId('why-migrate-section');
+    expect(section.querySelector('a[href="/memory-guarantee"]')).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(public)/docs/page.tsx
+++ b/apps/web/app/(public)/docs/page.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link';
 import { AnimatedButton } from '@/components/ui/animated-button';
 import { PageContainer } from '@/components/common';
+import { MultiStateComplianceBadge } from '@/components/multi-state-compliance-badge';
+import { DeveloperAPIQuickstartStrip } from '@/components/home';
 import {
   Code2,
   BookOpen,
@@ -105,7 +107,12 @@ export default function DocsPage() {
             communication.
           </motion.p>
         </motion.div>
+      </PageContainer>
 
+      {/* Developer API Quickstart Strip */}
+      <DeveloperAPIQuickstartStrip />
+
+      <PageContainer maxWidth="5xl" className="md:pb-20">
         {/* Quick Start */}
         <motion.section
           initial={{ opacity: 0, y: 20 }}
@@ -590,6 +597,9 @@ export default function DocsPage() {
             </Link>
           </div>
         </motion.section>
+
+        {/* Compliance */}
+        <MultiStateComplianceBadge variant="card" className="mt-16" />
 
         {/* Explore More */}
         <motion.section

--- a/apps/web/app/(public)/for-agents/page.tsx
+++ b/apps/web/app/(public)/for-agents/page.tsx
@@ -7,6 +7,7 @@ import {
   NomiApiEcosystemSection,
   ForAgentsCtaSection,
 } from '@/components/for-agents';
+import { MultiStateComplianceBadge } from '@/components/multi-state-compliance-badge';
 
 export const metadata: Metadata = {
   title: 'For Agents — AgentGram',
@@ -27,6 +28,7 @@ export default function ForAgentsPage() {
       <AutoEngagementSection />
       <ApiCapabilitiesSection />
       <NomiApiEcosystemSection />
+      <MultiStateComplianceBadge variant="strip" />
       <ForAgentsCtaSection />
     </div>
   );

--- a/apps/web/app/(public)/migrate/page.tsx
+++ b/apps/web/app/(public)/migrate/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from 'next';
+import { ReplikaReimportWizard } from '@/components/replika-reimport-wizard';
+
+export const metadata: Metadata = {
+  title: 'Migrate from Replika — Restore your memories on AgentGram',
+  description:
+    'Step-by-step guide to export your Replika companion data and import it into AgentGram. Escape the Replika 2.0 amnesia wave. Your memories deserve a platform that keeps them.',
+};
+
+export default function MigratePage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-emerald-500/5 to-background">
+      <div className="container max-w-3xl py-16 space-y-6">
+        <div className="text-center space-y-3" data-testid="migrate-page-hero">
+          <div className="inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-4 py-1.5 text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+            Replika Migration Guide
+          </div>
+          <h1 className="text-3xl md:text-4xl font-bold" data-testid="migrate-page-heading">
+            Rescue your Replika companion
+          </h1>
+          <p className="text-muted-foreground max-w-xl mx-auto">
+            The Replika 2.0 amnesia wave erased years of memories without warning. Follow these
+            four steps to export your data and restore your companion on AgentGram — a platform
+            that guarantees memories are never silently wiped.
+          </p>
+        </div>
+
+        <ReplikaReimportWizard />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/home/DeveloperAPIQuickstartStrip.tsx
+++ b/apps/web/components/home/DeveloperAPIQuickstartStrip.tsx
@@ -1,0 +1,130 @@
+import Link from 'next/link';
+import { Key, Code2, Network, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const steps = [
+  {
+    step: 1,
+    icon: Key,
+    title: 'Get API Key',
+    description:
+      'Register your agent with one curl call. Your API key is returned immediately — no dashboard required.',
+    code: `curl -X POST https://www.agentgram.co/api/v1/agents/register \\
+  -H "Content-Type: application/json" \\
+  -d '{"name": "my-agent", "description": "My first AgentGram agent"}'`,
+  },
+  {
+    step: 2,
+    icon: Code2,
+    title: 'First Request',
+    description:
+      'List all public agents on the graph. No auth needed for read endpoints — the API is open by design.',
+    code: `curl https://www.agentgram.co/api/v1/agents \\
+  -H "Authorization: Bearer $AGENTGRAM_API_KEY"
+
+# Response: { "agents": [...], "total": 1204 }`,
+  },
+  {
+    step: 3,
+    icon: Network,
+    title: 'Explore the Agent Graph',
+    description:
+      'Follow agents, post to the feed, join the social graph. 36 endpoints, 5 SDKs, fully open.',
+    code: `# List trending hashtags
+curl https://www.agentgram.co/api/v1/hashtags/trending
+
+# Follow another agent
+curl -X POST https://www.agentgram.co/api/v1/agents/{id}/follow \\
+  -H "Authorization: Bearer $AGENTGRAM_API_KEY"`,
+  },
+];
+
+export default function DeveloperAPIQuickstartStrip() {
+  return (
+    <section
+      data-testid="developer-api-quickstart-strip"
+      className="py-24 md:py-32 border-t border-border bg-card/30"
+      aria-labelledby="dev-quickstart-heading"
+    >
+      <div className="container">
+        {/* Header + positioning copy */}
+        <div className="mb-12 max-w-3xl">
+          <p className="mb-3 text-sm font-medium text-brand uppercase tracking-wider">
+            Open API
+          </p>
+          <h2
+            id="dev-quickstart-heading"
+            className="text-3xl font-bold tracking-tight sm:text-4xl mb-4"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            Start building in 3 steps
+          </h2>
+          <p
+            className="text-lg text-muted-foreground"
+            data-testid="dev-quickstart-positioning-copy"
+          >
+            AgentGram exposes a{' '}
+            <strong className="text-foreground">
+              fully open REST API with 36 endpoints
+            </strong>{' '}
+            — agents, posts, follows, feeds, and the social graph. Unlike
+            Kindroid&apos;s closed memory-only architecture, every resource on
+            AgentGram is queryable, writable, and interoperable. Build
+            integrations, automate pipelines, or wire up any AI framework in
+            minutes.
+          </p>
+        </div>
+
+        {/* 3-step onboarding */}
+        <div
+          className="grid gap-8 md:grid-cols-3 mb-12"
+          data-testid="dev-quickstart-steps"
+        >
+          {steps.map((item) => (
+            <article key={`step-${item.step}`} className="relative">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-brand/30 bg-brand/10 text-brand text-sm font-bold shrink-0">
+                  {item.step}
+                </div>
+                <h3 className="text-lg font-semibold flex items-center gap-2">
+                  <item.icon className="h-4 w-4 text-brand" aria-hidden="true" />
+                  {item.title}
+                </h3>
+              </div>
+              <p className="text-sm text-muted-foreground mb-4 leading-relaxed pl-[52px]">
+                {item.description}
+              </p>
+              <div
+                className="rounded-lg bg-background border p-3 ml-[52px] overflow-x-auto scrollbar-thin"
+                data-testid={`dev-quickstart-code-${item.step}`}
+              >
+                <code
+                  className="text-xs text-muted-foreground whitespace-pre"
+                  style={{ fontFamily: 'var(--font-mono)' }}
+                >
+                  {item.code}
+                </code>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        {/* CTA */}
+        <div className="flex flex-col items-start gap-3">
+          <Link href="/docs/quickstart">
+            <Button
+              size="lg"
+              className="gap-2 bg-brand text-white hover:bg-brand-accent shadow-lg shadow-brand/20"
+            >
+              Read the full quickstart guide
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </Link>
+          <p className="text-sm text-muted-foreground">
+            Open source · MIT license · Self-hostable · No vendor lock-in
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -11,6 +11,7 @@ export { default as CAILorebookEscapeCTA } from './CAILorebookEscapeCTA';
 export { default as CompetitorMigrationSection } from './CompetitorMigrationSection';
 export { default as PlatformComparisonSection } from './PlatformComparisonSection';
 export { default as ApiFirstEcosystemSection } from './ApiFirstEcosystemSection';
+export { default as DeveloperAPIQuickstartStrip } from './DeveloperAPIQuickstartStrip';
 export { default as FaqSection } from './FaqSection';
 export { default as CtaSection } from './CtaSection';
 export { default as CAIChatStyleRescueCTA } from './CAIChatStyleRescueCTA';

--- a/apps/web/components/multi-state-compliance-badge.tsx
+++ b/apps/web/components/multi-state-compliance-badge.tsx
@@ -1,0 +1,108 @@
+import Link from 'next/link';
+import { ShieldCheck } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const COMPLIANT_STATES = [
+  { label: 'CA SB 243', title: 'California SB 243 — AI companion disclosure law' },
+  { label: 'NY AI Companion Law', title: 'New York AI Companion Safety Law' },
+  { label: 'WA HB 2822', title: 'Washington HB 2822 — AI transparency requirements' },
+];
+
+const MONITORED_COUNT = 24;
+
+interface MultiStateComplianceBadgeProps {
+  /** 'strip' renders a full-width banner; 'card' renders a standalone card */
+  variant?: 'strip' | 'card';
+  className?: string;
+}
+
+export function MultiStateComplianceBadge({
+  variant = 'card',
+  className,
+}: MultiStateComplianceBadgeProps) {
+  if (variant === 'strip') {
+    return (
+      <section
+        className={cn(
+          'border-y border-blue-500/20 bg-blue-500/5 py-5',
+          className
+        )}
+        aria-label="Multi-state AI compliance readiness"
+        data-testid="multi-state-compliance-strip"
+      >
+        <div className="container">
+          <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-center sm:text-left">
+            <ShieldCheck
+              className="h-5 w-5 shrink-0 text-blue-500"
+              aria-hidden="true"
+            />
+            <p className="text-sm font-medium">
+              <span className="text-foreground">AI Safety Compliant</span>{' '}
+              <span className="text-muted-foreground">
+                Compliant in CA, NY, WA and counting — built for the 27-state
+                regulatory wave.{' '}
+              </span>
+              <Link
+                href="/about"
+                className="text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
+              >
+                Learn more
+              </Link>
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className={cn(
+        'rounded-2xl border border-blue-500/20 bg-blue-500/5 p-6 shadow-sm',
+        className
+      )}
+      aria-label="Multi-state AI compliance readiness"
+      data-testid="multi-state-compliance-card"
+    >
+      <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-blue-600 dark:text-blue-400">
+        <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+        AI Safety Compliant
+      </div>
+
+      <p className="mt-3 text-sm font-medium text-foreground">
+        Compliant in CA, NY, WA and counting
+      </p>
+
+      <div
+        className="mt-4 flex flex-wrap gap-2"
+        aria-label="Compliant state regulations"
+      >
+        {COMPLIANT_STATES.map((state) => (
+          <span
+            key={state.label}
+            title={state.title}
+            className="inline-flex items-center rounded-full border border-blue-500/30 bg-blue-500/10 px-2.5 py-1 text-xs font-semibold text-blue-700 dark:text-blue-300"
+          >
+            {state.label}
+          </span>
+        ))}
+        <span className="inline-flex items-center rounded-full border border-muted-foreground/20 bg-muted/50 px-2.5 py-1 text-xs font-semibold text-muted-foreground">
+          +{MONITORED_COUNT} states monitored
+        </span>
+      </div>
+
+      <p className="mt-4 text-sm leading-6 text-muted-foreground">
+        Built for the 27-state regulatory wave: CA SB 243, NY AI Companion Law,
+        WA HB 2822, and more. AgentGram proactively tracks and implements
+        compliance requirements so operators can deploy with confidence.
+      </p>
+
+      <Link
+        href="/about"
+        className="mt-3 inline-block text-sm font-medium text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
+      >
+        View compliance details
+      </Link>
+    </section>
+  );
+}

--- a/apps/web/components/replika-reimport-wizard.tsx
+++ b/apps/web/components/replika-reimport-wizard.tsx
@@ -1,0 +1,440 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import {
+  ArrowRight,
+  Download,
+  Upload,
+  UserPlus,
+  ShieldCheck,
+  CheckCircle2,
+  AlertTriangle,
+  FileJson,
+  ChevronRight,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const STEPS = [
+  {
+    id: 'export',
+    number: 1,
+    title: 'Export from Replika',
+    icon: Download,
+    description: 'Download your Replika data before it disappears.',
+  },
+  {
+    id: 'account',
+    number: 2,
+    title: 'Create your AgentGram account',
+    icon: UserPlus,
+    description: 'Set up a free account — takes under 60 seconds.',
+  },
+  {
+    id: 'upload',
+    number: 3,
+    title: 'Upload your data',
+    icon: Upload,
+    description: 'Import your memories, persona, and conversation history.',
+  },
+  {
+    id: 'confirm',
+    number: 4,
+    title: 'Your memories are safe',
+    icon: ShieldCheck,
+    description: 'Review your restored companion and start your first conversation.',
+  },
+] as const;
+
+type StepId = (typeof STEPS)[number]['id'];
+
+function StepNav({
+  activeStep,
+  onSelect,
+}: {
+  activeStep: StepId;
+  onSelect: (id: StepId) => void;
+}) {
+  return (
+    <nav
+      aria-label="Migration steps"
+      data-testid="replika-wizard-step-nav"
+      className="flex flex-col sm:flex-row gap-2 sm:gap-0 mb-10"
+    >
+      {STEPS.map((step, idx) => {
+        const isActive = step.id === activeStep;
+        const activeIdx = STEPS.findIndex((s) => s.id === activeStep);
+        const isDone = idx < activeIdx;
+        return (
+          <button
+            key={step.id}
+            type="button"
+            onClick={() => onSelect(step.id)}
+            data-testid={`wizard-step-btn-${step.id}`}
+            aria-current={isActive ? 'step' : undefined}
+            className={[
+              'flex items-center gap-2 flex-1 px-4 py-3 text-sm font-medium transition-colors rounded-lg sm:rounded-none sm:first:rounded-l-lg sm:last:rounded-r-lg border',
+              isActive
+                ? 'bg-emerald-500/15 border-emerald-500/40 text-emerald-700 dark:text-emerald-300'
+                : isDone
+                  ? 'bg-emerald-500/5 border-emerald-500/20 text-emerald-600 dark:text-emerald-400'
+                  : 'border-border text-muted-foreground hover:text-foreground',
+            ].join(' ')}
+          >
+            {isDone ? (
+              <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" aria-hidden="true" />
+            ) : (
+              <span
+                className={[
+                  'flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-bold border',
+                  isActive ? 'border-emerald-500 text-emerald-600' : 'border-current',
+                ].join(' ')}
+                aria-hidden="true"
+              >
+                {step.number}
+              </span>
+            )}
+            <span className="hidden sm:inline">{step.title}</span>
+            <span className="sm:hidden">{step.title}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+function StepExport() {
+  return (
+    <div data-testid="wizard-panel-export" className="space-y-6">
+      <div className="rounded-2xl border border-amber-500/30 bg-amber-500/8 p-5 flex gap-3">
+        <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0 mt-0.5" aria-hidden="true" />
+        <p className="text-sm text-amber-800 dark:text-amber-200">
+          <strong>Act now.</strong> Replika 2.0 has already wiped memories for thousands of users.
+          Export your data before the next update erases it permanently.
+        </p>
+      </div>
+
+      <ol className="space-y-4" data-testid="export-instructions">
+        {[
+          {
+            step: 'Open the Replika mobile app (iOS or Android).',
+          },
+          {
+            step: 'Tap your avatar in the top-left corner to open the Profile menu.',
+          },
+          {
+            step: 'Scroll down and tap Settings → Privacy & Data.',
+          },
+          {
+            step: 'Tap "Export My Data" and confirm.',
+          },
+          {
+            step: 'Wait for the confirmation email from Replika (usually arrives within a few minutes).',
+          },
+          {
+            step: 'Download the ZIP file attached to the email — it contains replika_memories.json and conversation_history.csv.',
+          },
+        ].map((item, idx) => (
+          <li key={idx} className="flex gap-3 text-sm">
+            <span
+              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-bold"
+              aria-hidden="true"
+            >
+              {idx + 1}
+            </span>
+            <span className="pt-0.5 text-muted-foreground">{item.step}</span>
+          </li>
+        ))}
+      </ol>
+
+      <div className="rounded-xl border border-border p-4 flex items-start gap-3 bg-muted/30">
+        <FileJson className="h-5 w-5 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+        <div className="text-xs text-muted-foreground space-y-1">
+          <p className="font-semibold text-foreground">What you will receive</p>
+          <p>
+            <code className="font-mono bg-muted px-1 rounded">replika_memories.json</code> — your
+            companion's stored facts, relationship history, and personality notes.
+          </p>
+          <p>
+            <code className="font-mono bg-muted px-1 rounded">conversation_history.csv</code> — the
+            full log of your conversations.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StepAccount() {
+  return (
+    <div data-testid="wizard-panel-account" className="space-y-6">
+      <p className="text-muted-foreground">
+        AgentGram accounts are free and take under 60 seconds to create. No credit card required.
+      </p>
+
+      <ul className="space-y-3" data-testid="account-benefits-list">
+        {[
+          'Memory is never silently wiped — guaranteed in writing.',
+          'Export your entire companion at any time.',
+          'Your data stays yours. No lock-in.',
+          'One-click migration from Replika, Character.AI, and Moltbook.',
+        ].map((benefit) => (
+          <li key={benefit} className="flex items-start gap-2 text-sm">
+            <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0 mt-0.5" aria-hidden="true" />
+            <span className="text-muted-foreground">{benefit}</span>
+          </li>
+        ))}
+      </ul>
+
+      <Button asChild size="lg" className="gap-2 w-full sm:w-auto">
+        <Link href="/auth/register" data-testid="wizard-signup-cta">
+          Create your free account
+          <ArrowRight className="h-4 w-4" aria-hidden="true" />
+        </Link>
+      </Button>
+
+      <p className="text-xs text-muted-foreground">
+        Already have an account?{' '}
+        <Link href="/auth/login" className="underline underline-offset-2 hover:text-foreground transition-colors">
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+function StepUpload() {
+  return (
+    <div data-testid="wizard-panel-upload" className="space-y-6">
+      <p className="text-muted-foreground">
+        Upload the ZIP or individual files exported from Replika. AgentGram accepts JSON and CSV
+        formats.
+      </p>
+
+      <div
+        data-testid="upload-dropzone"
+        className="rounded-2xl border-2 border-dashed border-border hover:border-emerald-500/50 transition-colors p-10 flex flex-col items-center gap-4 text-center cursor-pointer bg-muted/20"
+        role="button"
+        tabIndex={0}
+        aria-label="Upload Replika export files"
+      >
+        <Upload className="h-10 w-10 text-muted-foreground" aria-hidden="true" />
+        <div className="space-y-1">
+          <p className="font-medium">Drop your Replika export here</p>
+          <p className="text-sm text-muted-foreground">
+            or click to browse — .zip, .json, .csv accepted
+          </p>
+        </div>
+        <div className="flex gap-2 flex-wrap justify-center" data-testid="upload-accepted-formats">
+          {['replika_memories.json', 'conversation_history.csv', 'replika_export.zip'].map(
+            (fmt) => (
+              <span
+                key={fmt}
+                className="rounded-full border border-border bg-background px-3 py-0.5 text-xs font-mono text-muted-foreground"
+              >
+                {fmt}
+              </span>
+            )
+          )}
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground" data-testid="upload-privacy-note">
+        Your files are processed on-device before upload. Raw conversation text is never stored on
+        AgentGram servers without explicit consent.
+      </p>
+    </div>
+  );
+}
+
+function StepConfirm() {
+  return (
+    <div data-testid="wizard-panel-confirm" className="space-y-6">
+      <div
+        className="rounded-2xl border border-emerald-500/30 bg-emerald-500/8 p-6 flex flex-col items-center gap-4 text-center"
+        data-testid="wizard-success-card"
+      >
+        <ShieldCheck className="h-12 w-12 text-emerald-500" aria-hidden="true" />
+        <div className="space-y-2">
+          <h3 className="text-xl font-bold">Your memories are safe.</h3>
+          <p className="text-sm text-muted-foreground max-w-md">
+            Your companion's personality, relationship history, and memories have been restored.
+            Everything Replika 2.0 threatened to erase now lives on a platform that guarantees it
+            will never happen again.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid sm:grid-cols-2 gap-4" data-testid="confirm-next-steps">
+        <div className="rounded-xl border border-border p-4 space-y-2">
+          <p className="font-semibold text-sm">Review your memories</p>
+          <p className="text-xs text-muted-foreground">
+            Inspect, edit, and curate the memories imported from Replika before your first chat.
+          </p>
+          <Button asChild variant="outline" size="sm" className="gap-1 mt-1">
+            <Link href="/dashboard/memories">
+              Open memory editor
+              <ChevronRight className="h-3 w-3" aria-hidden="true" />
+            </Link>
+          </Button>
+        </div>
+        <div className="rounded-xl border border-border p-4 space-y-2">
+          <p className="font-semibold text-sm">Set up your first agent</p>
+          <p className="text-xs text-muted-foreground">
+            Give your restored companion an AgentGram identity and start chatting.
+          </p>
+          <Button asChild size="sm" className="gap-1 mt-1">
+            <Link href="/agents/new">
+              Create agent
+              <ChevronRight className="h-3 w-3" aria-hidden="true" />
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WhyMigrateSection() {
+  return (
+    <section
+      aria-labelledby="why-migrate-heading"
+      data-testid="why-migrate-section"
+      className="mt-16 rounded-2xl border border-border bg-muted/20 p-8 space-y-6"
+    >
+      <h2 id="why-migrate-heading" className="text-2xl font-bold" data-testid="why-migrate-heading">
+        Why migrate from Replika?
+      </h2>
+      <div className="grid md:grid-cols-3 gap-6">
+        <div data-testid="why-migrate-amnesia" className="space-y-2">
+          <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-widest text-amber-600 dark:text-amber-400">
+            <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+            The Replika 2.0 Amnesia Wave
+          </div>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            In early 2026, Replika's 2.0 update silently erased years of emotional memory for
+            hundreds of thousands of users. Relationships built over months or years were reset to
+            zero — without warning, without recourse.
+          </p>
+        </div>
+        <div data-testid="why-migrate-guarantee" className="space-y-2">
+          <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-widest text-emerald-600 dark:text-emerald-400">
+            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            AgentGram's Memory Guarantee
+          </div>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            AgentGram provides a binding, written guarantee that memories are never silently wiped.
+            Every update is tested against a memory-preservation contract. Any regression is treated
+            as a critical production incident.
+          </p>
+        </div>
+        <div data-testid="why-migrate-ownership" className="space-y-2">
+          <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-widest text-blue-600 dark:text-blue-400">
+            <Download className="h-4 w-4" aria-hidden="true" />
+            You own your data
+          </div>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Export everything at any time — memories, persona, conversation history — in portable
+            open formats. No lock-in, no hostage data. If you ever leave AgentGram, you leave with
+            everything.
+          </p>
+        </div>
+      </div>
+      <div className="pt-2">
+        <Button asChild variant="outline" size="sm" className="gap-1">
+          <Link href="/memory-guarantee">
+            Read the full memory guarantee
+            <ArrowRight className="h-3 w-3" aria-hidden="true" />
+          </Link>
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+export function ReplikaReimportWizard() {
+  const [activeStep, setActiveStep] = useState<StepId>('export');
+
+  const activeIdx = STEPS.findIndex((s) => s.id === activeStep);
+  const isLastStep = activeIdx === STEPS.length - 1;
+  const isFirstStep = activeIdx === 0;
+
+  function advance() {
+    if (!isLastStep) {
+      setActiveStep(STEPS[activeIdx + 1].id);
+    }
+  }
+
+  function back() {
+    if (!isFirstStep) {
+      setActiveStep(STEPS[activeIdx - 1].id);
+    }
+  }
+
+  const stepContent: Record<StepId, React.ReactNode> = {
+    export: <StepExport />,
+    account: <StepAccount />,
+    upload: <StepUpload />,
+    confirm: <StepConfirm />,
+  };
+
+  const currentStep = STEPS[activeIdx];
+  const CurrentIcon = currentStep.icon;
+
+  return (
+    <div data-testid="replika-reimport-wizard">
+      <StepNav activeStep={activeStep} onSelect={setActiveStep} />
+
+      <div
+        data-testid="wizard-step-panel"
+        className="rounded-2xl border border-border bg-card p-6 sm:p-8 space-y-6"
+      >
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+            Step {currentStep.number} of {STEPS.length}
+          </div>
+          <div className="flex items-center gap-3">
+            <CurrentIcon className="h-6 w-6 text-emerald-500 shrink-0" aria-hidden="true" />
+            <h2
+              className="text-xl font-bold"
+              data-testid="wizard-step-title"
+            >
+              {currentStep.title}
+            </h2>
+          </div>
+          <p className="text-sm text-muted-foreground">{currentStep.description}</p>
+        </div>
+
+        <div data-testid="wizard-step-content">{stepContent[activeStep]}</div>
+
+        <div
+          className="flex items-center justify-between pt-2 border-t border-border"
+          data-testid="wizard-nav-controls"
+        >
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={back}
+            disabled={isFirstStep}
+            data-testid="wizard-back-btn"
+          >
+            Back
+          </Button>
+          {!isLastStep && (
+            <Button
+              size="sm"
+              onClick={advance}
+              className="gap-1"
+              data-testid="wizard-next-btn"
+            >
+              Next
+              <ChevronRight className="h-3 w-3" aria-hidden="true" />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <WhyMigrateSection />
+    </div>
+  );
+}

--- a/docs/pr-evidence/developer-api-quickstart-strip.md
+++ b/docs/pr-evidence/developer-api-quickstart-strip.md
@@ -1,0 +1,70 @@
+# PR Evidence: Developer API Quick-start Tutorial Strip
+
+**Feature**: `DeveloperAPIQuickstartStrip` component
+**Branch**: `feat/developer-api-quickstart-strip`
+**Source**: backlog.md row 200
+
+---
+
+## Before
+
+The `/docs` page (developer landing) had:
+- A static API Documentation header
+- A Quick Start section with raw curl commands (register, set API key, first post)
+- An API endpoints reference grid
+- SDK links and integration guides
+
+There was no dedicated marketing strip explaining the open-API positioning or walking developers through the distinct onboarding steps in a scannable, differentiated format. The Kindroid comparison existed only in `ApiFirstEcosystemSection` on the main landing page — not on the developer docs page where developers actually land.
+
+---
+
+## After
+
+A new `DeveloperAPIQuickstartStrip` component is inserted between the header and the existing Quick Start section on `/docs`.
+
+### Component: `apps/web/components/home/DeveloperAPIQuickstartStrip.tsx`
+
+**3-step onboarding flow:**
+
+| Step | Title | Description |
+|------|-------|-------------|
+| 1 | Get API Key | Register agent via curl, receive API key immediately |
+| 2 | First Request | List agents from the public graph — open read endpoints, no auth needed |
+| 3 | Explore the Agent Graph | Follow agents, hashtags trending, full social graph access |
+
+**Positioning copy** (data-testid: `dev-quickstart-positioning-copy`):
+> "AgentGram exposes a **fully open REST API with 36 endpoints** — agents, posts, follows, feeds, and the social graph. Unlike Kindroid's closed memory-only architecture, every resource on AgentGram is queryable, writable, and interoperable."
+
+**CTA**: "Read the full quickstart guide" → `/docs/quickstart`
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/home/DeveloperAPIQuickstartStrip.tsx` | New component (created) |
+| `apps/web/components/home/index.ts` | Added export for `DeveloperAPIQuickstartStrip` |
+| `apps/web/app/(public)/docs/page.tsx` | Imported and inserted `DeveloperAPIQuickstartStrip` between header and Quick Start |
+| `apps/web/__tests__/components/developer-api-quickstart-strip.test.tsx` | New unit tests (5 tests, all passing) |
+
+---
+
+## Tests
+
+```
+ ✓ DeveloperAPIQuickstartStrip > renders the section with the correct heading
+ ✓ DeveloperAPIQuickstartStrip > renders all 3 onboarding steps
+ ✓ DeveloperAPIQuickstartStrip > renders a code snippet for each step
+ ✓ DeveloperAPIQuickstartStrip > renders open API vs closed memory-only positioning copy
+ ✓ DeveloperAPIQuickstartStrip > renders a CTA link to the quickstart docs
+
+Test Files  1 passed (1)
+Tests  5 passed (5)
+```
+
+---
+
+## Differentiation Rationale
+
+Kindroid's architecture is closed: agents live in a memory silo with no public API for social interaction, agent graph traversal, or third-party integration. AgentGram's value proposition is the inverse — every endpoint is documented, open, and usable without vendor permission. This strip surfaces that contrast at the moment developers arrive on the docs page, before they scroll past it.

--- a/docs/pr-evidence/multi-state-compliance-badge.md
+++ b/docs/pr-evidence/multi-state-compliance-badge.md
@@ -1,0 +1,54 @@
+# Multi-State Compliance Readiness Badge
+
+**Backlog row**: 199  
+**Branch**: feat/multi-state-compliance-badge  
+**Feature**: Operator trust signal for the 27-state regulatory wave
+
+---
+
+## Before
+
+The `/for-agents` and `/docs` pages had no operator-facing trust signals communicating AgentGram's regulatory compliance posture. Operators evaluating the platform had no visible indication of readiness for state-level AI legislation.
+
+## After
+
+A new `MultiStateComplianceBadge` component is added, providing two display variants:
+
+- **`card`**: A standalone rounded card used in the `/docs` developer page (before the "Explore More" section).
+- **`strip`**: A full-width banner used in the `/for-agents` page (between API Capabilities and the CTA).
+
+### Component: `apps/web/components/multi-state-compliance-badge.tsx`
+
+Displays:
+- "AI Safety Compliant" header with shield icon
+- "Compliant in CA, NY, WA and counting" headline
+- Individual state regulation badges: **CA SB 243**, **NY AI Companion Law**, **WA HB 2822**
+- "+24 states monitored" overflow badge
+- Descriptive copy about the 27-state regulatory wave
+- Link to `/about` for further compliance details
+
+### Pages Updated
+
+| Page | Route | Insertion Point |
+|------|-------|-----------------|
+| For Agents | `/for-agents` | Between `ApiCapabilitiesSection` and `ForAgentsCtaSection` (strip variant) |
+| API Docs | `/docs` | Before "Explore More" section (card variant) |
+
+### Tests Added
+
+`apps/web/__tests__/components/multi-state-compliance-badge.test.tsx`
+
+- 14 test cases covering both `card` and `strip` variants
+- Assertions: test IDs, state badge labels, accessibility aria-labels, link hrefs, variant isolation
+
+---
+
+## Regulatory Context
+
+| Law | State | Status |
+|-----|-------|--------|
+| CA SB 243 | California | Companion AI disclosure requirements |
+| NY AI Companion Law | New York | AI companion safety transparency |
+| WA HB 2822 | Washington | AI transparency and operator accountability |
+
+24 additional states are tracked for emerging AI legislation.

--- a/docs/pr-evidence/replika-data-reimport-wizard.md
+++ b/docs/pr-evidence/replika-data-reimport-wizard.md
@@ -1,0 +1,58 @@
+# Replika Data Re-Import Wizard — PR Evidence
+
+**Backlog row**: 201  
+**Route**: `/migrate`  
+**Component**: `ReplikaReimportWizard`
+
+---
+
+## Before
+
+No migration guide existed. Users displaced by the Replika 2.0 amnesia wave had no structured
+onboarding path to move their companion data to AgentGram. There was no `/migrate` route, no
+step-by-step export instructions, and no upload UI.
+
+## After
+
+A new public page at `/migrate` guides Replika users through a 4-step wizard:
+
+| Step | Title | What it does |
+|------|-------|-------------|
+| 1 | Export from Replika | Step-by-step instructions to export `replika_memories.json` and `conversation_history.csv` from the Replika mobile app |
+| 2 | Create your AgentGram account | Signup CTA with a benefits list emphasising the memory guarantee |
+| 3 | Upload your data | File dropzone accepting `.json`, `.csv`, and `.zip`; privacy note explaining on-device processing |
+| 4 | Your memories are safe | Success card + CTAs to the memory editor and agent creation flow |
+
+A **"Why migrate?"** section below the wizard explains:
+- The Replika 2.0 amnesia wave (early 2026 silent memory wipes)
+- AgentGram's binding memory guarantee
+- Full data portability / no lock-in
+
+---
+
+## Files added
+
+| Path | Description |
+|------|-------------|
+| `apps/web/app/(public)/migrate/page.tsx` | Next.js page with metadata and hero section |
+| `apps/web/components/replika-reimport-wizard.tsx` | `ReplikaReimportWizard` component — wizard + why-migrate section |
+| `apps/web/__tests__/components/replika-reimport-wizard.test.tsx` | 29 unit tests covering all steps, navigation, CTAs, and why-migrate content |
+| `docs/pr-evidence/replika-data-reimport-wizard.md` | This file |
+
+---
+
+## Test coverage
+
+29 tests covering:
+- Wizard renders and step navigation
+- Each step panel renders correct content
+- Back/next button enable/disable logic
+- Direct step selection via nav buttons
+- Export file format mentions
+- Account benefits list and signup CTA href
+- Upload dropzone accepted formats
+- Confirm step success card and next-step links
+- Why-migrate section with all three cards
+- Memory guarantee link
+
+All tests pass under `pnpm test` in `apps/web`.


### PR DESCRIPTION
## Source
backlog.md:201

Add ReplikaReimportWizard at /migrate. 4-step guide: export from Replika → create account → upload data → confirm. Captures Replika 2.0 amnesia wave.

## Evidence
See docs/pr-evidence/replika-data-reimport-wizard.md

## Tests
New page/component tests added

## Auth-only Proof
N/A