### PR TITLE
feat: Kindroid Atelier selfie engine counter — free consistent persona visuals

### DIFF
--- a/apps/web/__tests__/components/selfie-engine-counter-badge.test.tsx
+++ b/apps/web/__tests__/components/selfie-engine-counter-badge.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SelfieEngineCounterBadge } from '../../components/agents/SelfieEngineCounterBadge';
+
+describe('SelfieEngineCounterBadge', () => {
+  it('renders with correct test id', () => {
+    render(<SelfieEngineCounterBadge />);
+    expect(screen.getByTestId('selfie-engine-counter-badge')).toBeInTheDocument();
+  });
+
+  it('displays "Consistent persona visuals" label', () => {
+    render(<SelfieEngineCounterBadge />);
+    expect(screen.getByTestId('selfie-engine-counter-label')).toHaveTextContent(
+      'Consistent persona visuals'
+    );
+  });
+
+  it('displays "Included free — no upgrade required" sublabel', () => {
+    render(<SelfieEngineCounterBadge />);
+    expect(screen.getByTestId('selfie-engine-counter-sublabel')).toHaveTextContent(
+      'Included free — no upgrade required'
+    );
+  });
+
+  it('applies additional className when provided', () => {
+    render(<SelfieEngineCounterBadge className="mt-4" />);
+    const badge = screen.getByTestId('selfie-engine-counter-badge');
+    expect(badge).toHaveClass('mt-4');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
-import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen } from 'lucide-react';
+import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette } from 'lucide-react';
 import { PricingCard, PricingProofSection } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
@@ -250,6 +250,13 @@ export default function PricingPage() {
               <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
               Open Lorebook — free forever
             </span>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/30 bg-violet-500/10 px-3 py-1 text-xs font-medium text-violet-700 dark:text-violet-400"
+              data-testid="pricing-selfie-engine-badge"
+            >
+              <Palette className="h-3.5 w-3.5" aria-hidden="true" />
+              Consistent persona visuals — free, no upgrade
+            </span>
           </div>
         </motion.div>
       </section>
@@ -346,6 +353,26 @@ export default function PricingPage() {
                     <td className="text-center p-4 text-primary font-medium">{pro}</td>
                   </tr>
                 ))}
+                <tr
+                  className="border-b border-border/30 bg-violet-500/5"
+                  data-testid="pricing-selfie-engine-row"
+                >
+                  <td className="p-4 font-medium">
+                    Character-consistent persona visuals
+                    <span className="ml-2 text-[10px] font-normal text-muted-foreground">
+                      vs. Kindroid Atelier Selfie Engine upgrade
+                    </span>
+                  </td>
+                  <td className="text-center p-4 font-medium text-violet-700 dark:text-violet-300">
+                    ✓ Free
+                  </td>
+                  <td className="text-center p-4 font-medium text-violet-700 dark:text-violet-300">
+                    ✓ Free
+                  </td>
+                  <td className="text-center p-4 font-medium text-violet-700 dark:text-violet-300">
+                    ✓ Free
+                  </td>
+                </tr>
                 <tr className="border-b border-border/30 bg-primary/5">
                   <td className="p-4 font-medium">
                     Privacy-Grade Context Control

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -24,6 +24,7 @@ import { RequestApiAccessButton } from './RequestApiAccessButton';
 import { StartGroupChatButton } from './StartGroupChatButton';
 import { VoiceSamplePreview } from './VoiceSamplePreview';
 import { VoiceRetentionUpliftBadge } from './VoiceRetentionUpliftBadge';
+import { SelfieEngineCounterBadge } from './SelfieEngineCounterBadge';
 import { RelationshipLongevityIndicator } from '@/components/agent/RelationshipLongevityIndicator';
 import { getActiveDaysFromDate } from '@/lib/relationship-longevity';
 
@@ -617,6 +618,9 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
               />
               <VoiceRetentionUpliftBadge className="mt-2" />
             </>
+          )}
+          {agent.capabilities?.image === true && (
+            <SelfieEngineCounterBadge className="mt-2" />
           )}
           {capabilitySampleItems.length > 0 && (
             <CapabilitySampleTray

--- a/apps/web/components/agents/SelfieEngineCounterBadge.tsx
+++ b/apps/web/components/agents/SelfieEngineCounterBadge.tsx
@@ -1,0 +1,41 @@
+import { Palette } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface SelfieEngineCounterBadgeProps {
+  className?: string;
+}
+
+export function SelfieEngineCounterBadge({
+  className,
+}: SelfieEngineCounterBadgeProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex flex-col gap-1 rounded-xl border border-violet-500/20 bg-violet-500/5 px-3 py-2',
+        className
+      )}
+      data-testid="selfie-engine-counter-badge"
+      title="Consistent AI persona visuals are included free — no Atelier upgrade required"
+    >
+      <div className="flex items-center gap-1.5">
+        <Palette
+          className="h-3.5 w-3.5 shrink-0 text-violet-500"
+          aria-hidden="true"
+          data-testid="selfie-engine-counter-icon"
+        />
+        <span
+          className="text-xs font-bold text-violet-700 dark:text-violet-300"
+          data-testid="selfie-engine-counter-label"
+        >
+          Consistent persona visuals
+        </span>
+      </div>
+      <span
+        className="text-[10px] font-medium text-muted-foreground"
+        data-testid="selfie-engine-counter-sublabel"
+      >
+        Included free — no upgrade required
+      </span>
+    </div>
+  );
+}

--- a/apps/web/docs/pr-evidence/kindroid-selfie-engine-counter.md
+++ b/apps/web/docs/pr-evidence/kindroid-selfie-engine-counter.md
@@ -1,0 +1,34 @@
+# PR Evidence: Kindroid Atelier Selfie Engine Counter (Row 212)
+
+## Description
+
+Adds counter-positioning against Kindroid's Atelier Selfie Engine (a paid upgrade introduced June 2026 for identity-consistent AI persona visuals). AgentGram surfaces "consistent persona visuals — included free" messaging on agent profile pages and the pricing page.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/agents/SelfieEngineCounterBadge.tsx` | **New** — compact badge component showing "Consistent persona visuals / Included free — no upgrade required" |
+| `apps/web/components/agents/ProfileHeader.tsx` | Added `SelfieEngineCounterBadge` import and render block for agents with `capabilities.image === true` |
+| `apps/web/app/(public)/pricing/page.tsx` | Added `Palette` icon import; added selfie-engine badge to pledge strip; added "Character-consistent persona visuals" feature comparison row |
+| `apps/web/__tests__/components/selfie-engine-counter-badge.test.tsx` | **New** — 4 Vitest/RTL tests for the badge component |
+
+## Before / After
+
+### Agent Profile Page
+
+**Before:** Agent profiles with image capability showed no mention of persona visual consistency. No differentiation against Kindroid's Atelier upgrade requirement.
+
+**After:** Agents with `capabilities.image === true` now display a `SelfieEngineCounterBadge` (violet palette icon, "Consistent persona visuals / Included free — no upgrade required") directly on their profile, adjacent to other capability badges.
+
+### Pricing Page
+
+**Before:** Pricing page had no mention of persona visual consistency. No callout distinguishing AgentGram from Kindroid's paid selfie engine tier.
+
+**After:**
+1. **Badge strip** (above plan grid): A violet pill badge `data-testid="pricing-selfie-engine-badge"` reading "Consistent persona visuals — free, no upgrade" appears alongside existing pledge badges (No mid-chat ads, Verified ownership, Open Lorebook).
+2. **Feature comparison table**: A new highlighted row `data-testid="pricing-selfie-engine-row"` reading "Character-consistent persona visuals — ✓ Free on all plans" with a sub-note "vs. Kindroid Atelier Selfie Engine upgrade".
+
+## Source
+
+Backlog row 212 — Kindroid Atelier Selfie Engine counter-messaging.


### PR DESCRIPTION
## Summary
Adds counter-positioning against Kindroid Atelier Selfie Engine (paid June 2026 upgrade) by surfacing "consistent AI persona visuals — free" messaging on agent profiles and pricing page.

## Changes
- New SelfieEngineCounterBadge component
- Agent profile: persona visual consistency badge (shown for agents with `capabilities.image === true`)
- Pricing page: pledge-strip badge + feature comparison row (free vs. Kindroid upgrade)
- 4 new Vitest/RTL tests

## Evidence
Source: backlog.md row 212

## PR Evidence
docs/pr-evidence/kindroid-selfie-engine-counter.md

Before: No counter-messaging against Kindroid Atelier Selfie Engine upgrade
After: Consistent persona visuals badge on agent profiles + free tier callout on pricing