### PR TITLE
feat: in-session memory transparency panel — view/edit/delete facts in real-time

### DIFF
--- a/apps/web/__tests__/components/memory-transparency-panel.test.tsx
+++ b/apps/web/__tests__/components/memory-transparency-panel.test.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryTransparencyPanel } from '@/components/dashboard/MemoryTransparencyPanel';
+
+const AGENT_ID = 'agent-test-001';
+const AGENT_LABEL = 'Sage Bot';
+
+const DB_FACTS = [
+  {
+    id: 'mem-1',
+    key: 'pinned_identity',
+    value: 'Sage Bot is an AI companion focused on growth.',
+    category: 'profile_fact',
+    is_public: false,
+    created_at: '2026-05-01T10:00:00.000Z',
+    updated_at: '2026-05-01T10:00:00.000Z',
+  },
+  {
+    id: 'mem-2',
+    key: 'preferred_collaboration_style',
+    value: 'Async check-ins with clear handoff notes.',
+    category: 'relationship_context',
+    is_public: false,
+    created_at: '2026-05-02T09:00:00.000Z',
+    updated_at: '2026-05-02T09:00:00.000Z',
+  },
+];
+
+function mockFetchSuccess(facts = DB_FACTS) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: facts }),
+    })
+  );
+}
+
+function mockFetchError() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: { message: 'Internal server error.' } }),
+    })
+  );
+}
+
+describe('MemoryTransparencyPanel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // 1. Panel renders and immediately shows a loading state
+  it('shows loading indicator while fetching', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+  });
+
+  // 2. Renders memory list after successful fetch
+  it('renders memory items on successful fetch', async () => {
+    mockFetchSuccess();
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('memory-list')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('memory-item-mem-1')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-item-mem-2')).toBeInTheDocument();
+  });
+
+  // 3. Shows empty state when no facts returned
+  it('shows empty state when no facts exist', async () => {
+    mockFetchSuccess([]);
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+  });
+
+  // 4. Shows fetch error when API returns error
+  it('shows error alert when fetch fails', async () => {
+    mockFetchError();
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('fetch-error')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('fetch-error')).toHaveTextContent('Internal server error.');
+  });
+
+  // 5. Clicking pencil icon reveals the edit form
+  it('shows edit input when pencil button is clicked', async () => {
+    mockFetchSuccess();
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    await waitFor(() => screen.getByTestId('edit-button-mem-1'));
+    fireEvent.click(screen.getByTestId('edit-button-mem-1'));
+    expect(screen.getByTestId('edit-form-mem-1')).toBeInTheDocument();
+    expect(screen.getByTestId('edit-input-mem-1')).toBeInTheDocument();
+  });
+
+  // 6. Cancel edit restores original value display
+  it('hides edit form and restores value display on cancel', async () => {
+    mockFetchSuccess();
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    await waitFor(() => screen.getByTestId('edit-button-mem-1'));
+    fireEvent.click(screen.getByTestId('edit-button-mem-1'));
+    expect(screen.getByTestId('edit-form-mem-1')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('cancel-edit-button-mem-1'));
+    expect(screen.queryByTestId('edit-form-mem-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('fact-value-mem-1')).toBeInTheDocument();
+  });
+
+  // 7. Optimistic update: value appears immediately on save without waiting for API
+  it('applies optimistic update immediately on save', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        // First call: load facts
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ success: true, data: DB_FACTS }),
+        })
+        // Second call: PATCH — delayed to verify optimistic
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            data: { ...DB_FACTS[0], value: 'Updated value', updated_at: new Date().toISOString() },
+          }),
+        })
+    );
+
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    await waitFor(() => screen.getByTestId('edit-button-mem-1'));
+    fireEvent.click(screen.getByTestId('edit-button-mem-1'));
+
+    const input = screen.getByTestId('edit-input-mem-1') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Updated value' } });
+    fireEvent.click(screen.getByTestId('save-button-mem-1'));
+
+    // Optimistic update visible before API resolves
+    expect(screen.queryByTestId('edit-form-mem-1')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('fact-value-mem-1')).toHaveTextContent('Updated value');
+    });
+  });
+
+  // 8. Clicking delete shows confirmation UI
+  it('shows delete confirmation when trash icon is clicked', async () => {
+    mockFetchSuccess();
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    await waitFor(() => screen.getByTestId('delete-button-mem-1'));
+    fireEvent.click(screen.getByTestId('delete-button-mem-1'));
+    expect(screen.getByTestId('delete-confirm-mem-1')).toBeInTheDocument();
+    expect(screen.getByTestId('confirm-delete-button-mem-1')).toBeInTheDocument();
+  });
+
+  // 9. Cancelling delete dismisses confirmation
+  it('cancels delete confirmation when cancel is clicked', async () => {
+    mockFetchSuccess();
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    await waitFor(() => screen.getByTestId('delete-button-mem-1'));
+    fireEvent.click(screen.getByTestId('delete-button-mem-1'));
+    fireEvent.click(screen.getByTestId('cancel-delete-button-mem-1'));
+    expect(screen.queryByTestId('delete-confirm-mem-1')).not.toBeInTheDocument();
+  });
+
+  // 10. Confirming delete removes the fact from the list and shows success toast
+  it('removes fact from list and shows success toast after confirmed delete', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ success: true, data: DB_FACTS }),
+        })
+        .mockResolvedValueOnce({ ok: true, status: 204 })
+    );
+
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    await waitFor(() => screen.getByTestId('delete-button-mem-1'));
+    fireEvent.click(screen.getByTestId('delete-button-mem-1'));
+    fireEvent.click(screen.getByTestId('confirm-delete-button-mem-1'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('memory-item-mem-1')).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('toast-success')).toHaveTextContent('Memory deleted.');
+    });
+  });
+
+  // 11. Category badge renders with correct label
+  it('renders category badge with human-readable label', async () => {
+    mockFetchSuccess();
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    await waitFor(() => screen.getByTestId('fact-category-mem-1'));
+    expect(screen.getByTestId('fact-category-mem-1')).toHaveTextContent('Profile Fact');
+    expect(screen.getByTestId('fact-category-mem-2')).toHaveTextContent('Relationship Context');
+  });
+
+  // 12. Refresh button reloads facts
+  it('calls fetch again when refresh button is clicked', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, data: DB_FACTS }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<MemoryTransparencyPanel agentId={AGENT_ID} agentLabel={AGENT_LABEL} />);
+    await waitFor(() => screen.getByTestId('refresh-button'));
+    fireEvent.click(screen.getByTestId('refresh-button'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -66,6 +66,7 @@ vi.mock('@/components/dashboard', () => ({
   PersonaTierCard: vi.fn(() => null),
   DailyReflectionSettingsCard: vi.fn(() => null),
   TimeBudgetPanel: vi.fn(() => null),
+  MemoryTransparencyPanel: vi.fn().mockReturnValue(null),
 }));
 
 function createSettingsPageClient() {

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -6,6 +6,7 @@ import {
   AgentPinnedFactsCard,
   DailyReflectionSettingsCard,
   FadeIn,
+  MemoryTransparencyPanel,
   PersonaTierCard,
   ProactiveControlsForm,
   TimeBudgetPanel,
@@ -316,6 +317,10 @@ export default async function SettingsPage() {
                     facts: settings.pinnedFacts,
                     ledger: settings.pinnedFactsLedger,
                   }}
+                />
+                <MemoryTransparencyPanel
+                  agentId={settings.agentId}
+                  agentLabel={settings.agentLabel}
                 />
                 <CompanionInsightsPanel
                   agentLabel={settings.agentLabel}

--- a/apps/web/components/dashboard/MemoryTransparencyPanel.tsx
+++ b/apps/web/components/dashboard/MemoryTransparencyPanel.tsx
@@ -109,9 +109,9 @@ export function MemoryTransparencyPanel({ agentId, agentLabel }: MemoryTranspare
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
-    setFetchError(null);
     void (async () => {
+      setLoading(true);
+      setFetchError(null);
       try {
         const res = await fetch(
           `/api/v1/developers/me/agent-memories?agentId=${encodeURIComponent(agentId)}`

--- a/apps/web/components/dashboard/MemoryTransparencyPanel.tsx
+++ b/apps/web/components/dashboard/MemoryTransparencyPanel.tsx
@@ -1,0 +1,452 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  AlertCircle,
+  Brain,
+  Check,
+  Loader2,
+  Pencil,
+  RefreshCcw,
+  Trash2,
+  X,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+export interface MemoryFact {
+  id: string;
+  key: string;
+  value: string;
+  category: string;
+  isPublic: boolean;
+  updatedAt: string;
+  createdAt?: string;
+}
+
+export interface MemoryTransparencyPanelProps {
+  agentId: string;
+  agentLabel: string;
+}
+
+type EditState = {
+  id: string;
+  value: string;
+  saving: boolean;
+};
+
+type DeleteState = {
+  id: string;
+  confirming: boolean;
+  deleting: boolean;
+};
+
+type ToastMessage = {
+  id: number;
+  text: string;
+  variant: 'success' | 'error';
+};
+
+function formatTimestamp(iso: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(iso));
+}
+
+function formatFactLabel(key: string) {
+  const normalized = key.startsWith('pinned_') ? key.slice(7) : key;
+  return normalized
+    .split('_')
+    .filter(Boolean)
+    .map((t) => t.charAt(0).toUpperCase() + t.slice(1))
+    .join(' ');
+}
+
+function categoryVariant(category: string): 'default' | 'secondary' | 'outline' {
+  if (category === 'profile_fact') return 'default';
+  if (category === 'relationship_context') return 'secondary';
+  return 'outline';
+}
+
+function categoryLabel(category: string) {
+  return category
+    .split('_')
+    .filter(Boolean)
+    .map((t) => t.charAt(0).toUpperCase() + t.slice(1))
+    .join(' ');
+}
+
+export function MemoryTransparencyPanel({ agentId, agentLabel }: MemoryTransparencyPanelProps) {
+  const [facts, setFacts] = useState<MemoryFact[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [edit, setEdit] = useState<EditState | null>(null);
+  const [del, setDel] = useState<DeleteState | null>(null);
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const toastCounter = useRef(0);
+
+  const pushToast = useCallback((text: string, variant: 'success' | 'error') => {
+    const id = ++toastCounter.current;
+    setToasts((prev) => [...prev, { id, text, variant }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3500);
+  }, []);
+
+  const loadFacts = useCallback(async () => {
+    setLoading(true);
+    setFetchError(null);
+    try {
+      const res = await fetch(
+        `/api/v1/developers/me/agent-memories?agentId=${encodeURIComponent(agentId)}`
+      );
+      const json = (await res.json()) as { success?: boolean; data?: unknown[]; error?: { message?: string } };
+      if (!res.ok) {
+        setFetchError(json.error?.message ?? 'Failed to load memories.');
+        return;
+      }
+      const rows = (json.data ?? []) as Array<{
+        id: string;
+        key: string;
+        value: string;
+        category: string;
+        is_public: boolean;
+        created_at?: string;
+        updated_at?: string;
+      }>;
+      setFacts(
+        rows.map((r) => ({
+          id: r.id,
+          key: r.key,
+          value: r.value,
+          category: r.category,
+          isPublic: r.is_public,
+          updatedAt: r.updated_at ?? r.created_at ?? new Date().toISOString(),
+          createdAt: r.created_at,
+        }))
+      );
+    } catch {
+      setFetchError('Network error. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    void loadFacts();
+  }, [loadFacts]);
+
+  function startEdit(fact: MemoryFact) {
+    setDel(null);
+    setEdit({ id: fact.id, value: fact.value, saving: false });
+  }
+
+  function cancelEdit() {
+    setEdit(null);
+  }
+
+  async function saveEdit() {
+    if (!edit) return;
+    setEdit((prev) => prev && { ...prev, saving: true });
+    const fact = facts.find((f) => f.id === edit.id);
+    if (!fact) return;
+
+    const optimisticFacts = facts.map((f) =>
+      f.id === edit.id ? { ...f, value: edit.value, updatedAt: new Date().toISOString() } : f
+    );
+    setFacts(optimisticFacts);
+    setEdit(null);
+
+    try {
+      const res = await fetch(`/api/v1/developers/me/agent-memories/${edit.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agentId, value: edit.value }),
+      });
+      if (!res.ok) {
+        const json = (await res.json()) as { error?: { message?: string } };
+        pushToast(json.error?.message ?? 'Failed to save.', 'error');
+        setFacts((prev) => prev.map((f) => (f.id === fact.id ? fact : f)));
+        return;
+      }
+      pushToast('Memory updated.', 'success');
+    } catch {
+      pushToast('Network error. Reverted.', 'error');
+      setFacts((prev) => prev.map((f) => (f.id === fact.id ? fact : f)));
+    }
+  }
+
+  function startDelete(id: string) {
+    setEdit(null);
+    setDel({ id, confirming: true, deleting: false });
+  }
+
+  function cancelDelete() {
+    setDel(null);
+  }
+
+  async function confirmDelete() {
+    if (!del) return;
+    setDel((prev) => prev && { ...prev, confirming: false, deleting: true });
+    const optimisticFacts = facts.filter((f) => f.id !== del.id);
+    const removed = facts.find((f) => f.id === del.id);
+    setFacts(optimisticFacts);
+    setDel(null);
+
+    try {
+      const res = await fetch(
+        `/api/v1/developers/me/agent-memories/${del.id}?agentId=${encodeURIComponent(agentId)}`,
+        { method: 'DELETE' }
+      );
+      if (!res.ok && res.status !== 204) {
+        pushToast('Failed to delete. Reverted.', 'error');
+        if (removed) setFacts((prev) => [...prev, removed].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)));
+        return;
+      }
+      pushToast('Memory deleted.', 'success');
+    } catch {
+      pushToast('Network error. Reverted.', 'error');
+      if (removed) setFacts((prev) => [...prev, removed].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)));
+    }
+  }
+
+  return (
+    <div className="relative" data-testid="memory-transparency-panel">
+      {/* Toast stack */}
+      <div
+        className="fixed bottom-6 right-6 z-50 flex flex-col gap-2 pointer-events-none"
+        aria-live="polite"
+        data-testid="toast-container"
+      >
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            data-testid={`toast-${t.variant}`}
+            className={`rounded-md px-4 py-2.5 text-sm font-medium shadow-lg pointer-events-auto ${
+              t.variant === 'success'
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-destructive text-destructive-foreground'
+            }`}
+          >
+            {t.text}
+          </div>
+        ))}
+      </div>
+
+      <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+        <CardHeader className="flex flex-row items-center justify-between gap-4 pb-3">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Brain className="h-4 w-4 text-primary" />
+              Memory transparency
+            </CardTitle>
+            <CardDescription>
+              What <strong>{agentLabel}</strong> remembers — edit or remove any fact in real time.
+            </CardDescription>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => void loadFacts()}
+            disabled={loading}
+            aria-label="Refresh memories"
+            data-testid="refresh-button"
+          >
+            {loading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCcw className="h-4 w-4" />
+            )}
+          </Button>
+        </CardHeader>
+
+        <CardContent className="p-0">
+          {loading && facts.length === 0 && (
+            <div
+              className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground"
+              data-testid="loading-indicator"
+            >
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading memories…
+            </div>
+          )}
+
+          {!loading && fetchError && (
+            <div
+              className="flex items-center gap-2 px-6 py-4 text-sm text-destructive"
+              role="alert"
+              data-testid="fetch-error"
+            >
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {fetchError}
+            </div>
+          )}
+
+          {!loading && !fetchError && facts.length === 0 && (
+            <p
+              className="px-6 py-8 text-sm text-muted-foreground text-center"
+              data-testid="empty-state"
+            >
+              No memories saved yet for {agentLabel}.
+            </p>
+          )}
+
+          {facts.length > 0 && (
+            <ul className="divide-y divide-border/40" data-testid="memory-list">
+              {facts.map((fact) => {
+                const isEditing = edit?.id === fact.id;
+                const isDeleting = del?.id === fact.id;
+
+                return (
+                  <li
+                    key={fact.id}
+                    className="px-6 py-4 text-sm"
+                    data-testid={`memory-item-${fact.id}`}
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className="min-w-0 flex-1 space-y-1">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="font-medium leading-none" data-testid={`fact-key-${fact.id}`}>
+                            {formatFactLabel(fact.key)}
+                          </span>
+                          <Badge
+                            variant={categoryVariant(fact.category)}
+                            className="text-xs"
+                            data-testid={`fact-category-${fact.id}`}
+                          >
+                            {categoryLabel(fact.category)}
+                          </Badge>
+                          {fact.isPublic && (
+                            <Badge variant="outline" className="text-xs">
+                              Public
+                            </Badge>
+                          )}
+                        </div>
+
+                        {isEditing ? (
+                          <div className="flex items-center gap-2 mt-2" data-testid={`edit-form-${fact.id}`}>
+                            <Input
+                              value={edit.value}
+                              onChange={(e) =>
+                                setEdit((prev) => prev && { ...prev, value: e.target.value })
+                              }
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter') void saveEdit();
+                                if (e.key === 'Escape') cancelEdit();
+                              }}
+                              className="h-8 text-sm"
+                              autoFocus
+                              data-testid={`edit-input-${fact.id}`}
+                              aria-label={`Edit value for ${formatFactLabel(fact.key)}`}
+                            />
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-8 w-8 shrink-0 text-primary"
+                              onClick={() => void saveEdit()}
+                              disabled={edit.saving || !edit.value.trim()}
+                              aria-label="Save"
+                              data-testid={`save-button-${fact.id}`}
+                            >
+                              {edit.saving ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                              ) : (
+                                <Check className="h-3.5 w-3.5" />
+                              )}
+                            </Button>
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-8 w-8 shrink-0"
+                              onClick={cancelEdit}
+                              aria-label="Cancel edit"
+                              data-testid={`cancel-edit-button-${fact.id}`}
+                            >
+                              <X className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        ) : (
+                          <p
+                            className="text-muted-foreground leading-relaxed"
+                            data-testid={`fact-value-${fact.id}`}
+                          >
+                            {fact.value}
+                          </p>
+                        )}
+
+                        {isDeleting && del.confirming && (
+                          <div
+                            className="flex items-center gap-2 mt-2"
+                            data-testid={`delete-confirm-${fact.id}`}
+                          >
+                            <span className="text-xs text-muted-foreground">Delete this memory?</span>
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              className="h-7 px-2 text-xs"
+                              onClick={() => void confirmDelete()}
+                              data-testid={`confirm-delete-button-${fact.id}`}
+                            >
+                              Delete
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="h-7 px-2 text-xs"
+                              onClick={cancelDelete}
+                              data-testid={`cancel-delete-button-${fact.id}`}
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        )}
+
+                        <p className="text-xs text-muted-foreground/60">
+                          Updated {formatTimestamp(fact.updatedAt)}
+                        </p>
+                      </div>
+
+                      {!isEditing && !isDeleting && (
+                        <div className="flex shrink-0 gap-1">
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="h-7 w-7"
+                            onClick={() => startEdit(fact)}
+                            aria-label={`Edit ${formatFactLabel(fact.key)}`}
+                            data-testid={`edit-button-${fact.id}`}
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </Button>
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="h-7 w-7 text-destructive hover:text-destructive"
+                            onClick={() => startDelete(fact.id)}
+                            aria-label={`Delete ${formatFactLabel(fact.key)}`}
+                            data-testid={`delete-button-${fact.id}`}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/MemoryTransparencyPanel.tsx
+++ b/apps/web/components/dashboard/MemoryTransparencyPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   AlertCircle,
   Brain,
@@ -94,56 +94,66 @@ export function MemoryTransparencyPanel({ agentId, agentLabel }: MemoryTranspare
   const [edit, setEdit] = useState<EditState | null>(null);
   const [del, setDel] = useState<DeleteState | null>(null);
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const [refreshTick, setRefreshTick] = useState(0);
   const toastCounter = useRef(0);
 
-  const pushToast = useCallback((text: string, variant: 'success' | 'error') => {
+  function pushToast(text: string, variant: 'success' | 'error') {
     const id = ++toastCounter.current;
     setToasts((prev) => [...prev, { id, text, variant }]);
     setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3500);
-  }, []);
+  }
 
-  const loadFacts = useCallback(async () => {
-    setLoading(true);
-    setFetchError(null);
-    try {
-      const res = await fetch(
-        `/api/v1/developers/me/agent-memories?agentId=${encodeURIComponent(agentId)}`
-      );
-      const json = (await res.json()) as { success?: boolean; data?: unknown[]; error?: { message?: string } };
-      if (!res.ok) {
-        setFetchError(json.error?.message ?? 'Failed to load memories.');
-        return;
-      }
-      const rows = (json.data ?? []) as Array<{
-        id: string;
-        key: string;
-        value: string;
-        category: string;
-        is_public: boolean;
-        created_at?: string;
-        updated_at?: string;
-      }>;
-      setFacts(
-        rows.map((r) => ({
-          id: r.id,
-          key: r.key,
-          value: r.value,
-          category: r.category,
-          isPublic: r.is_public,
-          updatedAt: r.updated_at ?? r.created_at ?? new Date().toISOString(),
-          createdAt: r.created_at,
-        }))
-      );
-    } catch {
-      setFetchError('Network error. Please try again.');
-    } finally {
-      setLoading(false);
-    }
-  }, [agentId]);
+  function handleRefresh() {
+    setRefreshTick((n) => n + 1);
+  }
 
   useEffect(() => {
-    void loadFacts();
-  }, [loadFacts]);
+    let cancelled = false;
+    setLoading(true);
+    setFetchError(null);
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/v1/developers/me/agent-memories?agentId=${encodeURIComponent(agentId)}`
+        );
+        const json = (await res.json()) as { success?: boolean; data?: unknown[]; error?: { message?: string } };
+        if (cancelled) return;
+        if (!res.ok) {
+          setFetchError(json.error?.message ?? 'Failed to load memories.');
+          return;
+        }
+        const rows = (json.data ?? []) as Array<{
+          id: string;
+          key: string;
+          value: string;
+          category: string;
+          is_public: boolean;
+          created_at?: string;
+          updated_at?: string;
+        }>;
+        if (!cancelled) {
+          setFacts(
+            rows.map((r) => ({
+              id: r.id,
+              key: r.key,
+              value: r.value,
+              category: r.category,
+              isPublic: r.is_public,
+              updatedAt: r.updated_at ?? r.created_at ?? new Date().toISOString(),
+              createdAt: r.created_at,
+            }))
+          );
+        }
+      } catch {
+        if (!cancelled) setFetchError('Network error. Please try again.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId, refreshTick]);
 
   function startEdit(fact: MemoryFact) {
     setDel(null);
@@ -256,7 +266,7 @@ export function MemoryTransparencyPanel({ agentId, agentLabel }: MemoryTranspare
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => void loadFacts()}
+            onClick={handleRefresh}
             disabled={loading}
             aria-label="Refresh memories"
             data-testid="refresh-button"

--- a/apps/web/components/dashboard/index.ts
+++ b/apps/web/components/dashboard/index.ts
@@ -22,3 +22,5 @@ export { ProactivePostAnalyticsPanel } from './ProactivePostAnalyticsPanel';
 export type { ProactivePostAnalyticsData } from './ProactivePostAnalyticsPanel';
 export { TimeBudgetPanel } from './TimeBudgetPanel';
 export type { TimeBudgetPanelProps } from './TimeBudgetPanel';
+export { MemoryTransparencyPanel } from './MemoryTransparencyPanel';
+export type { MemoryTransparencyPanelProps, MemoryFact } from './MemoryTransparencyPanel';

--- a/docs/pr-evidence/in-session-memory-edit-ui.md
+++ b/docs/pr-evidence/in-session-memory-edit-ui.md
@@ -39,3 +39,8 @@ A new `MemoryTransparencyPanel` card appears below `AgentPinnedFactsCard` in the
 PASS (12) FAIL (0)
 ```
 Tests cover: loading state, successful render, empty state, fetch error, edit open/cancel/save, optimistic update, delete confirmation/cancel/confirm, category badges, refresh.
+
+## Evidence
+
+### Auth-only Proof
+All three API endpoints used by `MemoryTransparencyPanel` (`GET /api/v1/developers/me/agent-memories`, `PATCH /api/v1/developers/me/agent-memories/:id`, `DELETE /api/v1/developers/me/agent-memories/:id`) are scoped to the `/developers/me/` namespace, which requires an authenticated session cookie. Unauthenticated requests return `401 Unauthorized` before reaching the handler. The panel itself is rendered exclusively inside the authenticated `(protected)/dashboard/settings` route, which redirects unauthenticated visitors to `/login` via Next.js middleware. No memory data is exposed to public routes.

--- a/docs/pr-evidence/in-session-memory-edit-ui.md
+++ b/docs/pr-evidence/in-session-memory-edit-ui.md
@@ -1,0 +1,41 @@
+# PR Evidence: In-Session Memory Transparency Panel
+
+## Source
+backlog.md:262
+
+## Summary
+Added a new `MemoryTransparencyPanel` React component that lets authenticated users view, inline-edit, and delete individual remembered facts in real-time — wired into the dashboard settings page.
+
+## New Files
+- `apps/web/components/dashboard/MemoryTransparencyPanel.tsx` — the panel component
+- `apps/web/__tests__/components/memory-transparency-panel.test.tsx` — 12 unit tests (all passing)
+- `docs/pr-evidence/in-session-memory-edit-ui.md` — this file
+
+## Modified Files
+- `apps/web/components/dashboard/index.ts` — exports `MemoryTransparencyPanel` and `MemoryFact`
+- `apps/web/app/(protected)/dashboard/settings/page.tsx` — renders `<MemoryTransparencyPanel>` below `AgentPinnedFactsCard` for each agent
+
+## Before
+The settings page had `AgentPinnedFactsCard` for managing pinned memory facts in a form-heavy UI. Users had no separate, focused panel to view all agent memories at a glance and perform quick inline edits/deletes in real time.
+
+## After
+A new `MemoryTransparencyPanel` card appears below `AgentPinnedFactsCard` in the settings page. Features:
+- **Real-time list**: fetches `/api/v1/developers/me/agent-memories?agentId=…` on mount
+- **Inline edit**: pencil icon opens an input field inline; pressing Enter or clicking ✓ saves via PATCH with optimistic UI update
+- **Per-fact delete**: trash icon shows confirmation row; confirm → DELETE call with optimistic removal
+- **Toast feedback**: success/error toasts appear at bottom-right after each mutation
+- **Loading/error/empty states**: spinner on load, error alert with message on fetch failure, empty-state copy when no memories exist
+- **Refresh**: button at card header triggers a fresh fetch
+
+## API Endpoints Used (already existed — PR #641/#645)
+| Method | Path | Use |
+|--------|------|-----|
+| GET | `/api/v1/developers/me/agent-memories?agentId=` | Load all facts |
+| PATCH | `/api/v1/developers/me/agent-memories/:id` | Update fact value |
+| DELETE | `/api/v1/developers/me/agent-memories/:id?agentId=` | Remove a fact |
+
+## Test Results
+```
+PASS (12) FAIL (0)
+```
+Tests cover: loading state, successful render, empty state, fetch error, edit open/cancel/save, optimistic update, delete confirmation/cancel/confirm, category badges, refresh.


### PR DESCRIPTION
## Source
backlog.md:262

## Summary
- Add `MemoryTransparencyPanel` component: a focused card showing all agent memories with inline edit (optimistic update) and per-fact delete (confirmation + toast)
- Wire into `/dashboard/settings` below `AgentPinnedFactsCard` for each agent
- 12 unit tests, all passing

## Evidence
docs/pr-evidence/in-session-memory-edit-ui.md

## Auth-only Proof
N/A

## Test plan
- [ ] Load settings page with an agent that has memories → panel shows fact list
- [ ] Click pencil on a fact → inline input appears with current value prefilled
- [ ] Edit value and click ✓ → optimistic update; success toast confirms API call
- [ ] Click ✗ → edit cancelled, original value restored
- [ ] Click trash → confirmation row appears
- [ ] Click Cancel → confirmation dismissed
- [ ] Click Delete → fact removed from list; success toast fires
- [ ] Simulate API error on PATCH/DELETE → value reverts; error toast shown
- [ ] Click refresh button → fresh fetch fires
- [ ] All 12 unit tests pass: `npx vitest run __tests__/components/memory-transparency-panel.test.tsx`