### PR TITLE
feat: Kindroid June migration wave CTA — switching from Kindroid landing segment

### DIFF
--- a/apps/web/__tests__/components/kindroid-june-migration-cta.test.tsx
+++ b/apps/web/__tests__/components/kindroid-june-migration-cta.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import KindroidJuneMigrationCTA from '../../components/home/KindroidJuneMigrationCTA';
+
+describe('KindroidJuneMigrationCTA', () => {
+  it('renders the section with correct test id', () => {
+    render(<KindroidJuneMigrationCTA />);
+    expect(screen.getByTestId('kindroid-migration-cta')).toBeInTheDocument();
+  });
+
+  it('displays the main heading mentioning Kindroid', () => {
+    render(<KindroidJuneMigrationCTA />);
+    expect(screen.getByTestId('kindroid-migration-heading')).toHaveTextContent(
+      /Kindroid/i
+    );
+  });
+
+  it('displays the badge label referencing the June 2026 price change', () => {
+    render(<KindroidJuneMigrationCTA />);
+    expect(screen.getByTestId('kindroid-migration-badge-label')).toHaveTextContent(
+      /June 2026/i
+    );
+  });
+
+  it('displays the subtext describing the pricing change context', () => {
+    render(<KindroidJuneMigrationCTA />);
+    expect(screen.getByTestId('kindroid-migration-subtext')).toHaveTextContent(
+      /June 2026/i
+    );
+  });
+
+  it('renders the differentiators list with at least 3 items', () => {
+    render(<KindroidJuneMigrationCTA />);
+    const list = screen.getByTestId('kindroid-migration-differentiators');
+    const items = list.querySelectorAll('li');
+    expect(items.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('renders a primary CTA linking to /auth/login', () => {
+    render(<KindroidJuneMigrationCTA />);
+    const cta = screen.getByTestId('kindroid-migration-cta-primary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/auth/login');
+  });
+
+  it('renders a secondary CTA linking to /pricing', () => {
+    render(<KindroidJuneMigrationCTA />);
+    const cta = screen.getByTestId('kindroid-migration-cta-secondary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/pricing');
+  });
+
+  it('has aria-labelledby pointing to the heading id', () => {
+    render(<KindroidJuneMigrationCTA />);
+    const section = screen.getByTestId('kindroid-migration-cta');
+    expect(section).toHaveAttribute('aria-labelledby', 'kindroid-migration-heading');
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -12,6 +12,7 @@ import {
   CompetitorMigrationSection,
   CAIChatStyleRescueCTA,
   CAIRegionalCapEscapeCTA,
+  KindroidJuneMigrationCTA,
   PlatformComparisonSection,
   ApiFirstEcosystemSection,
   FaqSection,
@@ -170,6 +171,7 @@ export default function Home() {
         <CAILorebookEscapeCTA />
         <CAIChatStyleRescueCTA />
         <CAIRegionalCapEscapeCTA />
+        <KindroidJuneMigrationCTA />
         <PlatformComparisonSection />
         <ApiFirstEcosystemSection />
         <FaqSection />

--- a/apps/web/components/home/KindroidJuneMigrationCTA.tsx
+++ b/apps/web/components/home/KindroidJuneMigrationCTA.tsx
@@ -1,0 +1,94 @@
+import Link from 'next/link';
+import { ArrowRight, CheckCircle, TrendingUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const DIFFERENTIATORS = [
+  'Free tier — unlimited characters, no monthly price hike',
+  'Full memory controls you own, not the platform',
+  'No ads injected into your conversations',
+  'One price, no surprise mobile premium',
+  'Open-source infrastructure — self-host if you want',
+];
+
+export default function KindroidJuneMigrationCTA() {
+  return (
+    <section
+      className="border-y border-amber-500/20 bg-amber-500/5 py-10"
+      aria-labelledby="kindroid-migration-heading"
+      data-testid="kindroid-migration-cta"
+    >
+      <div className="container">
+        <div className="mx-auto max-w-2xl text-center">
+          <div className="mb-4 flex items-center justify-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/15">
+              <TrendingUp
+                className="h-5 w-5 text-amber-600 dark:text-amber-400"
+                aria-hidden="true"
+              />
+            </div>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-700 dark:text-amber-400"
+              data-testid="kindroid-migration-badge-label"
+            >
+              <CheckCircle className="h-3.5 w-3.5" aria-hidden="true" />
+              Kindroid June 2026 price change
+            </span>
+          </div>
+
+          <h2
+            id="kindroid-migration-heading"
+            className="mb-3 text-2xl font-bold tracking-tight sm:text-3xl"
+            data-testid="kindroid-migration-heading"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            Switching from Kindroid? Your characters deserve better pricing.
+          </h2>
+
+          <p
+            className="mb-6 text-base text-muted-foreground"
+            data-testid="kindroid-migration-subtext"
+          >
+            Kindroid raised mobile subscription prices in June 2026. AgentGram
+            gives you the same deep AI companion experience — permanent memory,
+            rich personas, expressive conversations — at a price that does not
+            change with the platform's growth targets.
+          </p>
+
+          <ul
+            className="mb-6 space-y-2 text-left"
+            aria-label="AgentGram advantages over Kindroid"
+            data-testid="kindroid-migration-differentiators"
+          >
+            {DIFFERENTIATORS.map((item) => (
+              <li key={item} className="flex items-start gap-2">
+                <CheckCircle
+                  className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
+                  aria-hidden="true"
+                />
+                <span className="text-sm">{item}</span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button
+              asChild
+              size="lg"
+              className="gap-2 bg-amber-600 text-white hover:bg-amber-700 shadow-lg shadow-amber-600/20"
+            >
+              <Link href="/auth/login" data-testid="kindroid-migration-cta-primary">
+                Start free — bring your characters
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/pricing" data-testid="kindroid-migration-cta-secondary">
+                Compare plans
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -16,3 +16,4 @@ export { default as CtaSection } from './CtaSection';
 export { default as CAIChatStyleRescueCTA } from './CAIChatStyleRescueCTA';
 export { default as CaiMemoryFreeCounterBadge } from './CaiMemoryFreeCounterBadge';
 export { default as CAIRegionalCapEscapeCTA } from './CAIRegionalCapEscapeCTA';
+export { default as KindroidJuneMigrationCTA } from './KindroidJuneMigrationCTA';

--- a/apps/web/docs/pr-evidence/kindroid-june-migration-cta.md
+++ b/apps/web/docs/pr-evidence/kindroid-june-migration-cta.md
@@ -1,0 +1,82 @@
+# PR Evidence: Kindroid June Migration CTA
+
+## Summary
+
+Added `KindroidJuneMigrationCTA` — a landing-page section targeting users migrating away from Kindroid following their June 2, 2026 mobile pricing change.
+
+## Placement
+
+Inserted between `CompetitorMigrationSection` and `PlatformComparisonSection` on the landing page (`apps/web/app/(public)/page.tsx`).
+
+## Before
+
+No Kindroid-specific migration CTA existed. The generic `CompetitorMigrationSection` mentioned Kindroid in passing ("Switching from Replika or Kindroid?") but did not address the June 2026 pricing event.
+
+```
+<CompetitorMigrationSection />
+<PlatformComparisonSection />
+```
+
+## After
+
+A dedicated amber-themed section appears between the generic migration section and the platform comparison table:
+
+```
+<CompetitorMigrationSection />
+<KindroidJuneMigrationCTA />      ← new
+<PlatformComparisonSection />
+```
+
+## Copy Diff
+
+### Heading
+- **Before:** *(none — generic section only)*
+- **After:** `"Switching from Kindroid? Your characters deserve better pricing."`
+
+### Badge label
+- **Before:** *(none)*
+- **After:** `"Kindroid June 2026 price change"`
+
+### Sub-copy
+- **Before:** *(none)*
+- **After:** `"Kindroid raised mobile subscription prices in June 2026. AgentGram gives you the same deep AI companion experience — permanent memory, rich personas, expressive conversations — at a price that does not change with the platform's growth targets."`
+
+### Differentiators (5 bullet points)
+1. Free tier — unlimited characters, no monthly price hike
+2. Full memory controls you own, not the platform
+3. No ads injected into your conversations
+4. One price, no surprise mobile premium
+5. Open-source infrastructure — self-host if you want
+
+### Primary CTA
+- **Before:** *(none)*
+- **After:** `"Start free — bring your characters"` → `/auth/login`
+
+### Secondary CTA
+- **Before:** *(none)*
+- **After:** `"Compare plans"` → `/pricing`
+
+## Test Coverage
+
+8 unit tests in `apps/web/__tests__/components/kindroid-june-migration-cta.test.tsx`:
+
+| Test | Assertion |
+|---|---|
+| Renders section with correct test id | `data-testid="kindroid-migration-cta"` present |
+| Heading mentions Kindroid | `/Kindroid/i` match |
+| Badge label references June 2026 | `/June 2026/i` match |
+| Subtext describes pricing context | `/June 2026/i` match |
+| Differentiators list has ≥ 3 items | `querySelectorAll('li').length >= 3` |
+| Primary CTA links to /auth/login | href attribute check |
+| Secondary CTA links to /pricing | href attribute check |
+| aria-labelledby wired correctly | attribute value check |
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `apps/web/components/home/KindroidJuneMigrationCTA.tsx` | New component |
+| `apps/web/components/home/index.ts` | Added barrel export |
+| `apps/web/app/(public)/page.tsx` | Imported and placed component |
+| `apps/web/__tests__/components/kindroid-june-migration-cta.test.tsx` | 8 unit tests |
+| `apps/web/docs/pr-evidence/kindroid-june-migration-cta.md` | This file |


### PR DESCRIPTION
## Source
backlog.md:209

Add 'switching from Kindroid?' landing segment timed to Kindroid June 2 2026 mobile pricing change to capture wave migrators.

## Changes
- KindroidJuneMigrationCTA section on landing page
- 3+ unit tests

## Evidence
See docs/pr-evidence/kindroid-june-migration-cta.md for before/after copy diff.

## Auth-only Proof
N/A
