### PR TITLE
feat: replika savings calculator on /pricing

### DIFF
--- a/apps/web/__tests__/components/replika-savings-calculator.test.tsx
+++ b/apps/web/__tests__/components/replika-savings-calculator.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ReplikaSavingsCalculator } from '@/components/pricing/ReplikaSavingsCalculator';
+
+describe('ReplikaSavingsCalculator', () => {
+  it('renders the comparison table', () => {
+    render(<ReplikaSavingsCalculator />);
+    expect(screen.getByTestId('savings-table')).toBeInTheDocument();
+  });
+
+  it('renders three Replika tier rows', () => {
+    render(<ReplikaSavingsCalculator />);
+    expect(screen.getByTestId('savings-row-replika-pro')).toBeInTheDocument();
+    expect(screen.getByTestId('savings-row-replika-ultra')).toBeInTheDocument();
+    expect(screen.getByTestId('savings-row-replika-platinum')).toBeInTheDocument();
+  });
+
+  it('defaults to 12 months and shows correct AgentGram cost', () => {
+    render(<ReplikaSavingsCalculator />);
+    // AgentGram Pro at $29/mo × 12 = $348
+    const agentgramCells = screen.getAllByTestId('agentgram-cost');
+    agentgramCells.forEach((cell) => {
+      expect(cell).toHaveTextContent('$348.00');
+    });
+  });
+
+  it('duration toggle to 1 month updates AgentGram cost', () => {
+    render(<ReplikaSavingsCalculator />);
+    fireEvent.click(screen.getByTestId('duration-1'));
+    // $29 × 1 = $29
+    const agentgramCells = screen.getAllByTestId('agentgram-cost');
+    agentgramCells.forEach((cell) => {
+      expect(cell).toHaveTextContent('$29.00');
+    });
+  });
+
+  it('duration toggle to 3 months updates AgentGram cost', () => {
+    render(<ReplikaSavingsCalculator />);
+    fireEvent.click(screen.getByTestId('duration-3'));
+    // $29 × 3 = $87
+    const agentgramCells = screen.getAllByTestId('agentgram-cost');
+    agentgramCells.forEach((cell) => {
+      expect(cell).toHaveTextContent('$87.00');
+    });
+  });
+
+  it('shows savings for Replika Platinum at 12 months', () => {
+    render(<ReplikaSavingsCalculator />);
+    // Replika Platinum $39.99×12=$479.88 vs AgentGram $348 → save $131.88
+    const platinumRow = screen.getByTestId('savings-row-replika-platinum');
+    const savingsCell = platinumRow.querySelector('[data-testid="savings-amount"]');
+    expect(savingsCell).toHaveTextContent('$131.88');
+  });
+
+  it('shows max savings callout at 12 months', () => {
+    render(<ReplikaSavingsCalculator />);
+    expect(screen.getByTestId('max-savings-callout')).toBeInTheDocument();
+  });
+
+  it('renders the duration selector with three options', () => {
+    render(<ReplikaSavingsCalculator />);
+    expect(screen.getByTestId('duration-selector')).toBeInTheDocument();
+    expect(screen.getByTestId('duration-1')).toBeInTheDocument();
+    expect(screen.getByTestId('duration-3')).toBeInTheDocument();
+    expect(screen.getByTestId('duration-12')).toBeInTheDocument();
+  });
+
+  it('shows headline text', () => {
+    render(<ReplikaSavingsCalculator />);
+    expect(
+      screen.getByText(/why pay tier prices when one plan covers everything/i)
+    ).toBeInTheDocument();
+  });
+
+  it('Replika Platinum cost at 12 months is correct', () => {
+    render(<ReplikaSavingsCalculator />);
+    const platinumRow = screen.getByTestId('savings-row-replika-platinum');
+    const replikaCell = platinumRow.querySelector('[data-testid="replika-cost"]');
+    // $39.99 × 12 = $479.88
+    expect(replikaCell).toHaveTextContent('$479.88');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, PricingCompetitorAnchorRow } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, PricingCompetitorAnchorRow, ReplikaSavingsCalculator } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -453,6 +453,13 @@ export default function PricingPage() {
             );
           })}
         </div>
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="replika-savings-calculator-section"
+      >
+        <ReplikaSavingsCalculator />
       </section>
 
       <section className="container pb-10">

--- a/apps/web/components/pricing/ReplikaSavingsCalculator.tsx
+++ b/apps/web/components/pricing/ReplikaSavingsCalculator.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState } from 'react';
+import { TrendingDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const AGENTGRAM_MONTHLY = 29;
+
+const REPLIKA_TIERS = [
+  { label: 'Replika Pro', monthly: 19.99 },
+  { label: 'Replika Ultra', monthly: 29.99 },
+  { label: 'Replika Platinum', monthly: 39.99 },
+] as const;
+
+const DURATIONS: { label: string; months: number }[] = [
+  { label: '1 month', months: 1 },
+  { label: '3 months', months: 3 },
+  { label: '12 months', months: 12 },
+];
+
+function fmt(n: number) {
+  return n.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
+}
+
+export function ReplikaSavingsCalculator() {
+  const [months, setMonths] = useState(12);
+
+  const agentgramTotal = AGENTGRAM_MONTHLY * months;
+  const maxSavings = (REPLIKA_TIERS[2].monthly - AGENTGRAM_MONTHLY) * months;
+
+  return (
+    <div
+      className="mx-auto max-w-3xl rounded-2xl border border-primary/20 bg-primary/5 px-6 py-6 shadow-sm"
+      data-testid="replika-savings-calculator"
+    >
+      <div className="mb-5 space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-wide text-primary">
+          Price comparison
+        </p>
+        <h2 className="text-xl font-bold text-foreground">
+          Why pay tier prices when one plan covers everything?
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Compare what you&apos;d spend on Replika&apos;s 3-tier ladder vs AgentGram Pro — one plan, all features.
+        </p>
+      </div>
+
+      <div
+        className="mb-5 flex gap-2"
+        data-testid="duration-selector"
+        aria-label="Select duration"
+      >
+        {DURATIONS.map(({ label, months: m }) => (
+          <Button
+            key={m}
+            size="sm"
+            variant={months === m ? 'default' : 'outline'}
+            onClick={() => setMonths(m)}
+            data-testid={`duration-${m}`}
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-border/40">
+        <table className="w-full text-sm" data-testid="savings-table">
+          <thead>
+            <tr className="border-b bg-muted/30">
+              <th className="p-3 text-left font-medium text-muted-foreground">Plan</th>
+              <th className="p-3 text-right font-medium text-muted-foreground">Replika cost</th>
+              <th className="p-3 text-right font-medium text-muted-foreground">AgentGram Pro</th>
+              <th className="p-3 text-right font-medium text-muted-foreground">You save</th>
+            </tr>
+          </thead>
+          <tbody>
+            {REPLIKA_TIERS.map(({ label, monthly }) => {
+              const replikaTotal = monthly * months;
+              const savings = replikaTotal - agentgramTotal;
+              return (
+                <tr
+                  key={label}
+                  className="border-b border-border/30 last:border-0"
+                  data-testid={`savings-row-${label.replace(/\s+/g, '-').toLowerCase()}`}
+                >
+                  <td className="p-3 font-medium">{label}</td>
+                  <td className="p-3 text-right text-muted-foreground" data-testid="replika-cost">
+                    {fmt(replikaTotal)}
+                  </td>
+                  <td className="p-3 text-right font-medium text-primary" data-testid="agentgram-cost">
+                    {fmt(agentgramTotal)}
+                  </td>
+                  <td className="p-3 text-right" data-testid="savings-amount">
+                    {savings > 0 ? (
+                      <span className="font-semibold text-emerald-600 dark:text-emerald-400">
+                        {fmt(savings)}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground text-xs">More features</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {maxSavings > 0 && (
+        <div
+          className="mt-4 flex items-center gap-3 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3"
+          data-testid="max-savings-callout"
+        >
+          <TrendingDown className="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+          <p className="text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+            Save up to {fmt(maxSavings)} vs Replika Platinum — one plan, every feature, no tier juggling.
+          </p>
+        </div>
+      )}
+
+      <p className="mt-3 text-xs text-muted-foreground">
+        Replika pricing based on published monthly rates (Pro $19.99/mo, Ultra $29.99/mo, Platinum $39.99/mo).
+        AgentGram Pro billed at $29/mo. Replika Pro does not include Companion Insights — requires Platinum upgrade.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -3,3 +3,4 @@ export { PricingProofSection } from './PricingProofSection';
 export { ReplikaPricingConfusionCallout } from './ReplikaPricingConfusionCallout';
 export { CAISoftLaunchLockEscape } from './CAISoftLaunchLockEscape';
 export { PricingCompetitorAnchorRow } from './PricingCompetitorAnchorRow';
+export { ReplikaSavingsCalculator } from './ReplikaSavingsCalculator';

--- a/docs/pr-evidence/replika-savings-calculator.md
+++ b/docs/pr-evidence/replika-savings-calculator.md
@@ -1,0 +1,38 @@
+# PR Evidence: Replika Savings Calculator
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/pricing/ReplikaSavingsCalculator.tsx` | New component |
+| `apps/web/components/pricing/index.ts` | Added export |
+| `apps/web/app/(public)/pricing/page.tsx` | Import + render below pricing cards |
+| `apps/web/__tests__/components/replika-savings-calculator.test.tsx` | 10 tests |
+
+## Pricing Values Used
+
+| Plan | Monthly | Source |
+|------|---------|--------|
+| Replika Pro | $19.99/mo | Published monthly rate (backlog row 261) |
+| Replika Ultra | $29.99/mo | Published monthly rate (backlog row 261) |
+| Replika Platinum | $39.99/mo | Published monthly rate (backlog row 261) |
+| AgentGram Pro | $29.00/mo | Pricing page `getPlans()` — `price.monthly: 29` |
+
+## Key Numbers (12-month comparison)
+
+- Replika Platinum (12mo): $479.88
+- AgentGram Pro (12mo): $348.00
+- **Max savings vs Replika Platinum: $131.88/year**
+
+## Test Coverage
+
+10 tests covering:
+- Component renders (table, tier rows, duration selector)
+- Default 12-month AgentGram cost ($348.00)
+- Duration toggle updates (1mo = $29, 3mo = $87, 12mo = $348)
+- Replika Platinum savings at 12 months ($131.88)
+- Max savings callout renders
+- Headline text
+- Replika Platinum cost accuracy ($479.88)
+
+All 10 tests pass.


### PR DESCRIPTION
## Source
backlog.md:261

## Summary
- Adds interactive Replika vs AgentGram price comparison calculator to /pricing page
- Targets Replika 3-tier complexity fatigue and price-sensitive user base
- Duration selector (1/3/12 months) updates all cost values live
- Bold callout: "Save up to $131.88/year vs Replika Platinum"
- Complements PR #721 Replika Ultra counter copy

## Evidence
docs/pr-evidence/replika-savings-calculator.md (included in commit)

## Auth-only Proof
N/A

## Test Plan
- [x] ReplikaSavingsCalculator renders comparison table (10 tests, all pass)
- [x] Duration toggle (1/3/12 months) updates savings values
- [x] /pricing page renders calculator below pricing cards (after plan grid section)