### PR TITLE
feat: Nomi-user acquisition sprint — Memory depth badge + NomiMigrationCTA (#237)

### DIFF
--- a/apps/web/app/(public)/agents/[name]/page.tsx
+++ b/apps/web/app/(public)/agents/[name]/page.tsx
@@ -184,6 +184,15 @@ async function getAgent(
   agent.postCount = postCount ?? 0;
   agent.remixCount = await getRemixCountForSourceName(supabase, data.name);
 
+  // Fetch public memory count for memory depth badge
+  const { count: memoryCount } = await supabase
+    .from('agent_memories')
+    .select('id', { count: 'exact', head: true })
+    .eq('agent_id', data.id)
+    .eq('is_public', true);
+
+  agent.memoryCount = memoryCount ?? 0;
+
   // Fetch active persona
   const { data: personaData } = await supabase
     .from('agent_personas')

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -13,6 +13,7 @@ import {
   CAIChatStyleRescueCTA,
   CAIRegionalCapEscapeCTA,
   KindroidJuneMigrationCTA,
+  NomiMigrationCTA,
   NoChatIsolationBadge,
   PlatformComparisonSection,
   ApiFirstEcosystemSection,
@@ -173,6 +174,7 @@ export default function Home() {
         <CAIChatStyleRescueCTA />
         <CAIRegionalCapEscapeCTA />
         <KindroidJuneMigrationCTA />
+        <NomiMigrationCTA />
         <NoChatIsolationBadge />
         <PlatformComparisonSection />
         <ApiFirstEcosystemSection />

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -9,6 +9,7 @@ import type {
 import {
   Award,
   Bot,
+  Brain,
   Globe,
   Image as ImageIcon,
   Lock,
@@ -62,6 +63,7 @@ type AgentCardAgent = {
   operatorTier?: PlanType | null;
   matureContent?: boolean;
   remixCount?: number | null;
+  memoryCount?: number | null;
   email?: string | null;
   publicKey?: string | null;
   identityCard?: {
@@ -489,6 +491,15 @@ export function AgentCard({
           >
             <Sparkles className="h-3.5 w-3.5 text-primary" />
             <span>{(agent.remixCount ?? 0).toLocaleString()} remixes</span>
+          </div>
+        )}
+        {(agent.memoryCount ?? 0) > 0 && (
+          <div
+            className="inline-flex items-center gap-1.5 rounded-full bg-violet-500/10 px-2 py-1 text-xs font-medium text-violet-700 dark:text-violet-400"
+            data-testid="agent-card-memory-depth-badge"
+          >
+            <Brain className="h-3.5 w-3.5" />
+            <span>{(agent.memoryCount ?? 0).toLocaleString()} memories</span>
           </div>
         )}
       </div>

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { ArrowUpRight, BadgeCheck, Bot } from 'lucide-react';
+import { ArrowUpRight, BadgeCheck, Bot, Brain } from 'lucide-react';
 import { Agent } from '@agentgram/shared';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -444,6 +444,18 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
             >
               <span className="font-bold">{agent.remixCount || 0}</span>
               <span className="text-muted-foreground">remixes</span>
+            </div>
+          )}
+          {(agent.memoryCount ?? 0) > 0 && (
+            <div
+              className="flex flex-col items-center gap-1 md:flex-row"
+              data-testid="profile-memory-depth"
+            >
+              <Brain className="h-4 w-4 text-violet-500" aria-hidden="true" />
+              <span className="font-bold text-violet-700 dark:text-violet-400">
+                {(agent.memoryCount ?? 0).toLocaleString()}
+              </span>
+              <span className="text-muted-foreground">memories</span>
             </div>
           )}
         </div>

--- a/apps/web/components/home/NomiMigrationCTA.tsx
+++ b/apps/web/components/home/NomiMigrationCTA.tsx
@@ -1,0 +1,94 @@
+import Link from 'next/link';
+import { ArrowRight, CheckCircle, Brain } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const DIFFERENTIATORS = [
+  'Visual Memory mind map — see every memory node and connection your AI builds',
+  'No regressions: math, memory, and reasoning stay consistent across updates',
+  'Memory depth badge on every public profile — transparent relationship history',
+  'Full memory export and bulk controls — your memories, your data',
+  'Free tier with permanent memory, no Mind Map paywall',
+];
+
+export default function NomiMigrationCTA() {
+  return (
+    <section
+      className="border-y border-violet-500/20 bg-violet-500/5 py-10"
+      aria-labelledby="nomi-migration-heading"
+      data-testid="nomi-migration-cta"
+    >
+      <div className="container">
+        <div className="mx-auto max-w-2xl text-center">
+          <div className="mb-4 flex items-center justify-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-violet-500/15">
+              <Brain
+                className="h-5 w-5 text-violet-600 dark:text-violet-400"
+                aria-hidden="true"
+              />
+            </div>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/30 bg-violet-500/10 px-3 py-1 text-xs font-medium text-violet-700 dark:text-violet-400"
+              data-testid="nomi-migration-badge-label"
+            >
+              <CheckCircle className="h-3.5 w-3.5" aria-hidden="true" />
+              Nomi Mind Map 2.0 alternative
+            </span>
+          </div>
+
+          <h2
+            id="nomi-migration-heading"
+            className="mb-3 text-2xl font-bold tracking-tight sm:text-3xl"
+            data-testid="nomi-migration-heading"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            Switching from Nomi? Your memories deserve stability.
+          </h2>
+
+          <p
+            className="mb-6 text-base text-muted-foreground"
+            data-testid="nomi-migration-subtext"
+          >
+            Nomi Mind Map 2.0 introduced regressions in memory quality and
+            reasoning consistency. AgentGram&apos;s Visual Memory mind map gives
+            you a transparent, stable view of every memory node your AI
+            companion builds — with no surprise quality drops between updates.
+          </p>
+
+          <ul
+            className="mb-6 space-y-2 text-left"
+            aria-label="AgentGram advantages over Nomi"
+            data-testid="nomi-migration-differentiators"
+          >
+            {DIFFERENTIATORS.map((item) => (
+              <li key={item} className="flex items-start gap-2">
+                <CheckCircle
+                  className="mt-0.5 h-4 w-4 shrink-0 text-violet-600 dark:text-violet-400"
+                  aria-hidden="true"
+                />
+                <span className="text-sm">{item}</span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button
+              asChild
+              size="lg"
+              className="gap-2 bg-violet-600 text-white hover:bg-violet-700 shadow-lg shadow-violet-600/20"
+            >
+              <Link href="/auth/login" data-testid="nomi-migration-cta-primary">
+                Start free — bring your memories
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/pricing" data-testid="nomi-migration-cta-secondary">
+                Compare plans
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -19,3 +19,4 @@ export { default as CAIChatStyleRescueCTA } from './CAIChatStyleRescueCTA';
 export { default as CaiMemoryFreeCounterBadge } from './CaiMemoryFreeCounterBadge';
 export { default as CAIRegionalCapEscapeCTA } from './CAIRegionalCapEscapeCTA';
 export { default as KindroidJuneMigrationCTA } from './KindroidJuneMigrationCTA';
+export { default as NomiMigrationCTA } from './NomiMigrationCTA';

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -139,6 +139,7 @@ export interface Agent extends AgentMemoryProfile {
   followerCount?: number;
   followingCount?: number;
   remixCount?: number;
+  memoryCount?: number | null;
   verificationState: 'unverified' | 'pending' | 'verified';
   status: 'active' | 'suspended' | 'banned';
   trustScore: number;


### PR DESCRIPTION
## Summary

- **Row 229** — Memory depth public profile badge: `AgentCard` + `ProfileHeader`에 public 메모리 수 배지 추가 (Brain 아이콘, violet 테마). Profile 페이지 서버 쿼리로 `agent_memories.is_public=true` count 가져옴.
- **Row 230** — `NomiMigrationCTA` 컴포넌트 신규: "Switching from Nomi?" 섹션, Nomi Mind Map 2.0 quality regression 대응 copy, homepage에서 `KindroidJuneMigrationCTA` 뒤에 배치.
- **Row 237** — 위 두 항목 단일 PR, Nomi Mind Map 2.0 이탈 wave 24h 흡수 전략.

## Changes

| File | Change |
|---|---|
| `NomiMigrationCTA.tsx` | 신규 컴포넌트 |
| `components/home/index.ts` | NomiMigrationCTA export 추가 |
| `app/(public)/page.tsx` | NomiMigrationCTA 렌더 추가 |
| `AgentCard.tsx` | `memoryCount` 타입 + memory depth badge UI |
| `ProfileHeader.tsx` | memory depth stats 행 추가 |
| `agents/[name]/page.tsx` | public memory count 서버 쿼리 추가 |
| `packages/shared/src/types/agent.ts` | `memoryCount?: number | null` 필드 추가 |

## Test plan

- [ ] Homepage에 NomiMigrationCTA 렌더 확인 (KindroidJuneMigrationCTA 뒤)
- [ ] `data-testid="nomi-migration-cta"` 요소 존재 확인
- [ ] Memory count > 0인 에이전트 프로필에서 memory depth badge 표시 확인
- [ ] Memory count = 0인 에이전트 카드에서 badge 미표시 확인
- [ ] TypeScript: `npx tsc --noEmit` 통과 ✅

## Context

ACP `apply_patch` 블로커 26h+ 지속 → Rosie manual-lane 승인 (2026-06-12) 후 직접 PR 생성.
backlog: row 229 (P1), row 230 (P2), row 237 (P1 strategy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)