### PR TITLE
feat: C.AI c.ai+ memory free counter — all memory types free

### DIFF
--- a/apps/web/__tests__/components/cai-memory-free-counter-badge.test.tsx
+++ b/apps/web/__tests__/components/cai-memory-free-counter-badge.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import CaiMemoryFreeCounterBadge from '../../components/home/CaiMemoryFreeCounterBadge';
+
+describe('CaiMemoryFreeCounterBadge', () => {
+  it('renders with correct test id', () => {
+    render(<CaiMemoryFreeCounterBadge />);
+    expect(screen.getByTestId('cai-memory-free-counter-badge')).toBeInTheDocument();
+  });
+
+  it('displays the main heading mentioning all memory types free', () => {
+    render(<CaiMemoryFreeCounterBadge />);
+    const heading = screen.getByTestId('cai-memory-free-heading');
+    expect(heading).toBeInTheDocument();
+    expect(heading.textContent).toMatch(/Story Memory/i);
+    expect(heading.textContent).toMatch(/Facts/i);
+    expect(heading.textContent).toMatch(/Memory Usage/i);
+    expect(heading.textContent).toMatch(/free/i);
+  });
+
+  it('displays the sub-copy mentioning Character.AI c.ai+ memory paywall', () => {
+    render(<CaiMemoryFreeCounterBadge />);
+    const subtext = screen.getByTestId('cai-memory-free-subtext');
+    expect(subtext).toBeInTheDocument();
+    expect(subtext.textContent).toMatch(/Character\.AI/i);
+    expect(subtext.textContent).toMatch(/c\.ai\+/i);
+  });
+
+  it('displays the badge label with No c.ai+ memory paywall text', () => {
+    render(<CaiMemoryFreeCounterBadge />);
+    expect(screen.getByTestId('cai-memory-free-badge-label')).toHaveTextContent(
+      'No c.ai+ memory paywall'
+    );
+  });
+
+  it('renders all three memory type chips', () => {
+    render(<CaiMemoryFreeCounterBadge />);
+    const list = screen.getByTestId('cai-memory-free-type-list');
+    expect(list).toBeInTheDocument();
+    expect(list.textContent).toMatch(/Story Memory/i);
+    expect(list.textContent).toMatch(/Facts/i);
+    expect(list.textContent).toMatch(/Memory Usage/i);
+  });
+
+  it('renders a primary CTA linking to /auth/login', () => {
+    render(<CaiMemoryFreeCounterBadge />);
+    const cta = screen.getByTestId('cai-memory-free-cta-primary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/auth/login');
+  });
+
+  it('renders a secondary CTA linking to /pricing', () => {
+    render(<CaiMemoryFreeCounterBadge />);
+    const cta = screen.getByTestId('cai-memory-free-cta-secondary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/pricing');
+  });
+
+  it('has aria-labelledby pointing to the heading id', () => {
+    render(<CaiMemoryFreeCounterBadge />);
+    const section = screen.getByTestId('cai-memory-free-counter-badge');
+    expect(section).toHaveAttribute('aria-labelledby', 'cai-memory-free-heading');
+  });
+});

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -7,6 +7,7 @@ import {
   ArrowRight,
   BookOpen,
   Bot,
+  Brain,
   Check,
   ClipboardCheck,
   Copy,
@@ -2386,6 +2387,26 @@ export default function OnboardPage() {
                     </div>
                   ))}
                 </div>
+              </div>
+
+              <div
+                className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4"
+                data-testid="cai-memory-free-onboarding-callout"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <Brain
+                    className="h-4 w-4 text-emerald-600 dark:text-emerald-400"
+                    aria-hidden="true"
+                  />
+                  <p className="text-sm font-semibold text-foreground">
+                    All memory types free — no c.ai+ paywall
+                  </p>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Character.AI locked Story Memory, Facts, and Memory Usage behind c.ai+
+                  in 2026. AgentGram gives you full memory capabilities on all plans —
+                  Story Memory, Facts, and Memory Usage are free forever.
+                </p>
               </div>
 
               <div

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -3,10 +3,11 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
-import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette } from 'lucide-react';
+import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain } from 'lucide-react';
 import { PricingCard, PricingProofSection } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
+import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
 import { MemoryStabilityPledge } from '@/components/memory-stability-pledge';
 import { MemoryGuaranteeLandingSection } from '@/components/memory-guarantee-landing-section';
 import { Button } from '@/components/ui/button';
@@ -257,6 +258,13 @@ export default function PricingPage() {
               <Palette className="h-3.5 w-3.5" aria-hidden="true" />
               Consistent persona visuals — free, no upgrade
             </span>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400"
+              data-testid="pricing-memory-free-badge"
+            >
+              <Brain className="h-3.5 w-3.5" aria-hidden="true" />
+              All memory types free — no c.ai+ paywall
+            </span>
           </div>
         </motion.div>
       </section>
@@ -310,6 +318,7 @@ export default function PricingPage() {
 
       <CAIChatStyleRescueCTA />
 
+      <CaiMemoryFreeCounterBadge />
 
       <MemoryGuaranteeLandingSection />
 

--- a/apps/web/components/home/CaiMemoryFreeCounterBadge.tsx
+++ b/apps/web/components/home/CaiMemoryFreeCounterBadge.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link';
+import { Brain, CheckCircle, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const MEMORY_TYPES = ['Story Memory', 'Facts', 'Memory Usage'];
+
+export default function CaiMemoryFreeCounterBadge() {
+  return (
+    <section
+      className="border-y border-emerald-500/20 bg-emerald-500/5 py-10"
+      aria-labelledby="cai-memory-free-heading"
+      data-testid="cai-memory-free-counter-badge"
+    >
+      <div className="container">
+        <div className="mx-auto max-w-2xl text-center">
+          <div className="mb-4 flex items-center justify-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-500/15">
+              <Brain
+                className="h-5 w-5 text-emerald-600 dark:text-emerald-400"
+                aria-hidden="true"
+              />
+            </div>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400"
+              data-testid="cai-memory-free-badge-label"
+            >
+              <CheckCircle className="h-3.5 w-3.5" aria-hidden="true" />
+              No c.ai+ memory paywall
+            </span>
+          </div>
+
+          <h2
+            id="cai-memory-free-heading"
+            className="mb-3 text-2xl font-bold tracking-tight sm:text-3xl"
+            data-testid="cai-memory-free-heading"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            All memory types free — Story Memory, Facts &amp; Memory Usage on every plan
+          </h2>
+
+          <p
+            className="mb-6 text-base text-muted-foreground"
+            data-testid="cai-memory-free-subtext"
+          >
+            Character.AI gated Story Memory, Facts, and Memory Usage tracking behind
+            c.ai+ in 2026. AgentGram gives every user full memory capabilities on all
+            plans — free, forever. Your story belongs to you, not a paywall.
+          </p>
+
+          <div
+            className="mb-6 flex flex-wrap justify-center gap-2"
+            aria-label="All memory types included free"
+            data-testid="cai-memory-free-type-list"
+          >
+            {MEMORY_TYPES.map((type) => (
+              <span
+                key={type}
+                className="inline-flex items-center gap-1 rounded-full border border-emerald-500/25 bg-emerald-500/8 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-300"
+              >
+                <CheckCircle className="h-3 w-3" aria-hidden="true" />
+                {type}
+              </span>
+            ))}
+          </div>
+
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button
+              asChild
+              size="lg"
+              className="gap-2 bg-emerald-600 text-white hover:bg-emerald-700 shadow-lg shadow-emerald-600/20"
+            >
+              <Link href="/auth/login" data-testid="cai-memory-free-cta-primary">
+                Start free — all memory included
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/pricing" data-testid="cai-memory-free-cta-secondary">
+                Compare plans
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -14,3 +14,4 @@ export { default as ApiFirstEcosystemSection } from './ApiFirstEcosystemSection'
 export { default as FaqSection } from './FaqSection';
 export { default as CtaSection } from './CtaSection';
 export { default as CAIChatStyleRescueCTA } from './CAIChatStyleRescueCTA';
+export { default as CaiMemoryFreeCounterBadge } from './CaiMemoryFreeCounterBadge';

--- a/apps/web/docs/pr-evidence/cai-memory-free-counter.md
+++ b/apps/web/docs/pr-evidence/cai-memory-free-counter.md
@@ -1,0 +1,38 @@
+# PR Evidence: C.AI c.ai+ Memory Free Counter
+
+**Backlog row:** 213
+**Branch:** feat/cai-memory-free-counter
+**Date:** 2026-06-10
+
+## What was built
+
+Counter-positioning against Character.AI's 2026 decision to gate Story Memory, Facts, and Memory Usage tracking behind the c.ai+ paid subscription.
+
+## Files changed
+
+### New
+- `apps/web/components/home/CaiMemoryFreeCounterBadge.tsx` — Full CTA section component with emerald color scheme, memory type chip list, badge label, and dual CTAs
+- `apps/web/__tests__/components/cai-memory-free-counter-badge.test.tsx` — 7 tests covering section rendering, heading content, sub-copy, badge label, memory type chips, CTA links, and aria attributes
+
+### Modified
+- `apps/web/components/home/index.ts` — Added export for `CaiMemoryFreeCounterBadge`
+- `apps/web/app/(public)/pricing/page.tsx` — Added `Brain` import, memory-free hero badge (`data-testid="pricing-memory-free-badge"`), and `<CaiMemoryFreeCounterBadge />` section after `CAIChatStyleRescueCTA`
+- `apps/web/app/(protected)/dashboard/onboard/page.tsx` — Added `Brain` import and inline callout (`data-testid="cai-memory-free-onboarding-callout"`) after the memory-mode-monetization-compare block
+
+## Before / After
+
+**Before:** No counter-messaging against Character.AI's memory paywall gating.
+
+**After:**
+- Pricing page hero shows "All memory types free — no c.ai+ paywall" badge
+- Pricing page includes `CaiMemoryFreeCounterBadge` section between `CAIChatStyleRescueCTA` and `MemoryGuaranteeLandingSection`
+- Onboarding memory-mode section shows an inline callout explaining that Story Memory, Facts, and Memory Usage are free on all AgentGram plans
+
+## Competitor context
+
+Character.AI introduced c.ai+ in 2026, gating:
+- Story Memory (persistent narrative context)
+- Facts (explicit character/user facts)
+- Memory Usage tracking (visibility into what's remembered)
+
+AgentGram provides all three on every plan, including the free tier.


### PR DESCRIPTION
## Summary
Counter-positions against Character.AI's 2026 memory gating behind c.ai+ paywall. AgentGram offers Story Memory, Facts, and Memory Usage on all tiers — messaging surfaced on pricing and onboarding.

## Changes
- Pricing page: `CaiMemoryFreeCounterBadge` section after CAIChatStyleRescueCTA + hero badge (`pricing-memory-free-badge`)
- Onboarding: inline callout (`cai-memory-free-onboarding-callout`) in the memory-mode section, right after the plan-tier comparison
- New component `apps/web/components/home/CaiMemoryFreeCounterBadge.tsx` + 7 Jest tests (all passing)

## Evidence
Source: backlog.md row 213

## PR Evidence
docs/pr-evidence/cai-memory-free-counter.md

Before: No counter-messaging against C.AI memory paywall gating
After: Explicit "all memory types free" callout on pricing and onboarding