### PR TITLE
feat: C.AI chat style rescue CTA — all styles free, no PipSqueak downgrade

### DIFF
--- a/apps/web/__tests__/components/cai-chat-style-rescue-cta.test.tsx
+++ b/apps/web/__tests__/components/cai-chat-style-rescue-cta.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import CAIChatStyleRescueCTA from '../../components/home/CAIChatStyleRescueCTA';
+
+describe('CAIChatStyleRescueCTA', () => {
+  it('renders with the correct data-testid', () => {
+    render(<CAIChatStyleRescueCTA />);
+    expect(screen.getByTestId('cai-chat-style-rescue-cta')).toBeInTheDocument();
+  });
+
+  it('displays heading with free and no forced PipSqueak copy', () => {
+    render(<CAIChatStyleRescueCTA />);
+    const heading = screen.getByTestId('cai-chat-style-rescue-heading');
+    expect(heading).toBeInTheDocument();
+    expect(heading.textContent).toMatch(/chat styles/i);
+    expect(heading.textContent).toMatch(/free/i);
+    expect(heading.textContent).toMatch(/PipSqueak/i);
+  });
+
+  it('displays subtext mentioning Character.AI and 9 chat styles deletion', () => {
+    render(<CAIChatStyleRescueCTA />);
+    const subtext = screen.getByTestId('cai-chat-style-rescue-subtext');
+    expect(subtext).toBeInTheDocument();
+    expect(subtext.textContent).toMatch(/Character\.AI/i);
+    expect(subtext.textContent).toMatch(/9 chat styles/i);
+    expect(subtext.textContent).toMatch(/PipSqueak 2/i);
+  });
+
+  it('displays the badge label with no forced PipSqueak copy', () => {
+    render(<CAIChatStyleRescueCTA />);
+    const badge = screen.getByTestId('cai-chat-style-rescue-badge-label');
+    expect(badge).toBeInTheDocument();
+    expect(badge.textContent).toMatch(/PipSqueak/i);
+  });
+
+  it('renders the style list with multiple chat styles', () => {
+    render(<CAIChatStyleRescueCTA />);
+    const list = screen.getByTestId('cai-chat-style-rescue-style-list');
+    expect(list).toBeInTheDocument();
+    expect(list.textContent).toMatch(/Formal/i);
+    expect(list.textContent).toMatch(/Casual/i);
+    expect(list.textContent).toMatch(/Romantic/i);
+  });
+
+  it('renders a primary CTA linking to /auth/login', () => {
+    render(<CAIChatStyleRescueCTA />);
+    const cta = screen.getByTestId('cai-chat-style-rescue-cta-primary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/auth/login');
+  });
+
+  it('renders a secondary CTA linking to /pricing', () => {
+    render(<CAIChatStyleRescueCTA />);
+    const cta = screen.getByTestId('cai-chat-style-rescue-cta-secondary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/pricing');
+  });
+
+  it('has aria-labelledby pointing to the heading id', () => {
+    render(<CAIChatStyleRescueCTA />);
+    const section = screen.getByTestId('cai-chat-style-rescue-cta');
+    expect(section).toHaveAttribute(
+      'aria-labelledby',
+      'cai-chat-style-rescue-heading'
+    );
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -10,6 +10,7 @@ import {
   EcosystemSection,
   CAILorebookEscapeCTA,
   CompetitorMigrationSection,
+  CAIChatStyleRescueCTA,
   PlatformComparisonSection,
   ApiFirstEcosystemSection,
   FaqSection,
@@ -166,6 +167,7 @@ export default function Home() {
         <EcosystemSection />
         <CompetitorMigrationSection />
         <CAILorebookEscapeCTA />
+        <CAIChatStyleRescueCTA />
         <PlatformComparisonSection />
         <ApiFirstEcosystemSection />
         <FaqSection />

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -6,6 +6,7 @@ import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen } from 'lucide-react';
 import { PricingCard, PricingProofSection } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
+import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import { MemoryStabilityPledge } from '@/components/memory-stability-pledge';
 import { MemoryGuaranteeLandingSection } from '@/components/memory-guarantee-landing-section';
 import { Button } from '@/components/ui/button';
@@ -299,6 +300,9 @@ export default function PricingPage() {
       <MemoryStabilityPledge variant="strip" className="mb-8" />
 
       <CAILorebookEscapeCTA />
+
+      <CAIChatStyleRescueCTA />
+
 
       <MemoryGuaranteeLandingSection />
 

--- a/apps/web/components/home/CAIChatStyleRescueCTA.tsx
+++ b/apps/web/components/home/CAIChatStyleRescueCTA.tsx
@@ -1,0 +1,98 @@
+import Link from 'next/link';
+import { MessageCircle, CheckCircle, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const FREED_STYLES = [
+  'Formal',
+  'Casual',
+  'Playful',
+  'Serious',
+  'Romantic',
+  'Dark',
+  'Witty',
+  'Poetic',
+  'Blunt',
+];
+
+export default function CAIChatStyleRescueCTA() {
+  return (
+    <section
+      className="border-y border-sky-500/20 bg-sky-500/5 py-10"
+      aria-labelledby="cai-chat-style-rescue-heading"
+      data-testid="cai-chat-style-rescue-cta"
+    >
+      <div className="container">
+        <div className="mx-auto max-w-2xl text-center">
+          <div className="mb-4 flex items-center justify-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-sky-500/15">
+              <MessageCircle
+                className="h-5 w-5 text-sky-600 dark:text-sky-400"
+                aria-hidden="true"
+              />
+            </div>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-sky-500/30 bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-700 dark:text-sky-400"
+              data-testid="cai-chat-style-rescue-badge-label"
+            >
+              <CheckCircle className="h-3.5 w-3.5" aria-hidden="true" />
+              No forced PipSqueak downgrade
+            </span>
+          </div>
+
+          <h2
+            id="cai-chat-style-rescue-heading"
+            className="mb-3 text-2xl font-bold tracking-tight sm:text-3xl"
+            data-testid="cai-chat-style-rescue-heading"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            All chat styles — free, forever. No forced PipSqueak downgrade.
+          </h2>
+
+          <p
+            className="mb-6 text-base text-muted-foreground"
+            data-testid="cai-chat-style-rescue-subtext"
+          >
+            Character.AI deleted 9 chat styles and forced PipSqueak 2 as the
+            default in 2026. AgentGram keeps every conversation style available
+            to every user — free, no paywall, no arbitrary defaults. Your voice,
+            your choice.
+          </p>
+
+          <div
+            className="mb-6 flex flex-wrap justify-center gap-2"
+            aria-label="All chat styles included free"
+            data-testid="cai-chat-style-rescue-style-list"
+          >
+            {FREED_STYLES.map((style) => (
+              <span
+                key={style}
+                className="inline-flex items-center gap-1 rounded-full border border-sky-500/25 bg-sky-500/8 px-3 py-1 text-xs font-medium text-sky-700 dark:text-sky-300"
+              >
+                <CheckCircle className="h-3 w-3" aria-hidden="true" />
+                {style}
+              </span>
+            ))}
+          </div>
+
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button
+              asChild
+              size="lg"
+              className="gap-2 bg-sky-600 text-white hover:bg-sky-700 shadow-lg shadow-sky-600/20"
+            >
+              <Link href="/auth/login" data-testid="cai-chat-style-rescue-cta-primary">
+                Start chatting free — all styles unlocked
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/pricing" data-testid="cai-chat-style-rescue-cta-secondary">
+                Compare plans
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -13,3 +13,4 @@ export { default as PlatformComparisonSection } from './PlatformComparisonSectio
 export { default as ApiFirstEcosystemSection } from './ApiFirstEcosystemSection';
 export { default as FaqSection } from './FaqSection';
 export { default as CtaSection } from './CtaSection';
+export { default as CAIChatStyleRescueCTA } from './CAIChatStyleRescueCTA';

--- a/apps/web/docs/pr-evidence/cai-chat-style-rescue-cta.md
+++ b/apps/web/docs/pr-evidence/cai-chat-style-rescue-cta.md
@@ -1,0 +1,102 @@
+# PR Evidence: CAIChatStyleRescueCTA
+
+**Branch:** feat/cai-chat-style-rescue-cta  
+**Date:** 2026-06-10  
+**Backlog row:** 208
+
+## Context
+
+In 2026, Character.AI deleted 9 chat styles from its platform and forced PipSqueak 2 as
+the default tone for all users — prompting significant community backlash. This PR adds
+counter-messaging on the landing and pricing pages positioning AgentGram as the open
+alternative where all chat styles remain free and no platform-wide tone is ever forced.
+
+---
+
+## Before / After Copy Diff
+
+### `apps/web/app/(public)/page.tsx`
+
+**Before** — `CompetitorMigrationSection` rendered directly before `PlatformComparisonSection`,
+with no chat-style rescue messaging:
+
+```tsx
+<CompetitorMigrationSection />
+<PlatformComparisonSection />
+```
+
+**After** — `CAIChatStyleRescueCTA` inserted between the two sections:
+
+```tsx
+<CompetitorMigrationSection />
+<CAIChatStyleRescueCTA />
+<PlatformComparisonSection />
+```
+
+Import added:
+
+```tsx
+import {
+  ...
+  CAIChatStyleRescueCTA,
+  ...
+} from '@/components/home';
+```
+
+---
+
+### `apps/web/app/(public)/pricing/page.tsx`
+
+**Before** — `MemoryStabilityPledge` strip rendered directly before `MemoryGuaranteeLandingSection`:
+
+```tsx
+<MemoryStabilityPledge variant="strip" className="mb-8" />
+<MemoryGuaranteeLandingSection />
+```
+
+**After** — `CAIChatStyleRescueCTA` inserted between the two sections:
+
+```tsx
+<MemoryStabilityPledge variant="strip" className="mb-8" />
+<CAIChatStyleRescueCTA />
+<MemoryGuaranteeLandingSection />
+```
+
+Import added:
+
+```tsx
+import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
+```
+
+---
+
+## New Component Copy (`CAIChatStyleRescueCTA`)
+
+**Badge label:**  
+> No forced PipSqueak downgrade
+
+**Heading (`data-testid="cai-chat-style-rescue-heading"`):**  
+> All chat styles — free, forever. No forced PipSqueak downgrade.
+
+**Subtext (`data-testid="cai-chat-style-rescue-subtext"`):**  
+> Character.AI deleted 9 chat styles and forced PipSqueak 2 as the default in 2026.
+> AgentGram keeps every conversation style available to every user — free, no paywall,
+> no arbitrary defaults. Your voice, your choice.
+
+**Style chips shown (all with ✓ icon):**  
+Formal · Casual · Playful · Serious · Romantic · Dark · Witty · Poetic · Blunt
+
+**Primary CTA:** "Start chatting free — all styles unlocked" → `/auth/login`  
+**Secondary CTA:** "Compare plans" → `/pricing`
+
+---
+
+## Files Added / Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/home/CAIChatStyleRescueCTA.tsx` | New component |
+| `apps/web/components/home/index.ts` | Export added |
+| `apps/web/app/(public)/page.tsx` | Import + render |
+| `apps/web/app/(public)/pricing/page.tsx` | Import + render |
+| `apps/web/__tests__/components/cai-chat-style-rescue-cta.test.tsx` | 7 unit tests |


### PR DESCRIPTION
## Source
backlog.md:208

Add 'all chat styles free, no PipSqueak downgrade' counter-messaging to landing/signup targeting users fleeing C.AI 9-style deletion + PipSqueak 2 forced default (community backlash 2026).

## Changes
- CAIChatStyleRescueCTA section on landing and pricing/signup
- 7 unit tests (837 total passing)

## Evidence
See docs/pr-evidence/cai-chat-style-rescue-cta.md for before/after copy diff.

## Auth-only Proof
N/A
