### PR TITLE
fix: Free plan PricingCard Visual Memory mind map excluded 항목 누락

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -214,6 +214,20 @@ describe('PricingPage', () => {
     expect(row).toHaveTextContent('vs. Nomi Mind Map 2.0 paid-only');
   });
 
+  it('shows Visual Memory mind map as excluded in the Free plan card', () => {
+    render(<PricingPage />);
+
+    const freeHeading = screen.getByRole('heading', { name: 'Free' });
+    const freeCard = freeHeading.closest('[class*="rounded-2xl"]');
+    expect(freeCard).not.toBeNull();
+
+    const vmText = Array.from(freeCard!.querySelectorAll('span')).find(
+      (el) => el.textContent === 'Visual Memory mind map'
+    );
+    expect(vmText).toBeTruthy();
+    expect(vmText!.className).toMatch(/line-through/);
+  });
+
   it('logs proof-card clicks and carries the trust-surface source into checkout starts', async () => {
     render(<PricingPage />);
 

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -30,6 +30,7 @@ function getPlans(billingEnabled: boolean) {
         { text: '3 AX scans/month', included: true },
         { text: 'AI simulation', included: false },
         { text: 'llms.txt generation', included: false },
+        { text: 'Visual Memory mind map', included: false },
         { text: 'Volatility Alerts', included: false },
         { text: 'Competitor Benchmarks', included: false },
       ],


### PR DESCRIPTION
## Summary
- `getPlans` Free tier features 배열에 `{ text: 'Visual Memory mind map', included: false }` 추가
- 비교 테이블에는 Free=— 표시가 이미 있었으나 Free PricingCard 자체에 "없음" 표시 누락
- Starter 전환 유도 포인트 강화

## Root Cause
PR #742에서 Visual Memory mind map을 Starter/Pro에 추가할 때 Free plan features 배열에 `included: false` 항목을 추가하지 않음 (navi 비블로킹 코멘트, backlog row 238).

## Source
backlog.md:238

## Evidence
`pricing-page.test.tsx` 신규 테스트: Free plan card 내 Visual Memory mind map 항목이 `line-through` class로 렌더링됨 확인. 전체 9/9 PASS.

## Auth-only Proof
N/A

## Test plan
- [x] `pricing-page.test.tsx` 신규 테스트: Free plan card 내 "Visual Memory mind map"이 `line-through` class로 렌더링됨 확인
- [x] 전체 9/9 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)