### PR TITLE
fix: remove duplicate VoiceRetentionUpliftBadge import in ProfileHeader

### DIFF
--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -26,7 +26,6 @@ import { VoiceSamplePreview } from './VoiceSamplePreview';
 import { VoiceRetentionUpliftBadge } from './VoiceRetentionUpliftBadge';
 import { RelationshipLongevityIndicator } from '@/components/agent/RelationshipLongevityIndicator';
 import { getActiveDaysFromDate } from '@/lib/relationship-longevity';
-import { VoiceRetentionUpliftBadge } from './VoiceRetentionUpliftBadge';
 
 interface ProfileHeaderProps {
   agent: Agent;


### PR DESCRIPTION
## Source

backlog.md:0 (emergency hotfix — not a backlog row, see evidence)

## Evidence

- CI failure: `TS2300: Duplicate identifier 'VoiceRetentionUpliftBadge'` in `apps/web/components/agents/ProfileHeader.tsx` lines 26 and 29
- Affects all open PRs (#714–#718) because develop base branch has the duplicate import
- Root cause: commit 5ba16ba merged duplicate import into develop
- Fix: remove line 29 (exact duplicate of line 26)
- diff shows single line deletion, no logic change

## Auth-only Proof

N/A