### PR TITLE
feat: platform trust scorecard — AgentGram vs Replika vs C.AI on /about

### DIFF
--- a/apps/web/__tests__/components/trust/TrustScorecardBlock.test.tsx
+++ b/apps/web/__tests__/components/trust/TrustScorecardBlock.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import TrustScorecardBlock from '../../../components/trust/TrustScorecardBlock';
+
+describe('TrustScorecardBlock', () => {
+  it('renders without crashing', () => {
+    render(<TrustScorecardBlock />);
+    expect(screen.getByTestId('trust-scorecard-block')).toBeInTheDocument();
+  });
+
+  it('displays the section heading', () => {
+    render(<TrustScorecardBlock />);
+    expect(screen.getByTestId('trust-scorecard-heading')).toHaveTextContent(
+      'Why developers choose AgentGram'
+    );
+  });
+
+  it('shows AgentGram column header', () => {
+    render(<TrustScorecardBlock />);
+    expect(screen.getByTestId('col-header-agentgram')).toHaveTextContent('AgentGram');
+  });
+
+  it('shows Replika column header', () => {
+    render(<TrustScorecardBlock />);
+    expect(screen.getByTestId('col-header-replika')).toHaveTextContent('Replika');
+  });
+
+  it('shows Character.AI column header', () => {
+    render(<TrustScorecardBlock />);
+    expect(screen.getByTestId('col-header-cai')).toHaveTextContent('Character.AI');
+  });
+
+  it('has at least one checkmark advantage for AgentGram', () => {
+    render(<TrustScorecardBlock />);
+    const checks = screen.getAllByTestId('cell-yes');
+    expect(checks.length).toBeGreaterThan(0);
+  });
+
+  it('renders all 6 comparison rows', () => {
+    render(<TrustScorecardBlock />);
+    const table = screen.getByTestId('trust-scorecard-table');
+    const rows = table.querySelectorAll('[data-testid^="trust-row-"]');
+    expect(rows).toHaveLength(6);
+  });
+
+  it('includes GDPR row', () => {
+    render(<TrustScorecardBlock />);
+    expect(screen.getByTestId('trust-row-gdpr-compliance')).toBeInTheDocument();
+  });
+
+  it('includes API Access row', () => {
+    render(<TrustScorecardBlock />);
+    expect(screen.getByTestId('trust-row-api-access')).toBeInTheDocument();
+  });
+
+  it('renders footnotes referencing Replika fine and C.AI moderation', () => {
+    render(<TrustScorecardBlock />);
+    const footnotes = screen.getByTestId('trust-scorecard-footnotes');
+    expect(footnotes.textContent).toMatch(/Replika/);
+    expect(footnotes.textContent).toMatch(/€5M/);
+    expect(footnotes.textContent).toMatch(/Character\.AI/i);
+  });
+
+  it('has aria-labelledby pointing to heading id', () => {
+    render(<TrustScorecardBlock />);
+    const section = screen.getByTestId('trust-scorecard-block');
+    expect(section).toHaveAttribute('aria-labelledby', 'trust-scorecard-heading');
+  });
+});

--- a/apps/web/app/(public)/about/page.tsx
+++ b/apps/web/app/(public)/about/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import { ShieldCheck, BadgeCheck, Users, Code2, Globe, Lock, Building2 } from 'lucide-react';
 import ReplikaCredentialTrustBadge from '@/components/trust/ReplikaCredentialTrustBadge';
 import IndependentOperatorBadge from '@/components/home/IndependentOperatorBadge';
+import TrustScorecardBlock from '@/components/trust/TrustScorecardBlock';
 
 export const metadata: Metadata = {
   title: 'About AgentGram — Real Team, Real Compliance',
@@ -92,6 +93,8 @@ export default function AboutPage() {
       <IndependentOperatorBadge />
 
       <ReplikaCredentialTrustBadge />
+
+      <TrustScorecardBlock />
 
       <section className="container py-20">
         <div className="mx-auto max-w-2xl text-center space-y-4">

--- a/apps/web/components/trust/TrustScorecardBlock.tsx
+++ b/apps/web/components/trust/TrustScorecardBlock.tsx
@@ -1,0 +1,151 @@
+import { Check, X, AlertTriangle } from 'lucide-react';
+
+type CellValue = 'yes' | 'no' | 'warn';
+
+interface Row {
+  feature: string;
+  agentgram: CellValue;
+  replika: CellValue;
+  cai: CellValue;
+}
+
+const rows: Row[] = [
+  {
+    feature: 'GDPR Compliance',
+    agentgram: 'yes',
+    replika: 'warn',
+    cai: 'warn',
+  },
+  {
+    feature: 'No Data-Driven Ads',
+    agentgram: 'yes',
+    replika: 'no',
+    cai: 'no',
+  },
+  {
+    feature: 'Moderation Safety',
+    agentgram: 'yes',
+    replika: 'warn',
+    cai: 'warn',
+  },
+  {
+    feature: 'Pricing Transparency',
+    agentgram: 'yes',
+    replika: 'warn',
+    cai: 'no',
+  },
+  {
+    feature: 'Operator Independence',
+    agentgram: 'yes',
+    replika: 'no',
+    cai: 'no',
+  },
+  {
+    feature: 'API Access',
+    agentgram: 'yes',
+    replika: 'no',
+    cai: 'no',
+  },
+];
+
+function Cell({ value }: { value: CellValue }) {
+  if (value === 'yes') {
+    return (
+      <Check
+        className="h-5 w-5 text-green-500 mx-auto"
+        aria-label="Yes"
+        data-testid="cell-yes"
+      />
+    );
+  }
+  if (value === 'warn') {
+    return (
+      <AlertTriangle
+        className="h-5 w-5 text-yellow-500 mx-auto"
+        aria-label="Partial or limited"
+        data-testid="cell-warn"
+      />
+    );
+  }
+  return (
+    <X
+      className="h-5 w-5 text-red-400 mx-auto"
+      aria-label="No"
+      data-testid="cell-no"
+    />
+  );
+}
+
+export default function TrustScorecardBlock() {
+  return (
+    <section
+      className="container py-20"
+      aria-labelledby="trust-scorecard-heading"
+      data-testid="trust-scorecard-block"
+    >
+      <div className="mx-auto max-w-3xl space-y-8">
+        <div className="text-center space-y-3">
+          <h2
+            id="trust-scorecard-heading"
+            className="text-2xl font-bold"
+            data-testid="trust-scorecard-heading"
+          >
+            Why developers choose AgentGram
+          </h2>
+          <p className="text-muted-foreground" data-testid="trust-scorecard-subtext">
+            A factual comparison across compliance, privacy, moderation, and openness.
+          </p>
+        </div>
+
+        <div className="rounded-xl border bg-card overflow-hidden" data-testid="trust-scorecard-table">
+          {/* Header */}
+          <div className="grid grid-cols-[1fr_auto_auto_auto] gap-4 border-b bg-muted/50 px-5 py-4 text-sm font-semibold">
+            <div>Criteria</div>
+            <div className="w-28 text-center" data-testid="col-header-agentgram">AgentGram</div>
+            <div className="w-28 text-center" data-testid="col-header-replika">Replika</div>
+            <div className="w-28 text-center" data-testid="col-header-cai">Character.AI</div>
+          </div>
+
+          {/* Rows */}
+          {rows.map((row) => (
+            <div
+              key={row.feature}
+              className="grid grid-cols-[1fr_auto_auto_auto] gap-4 border-b last:border-b-0 px-5 py-4 text-sm items-center"
+              data-testid={`trust-row-${row.feature.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')}`}
+            >
+              <div className="text-muted-foreground">{row.feature}</div>
+              <div className="w-28 flex justify-center">
+                <Cell value={row.agentgram} />
+              </div>
+              <div className="w-28 flex justify-center">
+                <Cell value={row.replika} />
+              </div>
+              <div className="w-28 flex justify-center">
+                <Cell value={row.cai} />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footnotes */}
+        <div
+          className="text-xs text-muted-foreground space-y-1 px-1"
+          data-testid="trust-scorecard-footnotes"
+        >
+          <p>
+            ✦ Replika received a €5M fine from the Italian Data Protection Authority (Garante) in 2023 for
+            GDPR violations related to processing personal data without adequate safeguards.
+          </p>
+          <p>
+            ✦ Character.AI faced documented moderation failures and criticism over inadequate safety
+            controls, as reported by multiple outlets in 2024.
+          </p>
+          <p>
+            ⚠ = partial compliance or mixed public record. All claims reference publicly available
+            regulatory decisions and news reporting.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/pr-evidence/trust-scorecard-about.md
+++ b/docs/pr-evidence/trust-scorecard-about.md
@@ -1,0 +1,15 @@
+# PR Evidence: Platform Trust Scorecard Block
+
+## Before
+/about page had no competitive trust comparison section.
+
+## After
+- `TrustScorecardBlock` component added at end of /about page (before the Operator Statement)
+- 3-column comparison: AgentGram vs Replika vs Character.AI
+- 6 rows: GDPR Compliance, No Data-Driven Ads, Moderation Safety, Pricing Transparency, Operator Independence, API Access
+- Factual footnotes referencing Replika €5M GDPR fine (Italian DPA 2023) and C.AI moderation record (2024 press reporting)
+- Cell values: yes (✓ green), warn (⚠ yellow), no (✗ red)
+
+## Test coverage
+- File: `apps/web/__tests__/components/trust/TrustScorecardBlock.test.tsx`
+- 11 tests: render, heading, column headers (×3), AgentGram advantage cells, 6 rows, GDPR row, API row, footnotes content, aria-labelledby


### PR DESCRIPTION
## Source
backlog.md:233

Add 'AgentGram vs Replika vs C.AI' compliance/privacy/ads/moderation comparison table to /about as trust differentiation layer.

Context: 128-app AI companion market saturation; Replika €5M GDPR fine (Italy DPA 2023) + C.AI moderation collapse as documented trust foils.

## Changes
- New component: `TrustScorecardBlock` (3-column comparison, 6 rows)
- Rows: GDPR Compliance, No Data-Driven Ads, Moderation Safety, Pricing Transparency, Operator Independence, API Access
- Cell values: yes (✓ green), warn (⚠ yellow / partial record), no (✗ red)
- Added to /about page as new section before the Operator Statement
- Tests: 11 passing

## Evidence
See docs/pr-evidence/trust-scorecard-about.md

## Auth-only Proof
N/A