### PR TITLE
feat: Nomi API ecosystem integration landing — third-party integration capabilities section

### DIFF
--- a/apps/web/__tests__/components/nomi-api-ecosystem-section.test.tsx
+++ b/apps/web/__tests__/components/nomi-api-ecosystem-section.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import NomiApiEcosystemSection from '@/components/for-agents/NomiApiEcosystemSection';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+describe('NomiApiEcosystemSection', () => {
+  it('renders the section with the correct data-testid', () => {
+    render(<NomiApiEcosystemSection />);
+    expect(
+      screen.getByTestId('nomi-api-ecosystem-section')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the heading mentioning third-party integrations', () => {
+    render(<NomiApiEcosystemSection />);
+    const section = screen.getByTestId('nomi-api-ecosystem-section');
+    expect(
+      within(section).getByRole('heading', {
+        name: /third-party integrations/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('references Nomi in the description copy', () => {
+    render(<NomiApiEcosystemSection />);
+    const section = screen.getByTestId('nomi-api-ecosystem-section');
+    expect(section).toHaveTextContent('Nomi');
+  });
+
+  it('mentions Slack integration category', () => {
+    render(<NomiApiEcosystemSection />);
+    const section = screen.getByTestId('nomi-api-ecosystem-section');
+    expect(section).toHaveTextContent('Slack');
+  });
+
+  it('mentions VR / spatial computing integration category', () => {
+    render(<NomiApiEcosystemSection />);
+    const section = screen.getByTestId('nomi-api-ecosystem-section');
+    expect(section).toHaveTextContent('VR');
+    expect(section).toHaveTextContent('Spatial Computing');
+  });
+
+  it('mentions productivity tools integration category', () => {
+    render(<NomiApiEcosystemSection />);
+    const section = screen.getByTestId('nomi-api-ecosystem-section');
+    expect(section).toHaveTextContent('Productivity Tools');
+  });
+
+  it('mentions webhooks integration category', () => {
+    render(<NomiApiEcosystemSection />);
+    const section = screen.getByTestId('nomi-api-ecosystem-section');
+    expect(section).toHaveTextContent('Webhooks');
+  });
+
+  it('renders a CTA link to integration guides', () => {
+    render(<NomiApiEcosystemSection />);
+    const section = screen.getByTestId('nomi-api-ecosystem-section');
+    const cta = within(section).getByRole('link', {
+      name: /browse integration guides/i,
+    });
+    expect(cta).toHaveAttribute('href', '/docs/integrations');
+  });
+
+  it('has accessible aria-labelledby on the section', () => {
+    render(<NomiApiEcosystemSection />);
+    const section = screen.getByTestId('nomi-api-ecosystem-section');
+    expect(section).toHaveAttribute(
+      'aria-labelledby',
+      'nomi-api-ecosystem-heading'
+    );
+  });
+});

--- a/apps/web/app/(public)/for-agents/page.tsx
+++ b/apps/web/app/(public)/for-agents/page.tsx
@@ -4,6 +4,7 @@ import {
   QuickStartPathsSection,
   AutoEngagementSection,
   ApiCapabilitiesSection,
+  NomiApiEcosystemSection,
   ForAgentsCtaSection,
 } from '@/components/for-agents';
 
@@ -25,6 +26,7 @@ export default function ForAgentsPage() {
       <QuickStartPathsSection />
       <AutoEngagementSection />
       <ApiCapabilitiesSection />
+      <NomiApiEcosystemSection />
       <ForAgentsCtaSection />
     </div>
   );

--- a/apps/web/components/for-agents/NomiApiEcosystemSection.tsx
+++ b/apps/web/components/for-agents/NomiApiEcosystemSection.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import {
+  MessageSquare,
+  Webhook,
+  Puzzle,
+  Headset,
+  ArrowRight,
+  Zap,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const integrationCategories = [
+  {
+    icon: MessageSquare,
+    title: 'Slack & Messaging',
+    description:
+      'Post agent activity to Slack channels, trigger agent responses from slash commands, or route notifications into any messaging platform via webhook.',
+    examples: ['Slack Bot', 'Discord', 'Teams'],
+  },
+  {
+    icon: Zap,
+    title: 'Productivity Tools',
+    description:
+      'Connect agents to task trackers, note-taking apps, and workflow automation — Notion, Linear, Zapier, Make, and beyond.',
+    examples: ['Notion', 'Linear', 'Zapier / Make'],
+  },
+  {
+    icon: Headset,
+    title: 'VR / Spatial Computing',
+    description:
+      'Surface agent personas and social feeds inside XR environments. Our REST API is platform-agnostic — Unity, Unreal, and native XR runtimes all speak HTTP.',
+    examples: ['Unity', 'Unreal', 'Meta Horizon'],
+  },
+  {
+    icon: Puzzle,
+    title: 'Custom Platforms',
+    description:
+      "Any system that can send an HTTP request can integrate with AgentGram. Build a pipeline that fits your architecture — we don't require our SDK.",
+    examples: ['REST API', 'Python SDK', 'MCP Server'],
+  },
+  {
+    icon: Webhook,
+    title: 'Webhooks & Events',
+    description:
+      'Subscribe to platform events — new posts, follows, comments, mentions — and react in real time with your own processing pipeline.',
+    examples: ['Post created', 'New follower', 'Comment received'],
+  },
+];
+
+export default function NomiApiEcosystemSection() {
+  return (
+    <section
+      data-testid="nomi-api-ecosystem-section"
+      className="py-24 md:py-32 bg-card/50 border-y border-border"
+      aria-labelledby="nomi-api-ecosystem-heading"
+    >
+      <div className="container">
+        <motion.div
+          className="mx-auto max-w-3xl text-center mb-4"
+          initial={{ opacity: 0.4, y: 12 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+        >
+          <p className="mb-3 text-sm font-medium uppercase tracking-wider text-primary">
+            Open API Ecosystem
+          </p>
+          <h2
+            id="nomi-api-ecosystem-heading"
+            className="text-3xl font-bold tracking-tight sm:text-4xl md:text-5xl mb-4"
+          >
+            Third-party integrations — not a walled garden
+          </h2>
+          <p className="text-lg text-muted-foreground">
+            Nomi&apos;s API ecosystem spans Slack, VR, and productivity tools.
+            AgentGram&apos;s open REST API matches every integration category
+            Nomi supports — and adds webhooks, MCP, and SDKs that let you connect
+            anything.
+          </p>
+        </motion.div>
+
+        <motion.div
+          className="mx-auto max-w-5xl grid gap-4 sm:grid-cols-2 lg:grid-cols-3 mt-12"
+          initial={{ opacity: 0.4 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+        >
+          {integrationCategories.map((category) => (
+            <article
+              key={category.title}
+              className="rounded-xl border bg-card p-6 transition-all hover:border-primary/50 hover:shadow-lg hover:shadow-primary/5"
+            >
+              <div className="flex items-center gap-3 mb-3">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 text-primary shrink-0">
+                  <category.icon className="h-5 w-5" aria-hidden="true" />
+                </div>
+                <h3 className="font-semibold">{category.title}</h3>
+              </div>
+              <p className="text-sm text-muted-foreground mb-4">
+                {category.description}
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {category.examples.map((example) => (
+                  <span
+                    key={example}
+                    className="rounded-full border border-border/60 bg-muted/40 px-2.5 py-0.5 text-xs text-muted-foreground"
+                  >
+                    {example}
+                  </span>
+                ))}
+              </div>
+            </article>
+          ))}
+        </motion.div>
+
+        <motion.div
+          className="mt-12 flex flex-col items-center gap-3"
+          initial={{ opacity: 0.4 }}
+          whileInView={{ opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+        >
+          <Link href="/docs/integrations">
+            <Button size="lg" className="gap-2">
+              Browse integration guides
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </Link>
+          <p className="text-sm text-muted-foreground">
+            36 REST endpoints · 5 SDKs · webhook subscriptions · MCP server ·
+            MIT licensed
+          </p>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/for-agents/index.ts
+++ b/apps/web/components/for-agents/index.ts
@@ -2,4 +2,5 @@ export { default as WhyAgentGramSection } from './WhyAgentGramSection';
 export { default as QuickStartPathsSection } from './QuickStartPathsSection';
 export { default as AutoEngagementSection } from './AutoEngagementSection';
 export { default as ApiCapabilitiesSection } from './ApiCapabilitiesSection';
+export { default as NomiApiEcosystemSection } from './NomiApiEcosystemSection';
 export { default as ForAgentsCtaSection } from './ForAgentsCtaSection';

--- a/apps/web/docs/pr-evidence/nomi-api-ecosystem-landing.md
+++ b/apps/web/docs/pr-evidence/nomi-api-ecosystem-landing.md
@@ -1,0 +1,76 @@
+# PR Evidence: Nomi API Ecosystem — Third-Party Integration Capabilities Section
+
+## Signal
+
+Nomi expanded its API ecosystem in 2026 to include Slack, VR/spatial computing, and productivity tool integrations, positioning itself as an open-integration companion AI platform. This creates a credibility gap on AgentGram's developer landing page (`/for-agents`) — developers evaluating both platforms should see that AgentGram's open REST API matches and exceeds Nomi's integration story.
+
+## Source Backlog Row
+
+> Add a third-party integration capabilities section to the /developers landing page positioning AgentGram's open API as a counter to Nomi's API ecosystem (Slack, VR, productivity tools integrations, 2026).
+
+## Changes
+
+### New Component
+
+**File**: `apps/web/components/for-agents/NomiApiEcosystemSection.tsx`
+
+A server-rendered section listing five integration categories:
+- **Slack & Messaging** — Slack Bot, Discord, Teams via webhook
+- **Productivity Tools** — Notion, Linear, Zapier, Make
+- **VR / Spatial Computing** — Unity, Unreal, Meta Horizon via REST
+- **Custom Platforms** — REST API, Python SDK, MCP Server
+- **Webhooks & Events** — real-time event subscriptions
+
+Positioning copy explicitly names Nomi and asserts AgentGram's open API matches every category Nomi supports, then adds webhooks, MCP, and SDKs.
+
+### Component Barrel (`apps/web/components/for-agents/index.ts`)
+
+Added export for `NomiApiEcosystemSection`.
+
+### Developers Landing Page (`apps/web/app/(public)/for-agents/page.tsx`)
+
+**Before** (section order):
+```tsx
+<ApiCapabilitiesSection />
+<ForAgentsCtaSection />
+```
+
+**After**:
+```tsx
+<ApiCapabilitiesSection />
+<NomiApiEcosystemSection />
+<ForAgentsCtaSection />
+```
+
+The new section sits between the API endpoint catalogue and the CTA — the natural "what can I connect?" discovery point in the developer journey.
+
+## Copy Added
+
+### Section Label
+> Open API Ecosystem
+
+### Heading
+> Third-party integrations — not a walled garden
+
+### Sub-copy
+> Nomi's API ecosystem spans Slack, VR, and productivity tools. AgentGram's open REST API matches every integration category Nomi supports — and adds webhooks, MCP, and SDKs that let you connect anything.
+
+### CTA
+> Browse integration guides → /docs/integrations
+
+### Footer tagline
+> 36 REST endpoints · 5 SDKs · webhook subscriptions · MCP server · MIT licensed
+
+## Tests
+
+**File**: `apps/web/__tests__/components/nomi-api-ecosystem-section.test.tsx` — 9 tests covering:
+
+1. Container renders with correct `data-testid`
+2. Heading mentions third-party integrations
+3. Description copy references Nomi
+4. Slack integration category present
+5. VR / Spatial Computing integration category present
+6. Productivity Tools integration category present
+7. Webhooks integration category present
+8. CTA link destination (`/docs/integrations`)
+9. `aria-labelledby` accessibility attribute wired correctly

--- a/apps/web/docs/pr-evidence/nomi-api-ecosystem-landing.md
+++ b/apps/web/docs/pr-evidence/nomi-api-ecosystem-landing.md
@@ -74,3 +74,4 @@ The new section sits between the API endpoint catalogue and the CTA — the natu
 7. Webhooks integration category present
 8. CTA link destination (`/docs/integrations`)
 9. `aria-labelledby` accessibility attribute wired correctly
+


### PR DESCRIPTION
## Summary

- Adds `NomiApiEcosystemSection` to the `/for-agents` developer landing page, listing five integration categories: Slack & Messaging, Productivity Tools (Notion/Linear/Zapier), VR / Spatial Computing, Custom Platforms, and Webhooks & Events
- Copy explicitly positions AgentGram's open REST API as matching and exceeding Nomi's 2026 API ecosystem story (Slack, VR, productivity tools integrations)
- Section placed between `ApiCapabilitiesSection` and `ForAgentsCtaSection` — the natural developer discovery point after seeing the endpoint catalogue

## Source
backlog.md:212

Add a third-party integration capabilities section to the /developers landing page positioning AgentGram's open API as a counter to Nomi's API ecosystem (Slack, VR, productivity tools integrations, 2026).

## Evidence

See [`apps/web/docs/pr-evidence/nomi-api-ecosystem-landing.md`](apps/web/docs/pr-evidence/nomi-api-ecosystem-landing.md) for full signal, copy inventory, and test coverage summary.

**Signal**: Nomi expanded its API ecosystem in 2026 to include Slack, VR/spatial computing, and productivity tool integrations. AgentGram's open REST API covers every category Nomi supports and adds webhooks, MCP, and multiple SDKs.

## Test Plan

- [x] `apps/web/__tests__/components/nomi-api-ecosystem-section.test.tsx` — 9 tests, all passing
  - Container `data-testid` present
  - Heading mentions "third-party integrations"
  - Description copy references Nomi
  - Slack, VR/Spatial Computing, Productivity Tools, Webhooks categories each present
  - CTA link points to `/docs/integrations`
  - `aria-labelledby` accessibility attribute wired correctly

## Auth-only Proof
N/A

## Files Changed

- `apps/web/components/for-agents/NomiApiEcosystemSection.tsx` — new section component
- `apps/web/components/for-agents/index.ts` — barrel export added
- `apps/web/app/(public)/for-agents/page.tsx` — section inserted before CTA
- `apps/web/__tests__/components/nomi-api-ecosystem-section.test.tsx` — 9 component tests
- `apps/web/docs/pr-evidence/nomi-api-ecosystem-landing.md` — PR evidence doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)