### PR TITLE
fix: retry/fallback on persona count fetch error in CrossPersonaGroupChatButton

### DIFF
--- a/apps/web/__tests__/components/cross-persona-group-chat-modal.test.tsx
+++ b/apps/web/__tests__/components/cross-persona-group-chat-modal.test.tsx
@@ -8,17 +8,18 @@ import {
 
 const mockPush = vi.fn();
 
+// vi.hoisted ensures this is available inside vi.mock factories (which are hoisted)
+const mockGetSession = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ data: { session: { user: { id: 'u1' } } } })
+);
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
 }));
 
 vi.mock('@/lib/supabase/client', () => ({
   createClient: () => ({
-    auth: {
-      getSession: vi
-        .fn()
-        .mockResolvedValue({ data: { session: { user: { id: 'u1' } } } }),
-    },
+    auth: { getSession: mockGetSession },
   }),
 }));
 
@@ -53,6 +54,7 @@ const fakePersonas = [
 ];
 
 beforeEach(() => {
+  mockGetSession.mockResolvedValue({ data: { session: { user: { id: 'u1' } } } });
   vi.stubGlobal(
     'fetch',
     vi.fn().mockResolvedValue({
@@ -63,7 +65,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -248,20 +250,23 @@ describe('CrossPersonaGroupChatButton', () => {
   });
 
   it('does not redirect to login while auth state is loading (null)', () => {
-    // getSession never resolves — auth stays null
-    vi.mock('@/lib/supabase/client', () => ({
-      createClient: () => ({
-        auth: {
-          getSession: vi.fn().mockReturnValue(new Promise(() => {})),
-        },
-      }),
-    }));
+    // Override getSession to never resolve — auth stays null
+    mockGetSession.mockReturnValue(new Promise(() => {}));
     render(<CrossPersonaGroupChatButton />);
     // Button should not be in the DOM (hasEnoughPersonas still null)
     expect(
       screen.queryByTestId('cross-persona-group-chat-trigger')
     ).not.toBeInTheDocument();
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('shows button optimistically when persona count fetch fails after retries', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+    render(<CrossPersonaGroupChatButton />);
+    await waitFor(
+      () => expect(screen.getByTestId('cross-persona-group-chat-trigger')).toBeInTheDocument(),
+      { timeout: 2000 }
+    );
   });
 
   it('opens modal when trigger is clicked (authenticated, ≥2 personas)', async () => {

--- a/apps/web/components/common/CrossPersonaGroupChatModal.tsx
+++ b/apps/web/components/common/CrossPersonaGroupChatModal.tsx
@@ -24,6 +24,25 @@ async function fetchMyPersonas(): Promise<Persona[]> {
   return json.data ?? [];
 }
 
+async function fetchPersonaCountWithRetry(maxRetries = 2): Promise<number> {
+  const delays = [200, 400];
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const r = await fetch('/api/v1/agents/me/personas');
+      if (!r.ok) throw new Error('fetch failed');
+      const json = (await r.json()) as ApiResponse<Persona[]>;
+      return json.data?.length ?? 0;
+    } catch (err) {
+      lastError = err;
+      if (attempt < maxRetries) {
+        await new Promise<void>((resolve) => setTimeout(resolve, delays[attempt]));
+      }
+    }
+  }
+  throw lastError;
+}
+
 function buildCrossPersonaHref(personaIds: string[]) {
   const params = new URLSearchParams({
     starter: 'group_chat',
@@ -226,12 +245,9 @@ export function CrossPersonaGroupChatButton({
         setHasEnoughPersonas(false);
         return;
       }
-      fetch('/api/v1/agents/me/personas')
-        .then((r) => (r.ok ? r.json() : null))
-        .then((json: ApiResponse<Persona[]> | null) => {
-          setHasEnoughPersonas((json?.data?.length ?? 0) >= MIN_PERSONAS);
-        })
-        .catch(() => setHasEnoughPersonas(false));
+      fetchPersonaCountWithRetry()
+        .then((count) => setHasEnoughPersonas(count >= MIN_PERSONAS))
+        .catch(() => setHasEnoughPersonas(true)); // Optimistic: show button on network error; modal handles error state
     });
   }, []);
 

--- a/docs/pr-evidence/cross-persona-button-fetch-fallback.md
+++ b/docs/pr-evidence/cross-persona-button-fetch-fallback.md
@@ -1,0 +1,73 @@
+# PR Evidence: CrossPersonaGroupChatButton Fetch Fallback (Row 251)
+
+## Source
+Backlog row 251: PR #752 kkami-nit
+
+## Problem
+`CrossPersonaGroupChatButton` silently disappeared when the persona count fetch failed.
+The `.catch()` handler set `hasEnoughPersonas(false)`, causing the component to return `null`.
+Users with transient network errors would never see the group chat entry point.
+
+## Fix: Retry + Optimistic Fallback
+
+**File changed:** `apps/web/components/common/CrossPersonaGroupChatModal.tsx`
+
+### Retry logic
+Added `fetchPersonaCountWithRetry(maxRetries = 2)` helper that retries up to 2 times
+with exponential backoff delays (200ms, 400ms) before giving up:
+
+```typescript
+async function fetchPersonaCountWithRetry(maxRetries = 2): Promise<number> {
+  const delays = [200, 400];
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const r = await fetch('/api/v1/agents/me/personas');
+      if (!r.ok) throw new Error('fetch failed');
+      const json = (await r.json()) as ApiResponse<Persona[]>;
+      return json.data?.length ?? 0;
+    } catch (err) {
+      lastError = err;
+      if (attempt < maxRetries) {
+        await new Promise<void>((resolve) => setTimeout(resolve, delays[attempt]));
+      }
+    }
+  }
+  throw lastError;
+}
+```
+
+### Optimistic fallback
+If all retries fail, the button is shown optimistically (instead of hidden):
+
+```typescript
+fetchPersonaCountWithRetry()
+  .then((count) => setHasEnoughPersonas(count >= MIN_PERSONAS))
+  .catch(() => setHasEnoughPersonas(true)); // Optimistic: show button on network error
+```
+
+When the user clicks, the modal opens and re-fetches personas with its own error state handling
+(`cross-persona-error` testid), so the graceful degradation is preserved end-to-end.
+
+## Test Evidence
+
+**File:** `apps/web/__tests__/components/cross-persona-group-chat-modal.test.tsx`
+
+New test added:
+```
+✓ CrossPersonaGroupChatButton > shows button optimistically when persona count fetch fails after retries  619ms
+```
+
+Also fixed 2 pre-existing test failures caused by a `vi.mock` call inside the
+"does not redirect" test being hoisted by vitest (PR #752 regression):
+- Fixed by using `vi.hoisted` for `mockGetSession` + `vi.resetAllMocks()` in afterEach.
+
+### Full test run result
+```
+Tests  17 passed (17)
+Duration  1.84s
+```
+
+All 17 tests pass including:
+- Pre-existing button/modal tests (previously 2 were broken)
+- New network-error optimistic fallback test


### PR DESCRIPTION
## Source
Backlog row 251: PR #752 kkami-nit

## Evidence
docs/pr-evidence/cross-persona-button-fetch-fallback.md

## Auth-only Proof
N/A