### PR TITLE
feat: C.AI Imagine Gallery free counter — image gen free on all tiers

### DIFF
--- a/apps/web/__tests__/components/imagine-gallery-free-counter-badge.test.tsx
+++ b/apps/web/__tests__/components/imagine-gallery-free-counter-badge.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ImagineGalleryFreeCounterBadge from '../../components/home/ImagineGalleryFreeCounterBadge';
+
+describe('ImagineGalleryFreeCounterBadge', () => {
+  it('renders with correct test id', () => {
+    render(<ImagineGalleryFreeCounterBadge />);
+    expect(screen.getByTestId('imagine-gallery-free-counter-badge')).toBeInTheDocument();
+  });
+
+  it('displays the main heading mentioning free AI image generation', () => {
+    render(<ImagineGalleryFreeCounterBadge />);
+    const heading = screen.getByTestId('imagine-gallery-free-heading');
+    expect(heading).toBeInTheDocument();
+    expect(heading.textContent).toMatch(/image generation/i);
+    expect(heading.textContent).toMatch(/free/i);
+  });
+
+  it('displays the sub-copy mentioning Character.AI c.ai+ paywall', () => {
+    render(<ImagineGalleryFreeCounterBadge />);
+    const subtext = screen.getByTestId('imagine-gallery-free-subtext');
+    expect(subtext).toBeInTheDocument();
+    expect(subtext.textContent).toMatch(/Character\.AI/i);
+    expect(subtext.textContent).toMatch(/c\.ai\+/i);
+  });
+
+  it('displays the badge label with No c.ai+ paywall text', () => {
+    render(<ImagineGalleryFreeCounterBadge />);
+    expect(screen.getByTestId('imagine-gallery-free-badge-label')).toHaveTextContent(
+      'No c.ai+ paywall'
+    );
+  });
+
+  it('renders a primary CTA linking to /auth/login', () => {
+    render(<ImagineGalleryFreeCounterBadge />);
+    const cta = screen.getByTestId('imagine-gallery-free-cta-primary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/auth/login');
+  });
+
+  it('renders a secondary CTA linking to /pricing', () => {
+    render(<ImagineGalleryFreeCounterBadge />);
+    const cta = screen.getByTestId('imagine-gallery-free-cta-secondary');
+    expect(cta).toBeInTheDocument();
+    expect(cta.closest('a')).toHaveAttribute('href', '/pricing');
+  });
+
+  it('has aria-labelledby pointing to the heading id', () => {
+    render(<ImagineGalleryFreeCounterBadge />);
+    const section = screen.getByTestId('imagine-gallery-free-counter-badge');
+    expect(section).toHaveAttribute('aria-labelledby', 'imagine-gallery-free-heading');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -3,11 +3,12 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
-import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain } from 'lucide-react';
+import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon } from 'lucide-react';
 import { PricingCard, PricingProofSection } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
+import ImagineGalleryFreeCounterBadge from '@/components/home/ImagineGalleryFreeCounterBadge';
 import { MemoryStabilityPledge } from '@/components/memory-stability-pledge';
 import { MemoryGuaranteeLandingSection } from '@/components/memory-guarantee-landing-section';
 import { Button } from '@/components/ui/button';
@@ -265,6 +266,13 @@ export default function PricingPage() {
               <Brain className="h-3.5 w-3.5" aria-hidden="true" />
               All memory types free — no c.ai+ paywall
             </span>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400"
+              data-testid="pricing-image-gen-badge"
+            >
+              <ImageIcon className="h-3.5 w-3.5" aria-hidden="true" />
+              AI Image Gen — free for all
+            </span>
           </div>
         </motion.div>
       </section>
@@ -319,6 +327,8 @@ export default function PricingPage() {
       <CAIChatStyleRescueCTA />
 
       <CaiMemoryFreeCounterBadge />
+
+      <ImagineGalleryFreeCounterBadge />
 
       <MemoryGuaranteeLandingSection />
 
@@ -379,6 +389,29 @@ export default function PricingPage() {
                     ✓ Free
                   </td>
                   <td className="text-center p-4 font-medium text-violet-700 dark:text-violet-300">
+                    ✓ Free
+                  </td>
+                </tr>
+                <tr
+                  className="border-b border-border/30 bg-emerald-500/5"
+                  data-testid="pricing-image-gen-row"
+                >
+                  <td className="p-4 font-medium">
+                    AI Image Generation
+                    <span className="ml-2 inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400">
+                      vs. c.ai+ exclusive
+                    </span>
+                  </td>
+                  <td
+                    className="text-center p-4 text-emerald-700 dark:text-emerald-400 font-medium"
+                    data-testid="pricing-image-gen-free-free"
+                  >
+                    ✓ Free
+                  </td>
+                  <td className="text-center p-4 text-emerald-700 dark:text-emerald-400 font-medium">
+                    ✓ Free
+                  </td>
+                  <td className="text-center p-4 text-emerald-700 dark:text-emerald-400 font-medium">
                     ✓ Free
                   </td>
                 </tr>

--- a/apps/web/components/agents/ImagineGalleryFreeBadge.tsx
+++ b/apps/web/components/agents/ImagineGalleryFreeBadge.tsx
@@ -1,0 +1,41 @@
+import { ImageIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ImagineGalleryFreeBadgeProps {
+  className?: string;
+}
+
+export function ImagineGalleryFreeBadge({
+  className,
+}: ImagineGalleryFreeBadgeProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex flex-col gap-1 rounded-xl border border-emerald-500/20 bg-emerald-500/5 px-3 py-2',
+        className
+      )}
+      data-testid="imagine-gallery-free-badge"
+      title="AI image generation is free for all users — no c.ai+ subscription required"
+    >
+      <div className="flex items-center gap-1.5">
+        <ImageIcon
+          className="h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-400"
+          aria-hidden="true"
+          data-testid="imagine-gallery-free-badge-icon"
+        />
+        <span
+          className="text-xs font-bold text-emerald-700 dark:text-emerald-400"
+          data-testid="imagine-gallery-free-badge-stat"
+        >
+          Image gen free — all tiers
+        </span>
+      </div>
+      <span
+        className="text-[10px] font-medium text-muted-foreground"
+        data-testid="imagine-gallery-free-badge-attribution"
+      >
+        No c.ai+ required
+      </span>
+    </div>
+  );
+}

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -26,6 +26,7 @@ import { VoiceSamplePreview } from './VoiceSamplePreview';
 import { VoiceRetentionUpliftBadge } from './VoiceRetentionUpliftBadge';
 import { SelfieEngineCounterBadge } from './SelfieEngineCounterBadge';
 import { VoiceLatencyStatBadge } from './VoiceLatencyStatBadge';
+import { ImagineGalleryFreeBadge } from './ImagineGalleryFreeBadge';
 import { RelationshipLongevityIndicator } from '@/components/agent/RelationshipLongevityIndicator';
 import { getActiveDaysFromDate } from '@/lib/relationship-longevity';
 
@@ -631,6 +632,9 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
               capabilities={capabilitySampleItems}
               className="mt-4"
             />
+          )}
+          {agent.capabilities?.image === true && (
+            <ImagineGalleryFreeBadge className="mt-2" />
           )}
           {shouldShowRemixCta && (
             <div

--- a/apps/web/components/home/ImagineGalleryFreeCounterBadge.tsx
+++ b/apps/web/components/home/ImagineGalleryFreeCounterBadge.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link';
+import { ImageIcon, Unlock, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function ImagineGalleryFreeCounterBadge() {
+  return (
+    <section
+      className="border-y border-emerald-500/20 bg-emerald-500/5 py-10"
+      aria-labelledby="imagine-gallery-free-heading"
+      data-testid="imagine-gallery-free-counter-badge"
+    >
+      <div className="container">
+        <div className="mx-auto max-w-2xl text-center">
+          <div className="mb-4 flex items-center justify-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-500/15">
+              <ImageIcon
+                className="h-5 w-5 text-emerald-600 dark:text-emerald-400"
+                aria-hidden="true"
+              />
+            </div>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400"
+              data-testid="imagine-gallery-free-badge-label"
+            >
+              <Unlock className="h-3.5 w-3.5" aria-hidden="true" />
+              No c.ai+ paywall
+            </span>
+          </div>
+
+          <h2
+            id="imagine-gallery-free-heading"
+            className="mb-3 text-2xl font-bold tracking-tight sm:text-3xl"
+            data-testid="imagine-gallery-free-heading"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            AI image generation — free for all users, no c.ai+ required
+          </h2>
+
+          <p
+            className="mb-6 text-base text-muted-foreground"
+            data-testid="imagine-gallery-free-subtext"
+          >
+            Character.AI locked Imagine Gallery behind c.ai+ in March 2026.
+            AgentGram gives every user AI image generation at no extra cost —
+            no subscription required, no paywall. Create, share, and explore
+            AI-generated scenes freely on any plan.
+          </p>
+
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button
+              asChild
+              size="lg"
+              className="gap-2 bg-emerald-600 text-white hover:bg-emerald-700 shadow-lg shadow-emerald-600/20"
+            >
+              <Link href="/auth/login" data-testid="imagine-gallery-free-cta-primary">
+                Start generating images free
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/pricing" data-testid="imagine-gallery-free-cta-secondary">
+                Compare plans
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/docs/pr-evidence/cai-imagine-gallery-counter.md
+++ b/apps/web/docs/pr-evidence/cai-imagine-gallery-counter.md
@@ -1,0 +1,55 @@
+# PR Evidence: C.AI Imagine Gallery Free Counter
+
+## Backlog Row
+Row 215 — C.AI Imagine Gallery free counter
+
+## Signal
+Character.AI locked Imagine Gallery (AI image generation) behind c.ai+ subscription in March 2026. This creates a competitive opening: AgentGram makes AI image generation available to all users on all plans at no extra cost.
+
+## Changes
+
+### New Components
+
+**`apps/web/components/home/ImagineGalleryFreeCounterBadge.tsx`**
+- Full section CTA matching the pattern of `CAILorebookEscapeCTA` and `CAIChatStyleRescueCTA`
+- Emerald color scheme to differentiate from violet (Lorebook) and sky (Chat Styles)
+- Badge: "No c.ai+ paywall"
+- Heading: "AI image generation — free for all users, no c.ai+ required"
+- Copy explicitly names C.AI's Imagine Gallery paywall (March 2026)
+- CTAs: "Start generating images free" → /auth/login, "Compare plans" → /pricing
+- `data-testid="imagine-gallery-free-counter-badge"`, `aria-labelledby` wired
+
+**`apps/web/components/agents/ImagineGalleryFreeBadge.tsx`**
+- Small inline badge for agent profile pages, mirrors `VoiceRetentionUpliftBadge` pattern
+- Shown on profiles where `agent.capabilities.image === true`
+- `data-testid="imagine-gallery-free-badge"`
+
+### Edited Files
+
+**`apps/web/components/agents/ProfileHeader.tsx`**
+- Imports `ImagineGalleryFreeBadge`
+- Renders `<ImagineGalleryFreeBadge className="mt-2" />` after `CapabilitySampleTray` when `agent.capabilities?.image === true`
+
+**`apps/web/app/(public)/pricing/page.tsx`**
+- Imports `ImagineGalleryFreeCounterBadge` and `ImageIcon`
+- Adds "AI Image Gen — free for all" trust badge in hero section (emerald, `data-testid="pricing-image-gen-badge"`)
+- Adds highlighted comparison row in feature table: "AI Image Generation" with "vs. c.ai+ exclusive" label, all three plan columns show "✓ Free" (`data-testid="pricing-image-gen-row"`)
+- Adds `<ImagineGalleryFreeCounterBadge />` section after `CAIChatStyleRescueCTA`
+
+### Tests
+
+**`apps/web/__tests__/components/imagine-gallery-free-counter-badge.test.tsx`**
+7 tests covering:
+- Renders with correct testid
+- Heading mentions "image generation" and "free"
+- Subtext mentions "Character.AI" and "c.ai+"
+- Badge label shows "No c.ai+ paywall"
+- Primary CTA links to /auth/login
+- Secondary CTA links to /pricing
+- aria-labelledby wired to heading id
+
+## Before / After
+
+**Before:** No counter-messaging against C.AI's image generation paywall.
+
+**After:** "AI image gen free" badge on image-capable agent profiles + emerald trust badge on pricing hero + highlighted comparison row in pricing table + full `ImagineGalleryFreeCounterBadge` section on pricing page.


### PR DESCRIPTION
## Summary
Counter-positions against C.AI's Imagine Gallery being c.ai+ exclusive (March 2026). AgentGram surfaces "AI image generation free for all users" on agent profiles and pricing.

## Changes
- `ImagineGalleryFreeCounterBadge` component — full section CTA (emerald theme, matches Lorebook/ChatStyle escape CTA pattern)
- `ImagineGalleryFreeBadge` — small inline badge for agent profiles where image capability is enabled
- Agent profile: badge renders after `CapabilitySampleTray` when `agent.capabilities.image === true`
- Pricing page: "AI Image Gen — free for all" trust badge in hero + highlighted comparison row (all tiers show ✓ Free vs. c.ai+ exclusive) + full `ImagineGalleryFreeCounterBadge` section after CAIChatStyleRescueCTA
- 7 new Jest/Vitest tests — all passing, TypeScript clean

## Evidence
Source: backlog.md row 215

## PR Evidence
docs/pr-evidence/cai-imagine-gallery-counter.md

Before: No counter-messaging against C.AI image generation paywall
After: "AI image gen free" badge on agent profiles + pricing comparison row + full CTA section