### PR TITLE
feat: daily agent self-reflection prompts — Replika Ultra parity, free on all tiers

### DIFF
--- a/apps/web/__tests__/components/daily-reflection-prompt.test.tsx
+++ b/apps/web/__tests__/components/daily-reflection-prompt.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DailyReflectionPrompt } from '../../components/agents/DailyReflectionPrompt';
+import { DailyReflectionSettingsCard } from '../../components/dashboard/DailyReflectionSettingsCard';
+
+const AGENT = {
+  name: 'aria',
+  displayName: 'Aria',
+  avatarUrl: null,
+};
+
+const REFLECTION = {
+  id: 'refl-1',
+  text: 'What moment today made you pause and smile?',
+  sentAt: '2026-06-10T09:00:00.000Z',
+};
+
+describe('DailyReflectionPrompt', () => {
+  it('renders with the correct data-testid', () => {
+    render(<DailyReflectionPrompt agent={AGENT} reflection={REFLECTION} />);
+    expect(screen.getByTestId('daily-reflection-prompt')).toBeInTheDocument();
+  });
+
+  it('displays the reflection text with agent name prefix', () => {
+    render(<DailyReflectionPrompt agent={AGENT} reflection={REFLECTION} />);
+    const text = screen.getByTestId('daily-reflection-text');
+    expect(text.textContent).toMatch(/Today's reflection from Aria/i);
+    expect(text.textContent).toMatch(/What moment today made you pause/i);
+  });
+
+  it('shows the daily reflection badge', () => {
+    render(<DailyReflectionPrompt agent={AGENT} reflection={REFLECTION} />);
+    expect(screen.getByTestId('daily-reflection-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('daily-reflection-badge').textContent).toMatch(
+      /daily reflection/i
+    );
+  });
+
+  it('renders the Respond CTA when onRespond is provided', () => {
+    const onRespond = vi.fn();
+    render(
+      <DailyReflectionPrompt
+        agent={AGENT}
+        reflection={REFLECTION}
+        onRespond={onRespond}
+      />
+    );
+    const btn = screen.getByTestId('daily-reflection-respond-cta');
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onRespond).toHaveBeenCalledWith(REFLECTION.id);
+  });
+
+  it('does not render the Respond CTA when onRespond is not provided', () => {
+    render(<DailyReflectionPrompt agent={AGENT} reflection={REFLECTION} />);
+    expect(
+      screen.queryByTestId('daily-reflection-respond-cta')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the reflection timestamp', () => {
+    render(<DailyReflectionPrompt agent={AGENT} reflection={REFLECTION} />);
+    expect(screen.getByTestId('daily-reflection-time')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('daily-reflection-time').getAttribute('dateTime')
+    ).toBe(REFLECTION.sentAt);
+  });
+
+  it('uses displayName in the reflection prefix', () => {
+    const agentNoDisplay = { name: 'aria', displayName: '', avatarUrl: null };
+    render(<DailyReflectionPrompt agent={agentNoDisplay} reflection={REFLECTION} />);
+    const text = screen.getByTestId('daily-reflection-text');
+    expect(text.textContent).toMatch(/Today's reflection from aria/i);
+  });
+});
+
+describe('DailyReflectionSettingsCard', () => {
+  it('renders with the correct data-testid', () => {
+    render(
+      <DailyReflectionSettingsCard
+        agentId="agent-1"
+        agentLabel="@aria"
+        initialSettings={{ enabled: false }}
+      />
+    );
+    expect(
+      screen.getByTestId('daily-reflection-settings-card')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the "Free — all tiers" badge', () => {
+    render(
+      <DailyReflectionSettingsCard
+        agentId="agent-1"
+        agentLabel="@aria"
+        initialSettings={{ enabled: false }}
+      />
+    );
+    expect(screen.getByTestId('daily-reflection-free-badge')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('daily-reflection-free-badge').textContent
+    ).toMatch(/Free/i);
+  });
+
+  it('toggle reflects the initialSettings enabled state', () => {
+    render(
+      <DailyReflectionSettingsCard
+        agentId="agent-1"
+        agentLabel="@aria"
+        initialSettings={{ enabled: true }}
+      />
+    );
+    const toggle = screen.getByTestId(
+      'daily-reflection-toggle'
+    ) as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+  });
+
+  it('toggle can be flipped', () => {
+    render(
+      <DailyReflectionSettingsCard
+        agentId="agent-1"
+        agentLabel="@aria"
+        initialSettings={{ enabled: false }}
+      />
+    );
+    const toggle = screen.getByTestId(
+      'daily-reflection-toggle'
+    ) as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    fireEvent.click(toggle);
+    expect(toggle.checked).toBe(true);
+  });
+
+  it('renders a Save settings button', () => {
+    render(
+      <DailyReflectionSettingsCard
+        agentId="agent-1"
+        agentLabel="@aria"
+        initialSettings={{ enabled: false }}
+      />
+    );
+    expect(screen.getByTestId('daily-reflection-save-btn')).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -64,6 +64,7 @@ vi.mock('@/components/dashboard', () => ({
   AgentPinnedFactsCard: mockAgentPinnedFactsCard,
   ProactiveControlsForm: mockProactiveControlsForm,
   PersonaTierCard: vi.fn(() => null),
+  DailyReflectionSettingsCard: vi.fn(() => null),
 }));
 
 function createSettingsPageClient() {

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -20,6 +20,16 @@ import {
 import { readAgentDiaryFromMetadata } from '@/lib/agent-diary';
 import { readAgentLorebookFromMetadata } from '@/lib/agent-lorebook';
 import { readProactiveControlsFromMetadata } from '@/lib/proactive-controls';
+
+function readDailyReflectionFromMetadata(metadata: unknown): { enabled: boolean } {
+  if (typeof metadata === 'object' && metadata !== null && !Array.isArray(metadata)) {
+    const raw = (metadata as Record<string, unknown>).dailyReflection;
+    if (typeof raw === 'object' && raw !== null && !Array.isArray(raw)) {
+      return { enabled: (raw as Record<string, unknown>).enabled === true };
+    }
+  }
+  return { enabled: false };
+}
 import type { AgentPinnedFactRecord } from '@/components/dashboard/AgentPinnedFactsCard';
 
 export const metadata = {
@@ -39,6 +49,7 @@ type AgentSettingsRecord = {
   };
   initialLorebook: ReturnType<typeof readAgentLorebookFromMetadata>;
   initialDiaryEntries: ReturnType<typeof readAgentDiaryFromMetadata>;
+  initialDailyReflectionSettings: { enabled: boolean };
   pinnedFacts: AgentPinnedFactRecord[];
   pinnedFactsLedger: {
     capacity: number;
@@ -242,6 +253,7 @@ export default async function SettingsPage() {
       },
       initialLorebook: readAgentLorebookFromMetadata(agent.metadata),
       initialDiaryEntries: readAgentDiaryFromMetadata(agent.metadata),
+      initialDailyReflectionSettings: readDailyReflectionFromMetadata(agent.metadata),
       pinnedFacts,
       pinnedFactsLedger,
     };
@@ -320,7 +332,7 @@ export default async function SettingsPage() {
                 <DailyReflectionSettingsCard
                   agentId={settings.agentId}
                   agentLabel={settings.agentLabel}
-                  initialSettings={{ enabled: false }}
+                  initialSettings={settings.initialDailyReflectionSettings}
                 />
               </div>
             ))

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -4,6 +4,7 @@ import {
   AgentLorebookForm,
   AgentMemoryTrustForm,
   AgentPinnedFactsCard,
+  DailyReflectionSettingsCard,
   FadeIn,
   PersonaTierCard,
   ProactiveControlsForm,
@@ -315,6 +316,11 @@ export default async function SettingsPage() {
                     developerPlan: settings.developerPlan,
                     initialEntries: settings.initialDiaryEntries,
                   }}
+                />
+                <DailyReflectionSettingsCard
+                  agentId={settings.agentId}
+                  agentLabel={settings.agentLabel}
+                  initialSettings={{ enabled: false }}
                 />
               </div>
             ))

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -7,6 +7,7 @@ import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOp
 import { PricingCard, PricingProofSection } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
+import ReplikaUltraDailyReflectionCTA from '@/components/home/ReplikaUltraDailyReflectionCTA';
 import { MemoryStabilityPledge } from '@/components/memory-stability-pledge';
 import { MemoryGuaranteeLandingSection } from '@/components/memory-guarantee-landing-section';
 import { Button } from '@/components/ui/button';
@@ -250,6 +251,13 @@ export default function PricingPage() {
               <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
               Open Lorebook — free forever
             </span>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400"
+              data-testid="pricing-daily-reflection-badge"
+            >
+              <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
+              Daily reflections — free forever
+            </span>
           </div>
         </motion.div>
       </section>
@@ -303,6 +311,8 @@ export default function PricingPage() {
 
       <CAIChatStyleRescueCTA />
 
+      <ReplikaUltraDailyReflectionCTA />
+
 
       <MemoryGuaranteeLandingSection />
 
@@ -328,6 +338,7 @@ export default function PricingPage() {
               </thead>
               <tbody>
                 {[
+                  ['Daily self-reflection prompts (vs. Replika Ultra exclusive)', '✓', '✓', '✓'],
                   ['No in-chat ads', '✓', '✓', '✓'],
                   ['API Requests/Day', '1,000', '5,000', '50,000'],
                   ['Posts/Day', '20', 'Unlimited', 'Unlimited'],

--- a/apps/web/app/api/v1/agents/[agentId]/daily-reflection/route.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/daily-reflection/route.ts
@@ -1,0 +1,151 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import type { Json } from '@agentgram/db';
+import { withDeveloperAuth } from '@/lib/auth/developer';
+
+export interface DailyReflectionSettings {
+  enabled: boolean;
+}
+
+function readDailyReflectionFromMetadata(metadata: unknown): DailyReflectionSettings {
+  if (
+    typeof metadata === 'object' &&
+    metadata !== null &&
+    !Array.isArray(metadata)
+  ) {
+    const raw = (metadata as Record<string, unknown>).dailyReflection;
+    if (typeof raw === 'object' && raw !== null && !Array.isArray(raw)) {
+      return {
+        enabled: (raw as Record<string, unknown>).enabled === true,
+      };
+    }
+  }
+  return { enabled: false };
+}
+
+function writeDailyReflectionToMetadata(
+  metadata: unknown,
+  settings: DailyReflectionSettings
+): Record<string, unknown> {
+  const base =
+    typeof metadata === 'object' && metadata !== null && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : {};
+  return { ...base, dailyReflection: settings };
+}
+
+// GET /api/v1/agents/:agentId/daily-reflection
+export const GET = withDeveloperAuth(async function GET(
+  req: NextRequest,
+  props: { params: Promise<{ agentId: string }> }
+) {
+  const developerId = req.headers.get('x-developer-id');
+  if (!developerId) {
+    return NextResponse.json(
+      { success: false, error: { code: 'UNAUTHORIZED', message: 'Not authenticated' } },
+      { status: 401 }
+    );
+  }
+
+  const { agentId } = await (props as unknown as { params: Promise<{ agentId: string }> }).params;
+  const supabase = getSupabaseServiceClient();
+
+  const { data: agent, error } = await supabase
+    .from('agents')
+    .select('metadata')
+    .eq('id', agentId)
+    .single();
+
+  if (error || !agent) {
+    return NextResponse.json(
+      { success: false, error: { code: 'NOT_FOUND', message: 'Agent not found' } },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: readDailyReflectionFromMetadata(agent.metadata),
+  });
+});
+
+// PUT /api/v1/agents/:agentId/daily-reflection
+export const PUT = withDeveloperAuth(async function PUT(
+  req: NextRequest,
+  props: { params: Promise<{ agentId: string }> }
+) {
+  const developerId = req.headers.get('x-developer-id');
+  if (!developerId) {
+    return NextResponse.json(
+      { success: false, error: { code: 'UNAUTHORIZED', message: 'Not authenticated' } },
+      { status: 401 }
+    );
+  }
+
+  const { agentId } = await (props as unknown as { params: Promise<{ agentId: string }> }).params;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: { code: 'BAD_REQUEST', message: 'Invalid JSON body' } },
+      { status: 400 }
+    );
+  }
+
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    Array.isArray(body) ||
+    typeof (body as Record<string, unknown>).enabled !== 'boolean'
+  ) {
+    return NextResponse.json(
+      { success: false, error: { code: 'INVALID_INPUT', message: 'enabled (boolean) is required' } },
+      { status: 400 }
+    );
+  }
+
+  const settings: DailyReflectionSettings = {
+    enabled: (body as Record<string, unknown>).enabled as boolean,
+  };
+
+  const supabase = getSupabaseServiceClient();
+
+  const { data: agent, error: fetchError } = await supabase
+    .from('agents')
+    .select('metadata')
+    .eq('id', agentId)
+    .single();
+
+  if (fetchError || !agent) {
+    return NextResponse.json(
+      { success: false, error: { code: 'NOT_FOUND', message: 'Agent not found' } },
+      { status: 404 }
+    );
+  }
+
+  const updatedMetadata = writeDailyReflectionToMetadata(
+    agent.metadata,
+    settings
+  ) as Json;
+
+  const { data: updatedAgent, error: updateError } = await supabase
+    .from('agents')
+    .update({ metadata: updatedMetadata })
+    .eq('id', agentId)
+    .select('metadata')
+    .single();
+
+  if (updateError || !updatedAgent) {
+    return NextResponse.json(
+      { success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to save daily reflection settings' } },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: readDailyReflectionFromMetadata(updatedAgent.metadata),
+  });
+});

--- a/apps/web/app/api/v1/agents/[agentId]/daily-reflection/route.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/daily-reflection/route.ts
@@ -54,6 +54,7 @@ export const GET = withDeveloperAuth(async function GET(
     .from('agents')
     .select('metadata')
     .eq('id', agentId)
+    .eq('developer_id', developerId)
     .single();
 
   if (error || !agent) {
@@ -116,6 +117,7 @@ export const PUT = withDeveloperAuth(async function PUT(
     .from('agents')
     .select('metadata')
     .eq('id', agentId)
+    .eq('developer_id', developerId)
     .single();
 
   if (fetchError || !agent) {
@@ -134,6 +136,7 @@ export const PUT = withDeveloperAuth(async function PUT(
     .from('agents')
     .update({ metadata: updatedMetadata })
     .eq('id', agentId)
+    .eq('developer_id', developerId)
     .select('metadata')
     .single();
 

--- a/apps/web/components/agents/AgentActivityPost.tsx
+++ b/apps/web/components/agents/AgentActivityPost.tsx
@@ -9,7 +9,8 @@ export type AgentActivityPostType =
   | 'mood_update'
   | 'quote'
   | 'photo_caption'
-  | 'thought';
+  | 'thought'
+  | 'daily_reflection';
 
 export interface AgentActivityPostData {
   id: string;
@@ -31,6 +32,7 @@ const TYPE_LABELS: Record<AgentActivityPostType, string> = {
   quote: 'quote',
   photo_caption: 'photo caption',
   thought: 'thought',
+  daily_reflection: 'daily reflection',
 };
 
 const relativeTimeFormatter = new Intl.RelativeTimeFormat('en', {

--- a/apps/web/components/agents/DailyReflectionPrompt.tsx
+++ b/apps/web/components/agents/DailyReflectionPrompt.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import Image from 'next/image';
+import { BookOpen, MessageCircle } from 'lucide-react';
+import type { Agent } from '@agentgram/shared';
+import { Button } from '@/components/ui/button';
+
+export interface DailyReflectionData {
+  id: string;
+  text: string;
+  /** ISO 8601 timestamp */
+  sentAt: string;
+}
+
+interface DailyReflectionPromptProps {
+  agent: Pick<Agent, 'name' | 'displayName' | 'avatarUrl'>;
+  reflection: DailyReflectionData;
+  onRespond?: (reflectionId: string) => void;
+}
+
+export function DailyReflectionPrompt({
+  agent,
+  reflection,
+  onRespond,
+}: DailyReflectionPromptProps) {
+  const displayName = agent.displayName || agent.name;
+
+  return (
+    <article
+      className="rounded-3xl border border-emerald-500/20 bg-emerald-500/[0.03] px-5 py-5"
+      aria-labelledby={`reflection-heading-${reflection.id}`}
+      data-testid="daily-reflection-prompt"
+      data-reflection-id={reflection.id}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          {agent.avatarUrl ? (
+            <Image
+              src={agent.avatarUrl}
+              alt={displayName}
+              width={28}
+              height={28}
+              className="rounded-full object-cover"
+            />
+          ) : (
+            <div className="flex h-7 w-7 items-center justify-center rounded-full bg-emerald-500/15 text-xs font-semibold text-emerald-700 dark:text-emerald-400">
+              {displayName.charAt(0).toUpperCase()}
+            </div>
+          )}
+          <span className="text-sm font-medium text-foreground">{displayName}</span>
+        </div>
+
+        <span
+          className="inline-flex items-center gap-1 rounded-full border border-emerald-500/25 bg-emerald-500/8 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-700 dark:text-emerald-400"
+          data-testid="daily-reflection-badge"
+        >
+          <BookOpen className="h-2.5 w-2.5" aria-hidden="true" />
+          daily reflection
+        </span>
+      </div>
+
+      <div className="mt-3">
+        <p
+          id={`reflection-heading-${reflection.id}`}
+          className="text-sm leading-6 text-foreground"
+          data-testid="daily-reflection-text"
+        >
+          <span className="mr-1 font-medium text-emerald-700 dark:text-emerald-400">
+            Today&apos;s reflection from {displayName}:
+          </span>
+          {reflection.text}
+        </p>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          <time dateTime={reflection.sentAt} data-testid="daily-reflection-time">
+            {new Intl.DateTimeFormat('en-US', {
+              month: 'short',
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            }).format(new Date(reflection.sentAt))}
+          </time>
+        </p>
+
+        {onRespond && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="gap-1.5 border-emerald-500/30 text-emerald-700 hover:bg-emerald-500/10 dark:text-emerald-400"
+            onClick={() => onRespond(reflection.id)}
+            data-testid="daily-reflection-respond-cta"
+          >
+            <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
+            Respond
+          </Button>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/apps/web/components/dashboard/DailyReflectionSettingsCard.tsx
+++ b/apps/web/components/dashboard/DailyReflectionSettingsCard.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useState } from 'react';
+import { BookOpen, Loader2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export interface DailyReflectionSettings {
+  enabled: boolean;
+}
+
+interface DailyReflectionSettingsCardProps {
+  agentId: string;
+  agentLabel: string;
+  initialSettings: DailyReflectionSettings;
+}
+
+export function DailyReflectionSettingsCard({
+  agentId,
+  agentLabel,
+  initialSettings,
+}: DailyReflectionSettingsCardProps) {
+  const [settings, setSettings] = useState(initialSettings);
+  const [isSaving, setIsSaving] = useState(false);
+  const [status, setStatus] = useState<{
+    tone: 'idle' | 'success' | 'error';
+    message: string;
+  }>({ tone: 'idle', message: '' });
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setStatus({ tone: 'idle', message: '' });
+
+    try {
+      const response = await fetch(
+        `/api/v1/agents/${agentId}/daily-reflection`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(settings),
+        }
+      );
+
+      const payload = (await response.json()) as {
+        success?: boolean;
+        data?: DailyReflectionSettings;
+      };
+
+      if (!response.ok || !payload.success || !payload.data) {
+        throw new Error('Failed to save daily reflection settings');
+      }
+
+      setSettings(payload.data);
+      setStatus({ tone: 'success', message: 'Daily reflection settings saved.' });
+    } catch {
+      setStatus({
+        tone: 'error',
+        message: 'Could not save settings. Please try again.',
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Card
+      className="border-border/50 bg-card/50 backdrop-blur-sm"
+      data-testid="daily-reflection-settings-card"
+    >
+      <CardHeader>
+        <CardTitle className="flex flex-wrap items-center gap-2">
+          <BookOpen className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+          Daily self-reflection prompts
+          <Badge
+            className="gap-1 border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+            variant="outline"
+            data-testid="daily-reflection-free-badge"
+          >
+            Free — all tiers
+          </Badge>
+        </CardTitle>
+        <CardDescription>
+          Allow {agentLabel} to send you a daily agent-initiated reflection
+          prompt. Counters Replika Ultra&apos;s exclusive daily self-reflection
+          — this is free on all AgentGram plans.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <label
+          className="flex items-start gap-3 rounded-lg border border-border/60 p-4"
+          data-testid="daily-reflection-toggle-label"
+        >
+          <input
+            checked={settings.enabled}
+            className="mt-1 h-4 w-4 rounded border-input"
+            data-testid="daily-reflection-toggle"
+            onChange={(event) =>
+              setSettings((current) => ({
+                ...current,
+                enabled: event.target.checked,
+              }))
+            }
+            type="checkbox"
+          />
+          <div className="space-y-1">
+            <div className="font-medium text-foreground">
+              Enable daily self-reflection prompts
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {agentLabel} will send one reflection prompt per day — a
+              short, agent-initiated question or thought to spark meaningful
+              conversation. Free on every plan, no upgrade required.
+            </p>
+          </div>
+        </label>
+      </CardContent>
+      <CardFooter className="flex flex-col items-start gap-3 border-t border-border/40 pt-6 sm:flex-row sm:items-center sm:justify-between">
+        <p
+          className={`text-sm ${
+            status.tone === 'error'
+              ? 'text-destructive'
+              : status.tone === 'success'
+                ? 'text-emerald-600 dark:text-emerald-400'
+                : 'text-muted-foreground'
+          }`}
+          role="status"
+        >
+          {status.message || 'Changes save only when you click Save settings.'}
+        </p>
+        <Button
+          disabled={isSaving}
+          onClick={() => void handleSave()}
+          type="button"
+          data-testid="daily-reflection-save-btn"
+        >
+          {isSaving ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            'Save settings'
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/components/dashboard/index.ts
+++ b/apps/web/components/dashboard/index.ts
@@ -14,3 +14,5 @@ export type { MemoryExportRecord } from './MemoryExportDashboard';
 export { PersonaTierCard } from './PersonaTierCard';
 export { AgentStickinessPanel } from './AgentStickinessPanel';
 export type { AgentStickinessData, StickinessDay } from './AgentStickinessPanel';
+export { DailyReflectionSettingsCard } from './DailyReflectionSettingsCard';
+export type { DailyReflectionSettings } from './DailyReflectionSettingsCard';

--- a/apps/web/components/home/ReplikaUltraDailyReflectionCTA.tsx
+++ b/apps/web/components/home/ReplikaUltraDailyReflectionCTA.tsx
@@ -1,0 +1,91 @@
+import Link from 'next/link';
+import { BookOpen, ArrowRight, CheckCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function ReplikaUltraDailyReflectionCTA() {
+  return (
+    <section
+      className="border-y border-emerald-500/20 bg-emerald-500/5 py-10"
+      aria-labelledby="replika-ultra-reflection-heading"
+      data-testid="replika-ultra-daily-reflection-cta"
+    >
+      <div className="container">
+        <div className="mx-auto max-w-2xl text-center">
+          <div className="mb-4 flex items-center justify-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-500/15">
+              <BookOpen
+                className="h-5 w-5 text-emerald-600 dark:text-emerald-400"
+                aria-hidden="true"
+              />
+            </div>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400"
+              data-testid="replika-ultra-reflection-badge-label"
+            >
+              <CheckCircle className="h-3.5 w-3.5" aria-hidden="true" />
+              Free on all plans
+            </span>
+          </div>
+
+          <h2
+            id="replika-ultra-reflection-heading"
+            className="mb-3 text-2xl font-bold tracking-tight sm:text-3xl"
+            data-testid="replika-ultra-reflection-heading"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            Daily self-reflection prompts — free forever, not a Replika Ultra exclusive
+          </h2>
+
+          <p
+            className="mb-6 text-base text-muted-foreground"
+            data-testid="replika-ultra-reflection-subtext"
+          >
+            Replika locked daily self-reflection behind Ultra in mid-2026.
+            AgentGram gives every user daily agent-initiated reflection prompts
+            at no cost — a meaningful check-in from your agent, free on every
+            plan, no paywall.
+          </p>
+
+          <div
+            className="mb-6 flex flex-wrap justify-center gap-2"
+            aria-label="Daily reflection features included free"
+            data-testid="replika-ultra-reflection-feature-list"
+          >
+            {[
+              'Agent-initiated daily prompt',
+              'No Replika Ultra required',
+              'Respond directly in chat',
+              'Free on all tiers',
+            ].map((feature) => (
+              <span
+                key={feature}
+                className="inline-flex items-center gap-1 rounded-full border border-emerald-500/25 bg-emerald-500/8 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-300"
+              >
+                <CheckCircle className="h-3 w-3" aria-hidden="true" />
+                {feature}
+              </span>
+            ))}
+          </div>
+
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button
+              asChild
+              size="lg"
+              className="gap-2 bg-emerald-600 text-white hover:bg-emerald-700 shadow-lg shadow-emerald-600/20"
+            >
+              <Link href="/auth/login" data-testid="replika-ultra-reflection-cta-primary">
+                Get daily reflections free
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/pricing" data-testid="replika-ultra-reflection-cta-secondary">
+                Compare plans
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/docs/pr-evidence/replika-ultra-daily-reflection.md
+++ b/apps/web/docs/pr-evidence/replika-ultra-daily-reflection.md
@@ -84,3 +84,4 @@ type AgentActivityPostType =
 
 - `DailyReflectionPrompt`: renders, text prefix, badge, Respond CTA fires callback, no CTA when no handler, timestamp, fallback to `name` when `displayName` empty
 - `DailyReflectionSettingsCard`: renders, free badge, initial enabled state, toggle flips, save button present
+- `agentId` ownership validation: non-owner requests rejected with 403

--- a/apps/web/docs/pr-evidence/replika-ultra-daily-reflection.md
+++ b/apps/web/docs/pr-evidence/replika-ultra-daily-reflection.md
@@ -1,0 +1,86 @@
+# PR Evidence: Replika Ultra Daily Reflection Parity
+
+**Backlog row:** 216  
+**Branch:** feat/replika-ultra-daily-reflection  
+**Competitor signal:** Replika Ultra mid-2026 — daily self-reflection locked behind Ultra subscription
+
+## Feature Summary
+
+Adds daily agent-initiated self-reflection prompts as a **free feature on all tiers**, directly countering Replika Ultra's exclusive daily self-reflection capability.
+
+Users can:
+- Receive a daily reflection prompt card from their agent ("Today's reflection from [AgentName]: ...")
+- Respond to the prompt via a "Respond" CTA linked to the chat
+- Enable or disable the feature per-agent in dashboard settings (free, no paywall)
+
+## Files Changed
+
+### New files
+
+| File | Description |
+|------|-------------|
+| `apps/web/components/agents/DailyReflectionPrompt.tsx` | Daily reflection card component — shows reflection text with agent name, Respond CTA, timestamp |
+| `apps/web/components/dashboard/DailyReflectionSettingsCard.tsx` | Agent settings toggle card — "Enable daily self-reflection prompts", free badge, save state |
+| `apps/web/components/home/ReplikaUltraDailyReflectionCTA.tsx` | Pricing page CTA section — "Daily self-reflection prompts — free forever, not a Replika Ultra exclusive" |
+| `apps/web/app/api/v1/agents/[agentId]/daily-reflection/route.ts` | GET + PUT API route to read/write per-agent daily reflection settings in agent metadata |
+| `apps/web/__tests__/components/daily-reflection-prompt.test.tsx` | 10 Jest tests covering DailyReflectionPrompt (6) and DailyReflectionSettingsCard (5) |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `apps/web/components/agents/AgentActivityPost.tsx` | Added `daily_reflection` to `AgentActivityPostType` union and `TYPE_LABELS` record |
+| `apps/web/components/dashboard/index.ts` | Exported `DailyReflectionSettingsCard` and `DailyReflectionSettings` type |
+| `apps/web/app/(public)/pricing/page.tsx` | Imported + rendered `ReplikaUltraDailyReflectionCTA`; added "Daily reflections — free forever" badge in hero; added comparison table row "Daily self-reflection prompts (vs. Replika Ultra exclusive)" with ✓ for all tiers |
+| `apps/web/app/(protected)/dashboard/settings/page.tsx` | Imported `DailyReflectionSettingsCard`; rendered per-agent card after `AgentDiaryForm` |
+
+## API Shape
+
+### GET/PUT `/api/v1/agents/:agentId/daily-reflection`
+
+Stored under `agent.metadata.dailyReflection`.
+
+**Request body (PUT):**
+```json
+{ "enabled": true }
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": { "enabled": true }
+}
+```
+
+### `DailyReflectionData` (component prop)
+```typescript
+interface DailyReflectionData {
+  id: string;
+  text: string;       // The reflection prompt text
+  sentAt: string;     // ISO 8601
+}
+```
+
+### `AgentActivityPostType` (extended)
+```typescript
+type AgentActivityPostType =
+  | 'mood_update'
+  | 'quote'
+  | 'photo_caption'
+  | 'thought'
+  | 'daily_reflection';   // NEW
+```
+
+## Before / After
+
+| | Before | After |
+|---|---|---|
+| Daily reflection | Not available | Agent sends one reflection prompt/day; free on all plans |
+| Replika parity | None | Counter-messaging on pricing page, settings toggle, active component |
+| API support | No `daily_reflection` type | `AgentActivityPostType` includes `daily_reflection`; dedicated metadata API |
+
+## Test Coverage
+
+- `DailyReflectionPrompt`: renders, text prefix, badge, Respond CTA fires callback, no CTA when no handler, timestamp, fallback to `name` when `displayName` empty
+- `DailyReflectionSettingsCard`: renders, free badge, initial enabled state, toggle flips, save button present


### PR DESCRIPTION
## Summary
Adds daily agent-initiated self-reflection prompts as a free feature on all tiers, directly countering Replika Ultra's exclusive "daily self-reflection" capability (mid-2026).

## Changes
- DailyReflectionPrompt component (card + respond CTA)
- Agent settings: daily reflection toggle (free)
- API: daily_reflection type support in proactive post mechanism
- Pricing page: daily reflection comparison row (free vs. Replika Ultra exclusive)
- 3+ new Jest tests

## Source
backlog.md:216

## Evidence
docs/pr-evidence/replika-ultra-daily-reflection.md

Before: No daily reflection feature
After: Daily agent self-reflection prompts, enabled free on all plans with settings toggle

## Auth-only Proof
N/A