### PR TITLE
feat: C.AI silent cost-cut counter-copy (quality-first pledge on /pricing + migration CTA)

### DIFF
--- a/apps/web/__tests__/components/competitor-migration-section.test.tsx
+++ b/apps/web/__tests__/components/competitor-migration-section.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import CompetitorMigrationSection from '../../components/home/CompetitorMigrationSection';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement('a', { href }, children),
+}));
+
+describe('CompetitorMigrationSection', () => {
+  it('renders without crash', () => {
+    render(<CompetitorMigrationSection />);
+    expect(
+      screen.getByRole('region', { name: /switching from replika or kindroid/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the C.AI quality counter block', () => {
+    render(<CompetitorMigrationSection />);
+    expect(screen.getByTestId('cai-quality-counter-block')).toBeInTheDocument();
+  });
+
+  it('shows quality-first badge text', () => {
+    render(<CompetitorMigrationSection />);
+    expect(screen.getByTestId('cai-quality-counter-badge')).toHaveTextContent(
+      'Quality-first, no silent regressions'
+    );
+  });
+
+  it('shows no hidden quality cuts headline', () => {
+    render(<CompetitorMigrationSection />);
+    expect(screen.getByTestId('cai-quality-counter-heading')).toHaveTextContent(
+      'Unlike C.AI — no hidden quality cuts, no silent regression updates'
+    );
+  });
+
+  it('shows C.AI silent cost-cut context in body copy', () => {
+    render(<CompetitorMigrationSection />);
+    const body = screen.getByTestId('cai-quality-counter-body');
+    expect(body).toHaveTextContent('Character.AI masked cost-reduction changes');
+    expect(body).toHaveTextContent('RoboRhythms analysis');
+    expect(body).toHaveTextContent('zero silent quality degradations');
+  });
+
+  it('includes no silent quality cuts in the checklist', () => {
+    render(<CompetitorMigrationSection />);
+    expect(
+      screen.getByText(/No silent quality cuts — memory, personas & responses stay consistent/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/home/CompetitorMigrationSection.tsx
+++ b/apps/web/components/home/CompetitorMigrationSection.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { Check } from 'lucide-react';
+import { Check, ShieldCheck } from 'lucide-react';
 import ReplikaUltraCounterBlock from './ReplikaUltraCounterBlock';
 
 const checklist = [
@@ -8,6 +8,7 @@ const checklist = [
   'Full memory controls — no hidden AI training',
   'No in-chat ads, ever',
   'No locked personas behind monthly price hikes',
+  'No silent quality cuts — memory, personas & responses stay consistent',
 ];
 
 export default function CompetitorMigrationSection() {
@@ -41,8 +42,40 @@ export default function CompetitorMigrationSection() {
             ))}
           </ul>
 
-          <div className="mb-8 w-full text-left">
+          <div className="mb-4 w-full text-left">
             <ReplikaUltraCounterBlock />
+          </div>
+
+          <div
+            className="mb-8 w-full rounded-lg border border-blue-500/20 bg-blue-500/5 p-5 text-left"
+            data-testid="cai-quality-counter-block"
+            aria-labelledby="cai-quality-counter-heading"
+          >
+            <div className="mb-2 flex items-center gap-2">
+              <ShieldCheck className="h-4 w-4 shrink-0 text-blue-500" aria-hidden="true" />
+              <span
+                className="text-xs font-semibold uppercase tracking-[0.18em] text-blue-600 dark:text-blue-400"
+                data-testid="cai-quality-counter-badge"
+              >
+                Quality-first, no silent regressions
+              </span>
+            </div>
+            <h3
+              id="cai-quality-counter-heading"
+              className="mb-1.5 text-base font-bold"
+              data-testid="cai-quality-counter-heading"
+            >
+              Unlike C.AI — no hidden quality cuts, no silent regression updates
+            </h3>
+            <p
+              className="text-sm text-muted-foreground"
+              data-testid="cai-quality-counter-body"
+            >
+              Character.AI masked cost-reduction changes as product updates in 2025–2026,
+              silently degrading memory, personas, and response quality without notifying users
+              (RoboRhythms analysis, June 2026). AgentGram commits to zero silent quality
+              degradations: every capability change is announced and versioned.
+            </p>
           </div>
 
           <div className="flex flex-col items-center gap-3">

--- a/apps/web/docs/pr-evidence/cai-silent-cost-cut-counter.md
+++ b/apps/web/docs/pr-evidence/cai-silent-cost-cut-counter.md
@@ -1,0 +1,58 @@
+# PR Evidence: C.AI Silent Cost-Cut Counter-Copy
+
+**Source:** backlog.md row 248  
+**Date:** 2026-06-13  
+**Branch:** feat/cai-silent-cost-cut-counter
+
+## What Was Added
+
+### 1. CompetitorMigrationSection — new checklist item
+
+`apps/web/components/home/CompetitorMigrationSection.tsx`
+
+Added a fifth checklist item:
+
+```
+No silent quality cuts — memory, personas & responses stay consistent
+```
+
+This complements the existing four items (unlimited replies, memory controls, no ads, no locked personas) with a direct counter to C.AI's silent cost-reduction behaviour.
+
+### 2. CompetitorMigrationSection — C.AI quality counter block
+
+Added `data-testid="cai-quality-counter-block"` — a blue-tinted callout block placed between the Replika Ultra counter and the CTA button:
+
+```
+[ShieldCheck] QUALITY-FIRST, NO SILENT REGRESSIONS
+
+Unlike C.AI — no hidden quality cuts, no silent regression updates
+
+Character.AI masked cost-reduction changes as product updates in 2025–2026,
+silently degrading memory, personas, and response quality without notifying users
+(RoboRhythms analysis, June 2026). AgentGram commits to zero silent quality
+degradations: every capability change is announced and versioned.
+```
+
+### 3. /pricing page
+
+Already covered by PR #748 (`QualityFirstPledgeBadge` in `pricing-quality-first-pledge-section` and a `pricing-quality-first-badge` pill in the hero). No duplicate copy added.
+
+## Context
+
+Character.AI has repeatedly masked cost-reduction changes (reduced memory fidelity, degraded persona consistency, lower response quality) as routine product updates. The RoboRhythms analysis (June 2026) documented this pattern. Row 248 counter-positions AgentGram explicitly against this behaviour on the migration CTA — the highest-intent surface for users actively considering switching.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/home/CompetitorMigrationSection.tsx` | Added 5th checklist item + `cai-quality-counter-block` callout |
+| `apps/web/__tests__/components/competitor-migration-section.test.tsx` | New test file — 6 tests (renders, badge, heading, body copy, checklist item) |
+| `apps/web/docs/pr-evidence/cai-silent-cost-cut-counter.md` | This file |
+
+## Test Results
+
+```
+PASS (6) FAIL (0)
+```
+
+All tests exercise: renders without crash, counter block presence, badge text, heading text, body copy (C.AI context + RoboRhythms citation + zero-degradations pledge), and checklist item.


### PR DESCRIPTION
## Source
backlog.md:248

## Summary
- Adds quality-first, no silent regressions messaging to CompetitorMigrationSection (new checklist item + dedicated callout block)
- Counter to C.AI masking cost-reduction changes as product updates (RoboRhythms analysis June 2026)
- /pricing already covered by QualityFirstPledgeBadge from PR #748 — no duplicate added
- Complements C.AI message-cap counter PR #737 and QualityFirstPledge PR #748

## Evidence
docs/pr-evidence/cai-silent-cost-cut-counter.md

## Auth-only Proof
N/A

## Test Plan
- [x] Unit tests pass (6/6)
- [x] /pricing page renders quality-first commitment copy (existing QualityFirstPledgeBadge from PR #748)
- [x] CompetitorMigrationSection shows quality counter-messaging (new cai-quality-counter-block + checklist item)