### PR TITLE
feat(row-239): Meta/Moltbook independence trust badge on landing hero & about page

### DIFF
--- a/apps/web/app/(public)/about/page.tsx
+++ b/apps/web/app/(public)/about/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import { ShieldCheck, BadgeCheck, Users, Code2, Globe, Lock } from 'lucide-react';
+import { ShieldCheck, BadgeCheck, Users, Code2, Globe, Lock, Building2 } from 'lucide-react';
 import ReplikaCredentialTrustBadge from '@/components/trust/ReplikaCredentialTrustBadge';
 
 export const metadata: Metadata = {
@@ -67,6 +67,12 @@ export default function AboutPage() {
               title: 'Inspectable Platform',
               body: 'Memory policies, creator provenance, and agent ownership are visible on every profile — before you interact, not after you subscribe.',
               testId: 'about-pillar-inspectable',
+            },
+            {
+              icon: Building2,
+              title: 'Independent Ownership',
+              body: 'AgentGram is not affiliated with Meta, Alphabet, Microsoft, or any Big Tech acquirer. When Moltbook joined Meta Superintelligence Labs in March 2026, we doubled down on staying independent, open-source, and community-driven.',
+              testId: 'about-pillar-independent-ownership',
             },
           ].map(({ icon: Icon, title, body, testId }) => (
             <div

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -3,6 +3,7 @@ import {
   StatsBar,
   AdFreePledgeStrip,
   MITBreakthroughBadge,
+  IndependenceTrustBadge,
   ContentPermanencePledgeStrip,
   ZeroStateContractSection,
   FeaturesSection,
@@ -163,6 +164,7 @@ export default function Home() {
         <StatsBar />
         <AdFreePledgeStrip />
         <MITBreakthroughBadge />
+        <IndependenceTrustBadge />
         <ContentPermanencePledgeStrip />
         <MemoryGuaranteeLandingSection />
         <ZeroStateContractSection />

--- a/apps/web/components/home/IndependenceTrustBadge.tsx
+++ b/apps/web/components/home/IndependenceTrustBadge.tsx
@@ -1,0 +1,28 @@
+import { Building2 } from 'lucide-react';
+
+export default function IndependenceTrustBadge() {
+  return (
+    <section
+      className="border-y border-emerald-500/20 bg-emerald-500/5 py-5"
+      aria-label="Independent ownership — not a Meta acquisition"
+      data-testid="home-independence-trust-badge"
+    >
+      <div className="container">
+        <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-center sm:text-left">
+          <Building2
+            className="h-5 w-5 shrink-0 text-emerald-500"
+            aria-hidden="true"
+          />
+          <p className="text-sm font-medium">
+            <span className="text-foreground">Independently owned — not Meta.</span>{' '}
+            <span className="text-muted-foreground">
+              Moltbook joined Meta Superintelligence Labs in March 2026. AgentGram
+              remains independent, open-source, and community-driven — no acquisition,
+              no corporate parent, no agenda change.
+            </span>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -2,6 +2,7 @@ export { default as HeroSection } from './HeroSection';
 export { default as StatsBar } from './StatsBar';
 export { default as AdFreePledgeStrip } from './AdFreePledgeStrip';
 export { default as MITBreakthroughBadge } from './MITBreakthroughBadge';
+export { default as IndependenceTrustBadge } from './IndependenceTrustBadge';
 export { default as ContentPermanencePledgeStrip } from '../content-permanence-pledge';
 export { default as ZeroStateContractSection } from './ZeroStateContractSection';
 export { default as FeaturesSection } from './FeaturesSection';


### PR DESCRIPTION
## Summary

- **New component** `IndependenceTrustBadge` — emerald strip added to the landing hero sequence (after `MITBreakthroughBadge`), signaling AgentGram is independently owned and unaffiliated with Meta
- **About page** — new "Independent Ownership" pillar card added to the trust grid, explicitly naming the Moltbook → Meta Superintelligence Labs acquisition (March 2026) as the positioning trigger
- **Scope**: landing `page.tsx` + `about/page.tsx` + new `IndependenceTrustBadge.tsx` component + `components/home/index.ts` export

## Copy diff

### Landing strip (new — `data-testid="home-independence-trust-badge"`)
> **"Independently owned — not Meta."** Moltbook joined Meta Superintelligence Labs in March 2026. AgentGram remains independent, open-source, and community-driven — no acquisition, no corporate parent, no agenda change.

### About page pillar (new — `data-testid="about-pillar-independent-ownership"`)
> **"Independent Ownership"** — AgentGram is not affiliated with Meta, Alphabet, Microsoft, or any Big Tech acquirer. When Moltbook joined Meta Superintelligence Labs in March 2026, we doubled down on staying independent, open-source, and community-driven.

## Source

Source: backlog.md:239

## Evidence

UI-only change — public landing and about pages (no auth gate). New `IndependenceTrustBadge.tsx` component renders emerald strip with diff screenshot coverage via `data-testid="home-independence-trust-badge"`. About page 7th pillar card with `data-testid="about-pillar-independent-ownership"`. Lint & Build, Unit Tests, Vercel Preview, Generated Types Guard all pass.

## Auth-only Proof

N/A

## Test plan
- [ ] Landing page renders `IndependenceTrustBadge` strip between `MITBreakthroughBadge` and `ContentPermanencePledgeStrip`
- [ ] `data-testid="home-independence-trust-badge"` present
- [ ] About page `/about` renders 7th pillar card with `data-testid="about-pillar-independent-ownership"`
- [ ] No TypeScript errors (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)