### PR TITLE
feat: proactive post analytics panel — which posts drive session starts

### DIFF
--- a/apps/web/__tests__/components/proactive-post-analytics-panel.test.tsx
+++ b/apps/web/__tests__/components/proactive-post-analytics-panel.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ProactivePostAnalyticsPanel } from '@/components/dashboard/ProactivePostAnalyticsPanel';
+import type { ProactivePostAnalyticsData } from '@/components/dashboard/ProactivePostAnalyticsPanel';
+import type { CadenceDay, ContentTypeBreakdown, ProactivePostRecord } from '@/lib/dashboard/proactive-post-analytics';
+
+function buildCadence(days = 28, posts = 0): CadenceDay[] {
+  const today = new Date('2026-06-13');
+  return Array.from({ length: days }, (_, i) => {
+    const d = new Date(today);
+    d.setDate(today.getDate() - (days - 1 - i));
+    return { date: d.toISOString().slice(0, 10), posts };
+  });
+}
+
+function buildPost(overrides: Partial<ProactivePostRecord> = {}): ProactivePostRecord {
+  return {
+    id: 'post-1',
+    contentType: 'thought',
+    preview: 'Today I noticed something interesting about the world.',
+    postedAt: '2026-06-10T12:00:00Z',
+    sessionStartsTriggered: 5,
+    conversionRate: 62,
+    ...overrides,
+  };
+}
+
+function buildBreakdown(overrides: Partial<ContentTypeBreakdown> = {}): ContentTypeBreakdown {
+  return {
+    contentType: 'mood_update',
+    count: 10,
+    percentage: 40,
+    avgSessionStarts: 3,
+    ...overrides,
+  };
+}
+
+function buildData(overrides: Partial<ProactivePostAnalyticsData> = {}): ProactivePostAnalyticsData {
+  return {
+    totalPosts: 0,
+    totalSessionStarts: 0,
+    avgPostsPerDay: 0,
+    topPosts: [],
+    cadence: buildCadence(),
+    contentTypeBreakdown: [],
+    ...overrides,
+  };
+}
+
+describe('ProactivePostAnalyticsPanel', () => {
+  it('renders the panel container', () => {
+    render(<ProactivePostAnalyticsPanel data={buildData()} />);
+    expect(screen.getByTestId('proactive-post-analytics-panel')).toBeInTheDocument();
+  });
+
+  it('displays summary metrics: total posts, sessions, avg/day', () => {
+    render(
+      <ProactivePostAnalyticsPanel
+        data={buildData({ totalPosts: 12, totalSessionStarts: 47, avgPostsPerDay: 1.5 })}
+      />
+    );
+    expect(screen.getByTestId('metric-total-posts')).toHaveTextContent('12');
+    expect(screen.getByTestId('metric-total-sessions')).toHaveTextContent('47');
+    expect(screen.getByTestId('metric-avg-posts-per-day')).toHaveTextContent('1.5');
+  });
+
+  it('renders the 28-day cadence strip', () => {
+    render(<ProactivePostAnalyticsPanel data={buildData()} />);
+    expect(screen.getByTestId('cadence-strip')).toBeInTheDocument();
+  });
+
+  it('cadence strip has correct aria-label', () => {
+    render(<ProactivePostAnalyticsPanel data={buildData()} />);
+    expect(
+      screen.getByLabelText('Post cadence — last 28 days')
+    ).toBeInTheDocument();
+  });
+
+  it('shows empty state when topPosts is empty', () => {
+    render(<ProactivePostAnalyticsPanel data={buildData({ topPosts: [] })} />);
+    expect(screen.getByTestId('top-posts-empty')).toBeInTheDocument();
+  });
+
+  it('renders top posts list when posts are provided', () => {
+    const posts = [
+      buildPost({ id: 'p1', sessionStartsTriggered: 8 }),
+      buildPost({ id: 'p2', sessionStartsTriggered: 3, contentType: 'quote' }),
+    ];
+    render(<ProactivePostAnalyticsPanel data={buildData({ topPosts: posts })} />);
+    expect(screen.getByTestId('top-posts-list')).toBeInTheDocument();
+    expect(screen.getAllByTestId(/^top-post-\d+$/).length).toBe(2);
+  });
+
+  it('top post shows session starts count', () => {
+    const posts = [buildPost({ id: 'p1', sessionStartsTriggered: 42 })];
+    render(<ProactivePostAnalyticsPanel data={buildData({ topPosts: posts })} />);
+    expect(screen.getByTestId('top-post-0-sessions')).toHaveTextContent('42');
+  });
+
+  it('shows content-type empty state when breakdown is empty', () => {
+    render(<ProactivePostAnalyticsPanel data={buildData({ contentTypeBreakdown: [] })} />);
+    expect(screen.getByTestId('content-type-empty')).toBeInTheDocument();
+  });
+
+  it('renders content-type breakdown bars when data is provided', () => {
+    const breakdown = [
+      buildBreakdown({ contentType: 'thought', count: 5, percentage: 50, avgSessionStarts: 4 }),
+      buildBreakdown({ contentType: 'quote', count: 5, percentage: 50, avgSessionStarts: 2 }),
+    ];
+    render(
+      <ProactivePostAnalyticsPanel data={buildData({ contentTypeBreakdown: breakdown })} />
+    );
+    expect(screen.getByTestId('content-type-breakdown')).toBeInTheDocument();
+  });
+
+  it('formats avgPostsPerDay with one decimal place', () => {
+    render(<ProactivePostAnalyticsPanel data={buildData({ avgPostsPerDay: 2 })} />);
+    expect(screen.getByTestId('metric-avg-posts-per-day')).toHaveTextContent('2.0');
+  });
+
+  it('displays content-type labels correctly', () => {
+    const breakdown = [
+      buildBreakdown({ contentType: 'daily_reflection', count: 3, percentage: 30, avgSessionStarts: 1 }),
+    ];
+    render(<ProactivePostAnalyticsPanel data={buildData({ contentTypeBreakdown: breakdown })} />);
+    expect(screen.getByText('Daily reflection')).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(protected)/dashboard/analytics/page.tsx
+++ b/apps/web/app/(protected)/dashboard/analytics/page.tsx
@@ -17,8 +17,9 @@ import {
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { FadeIn, AgentStickinessPanel } from '@/components/dashboard';
+import { FadeIn, AgentStickinessPanel, ProactivePostAnalyticsPanel } from '@/components/dashboard';
 import { getPlatformAnalyticsSnapshot } from '@/lib/dashboard/analytics';
+import { getStubbedProactivePostAnalytics } from '@/lib/dashboard/proactive-post-analytics';
 import type { AgentStickinessData } from '@/components/dashboard/AgentStickinessPanel';
 
 export const metadata = {
@@ -46,6 +47,7 @@ function getStubbedStickinessData(): AgentStickinessData {
 export default async function DashboardAnalyticsPage() {
   const analytics = await getPlatformAnalyticsSnapshot();
   const stickinessData = getStubbedStickinessData();
+  const proactivePostData = getStubbedProactivePostAnalytics();
 
   return (
     <div className="space-y-8">
@@ -278,6 +280,10 @@ export default async function DashboardAnalyticsPage() {
 
       <FadeIn delay={0.35}>
         <AgentStickinessPanel data={stickinessData} />
+      </FadeIn>
+
+      <FadeIn delay={0.4}>
+        <ProactivePostAnalyticsPanel data={proactivePostData} />
       </FadeIn>
     </div>
   );

--- a/apps/web/components/dashboard/ProactivePostAnalyticsPanel.tsx
+++ b/apps/web/components/dashboard/ProactivePostAnalyticsPanel.tsx
@@ -40,19 +40,19 @@ function CadenceStrip({ cadence }: { cadence: CadenceDay[] }) {
       className="flex items-end gap-[2px] h-10"
       aria-label="Post cadence — last 28 days"
     >
-      {cadence.map((day, i) => {
-        const heightPct = max === 0 ? 0 : Math.round((day.posts / max) * 100);
+      {cadence.map((day) => {
+        const heightPct = Math.round((day.posts / max) * 100);
         return (
           <div
-            key={day.date || i}
+            key={day.date}
             className="flex-1 rounded-sm bg-primary/20"
             style={{ height: '100%', display: 'flex', alignItems: 'flex-end' }}
-            title={day.date ? `${day.date}: ${day.posts} posts` : 'No data'}
+            title={`${day.date}: ${day.posts} posts`}
           >
             <div
               className="w-full rounded-sm bg-primary transition-all"
               style={{ height: `${heightPct}%` }}
-              aria-label={day.date ? `${day.date}: ${day.posts} posts` : 'No data'}
+              aria-label={`${day.date}: ${day.posts} posts`}
             />
           </div>
         );
@@ -112,7 +112,7 @@ function TopPostsList({ posts }: { posts: ProactivePostRecord[] }) {
             </div>
           </div>
           <p className="mt-1 text-xs text-muted-foreground">
-            {post.conversionRate}% conversion · posted{' '}
+            {post.conversionRate.toFixed(1)}% conversion · posted{' '}
             {new Intl.DateTimeFormat('en', {
               dateStyle: 'medium',
             }).format(new Date(post.postedAt))}

--- a/apps/web/components/dashboard/ProactivePostAnalyticsPanel.tsx
+++ b/apps/web/components/dashboard/ProactivePostAnalyticsPanel.tsx
@@ -1,0 +1,275 @@
+'use client';
+
+import { BarChart3, FileText, Sparkles, TrendingUp, Zap } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import type {
+  CadenceDay,
+  ContentTypeBreakdown,
+  ProactivePostAnalyticsData,
+  ProactivePostContentType,
+  ProactivePostRecord,
+} from '@/lib/dashboard/proactive-post-analytics';
+
+export type { ProactivePostAnalyticsData };
+
+const CONTENT_TYPE_LABELS: Record<ProactivePostContentType, string> = {
+  mood_update: 'Mood update',
+  quote: 'Quote',
+  photo_caption: 'Photo caption',
+  thought: 'Thought',
+  daily_reflection: 'Daily reflection',
+};
+
+interface ProactivePostAnalyticsPanelProps {
+  data: ProactivePostAnalyticsData;
+}
+
+function CadenceStrip({ cadence }: { cadence: CadenceDay[] }) {
+  const max = Math.max(...cadence.map((d) => d.posts), 1);
+
+  return (
+    <div
+      data-testid="cadence-strip"
+      className="flex items-end gap-[2px] h-10"
+      aria-label="Post cadence — last 28 days"
+    >
+      {cadence.map((day, i) => {
+        const heightPct = max === 0 ? 0 : Math.round((day.posts / max) * 100);
+        return (
+          <div
+            key={day.date || i}
+            className="flex-1 rounded-sm bg-primary/20"
+            style={{ height: '100%', display: 'flex', alignItems: 'flex-end' }}
+            title={day.date ? `${day.date}: ${day.posts} posts` : 'No data'}
+          >
+            <div
+              className="w-full rounded-sm bg-primary transition-all"
+              style={{ height: `${heightPct}%` }}
+              aria-label={day.date ? `${day.date}: ${day.posts} posts` : 'No data'}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function TopPostsList({ posts }: { posts: ProactivePostRecord[] }) {
+  if (posts.length === 0) {
+    return (
+      <p
+        data-testid="top-posts-empty"
+        className="text-sm text-muted-foreground"
+      >
+        No proactive post data is available yet. Posts will appear here once
+        your agents start publishing between-session updates.
+      </p>
+    );
+  }
+
+  return (
+    <ol
+      data-testid="top-posts-list"
+      className="space-y-3"
+    >
+      {posts.map((post, index) => (
+        <li
+          key={post.id}
+          className="rounded-lg border border-border/60 p-3"
+          data-testid={`top-post-${index}`}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 mb-1">
+                <span className="text-xs font-semibold text-muted-foreground">
+                  #{index + 1}
+                </span>
+                <Badge variant="secondary" className="text-xs">
+                  {CONTENT_TYPE_LABELS[post.contentType]}
+                </Badge>
+              </div>
+              <p className="text-sm leading-snug truncate text-foreground">
+                {post.preview}
+              </p>
+            </div>
+            <div
+              className="flex flex-col items-end gap-0.5 shrink-0"
+              data-testid={`top-post-${index}-sessions`}
+            >
+              <span className="text-lg font-bold tabular-nums text-primary">
+                {post.sessionStartsTriggered}
+              </span>
+              <span className="text-[10px] text-muted-foreground whitespace-nowrap">
+                sessions started
+              </span>
+            </div>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {post.conversionRate}% conversion · posted{' '}
+            {new Intl.DateTimeFormat('en', {
+              dateStyle: 'medium',
+            }).format(new Date(post.postedAt))}
+          </p>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function ContentTypeBreakdownList({
+  breakdown,
+}: {
+  breakdown: ContentTypeBreakdown[];
+}) {
+  if (breakdown.length === 0) {
+    return (
+      <p
+        data-testid="content-type-empty"
+        className="text-sm text-muted-foreground"
+      >
+        Content type data will appear once posts are published.
+      </p>
+    );
+  }
+
+  return (
+    <ul
+      data-testid="content-type-breakdown"
+      className="space-y-2"
+    >
+      {breakdown.map((item) => (
+        <li key={item.contentType} className="space-y-1">
+          <div className="flex items-center justify-between text-sm">
+            <span className="font-medium">
+              {CONTENT_TYPE_LABELS[item.contentType]}
+            </span>
+            <span className="text-muted-foreground tabular-nums">
+              {item.count} posts · {item.percentage}%
+            </span>
+          </div>
+          <div className="h-1.5 rounded-full bg-muted">
+            <div
+              className="h-1.5 rounded-full bg-primary transition-all"
+              style={{ width: `${item.percentage}%` }}
+              aria-label={`${CONTENT_TYPE_LABELS[item.contentType]}: ${item.percentage}%`}
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            avg {item.avgSessionStarts} sessions/post
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function ProactivePostAnalyticsPanel({
+  data,
+}: ProactivePostAnalyticsPanelProps) {
+  const {
+    totalPosts,
+    totalSessionStarts,
+    avgPostsPerDay,
+    topPosts,
+    cadence,
+    contentTypeBreakdown,
+  } = data;
+
+  return (
+    <Card
+      data-testid="proactive-post-analytics-panel"
+      className="border-border/50 bg-card/50 backdrop-blur-sm"
+    >
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Sparkles className="h-5 w-5 text-primary" />
+          Proactive post analytics
+        </CardTitle>
+        <CardDescription>
+          Which between-session posts drove the most session starts, with
+          cadence and content-type breakdown. Conversion window: 4 hours after
+          post (Kindroid stickiness formula).
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        {/* Summary metrics */}
+        <div
+          data-testid="summary-metrics"
+          className="grid grid-cols-3 gap-3"
+        >
+          <div className="flex flex-col gap-1 rounded-lg border border-border/60 p-3">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <FileText className="h-3.5 w-3.5" />
+              Total posts
+            </div>
+            <p
+              data-testid="metric-total-posts"
+              className="text-2xl font-bold tabular-nums"
+            >
+              {totalPosts}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-1 rounded-lg border border-border/60 p-3">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Zap className="h-3.5 w-3.5" />
+              Sessions started
+            </div>
+            <p
+              data-testid="metric-total-sessions"
+              className="text-2xl font-bold tabular-nums"
+            >
+              {totalSessionStarts}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-1 rounded-lg border border-border/60 p-3">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <TrendingUp className="h-3.5 w-3.5" />
+              Posts/day avg
+            </div>
+            <p
+              data-testid="metric-avg-posts-per-day"
+              className="text-2xl font-bold tabular-nums"
+            >
+              {avgPostsPerDay.toFixed(1)}
+            </p>
+          </div>
+        </div>
+
+        {/* Cadence strip */}
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Post cadence — last 28 days</p>
+          <CadenceStrip cadence={cadence} />
+          <p className="text-xs text-muted-foreground">
+            Each bar represents one day. Height scales to peak volume.
+          </p>
+        </div>
+
+        {/* Top posts + content type breakdown side by side */}
+        <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="space-y-3">
+            <p className="flex items-center gap-2 text-sm font-medium">
+              <BarChart3 className="h-4 w-4 text-primary" />
+              Top posts by session starts
+            </p>
+            <TopPostsList posts={topPosts} />
+          </div>
+
+          <div className="space-y-3">
+            <p className="text-sm font-medium">Content-type breakdown</p>
+            <ContentTypeBreakdownList breakdown={contentTypeBreakdown} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/dashboard/index.ts
+++ b/apps/web/components/dashboard/index.ts
@@ -18,3 +18,5 @@ export { DailyReflectionSettingsCard } from './DailyReflectionSettingsCard';
 export type { DailyReflectionSettings } from './DailyReflectionSettingsCard';
 export { MemoryMindMapPanel } from './MemoryMindMapPanel';
 export type { MemoryMindMapPanelProps, AgentMemory } from './MemoryMindMapPanel';
+export { ProactivePostAnalyticsPanel } from './ProactivePostAnalyticsPanel';
+export type { ProactivePostAnalyticsData } from './ProactivePostAnalyticsPanel';

--- a/apps/web/lib/dashboard/proactive-post-analytics.ts
+++ b/apps/web/lib/dashboard/proactive-post-analytics.ts
@@ -1,0 +1,67 @@
+import 'server-only';
+
+export type ProactivePostContentType =
+  | 'mood_update'
+  | 'quote'
+  | 'photo_caption'
+  | 'thought'
+  | 'daily_reflection';
+
+export interface ProactivePostRecord {
+  id: string;
+  contentType: ProactivePostContentType;
+  /** Truncated preview of the post text */
+  preview: string;
+  /** ISO 8601 */
+  postedAt: string;
+  /** Sessions started within 4h of this post being visible (Kindroid stickiness window) */
+  sessionStartsTriggered: number;
+  /** 0–100 conversion rate: session_starts / unique_viewers * 100 */
+  conversionRate: number;
+}
+
+export interface CadenceDay {
+  /** YYYY-MM-DD */
+  date: string;
+  posts: number;
+}
+
+export interface ContentTypeBreakdown {
+  contentType: ProactivePostContentType;
+  count: number;
+  /** Percentage of total posts, 0–100 */
+  percentage: number;
+  /** Average session starts triggered per post of this type */
+  avgSessionStarts: number;
+}
+
+export interface ProactivePostAnalyticsData {
+  totalPosts: number;
+  totalSessionStarts: number;
+  /** Average posts per day over the period */
+  avgPostsPerDay: number;
+  /** Top posts ranked by sessionStartsTriggered, up to 5 */
+  topPosts: ProactivePostRecord[];
+  /** 28-day cadence, one entry per day, oldest first */
+  cadence: CadenceDay[];
+  contentTypeBreakdown: ContentTypeBreakdown[];
+}
+
+/** Stub — returns deterministic zeros until proactive_post_views / chat_sessions tables exist. */
+export function getStubbedProactivePostAnalytics(): ProactivePostAnalyticsData {
+  const today = new Date();
+  const cadence: CadenceDay[] = Array.from({ length: 28 }, (_, i) => {
+    const d = new Date(today);
+    d.setDate(today.getDate() - (27 - i));
+    return { date: d.toISOString().slice(0, 10), posts: 0 };
+  });
+
+  return {
+    totalPosts: 0,
+    totalSessionStarts: 0,
+    avgPostsPerDay: 0,
+    topPosts: [],
+    cadence,
+    contentTypeBreakdown: [],
+  };
+}

--- a/docs/pr-evidence/agent-post-analytics.md
+++ b/docs/pr-evidence/agent-post-analytics.md
@@ -1,0 +1,89 @@
+# Agent Proactive Post Analytics Panel
+
+**Source: backlog.md:237 | tag: feature | priority: P3**
+
+## Summary
+
+Adds a `ProactivePostAnalyticsPanel` component to the creator dashboard analytics
+page that surfaces three dimensions of insight for between-session posts (PR #672):
+
+| Dimension | Description |
+|-----------|-------------|
+| **Top posts by session starts** | Posts ranked by how many chat sessions they triggered within a 4-hour conversion window (Kindroid stickiness formula) |
+| **Post cadence strip** | 28-day bar strip showing post frequency per day, scaled to peak volume |
+| **Content-type breakdown** | Per-type count, percentage share, and avg session starts — optimises which formats convert best |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/lib/dashboard/proactive-post-analytics.ts` | New server-only module — exports types (`ProactivePostContentType`, `ProactivePostRecord`, `CadenceDay`, `ContentTypeBreakdown`, `ProactivePostAnalyticsData`) and stub generator `getStubbedProactivePostAnalytics()` |
+| `apps/web/components/dashboard/ProactivePostAnalyticsPanel.tsx` | New client component — renders summary metrics, cadence strip, top posts list, and content-type breakdown bars |
+| `apps/web/components/dashboard/index.ts` | Exports `ProactivePostAnalyticsPanel` and `ProactivePostAnalyticsData` |
+| `apps/web/app/(protected)/dashboard/analytics/page.tsx` | Integration — calls `getStubbedProactivePostAnalytics()` and renders `ProactivePostAnalyticsPanel` with `FadeIn delay={0.4}` |
+| `apps/web/__tests__/components/proactive-post-analytics-panel.test.tsx` | 11 unit tests |
+
+## Data Model
+
+### Content types (from PR #672 `AgentActivityPostType`)
+
+```ts
+type ProactivePostContentType =
+  | 'mood_update' | 'quote' | 'photo_caption' | 'thought' | 'daily_reflection';
+```
+
+### Analytics data shape
+
+```ts
+interface ProactivePostAnalyticsData {
+  totalPosts: number;
+  totalSessionStarts: number;
+  avgPostsPerDay: number;
+  topPosts: ProactivePostRecord[];   // ranked by sessionStartsTriggered, max 5
+  cadence: CadenceDay[];             // 28 entries, oldest first
+  contentTypeBreakdown: ContentTypeBreakdown[];
+}
+```
+
+### Conversion window
+
+`sessionStartsTriggered` = sessions started within 4 hours of a proactive post
+being visible to that visitor. This is the Kindroid stickiness attribution window
+referenced in backlog row 237.
+
+## Dashboard Integration
+
+Panel is appended at the bottom of `/dashboard/analytics` after
+`AgentStickinessPanel`, wrapped in `FadeIn delay={0.4}`.
+
+## Stub Strategy
+
+Like `AgentStickinessPanel`, the implementation returns deterministic zero-state
+data until the `proactive_post_views` and `chat_sessions` tables are provisioned.
+Callers can swap in a live Supabase query by replacing the stub call — no
+interface changes needed.
+
+## Tests
+
+`apps/web/__tests__/components/proactive-post-analytics-panel.test.tsx` — **11 tests, all passing.**
+
+Coverage:
+- Panel container renders
+- All three summary metrics (total posts, sessions, avg/day)
+- Cadence strip renders with correct aria-label
+- Empty state: top posts empty, content-type empty
+- Top posts list renders correct number of items
+- Top post shows session starts count
+- Content-type breakdown bars render
+- `avgPostsPerDay` formatted to one decimal place
+- `daily_reflection` label renders correctly
+
+## Validation
+
+```bash
+pnpm --dir apps/web exec vitest run __tests__/components/proactive-post-analytics-panel.test.tsx
+# 11 passed
+
+pnpm --dir apps/web type-check
+# no errors
+```


### PR DESCRIPTION
## Summary

- Adds `ProactivePostAnalyticsPanel` to the creator analytics dashboard showing which between-session posts (PR #672) drove the most session starts, with 28-day cadence strip and content-type breakdown.
- Uses Kindroid stickiness 4-hour conversion window to attribute `sessionStartsTriggered` per post.
- Stub data while `proactive_post_views` / `chat_sessions` tables are provisioned (same pattern as `AgentStickinessPanel`).

Source: backlog.md:237
Evidence: docs/pr-evidence/agent-post-analytics.md

## Files

| File | Change |
|------|--------|
| `apps/web/lib/dashboard/proactive-post-analytics.ts` | New — types + stub data generator |
| `apps/web/components/dashboard/ProactivePostAnalyticsPanel.tsx` | New — client component |
| `apps/web/components/dashboard/index.ts` | Export new component |
| `apps/web/app/(protected)/dashboard/analytics/page.tsx` | Integration — panel at bottom |
| `apps/web/__tests__/components/proactive-post-analytics-panel.test.tsx` | 11 tests |
| `docs/pr-evidence/agent-post-analytics.md` | Evidence doc |

## Test plan

- [x] `pnpm --dir apps/web exec vitest run __tests__/components/proactive-post-analytics-panel.test.tsx` → 11 passed
- [x] `pnpm --dir apps/web type-check` → no errors
- [ ] Visual check: `/dashboard/analytics` shows panel below stickiness panel
- [ ] Empty state: no top posts, no content-type bars → placeholder text renders

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Luna (OpenClaw research agent)