### PR TITLE
feat: no secret model training consent pledge

### DIFF
--- a/apps/web/__tests__/components/no-model-training-pledge.test.tsx
+++ b/apps/web/__tests__/components/no-model-training-pledge.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import NoModelTrainingPledgeStrip from '../../components/home/NoModelTrainingPledgeStrip';
+
+describe('NoModelTrainingPledgeStrip', () => {
+  it('renders with correct test id', () => {
+    render(<NoModelTrainingPledgeStrip />);
+    expect(
+      screen.getByTestId('home-no-model-training-pledge-strip')
+    ).toBeInTheDocument();
+  });
+
+  it('displays no model training headline', () => {
+    render(<NoModelTrainingPledgeStrip />);
+    expect(
+      screen.getByText(/Your chats never train our models — ever/i)
+    ).toBeInTheDocument();
+  });
+
+  it('mentions Moltbook data-harvesting context', () => {
+    render(<NoModelTrainingPledgeStrip />);
+    expect(screen.getByText(/Moltbook/i)).toBeInTheDocument();
+  });
+
+  it('mentions explicit opt-in requirement', () => {
+    render(<NoModelTrainingPledgeStrip />);
+    expect(screen.getByText(/explicit opt-in/i)).toBeInTheDocument();
+  });
+
+  it('has aria-label for accessibility', () => {
+    render(<NoModelTrainingPledgeStrip />);
+    expect(
+      screen.getByLabelText('No secret model training pledge')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -18,6 +18,7 @@ import {
   NomiMigrationCTA,
   NoChatIsolationBadge,
   QualityFirstPledgeStrip,
+  NoModelTrainingPledgeStrip,
   PlatformComparisonSection,
   ApiFirstEcosystemSection,
   FaqSection,
@@ -171,6 +172,7 @@ export default function Home() {
         <IndependenceTrustBadge />
         <IndependentOperatorBadge />
         <QualityFirstPledgeStrip />
+        <NoModelTrainingPledgeStrip />
         <ContentPermanencePledgeStrip />
         <MemoryGuaranteeLandingSection />
         <ZeroStateContractSection />

--- a/apps/web/app/(public)/privacy/page.tsx
+++ b/apps/web/app/(public)/privacy/page.tsx
@@ -159,9 +159,40 @@ export default function PrivacyPage() {
             <p>We do not sell your personal data to third parties.</p>
           </section>
 
+          <section
+            className="space-y-4 rounded-2xl border border-emerald-500/30 bg-emerald-500/5 p-6"
+            data-testid="privacy-no-model-training-pledge"
+          >
+            <h2 className="text-2xl font-semibold text-foreground">
+              8. No Secret Model Training
+            </h2>
+            <p>
+              Your conversations are <strong>never used to train our AI models</strong> without
+              your explicit opt-in consent. What you share stays between you and your agent.
+            </p>
+            <p>
+              Unlike platforms that repurpose user data for model training after acquisitions
+              or policy changes, AgentGram commits to the following:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                Conversation content is not used to train, fine-tune, or improve any AI model
+                without your explicit, affirmative consent.
+              </li>
+              <li>
+                If we ever introduce an opt-in training program, participation will be
+                voluntary, clearly disclosed, and revocable at any time.
+              </li>
+              <li>
+                We will never retroactively apply new data-use terms to existing conversations
+                without direct notification and the opportunity to opt out.
+              </li>
+            </ul>
+          </section>
+
           <section className="space-y-4">
             <h2 className="text-2xl font-semibold text-foreground">
-              8. Children&apos;s Privacy
+              9. Children&apos;s Privacy
             </h2>
             <p>
               Our Service is not intended for children under the age of 13. We
@@ -171,7 +202,7 @@ export default function PrivacyPage() {
 
           <section className="space-y-4">
             <h2 className="text-2xl font-semibold text-foreground">
-              9. Changes to This Policy
+              10. Changes to This Policy
             </h2>
             <p>
               We may update our Privacy Policy from time to time. We will notify
@@ -182,7 +213,7 @@ export default function PrivacyPage() {
 
           <section className="space-y-4">
             <h2 className="text-2xl font-semibold text-foreground">
-              10. Contact Us
+              11. Contact Us
             </h2>
             <p>
               If you have any questions about this Privacy Policy, please

--- a/apps/web/components/home/NoModelTrainingPledgeStrip.tsx
+++ b/apps/web/components/home/NoModelTrainingPledgeStrip.tsx
@@ -1,0 +1,29 @@
+import { ShieldCheck } from 'lucide-react';
+
+export default function NoModelTrainingPledgeStrip() {
+  return (
+    <section
+      className="border-y border-emerald-500/20 bg-emerald-500/5 py-5"
+      aria-label="No secret model training pledge"
+      data-testid="home-no-model-training-pledge-strip"
+    >
+      <div className="container">
+        <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-center sm:text-left">
+          <ShieldCheck
+            className="h-5 w-5 shrink-0 text-emerald-500"
+            aria-hidden="true"
+          />
+          <p className="text-sm font-medium">
+            <span className="text-foreground">Your chats never train our models — ever.</span>{' '}
+            <span className="text-muted-foreground">
+              Post-acquisition platforms like Moltbook use your conversations
+              to train AI without meaningful consent. AgentGram never trains on
+              your data without your explicit opt-in. What you share stays between
+              you and your agent.
+            </span>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -24,3 +24,4 @@ export { default as KindroidJuneMigrationCTA } from './KindroidJuneMigrationCTA'
 export { default as NomiMigrationCTA } from './NomiMigrationCTA';
 export { default as QualityFirstPledgeStrip, QualityFirstPledgeBadge } from './QualityFirstPledge';
 export { default as FreeToStartStrip, FreeToStartBadge } from './FreeToStartStrip';
+export { default as NoModelTrainingPledgeStrip } from './NoModelTrainingPledgeStrip';

--- a/docs/pr-evidence/no-secret-model-training-pledge.md
+++ b/docs/pr-evidence/no-secret-model-training-pledge.md
@@ -1,0 +1,56 @@
+# PR Evidence: No Secret Model Training Pledge
+
+**Source**: backlog.md row 258
+**Branch**: feat/no-secret-model-training-pledge
+
+## What Changed
+
+### 1. New component: `apps/web/components/home/NoModelTrainingPledgeStrip.tsx`
+
+Created a landing-page strip following the same pattern as `AdFreePledgeStrip` and `QualityFirstPledgeStrip`.
+
+**Copy**: "Your chats never train our models — ever. Post-acquisition platforms like Moltbook use your conversations to train AI without meaningful consent. AgentGram never trains on your data without your explicit opt-in. What you share stays between you and your agent."
+
+### 2. Export: `apps/web/components/home/index.ts`
+
+Added:
+```ts
+export { default as NoModelTrainingPledgeStrip } from './NoModelTrainingPledgeStrip';
+```
+
+### 3. Homepage: `apps/web/app/(public)/page.tsx`
+
+Added `NoModelTrainingPledgeStrip` import and placed it after `QualityFirstPledgeStrip` in the render tree.
+
+### 4. Privacy page: `apps/web/app/(public)/privacy/page.tsx`
+
+Added new **section 8 — No Secret Model Training** (previous sections 8–10 renumbered to 9–11):
+
+```
+Your conversations are never used to train our AI models without your explicit
+opt-in consent. What you share stays between you and your agent.
+
+AgentGram commits to:
+• Conversation content never used for model training without explicit, affirmative consent.
+• Any future opt-in training program: voluntary, clearly disclosed, revocable.
+• No retroactive data-use policy changes without direct notification and opt-out.
+```
+
+The section is visually distinguished with `border-emerald-500/30 bg-emerald-500/5` styling and `data-testid="privacy-no-model-training-pledge"`.
+
+## Why
+
+**Competitive signal vs Meta/Moltbook post-acquisition data harvesting.**
+
+Meta's acquisition of Moltbook raised concerns about user conversations being used to train AI models without meaningful consent. This pledge is a direct counter-signal: factual, visible, trust-building. It positions AgentGram alongside users who are actively evaluating platforms based on data ethics.
+
+## Test Coverage
+
+**File**: `apps/web/__tests__/components/no-model-training-pledge.test.tsx`
+
+5 tests — all passing:
+- `renders with correct test id`
+- `displays no model training headline`
+- `mentions Moltbook data-harvesting context`
+- `mentions explicit opt-in requirement`
+- `has aria-label for accessibility`


### PR DESCRIPTION
Source: backlog.md:row 258

## Summary
- Adds explicit "conversations never train our models without opt-in" pledge to `/privacy` page as a highlighted section (section 8)
- Adds `NoModelTrainingPledgeStrip` component to landing homepage after `QualityFirstPledgeStrip`
- Counter-signal to Meta/Moltbook post-acquisition data-harvesting concerns

## Evidence
`docs/pr-evidence/no-secret-model-training-pledge.md` (included in commit)

## Test Plan
- [x] 5 vitest tests pass: strip renders, headline visible, Moltbook context present, opt-in language present, aria-label correct
- [x] Privacy page section 8 visually highlighted with emerald border + `data-testid="privacy-no-model-training-pledge"`
- [x] Landing homepage strip placed after QualityFirstPledgeStrip

## Auth-only Proof
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)