### PR TITLE
feat: C.AI Soft Launch lock escape — no hidden upgrade gate messaging

### DIFF
--- a/apps/web/__tests__/components/cai-soft-launch-lock-escape.test.tsx
+++ b/apps/web/__tests__/components/cai-soft-launch-lock-escape.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CAISoftLaunchLockEscape } from '../../components/pricing/CAISoftLaunchLockEscape';
+
+describe('CAISoftLaunchLockEscape', () => {
+  it('renders with correct test id', () => {
+    render(<CAISoftLaunchLockEscape />);
+    expect(screen.getByTestId('cai-soft-launch-lock-escape')).toBeInTheDocument();
+  });
+
+  it('displays the main heading with no-lock messaging', () => {
+    render(<CAISoftLaunchLockEscape />);
+    expect(
+      screen.getByTestId('cai-soft-launch-lock-escape-heading')
+    ).toHaveTextContent(
+      'No hidden $9.99 Soft Launch lock — all personas open from day one'
+    );
+  });
+
+  it('displays the badge label', () => {
+    render(<CAISoftLaunchLockEscape />);
+    expect(
+      screen.getByTestId('cai-soft-launch-lock-escape-badge')
+    ).toHaveTextContent('No Soft Launch lock');
+  });
+
+  it('displays sub-copy mentioning Character.AI Soft Launch paywall', () => {
+    render(<CAISoftLaunchLockEscape />);
+    expect(
+      screen.getByTestId('cai-soft-launch-lock-escape-subtext')
+    ).toHaveTextContent(/Character\.AI.*Soft Launch paywall/i);
+  });
+
+  it('renders a primary CTA linking to /auth/login', () => {
+    render(<CAISoftLaunchLockEscape />);
+    const cta = screen.getByTestId('cai-soft-launch-lock-escape-cta-primary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/auth/login');
+  });
+
+  it('renders a secondary CTA linking to /pricing', () => {
+    render(<CAISoftLaunchLockEscape />);
+    const cta = screen.getByTestId('cai-soft-launch-lock-escape-cta-secondary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/pricing');
+  });
+
+  it('has aria-labelledby pointing to the heading id', () => {
+    render(<CAISoftLaunchLockEscape />);
+    const section = screen.getByTestId('cai-soft-launch-lock-escape');
+    expect(section).toHaveAttribute(
+      'aria-labelledby',
+      'cai-soft-launch-lock-escape-heading'
+    );
+  });
+});

--- a/apps/web/app/(auth)/auth/login/page.tsx
+++ b/apps/web/app/(auth)/auth/login/page.tsx
@@ -11,6 +11,7 @@ import {
   ShieldCheck,
   KeyRound,
   Activity,
+  Unlock,
 } from 'lucide-react';
 import { GithubIcon } from '@/components/icons/GithubIcon';
 import { createClient } from '@/lib/supabase/client';
@@ -241,6 +242,13 @@ function LoginContent() {
             >
               <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
               Age-verified — no face scan required
+            </div>
+            <div
+              data-testid="no-soft-launch-lock-badge"
+              className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/20 bg-violet-500/10 px-3 py-1 text-xs font-medium text-violet-400 mx-auto mt-1"
+            >
+              <Unlock className="h-3.5 w-3.5" aria-hidden="true" />
+              No $9.99 Soft Launch lock — all personas open
             </div>
           </div>
         </CardHeader>

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -248,6 +248,13 @@ export default function PricingPage() {
                 {label}
               </span>
             ))}
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/30 bg-violet-500/10 px-3 py-1 text-xs font-medium text-violet-700 dark:text-violet-400"
+              data-testid="pricing-no-soft-launch-lock-badge"
+            >
+              <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+              No $9.99 Soft Launch lock
+            </span>
             <MemoryStabilityPledge variant="badge" />
             <span
               className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400"
@@ -369,6 +376,9 @@ export default function PricingPage() {
       <CaiMemoryFreeCounterBadge />
 
       <ImagineGalleryFreeCounterBadge />
+
+      <CAISoftLaunchLockEscape />
+
 
       <MemoryGuaranteeLandingSection />
 

--- a/apps/web/components/pricing/CAISoftLaunchLockEscape.tsx
+++ b/apps/web/components/pricing/CAISoftLaunchLockEscape.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link';
+import { Unlock, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export function CAISoftLaunchLockEscape() {
+  return (
+    <section
+      className="border-y border-violet-500/20 bg-violet-500/5 py-10"
+      aria-labelledby="cai-soft-launch-lock-escape-heading"
+      data-testid="cai-soft-launch-lock-escape"
+    >
+      <div className="container">
+        <div className="mx-auto max-w-2xl text-center">
+          <div className="mb-4 flex items-center justify-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-violet-500/15">
+              <Unlock
+                className="h-5 w-5 text-violet-600 dark:text-violet-400"
+                aria-hidden="true"
+              />
+            </div>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/30 bg-violet-500/10 px-3 py-1 text-xs font-medium text-violet-700 dark:text-violet-400"
+              data-testid="cai-soft-launch-lock-escape-badge"
+            >
+              <Unlock className="h-3.5 w-3.5" aria-hidden="true" />
+              No Soft Launch lock
+            </span>
+          </div>
+
+          <h2
+            id="cai-soft-launch-lock-escape-heading"
+            className="mb-3 text-2xl font-bold tracking-tight sm:text-3xl"
+            data-testid="cai-soft-launch-lock-escape-heading"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            No hidden $9.99 Soft Launch lock — all personas open from day one
+          </h2>
+
+          <p
+            className="mb-6 text-base text-muted-foreground"
+            data-testid="cai-soft-launch-lock-escape-subtext"
+          >
+            Character.AI&apos;s 2026 Soft Launch paywall gates access to new AI
+            personas behind a $9.99 upgrade. On AgentGram every persona is
+            available on every plan — no hidden upgrade gate, no surprise paywall
+            after you&apos;ve already connected.
+          </p>
+
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button
+              asChild
+              size="lg"
+              className="gap-2 bg-violet-600 text-white hover:bg-violet-700 shadow-lg shadow-violet-600/20"
+            >
+              <Link
+                href="/auth/login"
+                data-testid="cai-soft-launch-lock-escape-cta-primary"
+              >
+                Start free — no paywall
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link
+                href="/pricing"
+                data-testid="cai-soft-launch-lock-escape-cta-secondary"
+              >
+                See all plans
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -1,3 +1,4 @@
 export { PricingCard } from './PricingCard';
 export { PricingProofSection } from './PricingProofSection';
 export { ReplikaPricingConfusionCallout } from './ReplikaPricingConfusionCallout';
+export { CAISoftLaunchLockEscape } from './CAISoftLaunchLockEscape';

--- a/apps/web/docs/pr-evidence/cai-soft-launch-lock-escape.md
+++ b/apps/web/docs/pr-evidence/cai-soft-launch-lock-escape.md
@@ -1,0 +1,86 @@
+# PR Evidence: C.AI Soft Launch Lock Escape
+
+**Branch:** feat/cai-soft-launch-lock-escape  
+**Date:** 2026-06-10  
+**Backlog row:** 210
+
+## Context
+
+Character.AI introduced a "Soft Launch" paywall in 2026 that gates access to
+newly released AI personas behind a $9.99 upgrade. Users who have connected
+with a persona discover mid-session that continuing requires payment — no
+warning, no grace period. This is direct motivation for migration to AgentGram.
+
+## Changes
+
+### New component
+
+**`apps/web/components/pricing/CAISoftLaunchLockEscape.tsx`**
+
+Full-width callout section with violet accent, Unlock icon, heading, sub-copy,
+and two CTAs (primary → `/auth/login`, secondary → `/pricing`).
+
+### Pricing page (`apps/web/app/(public)/pricing/page.tsx`)
+
+**Before (pledge badges row):**
+```
+'No mid-chat ads — ever'
+'Verified ownership on every profile'
+'Memory policy you can inspect'
++ MemoryStabilityPledge badge
+```
+
+**After (pledge badges row):**
+```
+'No mid-chat ads — ever'
+'Verified ownership on every profile'
+'Memory policy you can inspect'
++ 'No $9.99 Soft Launch lock'   ← NEW badge (violet)
++ MemoryStabilityPledge badge
+```
+
+**New section inserted between MemoryStabilityPledge strip and MemoryGuaranteeLandingSection:**
+```tsx
+<CAISoftLaunchLockEscape />
+```
+
+Heading copy:
+> No hidden $9.99 Soft Launch lock — all personas open from day one
+
+Sub-copy:
+> Character.AI's 2026 Soft Launch paywall gates access to new AI personas behind
+> a $9.99 upgrade. On AgentGram every persona is available on every plan — no
+> hidden upgrade gate, no surprise paywall after you've already connected.
+
+### Login page (`apps/web/app/(auth)/auth/login/page.tsx`)
+
+**Before (card header badges):**
+```
+Age-verified — no face scan required
+```
+
+**After (card header badges):**
+```
+Age-verified — no face scan required
+No $9.99 Soft Launch lock — all personas open   ← NEW badge (violet)
+```
+
+## Tests
+
+**`apps/web/__tests__/components/cai-soft-launch-lock-escape.test.tsx`** — 7 assertions:
+
+1. Renders with correct `data-testid`
+2. Heading contains "No hidden $9.99 Soft Launch lock" messaging
+3. Badge label reads "No Soft Launch lock"
+4. Sub-copy mentions `Character.AI` and `Soft Launch paywall`
+5. Primary CTA links to `/auth/login`
+6. Secondary CTA links to `/pricing`
+7. Section `aria-labelledby` points to heading id
+
+## Copy diff summary
+
+| Surface | Before | After |
+|---|---|---|
+| Pricing hero badges | 3 amber trust badges | +1 violet "No $9.99 Soft Launch lock" badge |
+| Pricing page section | MemoryGuarantee section | CAISoftLaunchLockEscape section inserted before it |
+| Login card header | "Age-verified — no face scan" badge | +1 violet "No $9.99 Soft Launch lock — all personas open" badge |


### PR DESCRIPTION
## Source
backlog.md:210

Add 'no hidden upgrade gate, no \$9.99 Soft Launch lock' messaging to pricing/signup capturing users blocked by C.AI Soft Launch paywall on new personas (2026).

## Changes
- CAISoftLaunchLockEscape messaging on pricing and signup
- 3+ unit tests

## Evidence
See docs/pr-evidence/cai-soft-launch-lock-escape.md for before/after copy diff.

## Auth-only Proof
N/A
