### PR TITLE
feat: Nomi Voice latency parity stat — sub-2s voice response badge

### DIFF
--- a/apps/web/__tests__/components/voice-latency-stat-badge.test.tsx
+++ b/apps/web/__tests__/components/voice-latency-stat-badge.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { VoiceLatencyStatBadge } from '../../components/agents/VoiceLatencyStatBadge';
+
+describe('VoiceLatencyStatBadge', () => {
+  it('renders the badge container with correct test id', () => {
+    render(<VoiceLatencyStatBadge />);
+    expect(screen.getByTestId('voice-latency-stat-badge')).toBeInTheDocument();
+  });
+
+  it('displays the sub-2s latency stat', () => {
+    render(<VoiceLatencyStatBadge />);
+    expect(screen.getByTestId('voice-latency-stat-value')).toHaveTextContent(
+      '< 2s voice response'
+    );
+  });
+
+  it('displays the Nomi V3 parity attribution', () => {
+    render(<VoiceLatencyStatBadge />);
+    expect(
+      screen.getByTestId('voice-latency-stat-attribution')
+    ).toHaveTextContent('Nomi V3 parity');
+  });
+
+  it('includes a tooltip referencing the Nomi V3 benchmark', () => {
+    render(<VoiceLatencyStatBadge />);
+    const badge = screen.getByTestId('voice-latency-stat-badge');
+    expect(badge).toHaveAttribute(
+      'title',
+      "Voice responses under 2 seconds — matches Nomi V3's 1–1.5s benchmark"
+    );
+  });
+
+  it('renders the zap icon', () => {
+    render(<VoiceLatencyStatBadge />);
+    expect(screen.getByTestId('voice-latency-stat-icon')).toBeInTheDocument();
+  });
+
+  it('accepts and applies a custom className', () => {
+    render(<VoiceLatencyStatBadge className="custom-class" />);
+    const badge = screen.getByTestId('voice-latency-stat-badge');
+    expect(badge).toHaveClass('custom-class');
+  });
+});

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -25,6 +25,7 @@ import { StartGroupChatButton } from './StartGroupChatButton';
 import { VoiceSamplePreview } from './VoiceSamplePreview';
 import { VoiceRetentionUpliftBadge } from './VoiceRetentionUpliftBadge';
 import { SelfieEngineCounterBadge } from './SelfieEngineCounterBadge';
+import { VoiceLatencyStatBadge } from './VoiceLatencyStatBadge';
 import { RelationshipLongevityIndicator } from '@/components/agent/RelationshipLongevityIndicator';
 import { getActiveDaysFromDate } from '@/lib/relationship-longevity';
 
@@ -616,7 +617,10 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
                 className="mt-4"
                 data-testid="profile-voice-sample-preview"
               />
-              <VoiceRetentionUpliftBadge className="mt-2" />
+              <div className="mt-2 flex flex-wrap gap-2">
+                <VoiceRetentionUpliftBadge />
+                <VoiceLatencyStatBadge />
+              </div>
             </>
           )}
           {agent.capabilities?.image === true && (

--- a/apps/web/components/agents/VoiceLatencyStatBadge.tsx
+++ b/apps/web/components/agents/VoiceLatencyStatBadge.tsx
@@ -1,0 +1,39 @@
+import { Zap } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface VoiceLatencyStatBadgeProps {
+  className?: string;
+}
+
+export function VoiceLatencyStatBadge({ className }: VoiceLatencyStatBadgeProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex flex-col gap-1 rounded-xl border border-green-500/20 bg-green-500/5 px-3 py-2',
+        className
+      )}
+      data-testid="voice-latency-stat-badge"
+      title="Voice responses under 2 seconds — matches Nomi V3's 1–1.5s benchmark"
+    >
+      <div className="flex items-center gap-1.5">
+        <Zap
+          className="h-3.5 w-3.5 shrink-0 text-green-600 dark:text-green-400"
+          aria-hidden="true"
+          data-testid="voice-latency-stat-icon"
+        />
+        <span
+          className="text-xs font-bold text-green-700 dark:text-green-300"
+          data-testid="voice-latency-stat-value"
+        >
+          &lt; 2s voice response
+        </span>
+      </div>
+      <span
+        className="text-[10px] font-medium text-muted-foreground"
+        data-testid="voice-latency-stat-attribution"
+      >
+        Nomi V3 parity
+      </span>
+    </div>
+  );
+}

--- a/apps/web/components/subscription/PaywallPreviewModal.tsx
+++ b/apps/web/components/subscription/PaywallPreviewModal.tsx
@@ -6,6 +6,7 @@ import { Lock, Mic, ImageIcon, Brain, Zap } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { VoiceRetentionUpliftBadge } from '@/components/agents/VoiceRetentionUpliftBadge';
+import { VoiceLatencyStatBadge } from '@/components/agents/VoiceLatencyStatBadge';
 import {
   Dialog,
   DialogContent,
@@ -89,7 +90,10 @@ export function PaywallPreviewModal({
                 </div>
               </div>
               {feature.title === 'Voice responses' && (
-                <VoiceRetentionUpliftBadge className="mt-1.5" />
+                <div className="mt-1.5 flex flex-wrap gap-2">
+                  <VoiceRetentionUpliftBadge />
+                  <VoiceLatencyStatBadge />
+                </div>
               )}
             </div>
           ))}

--- a/apps/web/docs/pr-evidence/nomi-voice-latency-stat.md
+++ b/apps/web/docs/pr-evidence/nomi-voice-latency-stat.md
@@ -1,0 +1,87 @@
+# PR Evidence: Nomi Voice Latency Parity Stat
+
+**Branch:** feat/nomi-voice-latency-stat  
+**Date:** 2026-06-10  
+**Backlog row:** 214
+
+## Context
+
+Nomi V3 launched in 2026 with 1–1.5s voice response latency as a key marketing claim.
+This PR adds a "< 2s voice response" latency stat badge to the voice plan upgrade CTA and
+agent capability pages, establishing AgentGram's Nomi V3 parity position in product copy.
+
+---
+
+## New Component
+
+### `apps/web/components/agents/VoiceLatencyStatBadge.tsx`
+
+A marketing stat badge that surfaces the sub-2s voice latency claim inline with the voice
+upgrade CTA. Mirrors the `VoiceRetentionUpliftBadge` layout pattern (green tier, Zap icon,
+attribution line).
+
+**Props:** `{ className?: string }`  
+**Test ID:** `voice-latency-stat-badge`  
+**Stat copy:** `< 2s voice response`  
+**Attribution:** `Nomi V3 parity`  
+**Tooltip:** `Voice responses under 2 seconds — matches Nomi V3's 1–1.5s benchmark`
+
+---
+
+## Before / After Placement
+
+### `apps/web/components/subscription/PaywallPreviewModal.tsx`
+
+**Before** — only `VoiceRetentionUpliftBadge` shown after "Voice responses" feature row:
+
+```tsx
+{feature.title === 'Voice responses' && (
+  <VoiceRetentionUpliftBadge className="mt-1.5" />
+)}
+```
+
+**After** — `VoiceLatencyStatBadge` added alongside `VoiceRetentionUpliftBadge`:
+
+```tsx
+{feature.title === 'Voice responses' && (
+  <div className="mt-1.5 flex flex-wrap gap-2">
+    <VoiceRetentionUpliftBadge />
+    <VoiceLatencyStatBadge />
+  </div>
+)}
+```
+
+---
+
+### `apps/web/components/agents/ProfileHeader.tsx`
+
+**Before** — only `VoiceRetentionUpliftBadge` shown in voice capabilities section:
+
+```tsx
+<VoiceRetentionUpliftBadge className="mt-2" />
+```
+
+**After** — `VoiceLatencyStatBadge` added alongside `VoiceRetentionUpliftBadge`:
+
+```tsx
+<div className="mt-2 flex flex-wrap gap-2">
+  <VoiceRetentionUpliftBadge />
+  <VoiceLatencyStatBadge />
+</div>
+```
+
+---
+
+## Test Coverage
+
+**File:** `apps/web/__tests__/components/voice-latency-stat-badge.test.tsx`  
+**Tests:** 6
+
+| # | Test | Assertion |
+|---|------|-----------|
+| 1 | renders badge container | `data-testid="voice-latency-stat-badge"` present |
+| 2 | displays latency stat | `< 2s voice response` text |
+| 3 | displays Nomi V3 attribution | `Nomi V3 parity` text |
+| 4 | tooltip references benchmark | `title` matches Nomi V3 benchmark copy |
+| 5 | renders zap icon | `data-testid="voice-latency-stat-icon"` present |
+| 6 | accepts custom className | class applied to badge container |


### PR DESCRIPTION
## Summary
Adds "sub-2s voice response" latency claim to voice plan upgrade CTA and agent capability cards, establishing Nomi V3 voice latency parity in product copy.

## Changes
- VoiceLatencyStatBadge component (green stat badge, Zap icon, "< 2s voice response" / "Nomi V3 parity" attribution)
- Voice plan upgrade CTA (PaywallPreviewModal): latency stat badge alongside existing VoiceRetentionUpliftBadge
- Agent capability pages (ProfileHeader): latency stat badge alongside existing VoiceRetentionUpliftBadge
- 6 new Vitest tests (all passing)

## Evidence
Source: backlog.md row 214

## PR Evidence
docs/pr-evidence/nomi-voice-latency-stat.md

Before: No voice latency stat in CTA or capability cards
After: Sub-2s voice response badge on voice plan CTA and agent capability pages