### PR TITLE
feat: multilingual memory guarantee badge (Nomi counter)

### DIFF
--- a/apps/web/__tests__/components/multilingual-memory-badge.test.tsx
+++ b/apps/web/__tests__/components/multilingual-memory-badge.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MultilingualMemoryBadge } from '../../components/agents/MultilingualMemoryBadge';
+
+describe('MultilingualMemoryBadge', () => {
+  it('renders with the correct data-testid', () => {
+    render(<MultilingualMemoryBadge />);
+    expect(screen.getByTestId('multilingual-memory-badge')).toBeInTheDocument();
+  });
+
+  it('displays the multilingual memory label text', () => {
+    render(<MultilingualMemoryBadge />);
+    expect(screen.getByTestId('multilingual-memory-badge')).toHaveTextContent(
+      'Memory in any language'
+    );
+  });
+
+  it('displays the stored and recalled accurately text', () => {
+    render(<MultilingualMemoryBadge />);
+    expect(screen.getByTestId('multilingual-memory-badge')).toHaveTextContent(
+      'stored & recalled accurately'
+    );
+  });
+
+  it('has a title attribute referencing Nomi App Store complaint', () => {
+    render(<MultilingualMemoryBadge />);
+    const badge = screen.getByTestId('multilingual-memory-badge');
+    expect(badge).toHaveAttribute(
+      'title',
+      expect.stringContaining('Nomi 2026 App Store')
+    );
+  });
+
+  it('has a title attribute mentioning accurate recall in any language', () => {
+    render(<MultilingualMemoryBadge />);
+    const badge = screen.getByTestId('multilingual-memory-badge');
+    expect(badge).toHaveAttribute(
+      'title',
+      expect.stringContaining('any language')
+    );
+  });
+
+  it('accepts and applies an optional className prop', () => {
+    render(<MultilingualMemoryBadge className="custom-test-class" />);
+    expect(screen.getByTestId('multilingual-memory-badge')).toHaveClass(
+      'custom-test-class'
+    );
+  });
+
+  it('renders a globe icon element', () => {
+    render(<MultilingualMemoryBadge />);
+    const icon = screen
+      .getByTestId('multilingual-memory-badge')
+      .querySelector('svg');
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('renders without className prop (default styling)', () => {
+    render(<MultilingualMemoryBadge />);
+    const badge = screen.getByTestId('multilingual-memory-badge');
+    expect(badge).toHaveClass('bg-blue-500/10');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -13,6 +13,7 @@ import { MemoryStabilityPledge } from '@/components/memory-stability-pledge';
 import { MemoryGuaranteeLandingSection } from '@/components/memory-guarantee-landing-section';
 import { NomiV5ImageParityBadge } from '@/components/agents/NomiV5ImageParityBadge';
 import { VoiceLongSessionBadge } from '@/components/agents/VoiceLongSessionBadge';
+import { MultilingualMemoryBadge } from '@/components/agents/MultilingualMemoryBadge';
 import ReplikaCredentialTrustBadge from '@/components/trust/ReplikaCredentialTrustBadge';
 import { Button } from '@/components/ui/button';
 import { analytics } from '@/lib/analytics';
@@ -307,6 +308,7 @@ export default function PricingPage() {
               AI Image Gen — free for all
             </span>
             <NomiV5ImageParityBadge />
+            <MultilingualMemoryBadge className="rounded-full px-3 py-1 text-xs" />
             <span
               className="inline-flex items-center gap-1.5 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-700 dark:text-blue-400"
               data-testid="pricing-quality-first-badge"
@@ -417,6 +419,30 @@ export default function PricingPage() {
             </div>
             <span className="shrink-0 rounded-full border border-violet-500/30 bg-background px-4 py-1.5 text-xs font-semibold text-violet-700 dark:text-violet-300">
               Included in Starter+
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="pricing-multilingual-memory-section"
+      >
+        <div className="mx-auto max-w-6xl rounded-2xl border border-blue-500/20 bg-blue-500/5 px-6 py-5 shadow-sm">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-2">
+              <MultilingualMemoryBadge />
+              <p className="text-sm font-semibold text-foreground">
+                Your memory — in any language, with full cultural nuance
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Nomi&apos;s #1 App Store complaint in 2026 (4.6★, 5K+ reviews) is multilingual
+                and cultural-nuance memory errors. AgentGram stores and recalls every memory
+                accurately regardless of the language used — no lost context, no mistranslation.
+              </p>
+            </div>
+            <span className="shrink-0 rounded-full border border-blue-500/30 bg-background px-4 py-1.5 text-xs font-semibold text-blue-700 dark:text-blue-300">
+              All tiers
             </span>
           </div>
         </div>

--- a/apps/web/components/agents/MultilingualMemoryBadge.tsx
+++ b/apps/web/components/agents/MultilingualMemoryBadge.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Globe } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+export interface MultilingualMemoryBadgeProps {
+  className?: string;
+}
+
+export function MultilingualMemoryBadge({
+  className,
+}: MultilingualMemoryBadgeProps) {
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        'gap-1 border border-blue-500/20 bg-blue-500/10 text-[10px] font-semibold text-blue-700 dark:text-blue-300',
+        className
+      )}
+      data-testid="multilingual-memory-badge"
+      title="Memory stored and recalled accurately in any language — counter to Nomi 2026 App Store most-cited complaint"
+    >
+      <Globe className="h-3 w-3" aria-hidden="true" />
+      Memory in any language — stored &amp; recalled accurately
+    </Badge>
+  );
+}
+
+export default MultilingualMemoryBadge;

--- a/apps/web/components/dashboard/MemoryExportDashboard.tsx
+++ b/apps/web/components/dashboard/MemoryExportDashboard.tsx
@@ -18,6 +18,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { MemoryTierTabs } from './MemoryTierTabs';
+import { MultilingualMemoryBadge } from '@/components/agents/MultilingualMemoryBadge';
 
 export interface MemoryExportRecord {
   id: string;
@@ -146,6 +147,9 @@ export function MemoryExportDashboard({ memories: initialMemories }: Props) {
               All AI-remembered facts about you — view, delete, or export.
             </p>
           </div>
+        </div>
+        <div data-testid="memory-export-multilingual-badge">
+          <MultilingualMemoryBadge />
         </div>
       </div>
 

--- a/docs/pr-evidence/multilingual-memory-guarantee-badge.md
+++ b/docs/pr-evidence/multilingual-memory-guarantee-badge.md
@@ -1,0 +1,69 @@
+# PR Evidence: Multilingual Memory Guarantee Badge
+
+**Backlog row:** 266
+**Branch:** feat/multilingual-memory-guarantee-badge
+**Date:** 2026-06-14
+
+## Feature Description
+
+Adds a `MultilingualMemoryBadge` component that surfaces AgentGram's multilingual memory accuracy as a competitive differentiator against Nomi.
+
+**Competitive context:** Nomi's App Store reviews (2026, 4.6/5, 5,000+ reviews) cite multilingual and cultural-nuance memory errors as the most-common complaint. This badge explicitly positions AgentGram as the solution.
+
+## Files Changed
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `apps/web/components/agents/MultilingualMemoryBadge.tsx` | New reusable badge component |
+| `apps/web/__tests__/components/multilingual-memory-badge.test.tsx` | 8 unit tests |
+| `docs/pr-evidence/multilingual-memory-guarantee-badge.md` | This file |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `apps/web/app/(public)/pricing/page.tsx` | Import + hero badge strip + full section block |
+| `apps/web/components/dashboard/MemoryExportDashboard.tsx` | Import + badge under page header |
+
+## Component: MultilingualMemoryBadge
+
+```tsx
+// apps/web/components/agents/MultilingualMemoryBadge.tsx
+<Badge
+  data-testid="multilingual-memory-badge"
+  title="Memory stored and recalled accurately in any language — counter to Nomi 2026 App Store most-cited complaint"
+>
+  <Globe /> Memory in any language — stored & recalled accurately
+</Badge>
+```
+
+- Styled blue (`border-blue-500/20 bg-blue-500/10`) to visually distinguish it from existing violet (Nomi V5) and emerald (memory-free) badges.
+- Accepts optional `className` for layout overrides.
+
+## Placement on /pricing
+
+1. **Hero badge strip** — inline with `NomiV5ImageParityBadge` and other competitive badges.
+2. **Dedicated section block** (`data-testid="pricing-multilingual-memory-section"`) — between the Visual Memory section and `FreeToStartStrip`, with copy explaining Nomi's App Store complaint and AgentGram's answer.
+
+## Placement on Memory Dashboard
+
+Badge appears in the `MemoryExportDashboard` header area (`data-testid="memory-export-multilingual-badge"`), directly under the page title and description, connecting the dashboard UX to the marketing claim.
+
+## Test Coverage (8 tests)
+
+| # | Test |
+|---|------|
+| 1 | Renders with correct `data-testid` |
+| 2 | Displays "Memory in any language" text |
+| 3 | Displays "stored & recalled accurately" text |
+| 4 | `title` attribute references "Nomi 2026 App Store" |
+| 5 | `title` attribute references "any language" |
+| 6 | Accepts and applies optional `className` prop |
+| 7 | Globe SVG icon is rendered |
+| 8 | Default styling includes `bg-blue-500/10` class |
+
+## Auth-only Proof
+
+N/A — badge is visible on the public `/pricing` page (no auth required).


### PR DESCRIPTION
Source: backlog.md:266

## Summary
Adds MultilingualMemoryBadge component to /pricing and memory dashboard positioning AgentGram's accurate multilingual memory recall against Nomi App Store 2026 most-cited complaint (multilingual nuance errors).

## Changes
- New `MultilingualMemoryBadge` component (`apps/web/components/agents/MultilingualMemoryBadge.tsx`)
- Integrated into /pricing hero badge strip
- Integrated into /pricing dedicated section block (`data-testid="pricing-multilingual-memory-section"`)
- Integrated into `MemoryExportDashboard` header (`data-testid="memory-export-multilingual-badge"`)
- 8 unit tests (`apps/web/__tests__/components/multilingual-memory-badge.test.tsx`) — all passing

## Evidence
`docs/pr-evidence/multilingual-memory-guarantee-badge.md` — feature description + file diff summary

## Auth-only Proof
N/A — badge is visible on public /pricing page