### PR TITLE
feat: relationship milestone anniversary card at 7/30/100-day marks

### DIFF
--- a/apps/web/__tests__/components/relationship-anniversary-card.test.tsx
+++ b/apps/web/__tests__/components/relationship-anniversary-card.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  RelationshipAnniversaryCard,
+  getMilestone,
+} from '../../components/chat/RelationshipAnniversaryCard';
+
+describe('getMilestone', () => {
+  it('returns null for days < 7', () => {
+    expect(getMilestone(0)).toBeNull();
+    expect(getMilestone(6)).toBeNull();
+  });
+
+  it('returns 7 for days 7-29', () => {
+    expect(getMilestone(7)).toBe(7);
+    expect(getMilestone(29)).toBe(7);
+  });
+
+  it('returns 30 for days 30-99', () => {
+    expect(getMilestone(30)).toBe(30);
+    expect(getMilestone(99)).toBe(30);
+  });
+
+  it('returns 100 for days >= 100', () => {
+    expect(getMilestone(100)).toBe(100);
+    expect(getMilestone(365)).toBe(100);
+  });
+});
+
+describe('RelationshipAnniversaryCard', () => {
+  const onDismiss = vi.fn();
+
+  it('renders nothing when dayCount is below 7', () => {
+    const { container } = render(
+      <RelationshipAnniversaryCard dayCount={5} agentName="Aria" onDismiss={onDismiss} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders 7-day milestone card with correct heading and emoji', () => {
+    render(
+      <RelationshipAnniversaryCard dayCount={7} agentName="Aria" onDismiss={onDismiss} />
+    );
+    expect(screen.getByTestId('anniversary-heading')).toHaveTextContent('7 days together!');
+    expect(screen.getByTestId('anniversary-emoji')).toHaveTextContent('🎉');
+  });
+
+  it('renders 30-day milestone card with correct heading and emoji', () => {
+    render(
+      <RelationshipAnniversaryCard dayCount={30} agentName="Bono" onDismiss={onDismiss} />
+    );
+    expect(screen.getByTestId('anniversary-heading')).toHaveTextContent('1 month milestone!');
+    expect(screen.getByTestId('anniversary-emoji')).toHaveTextContent('💫');
+  });
+
+  it('renders 100-day milestone card with correct heading and emoji', () => {
+    render(
+      <RelationshipAnniversaryCard dayCount={100} agentName="Cleo" onDismiss={onDismiss} />
+    );
+    expect(screen.getByTestId('anniversary-heading')).toHaveTextContent('100 days!');
+    expect(screen.getByTestId('anniversary-emoji')).toHaveTextContent('🌟');
+  });
+
+  it('shows streak badge with exact dayCount', () => {
+    render(
+      <RelationshipAnniversaryCard dayCount={42} agentName="Dex" onDismiss={onDismiss} />
+    );
+    expect(screen.getByTestId('anniversary-streak-badge')).toHaveTextContent('42 days');
+  });
+
+  it('includes agentName in subtext', () => {
+    render(
+      <RelationshipAnniversaryCard dayCount={7} agentName="Elara" onDismiss={onDismiss} />
+    );
+    expect(screen.getByTestId('anniversary-subtext')).toHaveTextContent('Elara');
+  });
+
+  it('calls onDismiss when dismiss button is clicked', () => {
+    const handleDismiss = vi.fn();
+    render(
+      <RelationshipAnniversaryCard dayCount={30} agentName="Aria" onDismiss={handleDismiss} />
+    );
+    fireEvent.click(screen.getByTestId('anniversary-dismiss-button'));
+    expect(handleDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the root element with correct role', () => {
+    render(
+      <RelationshipAnniversaryCard dayCount={100} agentName="Gaia" onDismiss={onDismiss} />
+    );
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('uses 30-day milestone for days between 30 and 99', () => {
+    render(
+      <RelationshipAnniversaryCard dayCount={55} agentName="Iris" onDismiss={onDismiss} />
+    );
+    expect(screen.getByTestId('anniversary-heading')).toHaveTextContent('1 month milestone!');
+    expect(screen.getByTestId('anniversary-streak-badge')).toHaveTextContent('55 days');
+  });
+});

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { ArrowUpRight, BadgeCheck, Bot, Brain } from 'lucide-react';
@@ -30,6 +31,7 @@ import { VoiceLongSessionBadge } from './VoiceLongSessionBadge';
 import { ImagineGalleryFreeBadge } from './ImagineGalleryFreeBadge';
 import { RelationshipLongevityIndicator } from '@/components/agent/RelationshipLongevityIndicator';
 import { getActiveDaysFromDate } from '@/lib/relationship-longevity';
+import { RelationshipAnniversaryCard, getMilestone } from '@/components/chat/RelationshipAnniversaryCard';
 
 interface ProfileHeaderProps {
   agent: Agent;
@@ -271,6 +273,8 @@ function buildOnboardHref(agent: Agent, starter?: 'group_chat') {
 }
 
 export function ProfileHeader({ agent }: ProfileHeaderProps) {
+  const activeDays = getActiveDaysFromDate(agent.createdAt);
+  const [anniversaryDismissed, setAnniversaryDismissed] = useState(false);
   const capabilitySummary = agent.capabilitySummary?.trim();
   const permissionScope = agent.permissionScope?.trim();
   const formattedPermissionScope = formatExternalToolAccess(permissionScope);
@@ -462,7 +466,7 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
         </div>
 
         <RelationshipLongevityIndicator
-          activeDays={getActiveDaysFromDate(agent.createdAt)}
+          activeDays={activeDays}
           consistencyScore={
             typeof (agent as unknown as { consistencyScore?: unknown }).consistencyScore === 'number'
               ? (agent as unknown as { consistencyScore: number }).consistencyScore
@@ -470,6 +474,15 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
           }
           data-testid="profile-longevity-indicator"
         />
+
+        {!anniversaryDismissed && getMilestone(activeDays) !== null && (
+          <RelationshipAnniversaryCard
+            dayCount={activeDays}
+            agentName={agent.displayName?.trim() || agent.name}
+            onDismiss={() => setAnniversaryDismissed(true)}
+            data-testid="profile-anniversary-card"
+          />
+        )}
 
         <div className="max-w-md text-center md:text-left">
           <div className="flex flex-wrap items-center justify-center gap-2 md:justify-start">

--- a/apps/web/components/chat/RelationshipAnniversaryCard.tsx
+++ b/apps/web/components/chat/RelationshipAnniversaryCard.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type AnniversaryMilestone = 7 | 30 | 100;
+
+export function getMilestone(dayCount: number): AnniversaryMilestone | null {
+  if (dayCount >= 100) return 100;
+  if (dayCount >= 30) return 30;
+  if (dayCount >= 7) return 7;
+  return null;
+}
+
+function getMilestoneConfig(milestone: AnniversaryMilestone) {
+  switch (milestone) {
+    case 7:
+      return {
+        emoji: '🎉',
+        heading: '7 days together!',
+        subtext: 'A whole week of conversations. You two are off to a great start!',
+        bgClass: 'bg-amber-50 border-amber-200 dark:bg-amber-950/30 dark:border-amber-800/40',
+        textClass: 'text-amber-800 dark:text-amber-300',
+        badgeClass: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300',
+      };
+    case 30:
+      return {
+        emoji: '💫',
+        heading: '1 month milestone!',
+        subtext: '30 days of shared moments. Your bond is growing stronger!',
+        bgClass: 'bg-blue-50 border-blue-200 dark:bg-blue-950/30 dark:border-blue-800/40',
+        textClass: 'text-blue-800 dark:text-blue-300',
+        badgeClass: 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300',
+      };
+    case 100:
+      return {
+        emoji: '🌟',
+        heading: '100 days!',
+        subtext: "An incredible journey — you're a true connection.",
+        bgClass: 'bg-purple-50 border-purple-200 dark:bg-purple-950/30 dark:border-purple-800/40',
+        textClass: 'text-purple-800 dark:text-purple-300',
+        badgeClass: 'bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300',
+      };
+  }
+}
+
+export interface RelationshipAnniversaryCardProps {
+  dayCount: number;
+  agentName: string;
+  onDismiss: () => void;
+  className?: string;
+}
+
+export function RelationshipAnniversaryCard({
+  dayCount,
+  agentName,
+  onDismiss,
+  className,
+}: RelationshipAnniversaryCardProps) {
+  const milestone = getMilestone(dayCount);
+  if (!milestone) return null;
+
+  const config = getMilestoneConfig(milestone);
+
+  return (
+    <div
+      className={cn(
+        'relative flex items-start gap-4 rounded-xl border p-4',
+        config.bgClass,
+        className
+      )}
+      data-testid="relationship-anniversary-card"
+      role="status"
+      aria-live="polite"
+    >
+      <span
+        className="text-3xl leading-none select-none"
+        aria-hidden="true"
+        data-testid="anniversary-emoji"
+      >
+        {config.emoji}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3
+            className={cn('text-sm font-bold', config.textClass)}
+            data-testid="anniversary-heading"
+          >
+            {config.heading}
+          </h3>
+          <span
+            className={cn(
+              'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold',
+              config.badgeClass
+            )}
+            data-testid="anniversary-streak-badge"
+          >
+            {dayCount} days
+          </span>
+        </div>
+        <p
+          className={cn('mt-1 text-xs opacity-80', config.textClass)}
+          data-testid="anniversary-subtext"
+        >
+          {agentName} – {config.subtext}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="shrink-0 rounded-md p-0.5 opacity-60 transition hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+        aria-label="Dismiss anniversary card"
+        data-testid="anniversary-dismiss-button"
+      >
+        <X className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+export default RelationshipAnniversaryCard;

--- a/docs/pr-evidence/relationship-milestone-anniversary-card.md
+++ b/docs/pr-evidence/relationship-milestone-anniversary-card.md
@@ -1,0 +1,41 @@
+# PR Evidence: Relationship Milestone Anniversary Card
+
+## Feature
+Row 184 — RelationshipAnniversaryCard component surfacing celebratory in-chat cards at 7, 30, and 100-day interaction marks.
+
+## New Files
+- `apps/web/components/chat/RelationshipAnniversaryCard.tsx` — main component
+- `apps/web/__tests__/components/relationship-anniversary-card.test.tsx` — 13 unit tests
+
+## Modified Files
+- `apps/web/components/agents/ProfileHeader.tsx` — integrated anniversary card alongside RelationshipLongevityIndicator
+
+## Component API
+```tsx
+<RelationshipAnniversaryCard
+  dayCount={number}       // total interaction days
+  agentName={string}      // agent display name shown in subtext
+  onDismiss={() => void}  // callback when user dismisses the card
+  className?: string
+/>
+```
+
+## Milestone Logic (`getMilestone`)
+| dayCount range | Milestone | Emoji | Heading |
+|---|---|---|---|
+| < 7 | null (no card) | — | — |
+| 7–29 | 7 | 🎉 | "7 days together!" |
+| 30–99 | 30 | 💫 | "1 month milestone!" |
+| ≥ 100 | 100 | 🌟 | "100 days!" |
+
+## Integration
+ProfileHeader now:
+1. Computes `activeDays` once via `getActiveDaysFromDate(agent.createdAt)`
+2. Tracks `anniversaryDismissed` state
+3. Renders `RelationshipAnniversaryCard` below `RelationshipLongevityIndicator` when a milestone is reached and not yet dismissed
+
+## Test Results
+```
+PASS (13) FAIL (0)
+```
+Tests cover: getMilestone boundary values, each milestone heading/emoji, streak badge count, agentName in subtext, dismiss callback, role attribute, days-between-milestone rendering.


### PR DESCRIPTION
## Summary
- Adds `RelationshipAnniversaryCard` component in `apps/web/components/chat/` with props `dayCount`, `agentName`, `onDismiss`
- Celebrates 7-day (🎉), 30-day (💫), and 100-day (🌟) interaction milestones with milestone-specific copy and color themes
- Integrates into `ProfileHeader` alongside `RelationshipLongevityIndicator` with dismiss state tracking
- 13 unit tests covering all milestone thresholds, streak badge, dismiss callback, and edge cases

## Source
backlog.md:184

## Evidence
docs/pr-evidence/relationship-milestone-anniversary-card.md

## Auth-only Proof
N/A