### PR TITLE
[STRATEGY] Quality-first pledge — C.AI silent regression counter

### DIFF
--- a/apps/web/__tests__/components/quality-first-pledge.test.tsx
+++ b/apps/web/__tests__/components/quality-first-pledge.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import QualityFirstPledgeStrip, {
+  QualityFirstPledgeBadge,
+} from '../../components/home/QualityFirstPledge';
+
+describe('QualityFirstPledgeStrip', () => {
+  it('renders with correct test id', () => {
+    render(<QualityFirstPledgeStrip />);
+    expect(
+      screen.getByTestId('home-quality-first-pledge-strip')
+    ).toBeInTheDocument();
+  });
+
+  it('displays quality-first headline', () => {
+    render(<QualityFirstPledgeStrip />);
+    expect(
+      screen.getByText(/Quality-first — no silent regressions, ever/i)
+    ).toBeInTheDocument();
+  });
+
+  it('mentions C.AI silent degradation context', () => {
+    render(<QualityFirstPledgeStrip />);
+    expect(screen.getByText(/C\.AI silently degraded/i)).toBeInTheDocument();
+  });
+
+  it('has aria-label for accessibility', () => {
+    render(<QualityFirstPledgeStrip />);
+    expect(
+      screen.getByLabelText('Quality-first, no silent regressions pledge')
+    ).toBeInTheDocument();
+  });
+
+  it('mentions zero silent quality degradations commitment', () => {
+    render(<QualityFirstPledgeStrip />);
+    expect(
+      screen.getByText(/zero silent quality degradations/i)
+    ).toBeInTheDocument();
+  });
+});
+
+describe('QualityFirstPledgeBadge', () => {
+  it('renders with correct test id', () => {
+    render(<QualityFirstPledgeBadge />);
+    expect(
+      screen.getByTestId('quality-first-pledge-badge')
+    ).toBeInTheDocument();
+  });
+
+  it('displays Quality-First Guaranteed label', () => {
+    render(<QualityFirstPledgeBadge />);
+    expect(screen.getByText(/Quality-First Guaranteed/i)).toBeInTheDocument();
+  });
+
+  it('displays no silent regressions headline', () => {
+    render(<QualityFirstPledgeBadge />);
+    expect(
+      screen.getByText(/No silent quality regressions — ever/i)
+    ).toBeInTheDocument();
+  });
+
+  it('mentions versioned capability changes', () => {
+    render(<QualityFirstPledgeBadge />);
+    expect(screen.getByText(/versioned and announced/i)).toBeInTheDocument();
+  });
+
+  it('has aria-label for accessibility', () => {
+    render(<QualityFirstPledgeBadge />);
+    expect(
+      screen.getByLabelText('Quality-first pledge badge')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -16,6 +16,7 @@ import {
   KindroidJuneMigrationCTA,
   NomiMigrationCTA,
   NoChatIsolationBadge,
+  QualityFirstPledgeStrip,
   PlatformComparisonSection,
   ApiFirstEcosystemSection,
   FaqSection,
@@ -165,6 +166,7 @@ export default function Home() {
         <AdFreePledgeStrip />
         <MITBreakthroughBadge />
         <IndependenceTrustBadge />
+        <QualityFirstPledgeStrip />
         <ContentPermanencePledgeStrip />
         <MemoryGuaranteeLandingSection />
         <ZeroStateContractSection />

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -17,6 +17,7 @@ import ReplikaCredentialTrustBadge from '@/components/trust/ReplikaCredentialTru
 import { Button } from '@/components/ui/button';
 import { analytics } from '@/lib/analytics';
 import NoChatIsolationBadge from '@/components/home/NoChatIsolationBadge';
+import { QualityFirstPledgeBadge } from '@/components/home/QualityFirstPledge';
 
 function getPlans(billingEnabled: boolean) {
   return [
@@ -305,8 +306,24 @@ export default function PricingPage() {
               AI Image Gen — free for all
             </span>
             <NomiV5ImageParityBadge />
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-700 dark:text-blue-400"
+              data-testid="pricing-quality-first-badge"
+            >
+              <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+              Quality-first — no silent regressions
+            </span>
           </div>
         </motion.div>
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="pricing-quality-first-pledge-section"
+      >
+        <div className="mx-auto max-w-6xl">
+          <QualityFirstPledgeBadge />
+        </div>
       </section>
 
       <section className="container pb-10">

--- a/apps/web/components/home/QualityFirstPledge.tsx
+++ b/apps/web/components/home/QualityFirstPledge.tsx
@@ -1,0 +1,51 @@
+import { ShieldCheck } from 'lucide-react';
+
+export default function QualityFirstPledgeStrip() {
+  return (
+    <section
+      className="border-y border-blue-500/20 bg-blue-500/5 py-5"
+      aria-label="Quality-first, no silent regressions pledge"
+      data-testid="home-quality-first-pledge-strip"
+    >
+      <div className="container">
+        <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-center sm:text-left">
+          <ShieldCheck
+            className="h-5 w-5 shrink-0 text-blue-500"
+            aria-hidden="true"
+          />
+          <p className="text-sm font-medium">
+            <span className="text-foreground">Quality-first — no silent regressions, ever.</span>{' '}
+            <span className="text-muted-foreground">
+              C.AI silently degraded memory, personas, and response quality without
+              notifying users (2025–2026). AgentGram commits to zero silent quality
+              degradations: every capability change is announced and versioned.
+            </span>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function QualityFirstPledgeBadge() {
+  return (
+    <section
+      className="rounded-2xl border border-blue-500/20 bg-blue-500/5 p-4 shadow-sm"
+      aria-label="Quality-first pledge badge"
+      data-testid="quality-first-pledge-badge"
+    >
+      <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-blue-600 dark:text-blue-400">
+        <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+        Quality-First Guaranteed
+      </div>
+      <p className="mt-3 text-sm font-medium text-foreground">
+        No silent quality regressions — ever.
+      </p>
+      <p className="mt-1 text-sm leading-6 text-muted-foreground">
+        AgentGram pledges full transparency on every capability change.
+        Memory, personas, and response quality are versioned and announced —
+        never silently degraded.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -21,3 +21,4 @@ export { default as CaiMemoryFreeCounterBadge } from './CaiMemoryFreeCounterBadg
 export { default as CAIRegionalCapEscapeCTA } from './CAIRegionalCapEscapeCTA';
 export { default as KindroidJuneMigrationCTA } from './KindroidJuneMigrationCTA';
 export { default as NomiMigrationCTA } from './NomiMigrationCTA';
+export { default as QualityFirstPledgeStrip, QualityFirstPledgeBadge } from './QualityFirstPledge';

--- a/docs/pr-evidence/quality-first-pledge.md
+++ b/docs/pr-evidence/quality-first-pledge.md
@@ -1,0 +1,33 @@
+# PR Evidence: Quality-First Pledge
+
+## Source
+Backlog row 233 — `[STRATEGY] Independence trust badge + quality-first pledge`
+
+## Changes
+
+### New component: `QualityFirstPledge.tsx`
+- `QualityFirstPledgeStrip` — border-y banner strip (matches IndependenceTrustBadge / ContentPermanencePledgeStrip pattern)
+- `QualityFirstPledgeBadge` — card variant (matches CreatorProtectedBadge pattern)
+
+### Landing page `/`
+**Before:** `IndependenceTrustBadge` → `ContentPermanencePledgeStrip`
+**After:**  `IndependenceTrustBadge` → `QualityFirstPledgeStrip` → `ContentPermanencePledgeStrip`
+
+### Pricing page `/pricing`
+**Before:** badge row ends at `NomiV5ImageParityBadge`
+**After:**
+- Badge row: `NomiV5ImageParityBadge` + new `pricing-quality-first-badge` pill
+- New `pricing-quality-first-pledge-section` block with `QualityFirstPledgeBadge` card
+
+## Tests
+File: `__tests__/components/quality-first-pledge.test.tsx`
+- 10 tests, PASS (0 failures)
+- Covers: testid, copy text, C.AI context, aria-label, zero-regression commitment, versioned-changes copy
+
+## TypeScript
+`npx tsc --noEmit` → 0 errors
+
+## Competitive rationale
+C.AI silently degraded memory, personas, and response quality (2025–2026) without user notification.
+This pledge targets that specific trust gap for users migrating from C.AI — "quality-first, no silent regressions"
+as a direct counter-positioning statement on both the hero landing and pricing pages.


### PR DESCRIPTION
## Summary

- Add `QualityFirstPledgeStrip` banner on landing hero (/) after `IndependenceTrustBadge`
- Add `QualityFirstPledgeBadge` card + inline pill on /pricing hero badge row
- Target: C.AI users who experienced silent quality degradations (2025–2026)
- Messaging: "quality-first, no silent regressions" — every capability change announced and versioned

## Source

Backlog row 233 — `[STRATEGY] Independence trust badge + quality-first pledge`
PR #745 shipped `IndependenceTrustBadge` ("independently owned, not Meta-acquired"); this PR adds the quality-first pledge dimension.

## Changes

| File | Description |
|------|-------------|
| `components/home/QualityFirstPledge.tsx` | New component (strip + badge variants) |
| `components/home/index.ts` | Barrel export |
| `app/(public)/page.tsx` | Strip inserted after IndependenceTrustBadge |
| `app/(public)/pricing/page.tsx` | Badge card section + inline pill in hero badges |
| `__tests__/components/quality-first-pledge.test.tsx` | 10 tests |

## Evidence

See: `docs/pr-evidence/quality-first-pledge.md`

**Before landing:**
`IndependenceTrustBadge → ContentPermanencePledgeStrip`

**After landing:**
`IndependenceTrustBadge → QualityFirstPledgeStrip → ContentPermanencePledgeStrip`

**Pricing:** new `pricing-quality-first-pledge-section` + `pricing-quality-first-badge` pill added.

## Auth-only Proof

N/A

## Tests

```
PASS (10) FAIL (0)
```
`npx tsc --noEmit` → 0 errors

## Competitive context

C.AI silently degraded memory, personas, and response quality without user notification (2025–2026).
This pledge directly counter-positions AgentGram as the transparent, quality-first alternative for C.AI migrators.