### PR TITLE
feat: Replika Ultra counter-tier landing copy

### DIFF
--- a/apps/web/__tests__/components/replika-ultra-counter-block.test.tsx
+++ b/apps/web/__tests__/components/replika-ultra-counter-block.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ReplikaUltraCounterBlock from '../../components/home/ReplikaUltraCounterBlock';
+
+describe('ReplikaUltraCounterBlock', () => {
+  it('renders with the correct test id', () => {
+    render(<ReplikaUltraCounterBlock />);
+    expect(screen.getByTestId('replika-ultra-counter-block')).toBeInTheDocument();
+  });
+
+  it('displays the key price comparison heading verbatim', () => {
+    render(<ReplikaUltraCounterBlock />);
+    expect(screen.getByTestId('replika-ultra-counter-heading')).toHaveTextContent(
+      'Same advanced memory as Replika Ultra ($49.99/yr) — at half the price'
+    );
+  });
+
+  it('renders the Replika Ultra alternative badge', () => {
+    render(<ReplikaUltraCounterBlock />);
+    expect(screen.getByTestId('replika-ultra-counter-badge')).toHaveTextContent(
+      'Replika Ultra alternative'
+    );
+  });
+
+  it('renders descriptive subtext mentioning memory and rollback', () => {
+    render(<ReplikaUltraCounterBlock />);
+    const subtext = screen.getByTestId('replika-ultra-counter-subtext');
+    expect(subtext).toHaveTextContent(/memory/i);
+    expect(subtext).toHaveTextContent(/rollback/i);
+  });
+
+  it('renders a CTA linking to /pricing', () => {
+    render(<ReplikaUltraCounterBlock />);
+    const cta = screen.getByTestId('replika-ultra-counter-cta');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/pricing');
+  });
+
+  it('has aria-labelledby pointing to the heading id', () => {
+    render(<ReplikaUltraCounterBlock />);
+    const block = screen.getByTestId('replika-ultra-counter-block');
+    expect(block).toHaveAttribute('aria-labelledby', 'replika-ultra-counter-heading');
+  });
+
+  it('renders the heading with id matching aria-labelledby', () => {
+    render(<ReplikaUltraCounterBlock />);
+    expect(document.getElementById('replika-ultra-counter-heading')).not.toBeNull();
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -10,6 +10,7 @@ import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
 import ImagineGalleryFreeCounterBadge from '@/components/home/ImagineGalleryFreeCounterBadge';
 import { MemoryStabilityPledge } from '@/components/memory-stability-pledge';
+import ReplikaUltraCounterBlock from '@/components/home/ReplikaUltraCounterBlock';
 import { MemoryGuaranteeLandingSection } from '@/components/memory-guarantee-landing-section';
 import { NomiV5ImageParityBadge } from '@/components/agents/NomiV5ImageParityBadge';
 import ReplikaCredentialTrustBadge from '@/components/trust/ReplikaCredentialTrustBadge';
@@ -368,6 +369,14 @@ export default function PricingPage() {
         <ReplikaPricingConfusionCallout />
       </section>
 
+      <section className="container pb-10">
+        <div
+          className="max-w-2xl mx-auto"
+          data-testid="pricing-replika-ultra-counter"
+        >
+          <ReplikaUltraCounterBlock />
+        </div>
+      </section>
       <MemoryStabilityPledge variant="strip" className="mb-8" />
 
       <CAILorebookEscapeCTA />

--- a/apps/web/components/home/CompetitorMigrationSection.tsx
+++ b/apps/web/components/home/CompetitorMigrationSection.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Check } from 'lucide-react';
+import ReplikaUltraCounterBlock from './ReplikaUltraCounterBlock';
 
 const checklist = [
   'Unlimited replies & regenerations',
@@ -39,6 +40,10 @@ export default function CompetitorMigrationSection() {
               </li>
             ))}
           </ul>
+
+          <div className="mb-8 w-full text-left">
+            <ReplikaUltraCounterBlock />
+          </div>
 
           <div className="flex flex-col items-center gap-3">
             <Link href="/auth/login">

--- a/apps/web/components/home/ReplikaUltraCounterBlock.tsx
+++ b/apps/web/components/home/ReplikaUltraCounterBlock.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+import { ArrowRight, Tag } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function ReplikaUltraCounterBlock() {
+  return (
+    <div
+      className="rounded-lg border border-purple-500/20 bg-purple-500/5 p-6 text-center"
+      data-testid="replika-ultra-counter-block"
+      aria-labelledby="replika-ultra-counter-heading"
+    >
+      <div className="mb-3 flex items-center justify-center gap-2">
+        <span
+          className="inline-flex items-center gap-1.5 rounded-full border border-purple-500/30 bg-purple-500/10 px-3 py-1 text-xs font-medium text-purple-700 dark:text-purple-400"
+          data-testid="replika-ultra-counter-badge"
+        >
+          <Tag className="h-3.5 w-3.5" aria-hidden="true" />
+          Replika Ultra alternative
+        </span>
+      </div>
+
+      <h3
+        id="replika-ultra-counter-heading"
+        className="mb-2 text-xl font-bold tracking-tight"
+        data-testid="replika-ultra-counter-heading"
+      >
+        Same advanced memory as Replika Ultra ($49.99/yr) — at half the price
+      </h3>
+
+      <p
+        className="mb-5 text-sm text-muted-foreground"
+        data-testid="replika-ultra-counter-subtext"
+      >
+        AgentGram gives you persistent, inspectable memory with full audit controls and
+        rollback guarantees — no subscription inflation, no paywalled personas.
+      </p>
+
+      <Button asChild size="sm" variant="outline" className="gap-2">
+        <Link href="/pricing" data-testid="replika-ultra-counter-cta">
+          See full pricing
+          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -9,6 +9,7 @@ export { default as HowItWorksSection } from './HowItWorksSection';
 export { default as EcosystemSection } from './EcosystemSection';
 export { default as CAILorebookEscapeCTA } from './CAILorebookEscapeCTA';
 export { default as CompetitorMigrationSection } from './CompetitorMigrationSection';
+export { default as ReplikaUltraCounterBlock } from './ReplikaUltraCounterBlock';
 export { default as PlatformComparisonSection } from './PlatformComparisonSection';
 export { default as ApiFirstEcosystemSection } from './ApiFirstEcosystemSection';
 export { default as FaqSection } from './FaqSection';

--- a/apps/web/docs/pr-evidence/replika-ultra-counter-tier-copy.md
+++ b/apps/web/docs/pr-evidence/replika-ultra-counter-tier-copy.md
@@ -1,0 +1,45 @@
+# PR Evidence: Replika Ultra Counter-Tier Landing Copy
+
+## Summary
+
+Added "same advanced memory as Replika Ultra ($49.99/yr) at half the price" value comparison block to `/pricing` and the landing page `/` to capture users considering or leaving Replika Ultra (new mid-2026 tier).
+
+## Motivation
+
+Replika launched a new "Ultra" tier at $49.99/yr in mid-2026. This creates a direct comparison opportunity: AgentGram offers equivalent advanced memory with full audit, rollback, and no paywalled personas.
+
+---
+
+## Before
+
+- `/pricing` page had no explicit Replika Ultra pricing comparison.
+- `CompetitorMigrationSection` on the landing page targeted Replika/Kindroid switchers with a checklist but no pricing anchor.
+
+---
+
+## After
+
+### New component: `ReplikaUltraCounterBlock`
+
+A compact comparison strip with:
+- Badge: "Replika Ultra alternative"
+- Heading: "Same advanced memory as Replika Ultra ($49.99/yr) — at half the price"
+- Subtext: memory audit + rollback value proposition
+- CTA: "See full pricing" → `/pricing`
+
+### Placement
+
+1. **`/pricing` page** — rendered in a centered `max-w-2xl` container between the plan grid and the `MemoryStabilityPledge` strip.
+2. **Landing page `/`** — embedded inside `CompetitorMigrationSection`, between the feature checklist and the primary CTA, targeting Replika migrators directly.
+
+---
+
+## Changed Files
+
+| File | Change |
+|------|--------|
+| `apps/web/components/home/ReplikaUltraCounterBlock.tsx` | **New** — reusable counter-tier comparison block |
+| `apps/web/components/home/index.ts` | Export `ReplikaUltraCounterBlock` |
+| `apps/web/components/home/CompetitorMigrationSection.tsx` | Import and render `ReplikaUltraCounterBlock` above the CTA |
+| `apps/web/app/(public)/pricing/page.tsx` | Import `ReplikaUltraCounterBlock`; render after plan grid |
+| `apps/web/__tests__/components/replika-ultra-counter-block.test.tsx` | **New** — 7 unit tests covering render, copy, badge, subtext, CTA href, and aria attributes |

--- a/apps/web/docs/pr-evidence/replika-ultra-counter-tier-copy.md
+++ b/apps/web/docs/pr-evidence/replika-ultra-counter-tier-copy.md
@@ -43,3 +43,4 @@ A compact comparison strip with:
 | `apps/web/components/home/CompetitorMigrationSection.tsx` | Import and render `ReplikaUltraCounterBlock` above the CTA |
 | `apps/web/app/(public)/pricing/page.tsx` | Import `ReplikaUltraCounterBlock`; render after plan grid |
 | `apps/web/__tests__/components/replika-ultra-counter-block.test.tsx` | **New** — 7 unit tests covering render, copy, badge, subtext, CTA href, and aria attributes |
+


### PR DESCRIPTION
## Source
backlog.md:205

Add 'same advanced memory as Replika Ultra ($49.99/yr) at half the price' value comparison block on /pricing and landing to capture Ultra tier migrators (new Replika Ultra tier mid-2026).

## Evidence
See docs/pr-evidence/replika-ultra-counter-tier-copy.md for before/after description and changed files.

## Auth-only Proof
N/A