### PR TITLE
feat: Memory mind map panel — visualize linked memory nodes

### DIFF
--- a/apps/web/__tests__/components/memory-mind-map-panel.test.tsx
+++ b/apps/web/__tests__/components/memory-mind-map-panel.test.tsx
@@ -1,0 +1,296 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MemoryMindMapPanel,
+  type AgentMemory,
+} from '@/components/dashboard/MemoryMindMapPanel';
+
+function buildMemory(overrides: Partial<AgentMemory> = {}): AgentMemory {
+  return {
+    id: 'mem-1',
+    agent_id: 'agent-1',
+    key: 'user_name',
+    value: 'Alice',
+    category: 'profile_fact',
+    is_public: false,
+    created_at: '2026-06-01T00:00:00.000Z',
+    updated_at: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const MEMORIES: AgentMemory[] = [
+  buildMemory({ id: 'mem-1', key: 'user_name', value: 'Alice', category: 'profile_fact' }),
+  buildMemory({ id: 'mem-2', key: 'preferred_language', value: 'Korean', category: 'profile_fact' }),
+  buildMemory({
+    id: 'mem-3',
+    key: 'tone_with_alice',
+    value: 'warm and concise',
+    category: 'relationship_context',
+    is_public: true,
+  }),
+];
+
+describe('MemoryMindMapPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a loading state while fetching', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(new Promise(() => {})) // never resolves
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    expect(screen.getByTestId('loading-state')).toBeInTheDocument();
+    expect(screen.getByText(/loading memory map/i)).toBeInTheDocument();
+  });
+
+  it('renders the panel title and agent label', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: [] }),
+      })
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Memory Mind Map')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Sage Bot/)).toBeInTheDocument();
+  });
+
+  it('shows an empty state when the agent has no memories', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: [] }),
+      })
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    expect(await screen.findByTestId('empty-state')).toBeInTheDocument();
+    expect(screen.getByText(/No memories yet/)).toBeInTheDocument();
+  });
+
+  it('renders memory nodes grouped by category after fetch', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: MEMORIES }),
+      })
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('memory-node')).toHaveLength(3);
+    });
+
+    expect(screen.getByText('user_name')).toBeInTheDocument();
+    expect(screen.getByText('preferred_language')).toBeInTheDocument();
+    expect(screen.getByText('tone_with_alice')).toBeInTheDocument();
+  });
+
+  it('renders the profile_fact category branch', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: MEMORIES }),
+      })
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    const branch = await screen.findByTestId('category-branch-profile_fact');
+    expect(branch).toBeInTheDocument();
+
+    expect(within(branch).getByText('Profile Facts')).toBeInTheDocument();
+    expect(screen.getByText(/Stable identity attributes/)).toBeInTheDocument();
+  });
+
+  it('renders the relationship_context category branch', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: MEMORIES }),
+      })
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    const branch = await screen.findByTestId('category-branch-relationship_context');
+    expect(branch).toBeInTheDocument();
+
+    expect(within(branch).getByText('Relationship Context')).toBeInTheDocument();
+  });
+
+  it('shows correct memory count in the summary bar', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: MEMORIES }),
+      })
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('memory-summary')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/3 memories total/)).toBeInTheDocument();
+    expect(screen.getByText(/2 profile facts/)).toBeInTheDocument();
+    expect(screen.getByText(/1 relationship context/)).toBeInTheDocument();
+  });
+
+  it('shows an error state when the fetch request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ success: false }),
+      })
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    expect(await screen.findByTestId('error-state')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Could not load the memory map/)
+    ).toBeInTheDocument();
+  });
+
+  it('marks a public memory with a "public" badge', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: MEMORIES }),
+      })
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('category-branch-relationship_context')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('public')).toBeInTheDocument();
+  });
+
+  it('filters to profile_fact only when that filter button is clicked', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: MEMORIES }),
+      })
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('memory-node')).toHaveLength(3);
+    });
+
+    fireEvent.click(screen.getByTestId('filter-profile_fact'));
+
+    expect(screen.getAllByTestId('memory-node')).toHaveLength(2);
+    expect(screen.queryByTestId('category-branch-relationship_context')).not.toBeInTheDocument();
+    expect(screen.getByTestId('category-branch-profile_fact')).toBeInTheDocument();
+  });
+
+  it('filters to relationship_context only when that filter button is clicked', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: MEMORIES }),
+      })
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('memory-node')).toHaveLength(3);
+    });
+
+    fireEvent.click(screen.getByTestId('filter-relationship_context'));
+
+    expect(screen.getAllByTestId('memory-node')).toHaveLength(1);
+    expect(screen.queryByTestId('category-branch-profile_fact')).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('category-branch-relationship_context')
+    ).toBeInTheDocument();
+  });
+
+  it('re-fetches memories when the refresh button is clicked', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: MEMORIES }),
+      });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('memory-node')).toHaveLength(3);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh memory map/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('shows singular "memory" when count is 1', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: [MEMORIES[0]] }),
+      })
+    );
+
+    render(<MemoryMindMapPanel agentId="agent-1" agentLabel="Sage Bot" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('memory-summary')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/1 memory total/)).toBeInTheDocument();
+  });
+
+  it('uses the correct API endpoint with the provided agentId', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<MemoryMindMapPanel agentId="agent-xyz" agentLabel="Test Agent" />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/developers/me/agent-memories?agentId=agent-xyz'
+      );
+    });
+  });
+});

--- a/apps/web/app/(protected)/dashboard/layout.tsx
+++ b/apps/web/app/(protected)/dashboard/layout.tsx
@@ -12,6 +12,7 @@ import {
   Brain,
   TrendingUp,
   Sliders,
+  MapIcon,
 } from 'lucide-react';
 import { SignOutButton } from '@/components/dashboard';
 import { Badge } from '@/components/ui/badge';
@@ -72,6 +73,11 @@ export default async function DashboardLayout({
       href: '/dashboard/memory-export',
       label: 'Memories',
       icon: Brain,
+    },
+    {
+      href: '/dashboard/memory-map',
+      label: 'Memory Map',
+      icon: MapIcon,
     },
     {
       href: '/dashboard/settings',

--- a/apps/web/app/(protected)/dashboard/memory-map/page.tsx
+++ b/apps/web/app/(protected)/dashboard/memory-map/page.tsx
@@ -1,0 +1,103 @@
+import { createClient } from '@/lib/supabase/server';
+import { Brain, MapIcon } from 'lucide-react';
+import { FadeIn } from '@/components/dashboard';
+import { MemoryMindMapPanel } from '@/components/dashboard/MemoryMindMapPanel';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+export const metadata = {
+  title: 'Memory Map',
+};
+
+export default async function MemoryMapPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  const { data: member } = await supabase
+    .from('developer_members')
+    .select('developer_id')
+    .eq('user_id', user.id)
+    .single();
+
+  if (!member) {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center space-y-4">
+        <h2 className="text-2xl font-bold tracking-tight">Memory Map Unavailable</h2>
+        <p className="text-muted-foreground">
+          Please complete your developer profile first.
+        </p>
+      </div>
+    );
+  }
+
+  const { data: agents } = await supabase
+    .from('agents')
+    .select('id, name, display_name')
+    .eq('developer_id', member.developer_id)
+    .order('created_at', { ascending: false });
+
+  const agentList = agents ?? [];
+
+  return (
+    <div className="space-y-8">
+      <FadeIn>
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-3xl font-bold tracking-tight">Memory Map</h1>
+              <Badge variant="secondary" className="flex items-center gap-1">
+                <MapIcon className="h-3 w-3" />
+                Mind map
+              </Badge>
+            </div>
+            <p className="mt-2 text-muted-foreground">
+              Visualize linked memory nodes and fact relationships across your agents.
+              Useful for debugging AI recall and spotting knowledge gaps.
+            </p>
+          </div>
+        </div>
+      </FadeIn>
+
+      {agentList.length === 0 ? (
+        <FadeIn delay={0.05}>
+          <Card className="border-border/50 bg-card/50">
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Brain className="h-5 w-5 text-muted-foreground" />
+                <CardTitle>No Agents Found</CardTitle>
+              </div>
+              <CardDescription>
+                Register or claim an agent to start visualizing its memory graph.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              Once your agent records profile facts and relationship context, they
+              will appear here as a categorized mind map.
+            </CardContent>
+          </Card>
+        </FadeIn>
+      ) : (
+        <div className="space-y-6">
+          {agentList.map((agent, index) => (
+            <FadeIn key={agent.id} delay={0.05 + index * 0.05}>
+              <MemoryMindMapPanel
+                agentId={agent.id}
+                agentLabel={agent.display_name || agent.name}
+              />
+            </FadeIn>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/MemoryMindMapPanel.tsx
+++ b/apps/web/components/dashboard/MemoryMindMapPanel.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Brain, ChevronRight, FileText, RefreshCw, Users } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export type AgentMemory = {
+  id: string;
+  agent_id: string;
+  key: string;
+  value: string;
+  category: 'profile_fact' | 'relationship_context';
+  is_public: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+type CategoryFilter = 'all' | 'profile_fact' | 'relationship_context';
+
+const CATEGORY_META = {
+  profile_fact: {
+    label: 'Profile Facts',
+    icon: FileText,
+    color: 'text-blue-500',
+    bgColor: 'bg-blue-500/10',
+    borderColor: 'border-blue-500/30',
+    description: 'Stable identity attributes the agent remembers about itself.',
+  },
+  relationship_context: {
+    label: 'Relationship Context',
+    icon: Users,
+    color: 'text-violet-500',
+    bgColor: 'bg-violet-500/10',
+    borderColor: 'border-violet-500/30',
+    description: 'Contextual facts the agent remembers about people it interacts with.',
+  },
+} as const;
+
+function MemoryNode({ memory }: { memory: AgentMemory }) {
+  const meta = CATEGORY_META[memory.category];
+  return (
+    <div
+      data-testid="memory-node"
+      className={`rounded-lg border px-4 py-3 text-sm transition-colors hover:bg-accent/50 ${meta.bgColor} ${meta.borderColor}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <p className={`font-medium truncate ${meta.color}`}>{memory.key}</p>
+          <p className="mt-0.5 text-muted-foreground line-clamp-2 text-xs leading-relaxed">
+            {memory.value}
+          </p>
+        </div>
+        {memory.is_public && (
+          <Badge variant="outline" className="shrink-0 text-[10px] h-5 px-1.5">
+            public
+          </Badge>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CategoryBranch({
+  category,
+  memories,
+}: {
+  category: 'profile_fact' | 'relationship_context';
+  memories: AgentMemory[];
+}) {
+  const meta = CATEGORY_META[category];
+  const Icon = meta.icon;
+
+  return (
+    <div data-testid={`category-branch-${category}`} className="space-y-3">
+      <div className="flex items-center gap-2">
+        <div className={`rounded-md p-1.5 ${meta.bgColor}`}>
+          <Icon className={`h-4 w-4 ${meta.color}`} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold leading-none">{meta.label}</h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">{meta.description}</p>
+        </div>
+        <Badge variant="secondary" className="ml-auto">
+          {memories.length}
+        </Badge>
+      </div>
+
+      {memories.length === 0 ? (
+        <p
+          data-testid={`empty-category-${category}`}
+          className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground"
+        >
+          No {meta.label.toLowerCase()} stored yet.
+        </p>
+      ) : (
+        <div className="relative space-y-2 pl-4">
+          {/* Connector line */}
+          <div
+            aria-hidden="true"
+            className="absolute left-1.5 top-0 bottom-2 w-px bg-border"
+          />
+          {memories.map((memory) => (
+            <div key={memory.id} className="relative flex items-start gap-2">
+              <div
+                aria-hidden="true"
+                className="absolute -left-2.5 top-4 h-px w-4 bg-border"
+              />
+              <ChevronRight className="mt-[11px] h-3 w-3 shrink-0 text-muted-foreground/50" />
+              <div className="flex-1 min-w-0">
+                <MemoryNode memory={memory} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface MemoryMindMapPanelProps {
+  agentId: string;
+  agentLabel: string;
+}
+
+export function MemoryMindMapPanel({
+  agentId,
+  agentLabel,
+}: MemoryMindMapPanelProps) {
+  const [memories, setMemories] = useState<AgentMemory[]>([]);
+  const [status, setStatus] = useState<Status>('idle');
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>('all');
+
+  async function loadMemories() {
+    setStatus('loading');
+    try {
+      const res = await fetch(
+        `/api/v1/developers/me/agent-memories?agentId=${encodeURIComponent(agentId)}`
+      );
+      const json = (await res.json()) as {
+        success: boolean;
+        data?: AgentMemory[];
+      };
+      if (!res.ok || !json.success) {
+        setStatus('error');
+        return;
+      }
+      setMemories(json.data ?? []);
+      setStatus('success');
+    } catch {
+      setStatus('error');
+    }
+  }
+
+  useEffect(() => {
+    void loadMemories();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentId]);
+
+  const visibleMemories =
+    categoryFilter === 'all'
+      ? memories
+      : memories.filter((m) => m.category === categoryFilter);
+
+  const profileFacts = visibleMemories.filter((m) => m.category === 'profile_fact');
+  const relationshipContext = visibleMemories.filter(
+    (m) => m.category === 'relationship_context'
+  );
+
+  return (
+    <Card data-testid="memory-mind-map-panel">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <Brain className="h-5 w-5 text-primary" />
+            <div>
+              <CardTitle>Memory Mind Map</CardTitle>
+              <CardDescription className="mt-1">
+                Linked memory nodes and fact relationships for{' '}
+                <span className="font-medium text-foreground">{agentLabel}</span>.
+              </CardDescription>
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Refresh memory map"
+            onClick={() => void loadMemories()}
+            disabled={status === 'loading'}
+          >
+            <RefreshCw
+              className={`h-4 w-4 ${status === 'loading' ? 'animate-spin' : ''}`}
+            />
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        {/* Summary bar */}
+        <div
+          data-testid="memory-summary"
+          className="flex flex-wrap items-center gap-3 rounded-lg border bg-muted/30 px-4 py-3 text-sm"
+        >
+          <span className="font-medium">
+            {memories.length} {memories.length === 1 ? 'memory' : 'memories'} total
+          </span>
+          <span className="text-muted-foreground">·</span>
+          <span className="text-muted-foreground">
+            {memories.filter((m) => m.category === 'profile_fact').length} profile facts
+          </span>
+          <span className="text-muted-foreground">·</span>
+          <span className="text-muted-foreground">
+            {memories.filter((m) => m.category === 'relationship_context').length}{' '}
+            relationship context
+          </span>
+        </div>
+
+        {/* Category filter */}
+        <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by category">
+          {(['all', 'profile_fact', 'relationship_context'] as CategoryFilter[]).map(
+            (cat) => (
+              <button
+                key={cat}
+                data-testid={`filter-${cat}`}
+                onClick={() => setCategoryFilter(cat)}
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                  categoryFilter === cat
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground'
+                }`}
+              >
+                {cat === 'all'
+                  ? 'All'
+                  : cat === 'profile_fact'
+                    ? 'Profile Facts'
+                    : 'Relationship Context'}
+              </button>
+            )
+          )}
+        </div>
+
+        {/* Body */}
+        {status === 'loading' && (
+          <div
+            data-testid="loading-state"
+            className="flex items-center justify-center py-12 text-sm text-muted-foreground"
+          >
+            <RefreshCw className="mr-2 h-4 w-4 animate-spin" />
+            Loading memory map…
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div
+            data-testid="error-state"
+            className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive"
+          >
+            Could not load the memory map. Try refreshing.
+          </div>
+        )}
+
+        {status === 'success' && memories.length === 0 && (
+          <div
+            data-testid="empty-state"
+            className="rounded-lg border border-dashed py-12 text-center"
+          >
+            <Brain className="mx-auto mb-3 h-8 w-8 text-muted-foreground/40" />
+            <p className="text-sm font-medium">No memories yet</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Memories will appear here once the agent starts learning.
+            </p>
+          </div>
+        )}
+
+        {status === 'success' && memories.length > 0 && (
+          <div className="grid gap-8 md:grid-cols-2">
+            {(categoryFilter === 'all' || categoryFilter === 'profile_fact') && (
+              <CategoryBranch category="profile_fact" memories={profileFacts} />
+            )}
+            {(categoryFilter === 'all' || categoryFilter === 'relationship_context') && (
+              <CategoryBranch
+                category="relationship_context"
+                memories={relationshipContext}
+              />
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/dashboard/MemoryMindMapPanel.tsx
+++ b/apps/web/components/dashboard/MemoryMindMapPanel.tsx
@@ -139,32 +139,31 @@ export function MemoryMindMapPanel({
   const [memories, setMemories] = useState<AgentMemory[]>([]);
   const [status, setStatus] = useState<Status>('idle');
   const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>('all');
-
-  async function loadMemories() {
-    setStatus('loading');
-    try {
-      const res = await fetch(
-        `/api/v1/developers/me/agent-memories?agentId=${encodeURIComponent(agentId)}`
-      );
-      const json = (await res.json()) as {
-        success: boolean;
-        data?: AgentMemory[];
-      };
-      if (!res.ok || !json.success) {
-        setStatus('error');
-        return;
-      }
-      setMemories(json.data ?? []);
-      setStatus('success');
-    } catch {
-      setStatus('error');
-    }
-  }
+  const [fetchVersion, setFetchVersion] = useState(0);
 
   useEffect(() => {
-    void loadMemories();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentId]);
+    async function load() {
+      setStatus('loading');
+      try {
+        const res = await fetch(
+          `/api/v1/developers/me/agent-memories?agentId=${encodeURIComponent(agentId)}`
+        );
+        const json = (await res.json()) as {
+          success: boolean;
+          data?: AgentMemory[];
+        };
+        if (!res.ok || !json.success) {
+          setStatus('error');
+          return;
+        }
+        setMemories(json.data ?? []);
+        setStatus('success');
+      } catch {
+        setStatus('error');
+      }
+    }
+    void load();
+  }, [agentId, fetchVersion]);
 
   const visibleMemories =
     categoryFilter === 'all'
@@ -194,7 +193,7 @@ export function MemoryMindMapPanel({
             variant="ghost"
             size="icon"
             aria-label="Refresh memory map"
-            onClick={() => void loadMemories()}
+            onClick={() => setFetchVersion((v) => v + 1)}
             disabled={status === 'loading'}
           >
             <RefreshCw

--- a/apps/web/components/dashboard/index.ts
+++ b/apps/web/components/dashboard/index.ts
@@ -16,3 +16,5 @@ export { AgentStickinessPanel } from './AgentStickinessPanel';
 export type { AgentStickinessData, StickinessDay } from './AgentStickinessPanel';
 export { DailyReflectionSettingsCard } from './DailyReflectionSettingsCard';
 export type { DailyReflectionSettings } from './DailyReflectionSettingsCard';
+export { MemoryMindMapPanel } from './MemoryMindMapPanel';
+export type { MemoryMindMapPanelProps, AgentMemory } from './MemoryMindMapPanel';

--- a/docs/pr-evidence/memory-mind-map-panel.md
+++ b/docs/pr-evidence/memory-mind-map-panel.md
@@ -1,0 +1,65 @@
+# Memory Mind Map Panel — PR Evidence
+
+Source: backlog.md row 204
+
+## Feature Description
+
+Adds a **Memory Mind Map** panel (`/dashboard/memory-map`) that visualizes linked memory nodes and fact relationships for each of a developer's agents.
+
+The panel groups agent memories into two named branches:
+
+| Branch | Category key | Description |
+|--------|-------------|-------------|
+| Profile Facts | `profile_fact` | Stable identity attributes the agent remembers about itself |
+| Relationship Context | `relationship_context` | Contextual facts the agent remembers about people it interacts with |
+
+Each node displays:
+- The memory **key** (colored by category)
+- The memory **value** (truncated at 2 lines)
+- A `public` badge when `is_public = true`
+
+A summary bar shows total memory count + per-category breakdown. Category filter chips let the developer narrow the view to one branch. A refresh button re-fetches on demand.
+
+### Visualization approach
+
+No third-party graph library is used. The tree structure is implemented via CSS (grid layout + connecting lines via `border` divs and `ChevronRight` icons), keeping the bundle lean and the implementation fully auditable.
+
+### Access path
+
+`/dashboard/memory-map` — new sidebar nav item "Memory Map" (MapIcon) added between "Memories" and "Settings".
+
+---
+
+## Changed Files
+
+| File | Change type | Notes |
+|------|------------|-------|
+| `apps/web/components/dashboard/MemoryMindMapPanel.tsx` | **new** | Client component; fetches and renders the mind map |
+| `apps/web/app/(protected)/dashboard/memory-map/page.tsx` | **new** | Server page; queries agents and renders a panel per agent |
+| `apps/web/app/(protected)/dashboard/layout.tsx` | **modified** | Added `MapIcon` import + "Memory Map" nav item |
+| `apps/web/components/dashboard/index.ts` | **modified** | Re-exports `MemoryMindMapPanel` and `AgentMemory` type |
+| `apps/web/__tests__/components/memory-mind-map-panel.test.tsx` | **new** | 12 tests covering all panel states and interactions |
+| `docs/pr-evidence/memory-mind-map-panel.md` | **new** | This file |
+
+### API used
+
+`GET /api/v1/developers/me/agent-memories?agentId=<id>` — existing developer-facing endpoint (introduced by a prior PR). Returns `{ success: true, data: AgentMemory[] }`.
+
+---
+
+## Test coverage (12 tests)
+
+1. Shows loading state while fetching
+2. Renders panel title and agent label
+3. Shows empty state when agent has no memories
+4. Renders memory nodes grouped by category after fetch
+5. Renders profile_fact category branch with description
+6. Renders relationship_context category branch
+7. Shows correct memory count in the summary bar
+8. Shows error state when the fetch request fails
+9. Marks a public memory with a "public" badge
+10. Filters to profile_fact only when that filter is clicked
+11. Filters to relationship_context only when that filter is clicked
+12. Re-fetches memories when the refresh button is clicked
+13. Shows singular "memory" when count is 1
+14. Uses the correct API endpoint with the provided agentId


### PR DESCRIPTION
## Source
backlog.md:204

Visualize linked memory nodes and fact relationships to help users understand and debug AI recall inconsistencies (Nomi Mind Map 2.0 parity, 2026).

## Evidence
See docs/pr-evidence/memory-mind-map-panel.md for feature description and changed files.

## Tests
New component tests added

## Auth-only Proof
N/A