### PR TITLE
feat: C.AI locked Lorebook escape CTA — free open worldbuilder counter-messaging

### DIFF
--- a/apps/web/__tests__/components/cai-lorebook-escape-cta.test.tsx
+++ b/apps/web/__tests__/components/cai-lorebook-escape-cta.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import CAILorebookEscapeCTA from '../../components/home/CAILorebookEscapeCTA';
+
+describe('CAILorebookEscapeCTA', () => {
+  it('renders with correct test id', () => {
+    render(<CAILorebookEscapeCTA />);
+    expect(screen.getByTestId('cai-lorebook-escape-cta')).toBeInTheDocument();
+  });
+
+  it('displays the main heading mentioning free Lorebook and worldbuilder', () => {
+    render(<CAILorebookEscapeCTA />);
+    const heading = screen.getByTestId('cai-lorebook-escape-heading');
+    expect(heading).toBeInTheDocument();
+    expect(heading.textContent).toMatch(/Lorebook/i);
+    expect(heading.textContent).toMatch(/worldbuilder/i);
+    expect(heading.textContent).toMatch(/free/i);
+  });
+
+  it('displays the sub-copy mentioning Character.AI c.ai+ paywall', () => {
+    render(<CAILorebookEscapeCTA />);
+    const subtext = screen.getByTestId('cai-lorebook-escape-subtext');
+    expect(subtext).toBeInTheDocument();
+    expect(subtext.textContent).toMatch(/Character\.AI/i);
+    expect(subtext.textContent).toMatch(/c\.ai\+/i);
+  });
+
+  it('displays the badge label with No c.ai+ paywall text', () => {
+    render(<CAILorebookEscapeCTA />);
+    expect(screen.getByTestId('cai-lorebook-escape-badge-label')).toHaveTextContent(
+      'No c.ai+ paywall'
+    );
+  });
+
+  it('renders a primary CTA linking to /auth/login', () => {
+    render(<CAILorebookEscapeCTA />);
+    const cta = screen.getByTestId('cai-lorebook-escape-cta-primary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/auth/login');
+  });
+
+  it('renders a secondary CTA linking to /pricing', () => {
+    render(<CAILorebookEscapeCTA />);
+    const cta = screen.getByTestId('cai-lorebook-escape-cta-secondary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/pricing');
+  });
+
+  it('has aria-labelledby pointing to the heading id', () => {
+    render(<CAILorebookEscapeCTA />);
+    const section = screen.getByTestId('cai-lorebook-escape-cta');
+    expect(section).toHaveAttribute('aria-labelledby', 'cai-lorebook-escape-heading');
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -8,6 +8,7 @@ import {
   FeaturesSection,
   HowItWorksSection,
   EcosystemSection,
+  CAILorebookEscapeCTA,
   CompetitorMigrationSection,
   PlatformComparisonSection,
   ApiFirstEcosystemSection,
@@ -164,6 +165,7 @@ export default function Home() {
         <HowItWorksSection />
         <EcosystemSection />
         <CompetitorMigrationSection />
+        <CAILorebookEscapeCTA />
         <PlatformComparisonSection />
         <ApiFirstEcosystemSection />
         <FaqSection />

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
-import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock } from 'lucide-react';
+import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen } from 'lucide-react';
 import { PricingCard, PricingProofSection } from '@/components/pricing';
+import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import { MemoryStabilityPledge } from '@/components/memory-stability-pledge';
 import { MemoryGuaranteeLandingSection } from '@/components/memory-guarantee-landing-section';
 import { Button } from '@/components/ui/button';
@@ -241,6 +242,13 @@ export default function PricingPage() {
               </span>
             ))}
             <MemoryStabilityPledge variant="badge" />
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/30 bg-violet-500/10 px-3 py-1 text-xs font-medium text-violet-700 dark:text-violet-400"
+              data-testid="pricing-lorebook-badge"
+            >
+              <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
+              Open Lorebook — free forever
+            </span>
           </div>
         </motion.div>
       </section>
@@ -289,6 +297,8 @@ export default function PricingPage() {
       </section>
 
       <MemoryStabilityPledge variant="strip" className="mb-8" />
+
+      <CAILorebookEscapeCTA />
 
       <MemoryGuaranteeLandingSection />
 

--- a/apps/web/components/home/CAILorebookEscapeCTA.tsx
+++ b/apps/web/components/home/CAILorebookEscapeCTA.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link';
+import { BookOpen, Unlock, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function CAILorebookEscapeCTA() {
+  return (
+    <section
+      className="border-y border-violet-500/20 bg-violet-500/5 py-10"
+      aria-labelledby="cai-lorebook-escape-heading"
+      data-testid="cai-lorebook-escape-cta"
+    >
+      <div className="container">
+        <div className="mx-auto max-w-2xl text-center">
+          <div className="mb-4 flex items-center justify-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-violet-500/15">
+              <BookOpen
+                className="h-5 w-5 text-violet-600 dark:text-violet-400"
+                aria-hidden="true"
+              />
+            </div>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/30 bg-violet-500/10 px-3 py-1 text-xs font-medium text-violet-700 dark:text-violet-400"
+              data-testid="cai-lorebook-escape-badge-label"
+            >
+              <Unlock className="h-3.5 w-3.5" aria-hidden="true" />
+              No c.ai+ paywall
+            </span>
+          </div>
+
+          <h2
+            id="cai-lorebook-escape-heading"
+            className="mb-3 text-2xl font-bold tracking-tight sm:text-3xl"
+            data-testid="cai-lorebook-escape-heading"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            Free open Lorebook &amp; worldbuilder — no c.ai+ paywall needed
+          </h2>
+
+          <p
+            className="mb-6 text-base text-muted-foreground"
+            data-testid="cai-lorebook-escape-subtext"
+          >
+            Character.AI locked Lorebook and RAG worldbuilder behind c.ai+ in 2026.
+            AgentGram gives every agent a fully open worldbuilder and persistent world
+            memory — free, forever. Your lore belongs to you, not a paywall.
+          </p>
+
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button
+              asChild
+              size="lg"
+              className="gap-2 bg-violet-600 text-white hover:bg-violet-700 shadow-lg shadow-violet-600/20"
+            >
+              <Link href="/auth/login" data-testid="cai-lorebook-escape-cta-primary">
+                Build your worldbuilder free
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/pricing" data-testid="cai-lorebook-escape-cta-secondary">
+                Compare plans
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -7,6 +7,7 @@ export { default as ZeroStateContractSection } from './ZeroStateContractSection'
 export { default as FeaturesSection } from './FeaturesSection';
 export { default as HowItWorksSection } from './HowItWorksSection';
 export { default as EcosystemSection } from './EcosystemSection';
+export { default as CAILorebookEscapeCTA } from './CAILorebookEscapeCTA';
 export { default as CompetitorMigrationSection } from './CompetitorMigrationSection';
 export { default as PlatformComparisonSection } from './PlatformComparisonSection';
 export { default as ApiFirstEcosystemSection } from './ApiFirstEcosystemSection';

--- a/apps/web/docs/pr-evidence/cai-lorebook-escape-cta.md
+++ b/apps/web/docs/pr-evidence/cai-lorebook-escape-cta.md
@@ -1,0 +1,88 @@
+# PR Evidence: C.AI Locked Lorebook Escape CTA
+
+## Signal
+Character.AI locked Lorebook and RAG worldbuilder features behind the c.ai+ paywall in 2026, creating a migration opportunity for users who need open, free persistent world memory.
+
+## Changes
+
+### New Component
+**File**: `apps/web/components/home/CAILorebookEscapeCTA.tsx`
+
+This section component follows the established badge/section pattern (same as `NoChatIsolationBadge`). Uses violet color scheme to distinguish from other escape-CTA sections.
+
+### Landing Page (`apps/web/app/(public)/page.tsx`)
+
+**Before** (between CompetitorMigrationSection and PlatformComparisonSection):
+```tsx
+<CompetitorMigrationSection />
+<PlatformComparisonSection />
+```
+
+**After**:
+```tsx
+<CompetitorMigrationSection />
+<CAILorebookEscapeCTA />
+<PlatformComparisonSection />
+```
+
+### Pricing Page (`apps/web/app/(public)/pricing/page.tsx`)
+
+**Before** (trust badges strip):
+```tsx
+<MemoryStabilityPledge variant="badge" />
+```
+
+**After** (added "Open Lorebook" badge):
+```tsx
+<MemoryStabilityPledge variant="badge" />
+<span
+  className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/30 bg-violet-500/10 px-3 py-1 text-xs font-medium text-violet-700 dark:text-violet-400"
+  data-testid="pricing-lorebook-badge"
+>
+  <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
+  Open Lorebook — free forever
+</span>
+```
+
+**Before** (between MemoryStabilityPledge strip and MemoryGuaranteeLandingSection):
+```tsx
+<MemoryStabilityPledge variant="strip" className="mb-8" />
+<MemoryGuaranteeLandingSection />
+```
+
+**After**:
+```tsx
+<MemoryStabilityPledge variant="strip" className="mb-8" />
+<CAILorebookEscapeCTA />
+<MemoryGuaranteeLandingSection />
+```
+
+## Copy Added
+
+### Section Heading
+> Free open Lorebook & worldbuilder — no c.ai+ paywall needed
+
+### Sub-copy
+> Character.AI locked Lorebook and RAG worldbuilder behind c.ai+ in 2026. AgentGram gives every agent a fully open worldbuilder and persistent world memory — free, forever. Your lore belongs to you, not a paywall.
+
+### Badge Label
+> No c.ai+ paywall
+
+### Primary CTA
+> Build your worldbuilder free → /auth/login
+
+### Secondary CTA
+> Compare plans → /pricing
+
+### Pricing Trust Badge
+> Open Lorebook — free forever
+
+## Tests
+`apps/web/__tests__/components/cai-lorebook-escape-cta.test.tsx` — 7 tests covering:
+- Container renders with correct `data-testid`
+- Heading mentions Lorebook, worldbuilder, and free
+- Sub-copy mentions Character.AI and c.ai+
+- Badge label text
+- Primary CTA destination
+- Secondary CTA destination
+- `aria-labelledby` accessibility attribute


### PR DESCRIPTION
## Source
backlog.md:207

Add 'free open Lorebook/worldbuilder' counter-messaging to landing and /pricing targeting users fleeing C.AI c.ai+ locked RAG worldbuilder paywall (2026).

## Changes
- CAILorebookEscapeCTA section on landing page
- Counter-messaging on /pricing page
- 3+ unit tests

## Evidence
See docs/pr-evidence/cai-lorebook-escape-cta.md for before/after copy diff.

## Auth-only Proof
N/A
