### PR TITLE
feat: free-to-start pledge strip — try free, no credit card required

### DIFF
--- a/apps/web/__tests__/components/free-to-start-strip.test.tsx
+++ b/apps/web/__tests__/components/free-to-start-strip.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import FreeToStartStrip, {
+  FreeToStartBadge,
+} from '../../components/home/FreeToStartStrip';
+
+describe('FreeToStartStrip', () => {
+  it('renders with correct test id', () => {
+    render(<FreeToStartStrip />);
+    expect(
+      screen.getByTestId('home-free-to-start-strip')
+    ).toBeInTheDocument();
+  });
+
+  it('displays try free headline', () => {
+    render(<FreeToStartStrip />);
+    expect(
+      screen.getByText(/Try free · No credit card required/i)
+    ).toBeInTheDocument();
+  });
+
+  it('mentions Replika forced subscription context', () => {
+    render(<FreeToStartStrip />);
+    expect(
+      screen.getByText(/Replika requires a paid subscription/i)
+    ).toBeInTheDocument();
+  });
+
+  it('mentions no forced subscription differentiator', () => {
+    render(<FreeToStartStrip />);
+    expect(
+      screen.getByText(/no forced subscription/i)
+    ).toBeInTheDocument();
+  });
+
+  it('has aria-label for accessibility', () => {
+    render(<FreeToStartStrip />);
+    expect(
+      screen.getByLabelText('Try free, no credit card required')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('FreeToStartBadge', () => {
+  it('renders with correct test id', () => {
+    render(<FreeToStartBadge />);
+    expect(
+      screen.getByTestId('free-to-start-badge')
+    ).toBeInTheDocument();
+  });
+
+  it('displays try free label', () => {
+    render(<FreeToStartBadge />);
+    expect(
+      screen.getByText(/Try free · No credit card required/i)
+    ).toBeInTheDocument();
+  });
+
+  it('has aria-label for accessibility', () => {
+    render(<FreeToStartBadge />);
+    expect(
+      screen.getByLabelText('Free to start, no credit card required')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -22,6 +22,7 @@ import {
   ApiFirstEcosystemSection,
   FaqSection,
   CtaSection,
+  FreeToStartStrip,
 } from '@/components/home';
 import { MemoryGuaranteeLandingSection } from '@/components/memory-guarantee-landing-section';
 
@@ -164,6 +165,7 @@ export default function Home() {
       <div className="flex flex-col">
         <HeroSection />
         <StatsBar />
+        <FreeToStartStrip />
         <AdFreePledgeStrip />
         <MITBreakthroughBadge />
         <IndependenceTrustBadge />

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button';
 import { analytics } from '@/lib/analytics';
 import NoChatIsolationBadge from '@/components/home/NoChatIsolationBadge';
 import { QualityFirstPledgeBadge } from '@/components/home/QualityFirstPledge';
+import FreeToStartStrip from '@/components/home/FreeToStartStrip';
 
 function getPlans(billingEnabled: boolean) {
   return [
@@ -420,6 +421,8 @@ export default function PricingPage() {
           </div>
         </div>
       </section>
+
+      <FreeToStartStrip />
 
       <section className="container pb-24">
         <div

--- a/apps/web/components/home/FreeToStartStrip.tsx
+++ b/apps/web/components/home/FreeToStartStrip.tsx
@@ -1,0 +1,41 @@
+import { Sparkles } from 'lucide-react';
+
+export default function FreeToStartStrip() {
+  return (
+    <section
+      className="border-y border-green-500/20 bg-green-500/5 py-5"
+      aria-label="Try free, no credit card required"
+      data-testid="home-free-to-start-strip"
+    >
+      <div className="container">
+        <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-center sm:text-left">
+          <Sparkles
+            className="h-5 w-5 shrink-0 text-green-500"
+            aria-hidden="true"
+          />
+          <p className="text-sm font-medium">
+            <span className="text-foreground">Try free · No credit card required.</span>{' '}
+            <span className="text-muted-foreground">
+              Replika requires a paid subscription before you can explore core features.
+              AgentGram is free to start — no forced subscription, no paywall to see what
+              you&apos;re signing up for.
+            </span>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function FreeToStartBadge() {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full border border-green-500/30 bg-green-500/10 px-3 py-1 text-xs font-medium text-green-700 dark:text-green-400"
+      data-testid="free-to-start-badge"
+      aria-label="Free to start, no credit card required"
+    >
+      <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+      Try free · No credit card required
+    </span>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -23,3 +23,4 @@ export { default as CAIRegionalCapEscapeCTA } from './CAIRegionalCapEscapeCTA';
 export { default as KindroidJuneMigrationCTA } from './KindroidJuneMigrationCTA';
 export { default as NomiMigrationCTA } from './NomiMigrationCTA';
 export { default as QualityFirstPledgeStrip, QualityFirstPledgeBadge } from './QualityFirstPledge';
+export { default as FreeToStartStrip, FreeToStartBadge } from './FreeToStartStrip';

--- a/apps/web/docs/pr-evidence/free-to-start-pledge-strip.md
+++ b/apps/web/docs/pr-evidence/free-to-start-pledge-strip.md
@@ -1,0 +1,48 @@
+# PR Evidence: Free-to-Start Pledge Strip
+
+## Summary
+
+Added "Try free · No credit card required" messaging strip to the landing page (`/`) and `/pricing` page. Directly counters Replika's forced-subscription gate (40M users but no free trial) by making AgentGram's free-start layer visible at the moments of highest intent.
+
+## Motivation
+
+Backlog row 252 (2026-06-13-agentgram-research.md §핵심 발견 5): Replika requires a paid subscription before users can explore core features. This is a demonstrated friction point for its 40M-user base. AgentGram differentiates with a free-start layer — no credit card, no forced upgrade to explore.
+
+---
+
+## Before
+
+- No explicit "free to start" commitment visible in the landing page hero flow or pricing page header.
+- Replika's subscription gate was not addressed in any pledge strip.
+
+---
+
+## After
+
+### New component: `FreeToStartStrip`
+
+A pledge strip matching the existing `AdFreePledgeStrip` / `IndependenceTrustBadge` / `QualityFirstPledge` pattern:
+- Green color scheme (`border-green-500/20 bg-green-500/5`)
+- `Sparkles` icon from lucide-react
+- Bold headline: "Try free · No credit card required."
+- Supporting copy: names Replika's paid-before-explore gate as the contrast
+- `data-testid="home-free-to-start-strip"` for testing
+
+Also exports `FreeToStartBadge` — a compact inline badge variant for use in pricing badge rows or other contexts.
+
+### Placement
+
+1. **Landing page `/`** — inserted between `StatsBar` and `AdFreePledgeStrip`, early in the scroll so visitors see the free-start commitment immediately after the hero stats.
+2. **`/pricing` page** — inserted immediately before the plan grid so the "no credit card" signal is present at the moment of plan selection.
+
+---
+
+## Changed Files
+
+| File | Change |
+|------|--------|
+| `apps/web/components/home/FreeToStartStrip.tsx` | **New** — `FreeToStartStrip` (full strip) + `FreeToStartBadge` (compact inline variant) |
+| `apps/web/components/home/index.ts` | Export `FreeToStartStrip` and `FreeToStartBadge` |
+| `apps/web/app/(public)/page.tsx` | Import and render `FreeToStartStrip` between `StatsBar` and `AdFreePledgeStrip` |
+| `apps/web/app/(public)/pricing/page.tsx` | Import and render `FreeToStartStrip` before plan grid |
+| `apps/web/__tests__/components/free-to-start-strip.test.tsx` | **New** — 8 unit tests covering render, copy, Replika context, accessibility aria-labels |


### PR DESCRIPTION
## Summary
- Adds `FreeToStartStrip` component matching existing pledge strip patterns (AdFreePledgeStrip, QualityFirstPledge, IndependenceTrustBadge)
- Placed on landing page (/) between StatsBar and AdFreePledgeStrip, and on /pricing before the plan grid
- Counters Replika's forced-subscription gate with explicit "Try free · No credit card required" messaging
- 8 unit tests, `FreeToStartBadge` inline variant, and PR evidence file

## Source
backlog.md:252

## Evidence
docs/pr-evidence/free-to-start-pledge-strip.md

## Auth-only Proof
N/A

## Test plan
- [ ] `npx vitest run __tests__/components/free-to-start-strip.test.tsx` — 8 tests pass
- [ ] Landing page (/) shows green strip between StatsBar and AdFreePledgeStrip
- [ ] /pricing page shows green strip above plan grid
- [ ] Strip copy references Replika subscription gate as contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)