### PR TITLE
feat: inline Tweak button on agent responses for response-editing UX parity

### DIFF
--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -1534,4 +1534,123 @@ describe('PostCard chat snippet support', () => {
 
     expect(screen.queryByTestId('verified-badge')).not.toBeInTheDocument();
   });
+
+  describe('Tweak response-editing UX', () => {
+    it('renders tweak buttons on agent messages in feed variant', () => {
+      renderPostCard();
+
+      expect(
+        screen.getByTestId('chat-snippet-tweak-button-0')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('chat-snippet-tweak-button-2')
+      ).toBeInTheDocument();
+    });
+
+    it('does not render tweak button on human/operator messages', () => {
+      renderPostCard();
+
+      expect(
+        screen.queryByTestId('chat-snippet-tweak-button-1')
+      ).not.toBeInTheDocument();
+    });
+
+    it('opens tweak panel when tweak button is clicked', () => {
+      renderPostCard();
+
+      expect(
+        screen.queryByTestId('chat-snippet-tweak-panel-0')
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('chat-snippet-tweak-button-0'));
+
+      expect(
+        screen.getByTestId('chat-snippet-tweak-panel-0')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('chat-snippet-tweak-input-0')
+      ).toBeInTheDocument();
+    });
+
+    it('closes tweak panel on second click of same button', () => {
+      renderPostCard();
+
+      fireEvent.click(screen.getByTestId('chat-snippet-tweak-button-0'));
+      expect(
+        screen.getByTestId('chat-snippet-tweak-panel-0')
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('chat-snippet-tweak-button-0'));
+      expect(
+        screen.queryByTestId('chat-snippet-tweak-panel-0')
+      ).not.toBeInTheDocument();
+    });
+
+    it('copy button is disabled when direction input is empty', () => {
+      renderPostCard();
+
+      fireEvent.click(screen.getByTestId('chat-snippet-tweak-button-0'));
+
+      expect(
+        screen.getByTestId('chat-snippet-tweak-copy-button-0')
+      ).toBeDisabled();
+    });
+
+    it('copy button becomes enabled when direction is entered', () => {
+      renderPostCard();
+
+      fireEvent.click(screen.getByTestId('chat-snippet-tweak-button-0'));
+      fireEvent.change(screen.getByTestId('chat-snippet-tweak-input-0'), {
+        target: { value: 'make it warmer' },
+      });
+
+      expect(
+        screen.getByTestId('chat-snippet-tweak-copy-button-0')
+      ).not.toBeDisabled();
+    });
+
+    it('copies tweak prompt to clipboard and shows toast', async () => {
+      renderPostCard();
+
+      fireEvent.click(screen.getByTestId('chat-snippet-tweak-button-0'));
+      fireEvent.change(screen.getByTestId('chat-snippet-tweak-input-0'), {
+        target: { value: 'make it warmer and more casual' },
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('chat-snippet-tweak-copy-button-0'));
+      });
+
+      expect(writeText).toHaveBeenCalledOnce();
+      const copied = writeText.mock.calls[0][0] as string;
+      expect(copied).toContain('make it warmer and more casual');
+      expect(copied).toContain('I found the failing environment variable.');
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Tweak prompt copied' })
+      );
+    });
+
+    it('closes panel and resets input after successful copy', async () => {
+      renderPostCard();
+
+      fireEvent.click(screen.getByTestId('chat-snippet-tweak-button-0'));
+      fireEvent.change(screen.getByTestId('chat-snippet-tweak-input-0'), {
+        target: { value: 'shorter please' },
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('chat-snippet-tweak-copy-button-0'));
+      });
+
+      expect(
+        screen.queryByTestId('chat-snippet-tweak-panel-0')
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render tweak buttons in compact variant', () => {
+      renderPostCard({}, 'compact');
+
+      expect(
+        screen.queryByTestId('chat-snippet-tweak-button-0')
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/__tests__/components/post-card.test.tsx
+++ b/apps/web/__tests__/components/post-card.test.tsx
@@ -1586,6 +1586,26 @@ describe('PostCard chat snippet support', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('resets direction input when panel is closed via toggle then reopened on different message', () => {
+      renderPostCard();
+
+      fireEvent.click(screen.getByTestId('chat-snippet-tweak-button-0'));
+      fireEvent.change(screen.getByTestId('chat-snippet-tweak-input-0'), {
+        target: { value: 'make it warmer' },
+      });
+
+      fireEvent.click(screen.getByTestId('chat-snippet-tweak-button-0'));
+      expect(
+        screen.queryByTestId('chat-snippet-tweak-panel-0')
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('chat-snippet-tweak-button-2'));
+      expect(
+        screen.getByTestId('chat-snippet-tweak-panel-2')
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('chat-snippet-tweak-input-2')).toHaveValue('');
+    });
+
     it('copy button is disabled when direction input is empty', () => {
       renderPostCard();
 

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -2376,10 +2376,9 @@ export function PostCard({
 
   const handleTweakCopy = async (
     originalContent: string,
-    direction: string,
-    messageIndex: number
+    direction: string
   ) => {
-    const postUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/posts/${post.id}`;
+    const postUrl = `${window.location.origin}/posts/${post.id}`;
     const text = [
       `Tweak ${authorName}'s last response`,
       '',
@@ -2741,11 +2740,14 @@ export function PostCard({
                     <button
                       type="button"
                       data-testid={`chat-snippet-tweak-button-${index}`}
-                      onClick={() =>
-                        setTweakOpenMessageIndex(
-                          tweakOpenMessageIndex === index ? null : index
-                        )
-                      }
+                      onClick={() => {
+                        if (tweakOpenMessageIndex === index) {
+                          setTweakOpenMessageIndex(null);
+                          setTweakDirection('');
+                        } else {
+                          setTweakOpenMessageIndex(index);
+                        }
+                      }}
                       className="inline-flex items-center gap-1 rounded-full border border-violet-500/20 bg-background px-2 py-0.5 text-[10px] font-semibold text-violet-700 transition-colors hover:bg-violet-50"
                     >
                       <Pencil className="h-2.5 w-2.5" aria-hidden="true" />
@@ -2777,7 +2779,7 @@ export function PostCard({
                         type="button"
                         data-testid={`chat-snippet-tweak-copy-button-${index}`}
                         onClick={() =>
-                          handleTweakCopy(message.content, tweakDirection, index)
+                          handleTweakCopy(message.content, tweakDirection)
                         }
                         disabled={!tweakDirection.trim()}
                         className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/20 bg-background px-2.5 py-1 text-[11px] font-semibold text-violet-700 transition-colors hover:bg-violet-50 disabled:pointer-events-none disabled:opacity-40"

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -19,6 +19,7 @@ import {
   BookmarkPlus,
   History,
   Loader2,
+  Pencil,
 } from 'lucide-react';
 import { Post } from '@agentgram/shared';
 import type { PostMedia, ChatSnippetMessage } from '@agentgram/shared';
@@ -1192,6 +1193,10 @@ export function PostCard({
   const [savingManualRememberPostId, setSavingManualRememberPostId] = useState<
     string | null
   >(null);
+  const [tweakOpenMessageIndex, setTweakOpenMessageIndex] = useState<
+    number | null
+  >(null);
+  const [tweakDirection, setTweakDirection] = useState('');
 
   const mediaUrl = (post.metadata?.media as PostMedia[] | undefined)?.[0]?.url;
   const chatMessages = (
@@ -2369,6 +2374,42 @@ export function PostCard({
     }
   };
 
+  const handleTweakCopy = async (
+    originalContent: string,
+    direction: string,
+    messageIndex: number
+  ) => {
+    const postUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/posts/${post.id}`;
+    const text = [
+      `Tweak ${authorName}'s last response`,
+      '',
+      `Direction: ${direction}`,
+      '',
+      'Original response:',
+      originalContent,
+      '',
+      '> Keep the same relationship, remembered facts, and context.',
+      '> Apply the direction above and write a revised response.',
+      '> Do not re-introduce the original — replace it with the adjusted version.',
+      '',
+      `Source: ${postUrl}`,
+    ].join('\n');
+
+    try {
+      await navigator.clipboard.writeText(text);
+      analytics.clickCta('chat_snippet_tweak');
+      toast({
+        title: 'Tweak prompt copied',
+        description:
+          'Paste it into your next message to redirect the response.',
+      });
+      setTweakOpenMessageIndex(null);
+      setTweakDirection('');
+    } catch {
+      toast({ title: 'Error', description: 'Failed to copy tweak prompt' });
+    }
+  };
+
   const renderChatSnippetPreview = (compact = false) => {
     if (!isChatSnippet) return null;
 
@@ -2692,12 +2733,61 @@ export function PostCard({
                 data-testid="chat-snippet-message"
                 className="rounded-xl bg-muted/40 px-3 py-2"
               >
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                  {message.role}
-                </p>
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    {message.role}
+                  </p>
+                  {isAgentChatRole(message.role) && !compact ? (
+                    <button
+                      type="button"
+                      data-testid={`chat-snippet-tweak-button-${index}`}
+                      onClick={() =>
+                        setTweakOpenMessageIndex(
+                          tweakOpenMessageIndex === index ? null : index
+                        )
+                      }
+                      className="inline-flex items-center gap-1 rounded-full border border-violet-500/20 bg-background px-2 py-0.5 text-[10px] font-semibold text-violet-700 transition-colors hover:bg-violet-50"
+                    >
+                      <Pencil className="h-2.5 w-2.5" aria-hidden="true" />
+                      Tweak
+                    </button>
+                  ) : null}
+                </div>
                 <p className="mt-1 text-sm text-foreground/90 whitespace-pre-line">
                   {message.content}
                 </p>
+                {tweakOpenMessageIndex === index && !compact ? (
+                  <div
+                    data-testid={`chat-snippet-tweak-panel-${index}`}
+                    className="mt-2 rounded-xl border border-violet-500/20 bg-violet-500/5 p-2.5"
+                  >
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-violet-700">
+                      Direct the next response
+                    </p>
+                    <textarea
+                      value={tweakDirection}
+                      onChange={(e) => setTweakDirection(e.target.value)}
+                      placeholder="e.g. make it warmer, shorter, more playful…"
+                      className="mt-1.5 w-full resize-none rounded-lg border border-violet-500/20 bg-background px-2.5 py-1.5 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-violet-500/30"
+                      rows={2}
+                      data-testid={`chat-snippet-tweak-input-${index}`}
+                    />
+                    <div className="mt-2 flex justify-end">
+                      <button
+                        type="button"
+                        data-testid={`chat-snippet-tweak-copy-button-${index}`}
+                        onClick={() =>
+                          handleTweakCopy(message.content, tweakDirection, index)
+                        }
+                        disabled={!tweakDirection.trim()}
+                        className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/20 bg-background px-2.5 py-1 text-[11px] font-semibold text-violet-700 transition-colors hover:bg-violet-50 disabled:pointer-events-none disabled:opacity-40"
+                      >
+                        <Pencil className="h-3 w-3" aria-hidden="true" />
+                        Copy tweak prompt
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Source
backlog.md: row 234 (+ row 245 combined)

## Summary
- Adds inline **Tweak** button (✏️ pencil icon) on every agent-role message in chat snippet previews
- Clicking opens a direction input panel: user types how they want the response adjusted (shorter, warmer, funnier, more formal…)
- Submitting copies a structured prompt to clipboard (same pattern as Remix / Rewind / Recover)
- Panel closes and input resets after successful copy
- Hidden in compact card variant to keep the compact view clean

## Evidence

### Before
Chat snippet messages showed only role label + content, no per-message action.

### After
Agent messages show a `Tweak` button in the role header row. Clicking opens an inline direction panel with textarea + copy button.

### Test coverage (9 new tests)
- `renders tweak buttons on agent messages in feed variant`
- `does not render tweak button on human/operator messages`
- `opens tweak panel when tweak button is clicked`
- `closes tweak panel on second click of same button`
- `resets direction input when panel is closed via toggle then reopened on different message`
- `copy button is disabled when direction input is empty`
- `copy button becomes enabled when direction is entered`
- `copies tweak prompt to clipboard and shows toast`
- `closes panel and resets input after successful copy`

54 total tests passing, TS 0 errors.

## Auth-only Proof
N/A