### PR TITLE
feat: companion time-budget self-regulation panel

### DIFF
--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -65,6 +65,7 @@ vi.mock('@/components/dashboard', () => ({
   ProactiveControlsForm: mockProactiveControlsForm,
   PersonaTierCard: vi.fn(() => null),
   DailyReflectionSettingsCard: vi.fn(() => null),
+  TimeBudgetPanel: vi.fn(() => null),
 }));
 
 function createSettingsPageClient() {

--- a/apps/web/__tests__/components/time-budget-panel.test.tsx
+++ b/apps/web/__tests__/components/time-budget-panel.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TimeBudgetPanel } from '@/components/dashboard/TimeBudgetPanel';
+
+const STORAGE_KEY = 'agentgram:timeBudget';
+
+describe('TimeBudgetPanel', () => {
+  let store: Record<string, string> = {};
+
+  beforeEach(() => {
+    store = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: vi.fn((key: string) => store[key] ?? null),
+        setItem: vi.fn((key: string, val: string) => {
+          store[key] = val;
+        }),
+        removeItem: vi.fn((key: string) => {
+          delete store[key];
+        }),
+        clear: vi.fn(() => {
+          store = {};
+        }),
+      },
+      writable: true,
+    });
+  });
+
+  it('renders the panel container', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    expect(screen.getByTestId('time-budget-panel')).toBeInTheDocument();
+  });
+
+  it('renders the daily goal input with default value', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    const input = screen.getByTestId('daily-goal-input') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe('30');
+  });
+
+  it('renders the weekly goal input with default value', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    const input = screen.getByTestId('weekly-goal-input') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe('3');
+  });
+
+  it('renders the save goals button', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    expect(screen.getByTestId('time-budget-save-btn')).toBeInTheDocument();
+  });
+
+  it('renders the weekly trend chart', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    expect(screen.getByTestId('weekly-trend-chart')).toBeInTheDocument();
+  });
+
+  it('renders the weekly trend summary', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    expect(screen.getByTestId('weekly-trend-summary')).toBeInTheDocument();
+  });
+
+  it('renders 7 trend bars (one per weekday)', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    const chart = screen.getByTestId('weekly-trend-chart');
+    const days = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+    for (const day of days) {
+      expect(
+        chart.querySelector(`[data-testid="trend-bar-${day}"]`)
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('updates daily goal input when user types', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    const input = screen.getByTestId('daily-goal-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '45' } });
+    expect(input.value).toBe('45');
+  });
+
+  it('updates weekly goal input when user types', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    const input = screen.getByTestId('weekly-goal-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '5' } });
+    expect(input.value).toBe('5');
+  });
+
+  it('save button persists goals to localStorage', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    const dailyInput = screen.getByTestId('daily-goal-input');
+    const weeklyInput = screen.getByTestId('weekly-goal-input');
+    fireEvent.change(dailyInput, { target: { value: '60' } });
+    fireEvent.change(weeklyInput, { target: { value: '5' } });
+    fireEvent.click(screen.getByTestId('time-budget-save-btn'));
+    const raw = store[STORAGE_KEY];
+    expect(raw).toBeDefined();
+    const stored = JSON.parse(raw) as { dailyMinutes: number; weeklyHours: number };
+    expect(stored.dailyMinutes).toBe(60);
+    expect(stored.weeklyHours).toBe(5);
+  });
+
+  it('shows success status message after saving', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    fireEvent.click(screen.getByTestId('time-budget-save-btn'));
+    expect(screen.getByRole('status')).toHaveTextContent('Session goals saved.');
+  });
+
+  it('renders the wellbeing badge', () => {
+    render(<TimeBudgetPanel initialGoals={{ dailyMinutes: 30, weeklyHours: 3 }} />);
+    expect(screen.getByTestId('time-budget-free-badge')).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -8,6 +8,7 @@ import {
   FadeIn,
   PersonaTierCard,
   ProactiveControlsForm,
+  TimeBudgetPanel,
 } from '@/components/dashboard';
 import { CompanionInsightsPanel } from '@/components/companion-insights-panel';
 import type { UserProfile } from '@/lib/minor-safe-mode';
@@ -287,6 +288,10 @@ export default async function SettingsPage() {
           }
           initialSettings={initialSettings}
         />
+      </FadeIn>
+
+      <FadeIn delay={0.08}>
+        <TimeBudgetPanel />
       </FadeIn>
 
       <FadeIn delay={0.1}>

--- a/apps/web/components/dashboard/TimeBudgetPanel.tsx
+++ b/apps/web/components/dashboard/TimeBudgetPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Clock, Loader2, Target } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -93,19 +93,13 @@ export interface TimeBudgetPanelProps {
 
 export function TimeBudgetPanel({ initialGoals }: TimeBudgetPanelProps) {
   const [goals, setGoals] = useState<TimeBudgetGoals>(
-    initialGoals ?? { dailyMinutes: 30, weeklyHours: 3 }
+    () => initialGoals ?? loadGoals()
   );
   const [isSaving, setIsSaving] = useState(false);
   const [status, setStatus] = useState<{
     tone: 'idle' | 'success' | 'error';
     message: string;
   }>({ tone: 'idle', message: '' });
-
-  useEffect(() => {
-    if (!initialGoals) {
-      setGoals(loadGoals());
-    }
-  }, [initialGoals]);
 
   const handleSave = () => {
     setIsSaving(true);

--- a/apps/web/components/dashboard/TimeBudgetPanel.tsx
+++ b/apps/web/components/dashboard/TimeBudgetPanel.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Clock, Loader2, Target } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+const STORAGE_KEY = 'agentgram:timeBudget';
+
+const WEEK_DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const MOCK_WEEKLY_MINUTES = [25, 45, 0, 60, 30, 10, 0];
+
+interface TimeBudgetGoals {
+  dailyMinutes: number;
+  weeklyHours: number;
+}
+
+function loadGoals(): TimeBudgetGoals {
+  if (typeof window === 'undefined') {
+    return { dailyMinutes: 30, weeklyHours: 3 };
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { dailyMinutes: 30, weeklyHours: 3 };
+    const parsed = JSON.parse(raw) as Partial<TimeBudgetGoals>;
+    return {
+      dailyMinutes: typeof parsed.dailyMinutes === 'number' ? parsed.dailyMinutes : 30,
+      weeklyHours: typeof parsed.weeklyHours === 'number' ? parsed.weeklyHours : 3,
+    };
+  } catch {
+    return { dailyMinutes: 30, weeklyHours: 3 };
+  }
+}
+
+function saveGoals(goals: TimeBudgetGoals): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(goals));
+  } catch {
+    // storage full — silently ignore
+  }
+}
+
+function WeeklyTrendBar({
+  label,
+  minutes,
+  goalMinutes,
+}: {
+  label: string;
+  minutes: number;
+  goalMinutes: number;
+}) {
+  const maxBarHeight = 48;
+  const maxMinutes = Math.max(...MOCK_WEEKLY_MINUTES, goalMinutes, 1);
+  const heightPct = Math.min(minutes / maxMinutes, 1);
+  const overGoal = minutes > goalMinutes;
+
+  return (
+    <div
+      className="flex flex-col items-center gap-1"
+      data-testid={`trend-bar-${label.toLowerCase()}`}
+    >
+      <div
+        className="relative flex w-8 flex-col justify-end"
+        style={{ height: `${maxBarHeight}px` }}
+      >
+        <div
+          aria-label={`${label}: ${minutes} min`}
+          className={`w-full rounded-sm transition-all ${
+            overGoal
+              ? 'bg-amber-500/80 dark:bg-amber-400/80'
+              : 'bg-primary/60'
+          }`}
+          style={{ height: `${Math.round(heightPct * maxBarHeight)}px` }}
+        />
+      </div>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+export interface TimeBudgetPanelProps {
+  /** Injected in tests to avoid localStorage access during SSR */
+  initialGoals?: TimeBudgetGoals;
+}
+
+export function TimeBudgetPanel({ initialGoals }: TimeBudgetPanelProps) {
+  const [goals, setGoals] = useState<TimeBudgetGoals>(
+    initialGoals ?? { dailyMinutes: 30, weeklyHours: 3 }
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [status, setStatus] = useState<{
+    tone: 'idle' | 'success' | 'error';
+    message: string;
+  }>({ tone: 'idle', message: '' });
+
+  useEffect(() => {
+    if (!initialGoals) {
+      setGoals(loadGoals());
+    }
+  }, [initialGoals]);
+
+  const handleSave = () => {
+    setIsSaving(true);
+    setStatus({ tone: 'idle', message: '' });
+    try {
+      saveGoals(goals);
+      setStatus({ tone: 'success', message: 'Session goals saved.' });
+    } catch {
+      setStatus({ tone: 'error', message: 'Could not save. Please try again.' });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const totalWeekMinutes = MOCK_WEEKLY_MINUTES.reduce((a, b) => a + b, 0);
+  const weeklyGoalMinutes = goals.weeklyHours * 60;
+  const weeklyPct = Math.round((totalWeekMinutes / Math.max(weeklyGoalMinutes, 1)) * 100);
+
+  return (
+    <Card
+      className="border-border/50 bg-card/50 backdrop-blur-sm"
+      data-testid="time-budget-panel"
+    >
+      <CardHeader>
+        <CardTitle className="flex flex-wrap items-center gap-2">
+          <Clock className="h-5 w-5 text-sky-600 dark:text-sky-400" aria-hidden="true" />
+          Session time goals
+          <Badge
+            className="gap-1 border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-400"
+            variant="outline"
+            data-testid="time-budget-free-badge"
+          >
+            Wellbeing
+          </Badge>
+        </CardTitle>
+        <CardDescription>
+          Set voluntary daily and weekly session goals to keep your companion
+          time intentional. Based on CHI 2026 research on healthy AI companion
+          use patterns.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <label
+              className="text-sm font-medium text-foreground"
+              htmlFor="daily-goal"
+            >
+              Daily session goal (minutes)
+            </label>
+            <div className="flex items-center gap-2">
+              <Target className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <input
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                data-testid="daily-goal-input"
+                id="daily-goal"
+                min={5}
+                max={480}
+                onChange={(e) =>
+                  setGoals((prev) => ({
+                    ...prev,
+                    dailyMinutes: Math.max(5, Number(e.target.value) || 5),
+                  }))
+                }
+                type="number"
+                value={goals.dailyMinutes}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Recommended: 30 min/day
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <label
+              className="text-sm font-medium text-foreground"
+              htmlFor="weekly-goal"
+            >
+              Weekly session goal (hours)
+            </label>
+            <div className="flex items-center gap-2">
+              <Target className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <input
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                data-testid="weekly-goal-input"
+                id="weekly-goal"
+                min={0.5}
+                max={40}
+                step={0.5}
+                onChange={(e) =>
+                  setGoals((prev) => ({
+                    ...prev,
+                    weeklyHours: Math.max(0.5, Number(e.target.value) || 0.5),
+                  }))
+                }
+                type="number"
+                value={goals.weeklyHours}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Recommended: 3 hr/week
+            </p>
+          </div>
+        </div>
+
+        <div
+          className="space-y-3 rounded-lg border border-border/60 bg-background/60 p-4"
+          data-testid="weekly-trend-section"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-semibold text-foreground">
+              This week
+            </span>
+            <span
+              className="text-xs text-muted-foreground"
+              data-testid="weekly-trend-summary"
+            >
+              {totalWeekMinutes} min of {weeklyGoalMinutes} min goal ({weeklyPct}%)
+            </span>
+          </div>
+          <div
+            className="flex items-end justify-between gap-1"
+            data-testid="weekly-trend-chart"
+          >
+            {WEEK_DAYS.map((day, i) => (
+              <WeeklyTrendBar
+                key={day}
+                label={day}
+                minutes={MOCK_WEEKLY_MINUTES[i]}
+                goalMinutes={goals.dailyMinutes}
+              />
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Amber bars exceed your daily goal.
+          </p>
+        </div>
+      </CardContent>
+
+      <CardFooter className="flex flex-col items-start gap-3 border-t border-border/40 pt-6 sm:flex-row sm:items-center sm:justify-between">
+        <p
+          className={`text-sm ${
+            status.tone === 'error'
+              ? 'text-destructive'
+              : status.tone === 'success'
+                ? 'text-sky-600 dark:text-sky-400'
+                : 'text-muted-foreground'
+          }`}
+          role="status"
+        >
+          {status.message || 'Goals are saved locally on this device.'}
+        </p>
+        <Button
+          data-testid="time-budget-save-btn"
+          disabled={isSaving}
+          onClick={handleSave}
+          type="button"
+        >
+          {isSaving ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            'Save goals'
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/components/dashboard/index.ts
+++ b/apps/web/components/dashboard/index.ts
@@ -20,3 +20,5 @@ export { MemoryMindMapPanel } from './MemoryMindMapPanel';
 export type { MemoryMindMapPanelProps, AgentMemory } from './MemoryMindMapPanel';
 export { ProactivePostAnalyticsPanel } from './ProactivePostAnalyticsPanel';
 export type { ProactivePostAnalyticsData } from './ProactivePostAnalyticsPanel';
+export { TimeBudgetPanel } from './TimeBudgetPanel';
+export type { TimeBudgetPanelProps } from './TimeBudgetPanel';

--- a/docs/pr-evidence/companion-time-budget-panel.md
+++ b/docs/pr-evidence/companion-time-budget-panel.md
@@ -1,0 +1,50 @@
+# PR Evidence: Companion Time-Budget Self-Regulation Panel
+
+Source: backlog.md row 259
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/dashboard/TimeBudgetPanel.tsx` | New component |
+| `apps/web/components/dashboard/index.ts` | Export `TimeBudgetPanel` and `TimeBudgetPanelProps` |
+| `apps/web/app/(protected)/dashboard/settings/page.tsx` | Import and render `<TimeBudgetPanel />` with FadeIn |
+| `apps/web/__tests__/components/time-budget-panel.test.tsx` | New test file — 11 tests |
+| `apps/web/__tests__/components/proactive-controls-settings.test.tsx` | Add `TimeBudgetPanel: vi.fn(() => null)` to dashboard mock |
+
+## Component Description
+
+`TimeBudgetPanel` is a `'use client'` React component rendered in the user settings page under a "Wellbeing" context. It provides:
+
+- **Daily goal input** — numeric input (minutes, default 30, min 5, max 480)
+- **Weekly goal input** — numeric input (hours, default 3, min 0.5, max 40, step 0.5)
+- **Weekly usage trend chart** — 7-bar visual (Mon–Sun) using mock session data; bars turn amber when a day exceeds the daily goal
+- **Save goals button** — persists goals to `localStorage` under key `agentgram:timeBudget`
+- **Status feedback** — success/error message after save
+
+Goals are loaded from `localStorage` on mount via `useEffect`. An `initialGoals` prop bypasses localStorage (used in tests to avoid SSR/jsdom issues).
+
+## Motivation
+
+CHI 2026 Aalto research shows heavy AI companion users exhibit loneliness signals. This panel is a voluntary self-regulation tool — no enforcement, just intentional goal-setting. Complements PR #760 session nudge.
+
+## Test Coverage
+
+File: `apps/web/__tests__/components/time-budget-panel.test.tsx`
+
+| Test | Coverage |
+|------|----------|
+| renders panel container | Panel mounts |
+| renders daily goal input with default | Input present, value=30 |
+| renders weekly goal input with default | Input present, value=3 |
+| renders save goals button | Button present |
+| renders weekly trend chart | Chart section present |
+| renders weekly trend summary | Summary text present |
+| renders 7 trend bars (one per weekday) | Mon–Sun bars present |
+| updates daily goal when user types | Controlled input works |
+| updates weekly goal when user types | Controlled input works |
+| save button persists goals to localStorage | localStorage.setItem called with correct values |
+| shows success status message after saving | Status text updates |
+| renders wellbeing badge | Badge present |
+
+All 12 tests pass. Full suite: 139 test files / 1292 tests — all green.


### PR DESCRIPTION
## Source
backlog.md:259

## Summary
- Adds `TimeBudgetPanel` component to user settings with daily (minutes) and weekly (hours) session goal inputs
- Renders a weekly usage trend bar chart (Mon–Sun, mock data for MVP) — amber bars flag days over goal
- Goals persist to `localStorage`; loaded via lazy useState initializer
- Based on CHI 2026 Aalto research on heavy-user loneliness signals; complements PR #760 session nudge with voluntary self-regulation
- Panel placed in settings page under `FadeIn` between `ProactiveControlsForm` and per-agent settings

## Evidence
docs/pr-evidence/companion-time-budget-panel.md (included in commit)

## Test Plan
- [x] TimeBudgetPanel renders daily/weekly goal inputs (tested)
- [x] Save goals persists values to localStorage (tested)
- [x] Weekly trend chart renders 7 bars Mon–Sun (tested)
- [x] Success status message shown after save (tested)
- [x] Settings page mock updated — existing page test suite green (139 files / 1292 tests all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Auth-only Proof
N/A