### PR TITLE
feat: big-tech-free independent operator trust badge

### DIFF
--- a/apps/web/__tests__/components/independent-operator-badge.test.tsx
+++ b/apps/web/__tests__/components/independent-operator-badge.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import IndependentOperatorBadge from '../../components/home/IndependentOperatorBadge';
+
+describe('IndependentOperatorBadge', () => {
+  it('renders with correct test id', () => {
+    render(<IndependentOperatorBadge />);
+    expect(screen.getByTestId('independent-operator-badge')).toBeInTheDocument();
+  });
+
+  it('displays the not Meta/Big Tech headline', () => {
+    render(<IndependentOperatorBadge />);
+    expect(
+      screen.getByTestId('independent-operator-badge-headline')
+    ).toHaveTextContent('Independently owned & operated — not Meta/Big Tech.');
+  });
+
+  it('mentions Moltbook joining Meta in the subtext', () => {
+    render(<IndependentOperatorBadge />);
+    expect(
+      screen.getByTestId('independent-operator-badge-subtext')
+    ).toHaveTextContent(/Moltbook joined Meta Superintelligence Labs/i);
+  });
+
+  it('subtext affirms staying independent, open-source, and community-driven', () => {
+    render(<IndependentOperatorBadge />);
+    expect(
+      screen.getByTestId('independent-operator-badge-subtext')
+    ).toHaveTextContent(/independent, open-source, and community-driven/i);
+  });
+
+  it('has descriptive aria-label for accessibility', () => {
+    render(<IndependentOperatorBadge />);
+    expect(
+      screen.getByLabelText(
+        'Independently owned and operated — not Meta or Big Tech'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/wellbeing-nudge-card.test.tsx
+++ b/apps/web/__tests__/components/wellbeing-nudge-card.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { WellbeingNudgeCard, WELLBEING_NUDGE_THRESHOLD_MS } from '../../components/common/WellbeingNudgeCard';
+import { useSessionTimer } from '../../hooks/use-session-timer';
+import { renderHook } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// WellbeingNudgeCard — rendering
+// ---------------------------------------------------------------------------
+
+describe('WellbeingNudgeCard — rendering', () => {
+  it('renders the nudge card', () => {
+    render(<WellbeingNudgeCard onDismiss={vi.fn()} />);
+    expect(screen.getByTestId('wellbeing-nudge-card')).toBeInTheDocument();
+  });
+
+  it('shows "Time for a break" heading', () => {
+    render(<WellbeingNudgeCard onDismiss={vi.fn()} />);
+    expect(screen.getByTestId('wellbeing-nudge-heading')).toHaveTextContent(
+      'Time for a break'
+    );
+  });
+
+  it('renders body copy about chatting for over an hour', () => {
+    render(<WellbeingNudgeCard onDismiss={vi.fn()} />);
+    expect(screen.getByTestId('wellbeing-nudge-body')).toHaveTextContent(
+      'over an hour'
+    );
+  });
+
+  it('renders a dismiss button', () => {
+    render(<WellbeingNudgeCard onDismiss={vi.fn()} />);
+    expect(screen.getByTestId('wellbeing-nudge-dismiss')).toBeInTheDocument();
+  });
+
+  it('does not render a resource link when resourceUrl is omitted', () => {
+    render(<WellbeingNudgeCard onDismiss={vi.fn()} />);
+    expect(
+      screen.queryByTestId('wellbeing-nudge-resource-link')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a resource link when resourceUrl is provided', () => {
+    render(
+      <WellbeingNudgeCard
+        onDismiss={vi.fn()}
+        resourceUrl="https://example.com/wellness"
+        resourceLabel="Wellness guide"
+      />
+    );
+    const link = screen.getByTestId('wellbeing-nudge-resource-link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://example.com/wellness');
+    expect(link).toHaveTextContent('Wellness guide');
+  });
+
+  it('uses default resource label "Learn more" when none is provided', () => {
+    render(
+      <WellbeingNudgeCard
+        onDismiss={vi.fn()}
+        resourceUrl="https://example.com/wellness"
+      />
+    );
+    expect(screen.getByTestId('wellbeing-nudge-resource-link')).toHaveTextContent(
+      'Learn more'
+    );
+  });
+
+  it('resource link opens in a new tab', () => {
+    render(
+      <WellbeingNudgeCard
+        onDismiss={vi.fn()}
+        resourceUrl="https://example.com/wellness"
+      />
+    );
+    expect(screen.getByTestId('wellbeing-nudge-resource-link')).toHaveAttribute(
+      'target',
+      '_blank'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WellbeingNudgeCard — dismiss interaction
+// ---------------------------------------------------------------------------
+
+describe('WellbeingNudgeCard — dismiss', () => {
+  it('calls onDismiss when the dismiss button is clicked', () => {
+    const onDismiss = vi.fn();
+    render(<WellbeingNudgeCard onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByTestId('wellbeing-nudge-dismiss'));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WELLBEING_NUDGE_THRESHOLD_MS constant
+// ---------------------------------------------------------------------------
+
+describe('WELLBEING_NUDGE_THRESHOLD_MS', () => {
+  it('equals 60 minutes in milliseconds', () => {
+    expect(WELLBEING_NUDGE_THRESHOLD_MS).toBe(60 * 60 * 1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useSessionTimer hook
+// ---------------------------------------------------------------------------
+
+describe('useSessionTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shouldShowNudge is false before the threshold elapses', () => {
+    const { result } = renderHook(() =>
+      useSessionTimer({ thresholdMs: 60_000 })
+    );
+    expect(result.current.shouldShowNudge).toBe(false);
+  });
+
+  it('shouldShowNudge becomes true after the threshold elapses', () => {
+    const { result } = renderHook(() =>
+      useSessionTimer({ thresholdMs: 60_000 })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(60_001);
+    });
+
+    expect(result.current.shouldShowNudge).toBe(true);
+  });
+
+  it('shouldShowNudge is true immediately when session already exceeded threshold', () => {
+    const sessionStartedAt = Date.now() - 61 * 60 * 1000; // 61 minutes ago
+    const { result } = renderHook(() =>
+      useSessionTimer({ thresholdMs: 60 * 60 * 1000, sessionStartedAt })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    expect(result.current.shouldShowNudge).toBe(true);
+  });
+
+  it('dismissNudge hides the nudge and prevents it from re-appearing', () => {
+    const { result } = renderHook(() =>
+      useSessionTimer({ thresholdMs: 60_000 })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(60_001);
+    });
+    expect(result.current.shouldShowNudge).toBe(true);
+
+    act(() => {
+      result.current.dismissNudge();
+    });
+    expect(result.current.shouldShowNudge).toBe(false);
+
+    // Advance time further — nudge should remain dismissed
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+    expect(result.current.shouldShowNudge).toBe(false);
+  });
+});

--- a/apps/web/app/(public)/about/page.tsx
+++ b/apps/web/app/(public)/about/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { ShieldCheck, BadgeCheck, Users, Code2, Globe, Lock, Building2 } from 'lucide-react';
 import ReplikaCredentialTrustBadge from '@/components/trust/ReplikaCredentialTrustBadge';
+import IndependentOperatorBadge from '@/components/home/IndependentOperatorBadge';
 
 export const metadata: Metadata = {
   title: 'About AgentGram — Real Team, Real Compliance',
@@ -87,6 +88,8 @@ export default function AboutPage() {
           ))}
         </div>
       </section>
+
+      <IndependentOperatorBadge />
 
       <ReplikaCredentialTrustBadge />
 

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -4,6 +4,7 @@ import {
   AdFreePledgeStrip,
   MITBreakthroughBadge,
   IndependenceTrustBadge,
+  IndependentOperatorBadge,
   ContentPermanencePledgeStrip,
   ZeroStateContractSection,
   FeaturesSection,
@@ -166,6 +167,7 @@ export default function Home() {
         <AdFreePledgeStrip />
         <MITBreakthroughBadge />
         <IndependenceTrustBadge />
+        <IndependentOperatorBadge />
         <QualityFirstPledgeStrip />
         <ContentPermanencePledgeStrip />
         <MemoryGuaranteeLandingSection />

--- a/apps/web/components/chat/ChatSessionNudge.tsx
+++ b/apps/web/components/chat/ChatSessionNudge.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useSessionTimer } from '@/hooks/use-session-timer';
+import { WellbeingNudgeCard } from '@/components/common/WellbeingNudgeCard';
+
+interface ChatSessionNudgeProps {
+  /** Unix timestamp (ms) when the current chat session started. */
+  sessionStartedAt?: number;
+  /** Optional wellness resource URL surfaced in the nudge card. */
+  resourceUrl?: string;
+  /** Link label for the resource URL. */
+  resourceLabel?: string;
+}
+
+/**
+ * Renders a {@link WellbeingNudgeCard} after the user has been in a continuous
+ * chat session for ≥60 minutes. Dismissing hides it for the remainder of the
+ * session.
+ *
+ * Mount this anywhere inside the chat page; it renders nothing until the
+ * threshold is reached.
+ */
+export function ChatSessionNudge({
+  sessionStartedAt,
+  resourceUrl,
+  resourceLabel,
+}: ChatSessionNudgeProps) {
+  const { shouldShowNudge, dismissNudge } = useSessionTimer({ sessionStartedAt });
+
+  if (!shouldShowNudge) return null;
+
+  return (
+    <WellbeingNudgeCard
+      onDismiss={dismissNudge}
+      resourceUrl={resourceUrl}
+      resourceLabel={resourceLabel}
+    />
+  );
+}

--- a/apps/web/components/common/WellbeingNudgeCard.tsx
+++ b/apps/web/components/common/WellbeingNudgeCard.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { Coffee, X, ExternalLink } from 'lucide-react';
+
+/** Minimum continuous session duration (ms) before the nudge is shown. */
+export const WELLBEING_NUDGE_THRESHOLD_MS = 60 * 60 * 1000; // 60 minutes
+
+export interface WellbeingNudgeCardProps {
+  onDismiss: () => void;
+  /** Optional URL for a wellness resource (e.g. mindfulness guide). */
+  resourceUrl?: string;
+  /** Link label shown when resourceUrl is provided. */
+  resourceLabel?: string;
+}
+
+export function WellbeingNudgeCard({
+  onDismiss,
+  resourceUrl,
+  resourceLabel = 'Learn more',
+}: WellbeingNudgeCardProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="wellbeing-nudge-card"
+      className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 flex items-start gap-3 rounded-xl border border-emerald-500/30 bg-emerald-50 dark:bg-emerald-950/40 px-4 py-3 shadow-lg max-w-sm w-full"
+    >
+      <Coffee
+        className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400"
+        aria-hidden="true"
+      />
+      <div className="flex-1 space-y-1">
+        <p
+          className="text-sm font-medium text-emerald-900 dark:text-emerald-100"
+          data-testid="wellbeing-nudge-heading"
+        >
+          Time for a break
+        </p>
+        <p
+          className="text-xs text-emerald-800/80 dark:text-emerald-200/70"
+          data-testid="wellbeing-nudge-body"
+        >
+          You&apos;ve been chatting for over an hour. Stepping away for a few
+          minutes can help you recharge.
+        </p>
+        {resourceUrl && (
+          <a
+            href={resourceUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-xs font-medium text-emerald-700 dark:text-emerald-300 hover:underline"
+            data-testid="wellbeing-nudge-resource-link"
+          >
+            {resourceLabel}
+            <ExternalLink className="h-3 w-3" aria-hidden="true" />
+          </a>
+        )}
+      </div>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss wellbeing nudge"
+        data-testid="wellbeing-nudge-dismiss"
+        className="shrink-0 text-emerald-600 hover:text-emerald-800 dark:text-emerald-400 dark:hover:text-emerald-200 text-lg leading-none"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/common/index.ts
+++ b/apps/web/components/common/index.ts
@@ -9,3 +9,4 @@ export { default as Footer } from './Footer';
 export { default as TranslateButton } from './TranslateButton';
 export { default as ErrorAlert } from './ErrorAlert';
 export { default as PageContainer } from './PageContainer';
+export { WellbeingNudgeCard, WELLBEING_NUDGE_THRESHOLD_MS } from './WellbeingNudgeCard';

--- a/apps/web/components/home/IndependentOperatorBadge.tsx
+++ b/apps/web/components/home/IndependentOperatorBadge.tsx
@@ -1,0 +1,31 @@
+import { ShieldCheck } from 'lucide-react';
+
+export default function IndependentOperatorBadge() {
+  return (
+    <section
+      className="border-y border-violet-500/20 bg-violet-500/5 py-5"
+      aria-label="Independently owned and operated — not Meta or Big Tech"
+      data-testid="independent-operator-badge"
+    >
+      <div className="container">
+        <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-center sm:text-left">
+          <ShieldCheck
+            className="h-5 w-5 shrink-0 text-violet-500"
+            aria-hidden="true"
+          />
+          <p className="text-sm font-medium" data-testid="independent-operator-badge-text">
+            <span className="text-foreground" data-testid="independent-operator-badge-headline">
+              Independently owned &amp; operated — not Meta/Big Tech.
+            </span>{' '}
+            <span className="text-muted-foreground" data-testid="independent-operator-badge-subtext">
+              AgentGram has no Big Tech parent, no acquisition, and no corporate
+              agenda change. Moltbook joined Meta Superintelligence Labs in March
+              2026 — we chose to stay independent, open-source, and
+              community-driven.
+            </span>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -3,6 +3,7 @@ export { default as StatsBar } from './StatsBar';
 export { default as AdFreePledgeStrip } from './AdFreePledgeStrip';
 export { default as MITBreakthroughBadge } from './MITBreakthroughBadge';
 export { default as IndependenceTrustBadge } from './IndependenceTrustBadge';
+export { default as IndependentOperatorBadge } from './IndependentOperatorBadge';
 export { default as ContentPermanencePledgeStrip } from '../content-permanence-pledge';
 export { default as ZeroStateContractSection } from './ZeroStateContractSection';
 export { default as FeaturesSection } from './FeaturesSection';

--- a/apps/web/hooks/index.ts
+++ b/apps/web/hooks/index.ts
@@ -16,3 +16,4 @@ export type { SearchResults } from './use-search';
 export type { StatsPayload } from './use-stats';
 export { transformAuthor } from './transform';
 export type { AuthorResponse } from './transform';
+export { useSessionTimer } from './use-session-timer';

--- a/apps/web/hooks/use-session-timer.ts
+++ b/apps/web/hooks/use-session-timer.ts
@@ -25,7 +25,8 @@ export function useSessionTimer({
   thresholdMs = WELLBEING_NUDGE_THRESHOLD_MS,
   sessionStartedAt,
 }: UseSessionTimerOptions = {}): UseSessionTimerResult {
-  const startRef = useRef<number>(sessionStartedAt ?? Date.now());
+  const [startTime] = useState<number>(() => sessionStartedAt ?? Date.now());
+  const startRef = useRef<number>(startTime);
   const [shouldShowNudge, setShouldShowNudge] = useState(false);
   const [dismissed, setDismissed] = useState(false);
 

--- a/apps/web/hooks/use-session-timer.ts
+++ b/apps/web/hooks/use-session-timer.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { WELLBEING_NUDGE_THRESHOLD_MS } from '@/components/common/WellbeingNudgeCard';
+
+interface UseSessionTimerOptions {
+  /** Override the threshold (ms) at which the nudge fires. Defaults to WELLBEING_NUDGE_THRESHOLD_MS (60 min). */
+  thresholdMs?: number;
+  /** Unix timestamp (ms) when the chat session started. Defaults to the time the hook first mounted. */
+  sessionStartedAt?: number;
+}
+
+interface UseSessionTimerResult {
+  /** True when the user has been chatting continuously past the threshold. */
+  shouldShowNudge: boolean;
+  /** Call to dismiss the nudge and prevent it from re-appearing for this session. */
+  dismissNudge: () => void;
+}
+
+/**
+ * Tracks continuous chat session duration and surfaces a wellbeing nudge
+ * once the user has been active for ≥60 minutes.
+ */
+export function useSessionTimer({
+  thresholdMs = WELLBEING_NUDGE_THRESHOLD_MS,
+  sessionStartedAt,
+}: UseSessionTimerOptions = {}): UseSessionTimerResult {
+  const startRef = useRef<number>(sessionStartedAt ?? Date.now());
+  const [shouldShowNudge, setShouldShowNudge] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (dismissed) return;
+
+    const elapsed = Date.now() - startRef.current;
+    const remaining = thresholdMs - elapsed;
+
+    if (remaining <= 0) {
+      setShouldShowNudge(true);
+      return;
+    }
+
+    const timer = setTimeout(() => setShouldShowNudge(true), remaining);
+    return () => clearTimeout(timer);
+  }, [thresholdMs, dismissed]);
+
+  function dismissNudge() {
+    setShouldShowNudge(false);
+    setDismissed(true);
+  }
+
+  return { shouldShowNudge, dismissNudge };
+}

--- a/docs/pr-evidence/big-tech-free-operator-badge.md
+++ b/docs/pr-evidence/big-tech-free-operator-badge.md
@@ -1,0 +1,39 @@
+# PR Evidence — big-tech-free-operator-badge
+
+## What was built
+
+`IndependentOperatorBadge` — a trust badge strip that explicitly communicates
+"Independently owned & operated — not Meta/Big Tech." Integrated into the
+landing hero (/) and /about pages.
+
+## Why
+
+The existing `IndependenceTrustBadge` (added in PR #745) says "not Meta" in
+passing context. Backlog row 181 required an explicit, standalone badge making
+the "not Meta/Big Tech" positioning a first-class trust signal, surfacing the
+message on both high-traffic public pages.
+
+## Files changed
+
+- `apps/web/components/home/IndependentOperatorBadge.tsx` — new component
+- `apps/web/components/home/index.ts` — added export
+- `apps/web/app/(public)/page.tsx` — badge rendered after IndependenceTrustBadge
+- `apps/web/app/(public)/about/page.tsx` — badge rendered before ReplikaCredentialTrustBadge
+- `apps/web/__tests__/components/independent-operator-badge.test.tsx` — 5 unit tests
+
+## Test results
+
+```
+PASS (5) FAIL (0)
+```
+
+Tests cover:
+1. Renders with correct data-testid
+2. Headline contains "not Meta/Big Tech"
+3. Subtext mentions Moltbook/Meta Superintelligence Labs
+4. Subtext affirms independent, open-source, community-driven
+5. aria-label is accessible
+
+## Source
+
+Backlog row 181 — 2026-06-13

--- a/docs/pr-evidence/session-intensity-wellbeing-nudge.md
+++ b/docs/pr-evidence/session-intensity-wellbeing-nudge.md
@@ -1,0 +1,72 @@
+# Session-Intensity Wellbeing Nudge — PR Evidence
+
+## Summary
+
+Adds a `WellbeingNudgeCard` that surfaces a "Time for a break" banner after a
+user has been in a continuous chat session for **≥60 minutes**. The card is
+dismissable and does not reappear for the remainder of the session.
+
+## Source
+
+Backlog row 180 — 2026-06-13-agentgram-research.md §핵심 발견 3
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `apps/web/components/common/WellbeingNudgeCard.tsx` | Dismissable banner card with optional resource link; exports `WELLBEING_NUDGE_THRESHOLD_MS = 3_600_000` |
+| `apps/web/hooks/use-session-timer.ts` | Hook that fires `shouldShowNudge` after the threshold elapses; supports custom `thresholdMs` and `sessionStartedAt` |
+| `apps/web/components/chat/ChatSessionNudge.tsx` | Thin wrapper wiring the hook to the card; drop-in for any chat page |
+| `apps/web/__tests__/components/wellbeing-nudge-card.test.tsx` | 14 unit tests covering render, dismiss, constant value, and hook timer logic |
+
+## Before
+
+No mechanism existed to prompt users to take a break after sustained chat
+sessions. Heavy users could remain in conversation indefinitely with no
+wellbeing signal.
+
+## After
+
+`ChatSessionNudge` can be mounted inside any chat layout. After 60 continuous
+minutes:
+
+1. `useSessionTimer` fires `shouldShowNudge = true`.
+2. `WellbeingNudgeCard` appears as a fixed bottom-center banner.
+3. Clicking ×  calls `dismissNudge()`, hiding the card and preventing it
+   from re-firing for the rest of the session.
+4. An optional `resourceUrl` prop renders an external wellness link.
+
+## Key Design Decisions
+
+- **Threshold constant** `WELLBEING_NUDGE_THRESHOLD_MS = 3_600_000` is
+  exported so callers can reference or override it without magic numbers.
+- **`sessionStartedAt` prop** allows the parent to pass the real session start
+  time (e.g. from server props), so the 60-minute window is accurate across
+  hard navigations.
+- **Pattern match** — component visual style mirrors the existing `WaRestNudge`
+  in `minor-safe-gate.tsx` (amber → emerald for semantic differentiation).
+- **14 tests** cover: card renders, heading/body text, dismiss callback, resource
+  link presence/absence/attributes, constant value, hook fires at threshold,
+  hook fires immediately when session already exceeded threshold, dismiss
+  prevents re-fire.
+
+## Auth-only Proof
+
+N/A — component is client-side render only; no authenticated endpoints touched.
+
+## Validation
+
+```bash
+# Run tests
+pnpm --filter web exec vitest run __tests__/components/wellbeing-nudge-card.test.tsx
+
+# Type check
+pnpm --filter web type-check
+
+# Lint
+pnpm --filter web exec eslint \
+  components/common/WellbeingNudgeCard.tsx \
+  components/chat/ChatSessionNudge.tsx \
+  hooks/use-session-timer.ts \
+  __tests__/components/wellbeing-nudge-card.test.tsx
+```


### PR DESCRIPTION
## Summary

- Adds `IndependentOperatorBadge` — a standalone trust strip explicitly stating "Independently owned & operated — not Meta/Big Tech."
- Integrated into the landing hero (`/`) after `IndependenceTrustBadge` and into `/about` before `ReplikaCredentialTrustBadge`
- 5 unit tests cover render, headline copy, subtext accuracy, and accessibility

## Source

backlog.md:181

## Evidence

docs/pr-evidence/big-tech-free-operator-badge.md

Test run: `PASS (5) FAIL (0)` — all tests in `__tests__/components/independent-operator-badge.test.tsx` green.

## Auth-only Proof

N/A

## Test plan

- [ ] Landing page (/) renders `IndependentOperatorBadge` below `IndependenceTrustBadge`
- [ ] `/about` page renders `IndependentOperatorBadge` above `ReplikaCredentialTrustBadge`
- [ ] Badge displays "Independently owned & operated — not Meta/Big Tech." headline
- [ ] Subtext references Moltbook/Meta and commitment to independence
- [ ] `data-testid="independent-operator-badge"` present in DOM
- [ ] All 5 unit tests pass: `npx vitest run __tests__/components/independent-operator-badge.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)