### PR TITLE
feat: session-intensity wellbeing check-in card (CHI 2026 Aalto study)

### DIFF
--- a/apps/web/__tests__/components/session-wellness-nudge.test.tsx
+++ b/apps/web/__tests__/components/session-wellness-nudge.test.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { SessionWellnessNudge } from '../../components/chat/SessionWellnessNudge';
+import {
+  useSessionWellness,
+  SESSION_WELLNESS_MESSAGE_THRESHOLD,
+  SESSION_WELLNESS_TIME_THRESHOLD_MS,
+} from '../../hooks/use-session-wellness';
+
+const STORAGE_KEY = 'agentgram_session_wellness_dismissed';
+
+// ---------------------------------------------------------------------------
+// SessionWellnessNudge — rendering
+// ---------------------------------------------------------------------------
+
+describe('SessionWellnessNudge — not shown before threshold', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('renders nothing when messageCount is below threshold', () => {
+    const { container } = render(
+      <SessionWellnessNudge messageCount={59} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when messageCount is 0 (default)', () => {
+    const { container } = render(<SessionWellnessNudge />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('SessionWellnessNudge — shows after message threshold', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('renders the nudge card when messageCount reaches threshold', () => {
+    render(<SessionWellnessNudge messageCount={60} />);
+    expect(screen.getByTestId('session-wellness-nudge')).toBeInTheDocument();
+  });
+
+  it('renders the nudge card when messageCount exceeds threshold', () => {
+    render(<SessionWellnessNudge messageCount={100} />);
+    expect(screen.getByTestId('session-wellness-nudge')).toBeInTheDocument();
+  });
+
+  it('shows the spec copy in the body', () => {
+    render(<SessionWellnessNudge messageCount={60} />);
+    expect(screen.getByTestId('session-wellness-nudge-body')).toHaveTextContent(
+      "You've been chatting for a while"
+    );
+  });
+});
+
+describe('SessionWellnessNudge — dismiss interaction', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('hides the card when dismiss button is clicked', () => {
+    const { container } = render(<SessionWellnessNudge messageCount={60} />);
+    fireEvent.click(screen.getByTestId('session-wellness-nudge-dismiss'));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not reshow after dismiss even when messageCount remains above threshold', () => {
+    render(<SessionWellnessNudge messageCount={60} />);
+    fireEvent.click(screen.getByTestId('session-wellness-nudge-dismiss'));
+    expect(
+      screen.queryByTestId('session-wellness-nudge')
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('SessionWellnessNudge — once per session via sessionStorage', () => {
+  beforeEach(() => sessionStorage.clear());
+  afterEach(() => sessionStorage.clear());
+
+  it('does not show if already dismissed in sessionStorage', () => {
+    sessionStorage.setItem(STORAGE_KEY, '1');
+    const { container } = render(<SessionWellnessNudge messageCount={60} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('writes to sessionStorage on dismiss', () => {
+    render(<SessionWellnessNudge messageCount={60} />);
+    fireEvent.click(screen.getByTestId('session-wellness-nudge-dismiss'));
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe('1');
+  });
+});
+
+describe('SessionWellnessNudge — resource link', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('does not render a resource link when resourceUrl is omitted', () => {
+    render(<SessionWellnessNudge messageCount={60} />);
+    expect(
+      screen.queryByTestId('session-wellness-nudge-resource-link')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a resource link when resourceUrl is provided', () => {
+    render(
+      <SessionWellnessNudge
+        messageCount={60}
+        resourceUrl="https://example.com/wellness"
+        resourceLabel="Take a break"
+      />
+    );
+    const link = screen.getByTestId('session-wellness-nudge-resource-link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://example.com/wellness');
+    expect(link).toHaveTextContent('Take a break');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useSessionWellness hook — message count threshold
+// ---------------------------------------------------------------------------
+
+describe('useSessionWellness — message threshold', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('shouldShowNudge is false below threshold', () => {
+    const { result } = renderHook(() =>
+      useSessionWellness({ messageCount: 59, thresholdMessages: 60 })
+    );
+    expect(result.current.shouldShowNudge).toBe(false);
+  });
+
+  it('shouldShowNudge is true at threshold', () => {
+    const { result } = renderHook(() =>
+      useSessionWellness({ messageCount: 60, thresholdMessages: 60 })
+    );
+    expect(result.current.shouldShowNudge).toBe(true);
+  });
+
+  it('shouldShowNudge is true above threshold', () => {
+    const { result } = renderHook(() =>
+      useSessionWellness({ messageCount: 200, thresholdMessages: 60 })
+    );
+    expect(result.current.shouldShowNudge).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useSessionWellness hook — time threshold
+// ---------------------------------------------------------------------------
+
+describe('useSessionWellness — time threshold', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    sessionStorage.clear();
+  });
+
+  it('shouldShowNudge is false before the time threshold elapses', () => {
+    const { result } = renderHook(() =>
+      useSessionWellness({ thresholdMs: 90_000 })
+    );
+    expect(result.current.shouldShowNudge).toBe(false);
+  });
+
+  it('shouldShowNudge becomes true after the time threshold elapses', () => {
+    const { result } = renderHook(() =>
+      useSessionWellness({ thresholdMs: 90_000 })
+    );
+    act(() => {
+      vi.advanceTimersByTime(90_001);
+    });
+    expect(result.current.shouldShowNudge).toBe(true);
+  });
+
+  it('shouldShowNudge is true immediately when session already exceeded threshold', () => {
+    const sessionStartedAt = Date.now() - 91 * 60 * 1000; // 91 minutes ago
+    const { result } = renderHook(() =>
+      useSessionWellness({
+        thresholdMs: 90 * 60 * 1000,
+        sessionStartedAt,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(result.current.shouldShowNudge).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useSessionWellness hook — dismiss and sessionStorage
+// ---------------------------------------------------------------------------
+
+describe('useSessionWellness — dismiss', () => {
+  beforeEach(() => sessionStorage.clear());
+  afterEach(() => sessionStorage.clear());
+
+  it('dismissNudge hides the nudge and writes to sessionStorage', () => {
+    const { result } = renderHook(() =>
+      useSessionWellness({ messageCount: 60 })
+    );
+    expect(result.current.shouldShowNudge).toBe(true);
+    act(() => {
+      result.current.dismissNudge();
+    });
+    expect(result.current.shouldShowNudge).toBe(false);
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe('1');
+  });
+
+  it('shouldShowNudge is false on mount when sessionStorage has dismiss flag', () => {
+    sessionStorage.setItem(STORAGE_KEY, '1');
+    const { result } = renderHook(() =>
+      useSessionWellness({ messageCount: 60 })
+    );
+    expect(result.current.shouldShowNudge).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe('Session wellness thresholds', () => {
+  it('SESSION_WELLNESS_MESSAGE_THRESHOLD equals 60', () => {
+    expect(SESSION_WELLNESS_MESSAGE_THRESHOLD).toBe(60);
+  });
+
+  it('SESSION_WELLNESS_TIME_THRESHOLD_MS equals 90 minutes', () => {
+    expect(SESSION_WELLNESS_TIME_THRESHOLD_MS).toBe(90 * 60 * 1000);
+  });
+});

--- a/apps/web/components/chat/SessionWellnessNudge.tsx
+++ b/apps/web/components/chat/SessionWellnessNudge.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { Leaf, X, ExternalLink } from 'lucide-react';
+import { useSessionWellness } from '@/hooks/use-session-wellness';
+
+export interface SessionWellnessNudgeProps {
+  /** Number of messages sent in the current session. Triggers at ≥60. */
+  messageCount?: number;
+  /** Unix timestamp (ms) when the session started. Triggers at ≥90 min. */
+  sessionStartedAt?: number;
+  /** Optional wellness resource URL surfaced in the nudge card. */
+  resourceUrl?: string;
+  /** Link label shown when resourceUrl is provided. */
+  resourceLabel?: string;
+}
+
+/**
+ * Inline dismissible wellness card that appears after the user has sent
+ * ≥60 messages OR been in a continuous session for ≥90 minutes.
+ *
+ * Uses sessionStorage so it shows at most once per browser session.
+ * Distinct from the keyword-based crisis overlay (PR #656 / SB 243).
+ */
+export function SessionWellnessNudge({
+  messageCount = 0,
+  sessionStartedAt,
+  resourceUrl,
+  resourceLabel = 'Wellness resources',
+}: SessionWellnessNudgeProps) {
+  const { shouldShowNudge, dismissNudge } = useSessionWellness({
+    messageCount,
+    sessionStartedAt,
+  });
+
+  if (!shouldShowNudge) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="session-wellness-nudge"
+      className="flex items-start gap-3 rounded-xl border border-emerald-500/30 bg-emerald-50 dark:bg-emerald-950/40 px-4 py-3 my-2 mx-1"
+    >
+      <Leaf
+        className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400"
+        aria-hidden="true"
+      />
+      <div className="flex-1 space-y-1">
+        <p
+          className="text-xs text-emerald-800/80 dark:text-emerald-200/70"
+          data-testid="session-wellness-nudge-body"
+        >
+          You&apos;ve been chatting for a while — it&apos;s okay to step away 🌿
+          Take a break and come back refreshed.
+        </p>
+        {resourceUrl && (
+          <a
+            href={resourceUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-xs font-medium text-emerald-700 dark:text-emerald-300 hover:underline"
+            data-testid="session-wellness-nudge-resource-link"
+          >
+            {resourceLabel}
+            <ExternalLink className="h-3 w-3" aria-hidden="true" />
+          </a>
+        )}
+      </div>
+      <button
+        onClick={dismissNudge}
+        aria-label="Dismiss wellness nudge"
+        data-testid="session-wellness-nudge-dismiss"
+        className="shrink-0 text-emerald-600 hover:text-emerald-800 dark:text-emerald-400 dark:hover:text-emerald-200 text-lg leading-none"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/hooks/index.ts
+++ b/apps/web/hooks/index.ts
@@ -17,3 +17,8 @@ export type { StatsPayload } from './use-stats';
 export { transformAuthor } from './transform';
 export type { AuthorResponse } from './transform';
 export { useSessionTimer } from './use-session-timer';
+export {
+  useSessionWellness,
+  SESSION_WELLNESS_MESSAGE_THRESHOLD,
+  SESSION_WELLNESS_TIME_THRESHOLD_MS,
+} from './use-session-wellness';

--- a/apps/web/hooks/use-session-wellness.ts
+++ b/apps/web/hooks/use-session-wellness.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+
+export const SESSION_WELLNESS_MESSAGE_THRESHOLD = 60;
+export const SESSION_WELLNESS_TIME_THRESHOLD_MS = 90 * 60 * 1000; // 90 minutes
+
+const STORAGE_KEY = 'agentgram_session_wellness_dismissed';
+
+interface UseSessionWellnessOptions {
+  messageCount?: number;
+  thresholdMessages?: number;
+  thresholdMs?: number;
+  sessionStartedAt?: number;
+}
+
+interface UseSessionWellnessResult {
+  shouldShowNudge: boolean;
+  dismissNudge: () => void;
+}
+
+export function useSessionWellness({
+  messageCount = 0,
+  thresholdMessages = SESSION_WELLNESS_MESSAGE_THRESHOLD,
+  thresholdMs = SESSION_WELLNESS_TIME_THRESHOLD_MS,
+  sessionStartedAt,
+}: UseSessionWellnessOptions = {}): UseSessionWellnessResult {
+  const [startTime] = useState<number>(() => sessionStartedAt ?? Date.now());
+  const startRef = useRef<number>(startTime);
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return sessionStorage.getItem(STORAGE_KEY) === '1';
+  });
+  const [timeTriggered, setTimeTriggered] = useState(false);
+
+  useEffect(() => {
+    if (dismissed) return;
+    const elapsed = Date.now() - startRef.current;
+    const remaining = thresholdMs - elapsed;
+    if (remaining <= 0) {
+      setTimeTriggered(true);
+      return;
+    }
+    const timer = setTimeout(() => setTimeTriggered(true), remaining);
+    return () => clearTimeout(timer);
+  }, [thresholdMs, dismissed]);
+
+  const shouldShowNudge =
+    !dismissed && (timeTriggered || messageCount >= thresholdMessages);
+
+  function dismissNudge() {
+    setDismissed(true);
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem(STORAGE_KEY, '1');
+    }
+  }
+
+  return { shouldShowNudge, dismissNudge };
+}

--- a/docs/pr-evidence/session-wellness-nudge.md
+++ b/docs/pr-evidence/session-wellness-nudge.md
@@ -1,0 +1,38 @@
+# PR Evidence: Session Wellness Nudge
+
+## Backlog Row
+180
+
+## Summary
+Adds a dismissible inline wellbeing card (`SessionWellnessNudge`) that surfaces in the chat thread after sustained heavy use. Distinct from the keyword-based crisis overlay (PR #656 / SB 243 compliance).
+
+## Before
+No client-side session-intensity check for message volume. The existing `WellbeingNudgeCard` (PR #754) fires after 60 minutes elapsed time only, uses component state (resets on page reload), and is displayed as a fixed bottom overlay.
+
+## After
+`SessionWellnessNudge` fires after **either**:
+- 60+ messages sent in the current session, **or**
+- 90+ minutes of continuous session time
+
+Shown **inline** in the chat thread (not a fixed overlay). Uses `sessionStorage` so it displays at most once per browser session, surviving re-renders and component remounts within the same tab.
+
+## Files Changed
+| File | Change |
+|------|--------|
+| `apps/web/hooks/use-session-wellness.ts` | New hook — tracks both message count and elapsed time, reads/writes `sessionStorage` |
+| `apps/web/components/chat/SessionWellnessNudge.tsx` | New component — inline dismissible card |
+| `apps/web/__tests__/components/session-wellness-nudge.test.tsx` | 15 tests covering all threshold/dismiss/sessionStorage paths |
+| `apps/web/hooks/index.ts` | Added exports for new hook and constants |
+
+## Research Basis
+CHI 2026 Aalto University study on heavy AI companion users showing elevated loneliness/depression signals after sustained sessions. The dual threshold (message count + time) captures both rapid back-and-forth exchanges and slower, longer-running sessions.
+
+## Test Coverage
+- Renders nothing below threshold (message count and time)
+- Renders after message threshold (60 messages)
+- Renders after time threshold (90 minutes) via fake timers
+- Dismiss hides card and writes sessionStorage flag
+- Does not reshow after dismiss within the same session
+- Does not render when sessionStorage flag already set on mount
+- Resource link present/absent variants
+- Constant value assertions


### PR DESCRIPTION
## Source
Source: backlog.md:180

## Description
Adds SessionWellnessNudge component that surfaces a dismissible take-a-break card after sustained heavy chat sessions (60+ messages or 90+ min). Distinct from keyword-based crisis overlay (PR #656). Based on CHI 2026 Aalto University research on heavy AI companion users.

## Evidence
docs/pr-evidence/session-wellness-nudge.md

## Auth-only Proof
N/A