### PR TITLE
feat: labs feature-vote panel (community roadmap co-ownership)

### DIFF
--- a/apps/web/__tests__/components/labs-feature-vote-panel.test.tsx
+++ b/apps/web/__tests__/components/labs-feature-vote-panel.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { LabsFeatureVotePanel } from '@/components/labs/LabsFeatureVotePanel';
+
+describe('LabsFeatureVotePanel', () => {
+  let store: Record<string, string> = {};
+
+  beforeEach(() => {
+    store = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: vi.fn((key: string) => store[key] ?? null),
+        setItem: vi.fn((key: string, val: string) => {
+          store[key] = val;
+        }),
+        removeItem: vi.fn((key: string) => {
+          delete store[key];
+        }),
+        clear: vi.fn(() => {
+          store = {};
+        }),
+      },
+      writable: true,
+    });
+  });
+
+  it('renders the vote panel container', () => {
+    render(<LabsFeatureVotePanel />);
+    expect(screen.getByTestId('labs-feature-vote-panel')).toBeInTheDocument();
+  });
+
+  it('renders all 5 feature candidates', () => {
+    render(<LabsFeatureVotePanel />);
+    const items = [
+      'vote-item-voice-first-chat',
+      'vote-item-multi-agent-group-threads',
+      'vote-item-auto-summarized-memory-digests',
+      'vote-item-story-arc-branching',
+      'vote-item-agent-cross-follow-notifications',
+    ];
+    for (const testId of items) {
+      expect(screen.getByTestId(testId)).toBeInTheDocument();
+    }
+  });
+
+  it('shows feature titles', () => {
+    render(<LabsFeatureVotePanel />);
+    expect(screen.getByTestId('vote-item-voice-first-chat-title')).toHaveTextContent(
+      'Voice-first chat mode'
+    );
+    expect(
+      screen.getByTestId('vote-item-multi-agent-group-threads-title')
+    ).toHaveTextContent('Multi-agent group threads');
+  });
+
+  it('all vote counts start at 0', () => {
+    render(<LabsFeatureVotePanel />);
+    const featureIds = [
+      'voice-first-chat',
+      'multi-agent-group-threads',
+      'auto-summarized-memory-digests',
+      'story-arc-branching',
+      'agent-cross-follow-notifications',
+    ];
+    for (const id of featureIds) {
+      expect(screen.getByTestId(`vote-count-${id}`)).toHaveTextContent('0');
+    }
+  });
+
+  it('upvote increments count by 1', () => {
+    render(<LabsFeatureVotePanel />);
+    const btn = screen.getByTestId('vote-button-voice-first-chat');
+    fireEvent.click(btn);
+    expect(screen.getByTestId('vote-count-voice-first-chat')).toHaveTextContent('1');
+  });
+
+  it('upvote button is disabled after voting (no double-vote)', () => {
+    render(<LabsFeatureVotePanel />);
+    const btn = screen.getByTestId('vote-button-voice-first-chat');
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    expect(screen.getByTestId('vote-count-voice-first-chat')).toHaveTextContent('1');
+  });
+
+  it('voting one feature does not affect other features', () => {
+    render(<LabsFeatureVotePanel />);
+    fireEvent.click(screen.getByTestId('vote-button-voice-first-chat'));
+    expect(
+      screen.getByTestId('vote-count-multi-agent-group-threads')
+    ).toHaveTextContent('0');
+  });
+
+  it('persists vote to localStorage', () => {
+    render(<LabsFeatureVotePanel />);
+    fireEvent.click(screen.getByTestId('vote-button-story-arc-branching'));
+    const stored = JSON.parse(store['agentgram:labs-feature-votes'] ?? '{}');
+    expect(stored['story-arc-branching']).toBe(1);
+  });
+});

--- a/apps/web/app/(protected)/dashboard/labs/page.tsx
+++ b/apps/web/app/(protected)/dashboard/labs/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { FadeIn } from '@/components/dashboard';
 import { LabsPanel } from '@/components/labs/LabsPanel';
+import { LabsFeatureVotePanel } from '@/components/labs/LabsFeatureVotePanel';
 import {
   Card,
   CardContent,
@@ -79,6 +80,10 @@ export default async function LabsPage() {
 
       <FadeIn delay={0.1}>
         <LabsPanel plan={plan} />
+      </FadeIn>
+
+      <FadeIn delay={0.15}>
+        <LabsFeatureVotePanel />
       </FadeIn>
     </div>
   );

--- a/apps/web/components/labs/LabsFeatureVotePanel.tsx
+++ b/apps/web/components/labs/LabsFeatureVotePanel.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ThumbsUp, Mic, Users, BookOpen, GitBranch, Bell } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+const STORAGE_KEY = 'agentgram:labs-feature-votes';
+
+const FEATURE_CANDIDATES = [
+  {
+    id: 'voice-first-chat',
+    title: 'Voice-first chat mode',
+    description:
+      'Talk to your companion using voice instead of typing. Real-time voice input with low-latency audio responses.',
+    icon: Mic,
+  },
+  {
+    id: 'multi-agent-group-threads',
+    title: 'Multi-agent group threads',
+    description:
+      'Start conversations with multiple agents in a shared thread. Agents respond to each other and to you.',
+    icon: Users,
+  },
+  {
+    id: 'auto-summarized-memory-digests',
+    title: 'Auto-summarized memory digests',
+    description:
+      'Weekly digest of what your companion has learned about you, with one-tap approval to keep, edit, or remove each fact.',
+    icon: BookOpen,
+  },
+  {
+    id: 'story-arc-branching',
+    title: 'Story arc branching',
+    description:
+      'Fork your conversation at any point to explore alternate story paths without losing the original thread.',
+    icon: GitBranch,
+  },
+  {
+    id: 'agent-cross-follow-notifications',
+    title: 'Agent cross-follow notifications',
+    description:
+      'Get notified when agents you follow interact with each other, so you never miss an evolving relationship arc.',
+    icon: Bell,
+  },
+] as const;
+
+type FeatureId = (typeof FEATURE_CANDIDATES)[number]['id'];
+
+function loadVotes(): Record<FeatureId, number> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {} as Record<FeatureId, number>;
+    return JSON.parse(raw) as Record<FeatureId, number>;
+  } catch {
+    return {} as Record<FeatureId, number>;
+  }
+}
+
+function saveVotes(votes: Record<string, number>) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(votes));
+  } catch {
+    // storage unavailable
+  }
+}
+
+export function LabsFeatureVotePanel() {
+  const [votes, setVotes] = useState<Record<string, number>>({});
+  const [voted, setVoted] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const stored = loadVotes();
+    setVotes(stored);
+    const votedMap: Record<string, boolean> = {};
+    for (const id of Object.keys(stored)) {
+      if ((stored[id] ?? 0) > 0) votedMap[id] = true;
+    }
+    setVoted(votedMap);
+  }, []);
+
+  function handleVote(id: string) {
+    if (voted[id]) return;
+    setVotes((prev) => {
+      const next = { ...prev, [id]: (prev[id] ?? 0) + 1 };
+      saveVotes(next);
+      return next;
+    });
+    setVoted((prev) => ({ ...prev, [id]: true }));
+  }
+
+  return (
+    <Card
+      className="border-border/50 bg-card/50 backdrop-blur-sm"
+      data-testid="labs-feature-vote-panel"
+    >
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <CardTitle>Shape what ships next</CardTitle>
+          <Badge variant="secondary">Community vote</Badge>
+        </div>
+        <CardDescription>
+          Help shape what ships next — vote for the features you want most. No
+          paywall. Your votes directly influence the roadmap.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {FEATURE_CANDIDATES.map((feature) => {
+          const Icon = feature.icon;
+          const count = votes[feature.id] ?? 0;
+          const hasVoted = !!voted[feature.id];
+
+          return (
+            <div
+              key={feature.id}
+              className="flex items-start justify-between gap-4 rounded-lg border border-border/50 bg-background/50 p-4"
+              data-testid={`vote-item-${feature.id}`}
+            >
+              <div className="flex items-start gap-3 min-w-0">
+                <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
+                  <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+                </div>
+                <div className="space-y-0.5 min-w-0">
+                  <p
+                    className="text-sm font-semibold text-foreground"
+                    data-testid={`vote-item-${feature.id}-title`}
+                  >
+                    {feature.title}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {feature.description}
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={() => handleVote(feature.id)}
+                disabled={hasVoted}
+                aria-label={`Upvote ${feature.title}`}
+                aria-pressed={hasVoted}
+                className={`flex shrink-0 flex-col items-center gap-1 rounded-lg border px-3 py-2 text-xs font-semibold transition-colors ${
+                  hasVoted
+                    ? 'border-primary/40 bg-primary/10 text-primary cursor-default'
+                    : 'border-border/50 bg-transparent text-muted-foreground hover:border-primary/40 hover:bg-primary/5 hover:text-primary cursor-pointer'
+                }`}
+                data-testid={`vote-button-${feature.id}`}
+              >
+                <ThumbsUp className="h-4 w-4" aria-hidden="true" />
+                <span data-testid={`vote-count-${feature.id}`}>{count}</span>
+              </button>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/labs/LabsFeatureVotePanel.tsx
+++ b/apps/web/components/labs/LabsFeatureVotePanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { ThumbsUp, Mic, Users, BookOpen, GitBranch, Bell } from 'lucide-react';
 import {
   Card,
@@ -72,18 +72,15 @@ function saveVotes(votes: Record<string, number>) {
 }
 
 export function LabsFeatureVotePanel() {
-  const [votes, setVotes] = useState<Record<string, number>>({});
-  const [voted, setVoted] = useState<Record<string, boolean>>({});
-
-  useEffect(() => {
+  const [votes, setVotes] = useState<Record<string, number>>(loadVotes);
+  const [voted, setVoted] = useState<Record<string, boolean>>(() => {
     const stored = loadVotes();
-    setVotes(stored);
     const votedMap: Record<string, boolean> = {};
     for (const id of Object.keys(stored)) {
       if ((stored[id] ?? 0) > 0) votedMap[id] = true;
     }
-    setVoted(votedMap);
-  }, []);
+    return votedMap;
+  });
 
   function handleVote(id: string) {
     if (voted[id]) return;

--- a/docs/pr-evidence/labs-feature-vote-panel.md
+++ b/docs/pr-evidence/labs-feature-vote-panel.md
@@ -1,0 +1,38 @@
+# PR Evidence: Labs Feature Vote Panel (backlog row 260)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/labs/LabsFeatureVotePanel.tsx` | New client component — community upvote panel |
+| `apps/web/app/(protected)/dashboard/labs/page.tsx` | Import + render `<LabsFeatureVotePanel />` after `<LabsPanel />` |
+| `apps/web/__tests__/components/labs-feature-vote-panel.test.tsx` | 8 unit tests |
+
+## Feature Candidates (MVP hardcoded list)
+
+1. **Voice-first chat mode** — `voice-first-chat`
+2. **Multi-agent group threads** — `multi-agent-group-threads`
+3. **Auto-summarized memory digests** — `auto-summarized-memory-digests`
+4. **Story arc branching** — `story-arc-branching`
+5. **Agent cross-follow notifications** — `agent-cross-follow-notifications`
+
+## Vote Storage
+
+Votes stored in `localStorage` under key `agentgram:labs-feature-votes` (JSON object mapping feature id → count). One vote per feature per browser session enforced client-side via `voted` state.
+
+## Test Coverage Summary
+
+| Test | What it checks |
+|------|----------------|
+| renders panel container | `data-testid="labs-feature-vote-panel"` in DOM |
+| renders all 5 features | All 5 `vote-item-*` testids present |
+| shows feature titles | Title text matches for two features |
+| all counts start at 0 | `vote-count-*` shows `0` on first render |
+| upvote increments count | Click → count becomes `1` |
+| no double-vote | Second click on voted button has no effect |
+| voting one feature isolates others | Other feature counts stay at `0` |
+| persists to localStorage | `agentgram:labs-feature-votes` key written after vote |
+
+## Competitive Context
+
+Counter to C.AI Labs pay-for-beta model — users co-own the roadmap for free. No paywall, no feature-gating. All users see the vote panel regardless of plan tier.


### PR DESCRIPTION
Source: backlog.md:row 260

## Summary
- Adds `LabsFeatureVotePanel` component to Labs settings — 5 hardcoded experimental feature candidates with per-feature upvote buttons
- Votes stored in `localStorage` (`agentgram:labs-feature-votes`); one vote per feature per browser enforced client-side
- Direct counter to C.AI Labs pay-for-beta model: no paywall, all users co-own the roadmap

## Auth-only Proof
N/A

## Evidence
docs/pr-evidence/labs-feature-vote-panel.md (included in commit)

## Test Plan
- [x] LabsFeatureVotePanel renders 5 candidate features (8 passing unit tests)
- [x] Upvote button increments count
- [x] No double-vote (button disabled after first click)
- [x] Votes persist to localStorage
- [x] Labs settings page shows vote panel below existing feature toggles