### PR TITLE
feat: graduated age verification tiering — 4-tier content gate (WA HB 2822 + 27-state compliance)

### DIFF
--- a/apps/web/__tests__/components/age-verification/age-verification-tier.test.tsx
+++ b/apps/web/__tests__/components/age-verification/age-verification-tier.test.tsx
@@ -1,0 +1,277 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getAgeVerificationTier,
+  TIER_CONTENT_ACCESS,
+  TIER_LABELS,
+  TIER_DESCRIPTIONS,
+} from '../../../lib/age-verification-tier';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+// ──────────────────────────────────────────────
+// getAgeVerificationTier — pure function tests
+// ──────────────────────────────────────────────
+
+describe('getAgeVerificationTier', () => {
+  it('returns "unknown" for null profile', () => {
+    expect(getAgeVerificationTier(null)).toBe('unknown');
+  });
+
+  it('returns "adult_unverified" when age_verified is false', () => {
+    expect(getAgeVerificationTier({ age_verified: false })).toBe(
+      'adult_unverified'
+    );
+  });
+
+  it('returns "adult_unverified" when age_verified is null', () => {
+    expect(getAgeVerificationTier({ age_verified: null })).toBe(
+      'adult_unverified'
+    );
+  });
+
+  it('returns "adult_unverified" when age_verified is undefined (empty profile)', () => {
+    expect(getAgeVerificationTier({})).toBe('adult_unverified');
+  });
+
+  it('returns "minor" when age_verified=true and dob indicates under-18', () => {
+    const dob = new Date();
+    dob.setFullYear(dob.getFullYear() - 16);
+    expect(
+      getAgeVerificationTier({ age_verified: true, date_of_birth: dob.toISOString() })
+    ).toBe('minor');
+  });
+
+  it('returns "adult_verified" when age_verified=true and dob indicates 20-year-old', () => {
+    const dob = new Date();
+    dob.setFullYear(dob.getFullYear() - 20);
+    expect(
+      getAgeVerificationTier({ age_verified: true, date_of_birth: dob.toISOString() })
+    ).toBe('adult_verified');
+  });
+
+  it('returns "adult_verified" when age_verified=true and no date_of_birth', () => {
+    expect(getAgeVerificationTier({ age_verified: true })).toBe('adult_verified');
+  });
+
+  it('returns "minor" exactly at 17 years + 364 days (one day under 18)', () => {
+    const dob = new Date();
+    dob.setFullYear(dob.getFullYear() - 18);
+    dob.setDate(dob.getDate() + 1);
+    expect(
+      getAgeVerificationTier({ age_verified: true, date_of_birth: dob.toISOString() })
+    ).toBe('minor');
+  });
+
+  it('returns "adult_verified" one day past the 18-year cutoff', () => {
+    const dob = new Date();
+    dob.setFullYear(dob.getFullYear() - 18);
+    dob.setDate(dob.getDate() - 1);
+    expect(
+      getAgeVerificationTier({ age_verified: true, date_of_birth: dob.toISOString() })
+    ).toBe('adult_verified');
+  });
+});
+
+// ──────────────────────────────────────────────
+// TIER_CONTENT_ACCESS rules
+// ──────────────────────────────────────────────
+
+describe('TIER_CONTENT_ACCESS', () => {
+  it('"minor" tier has safetyModeOnly=true', () => {
+    expect(TIER_CONTENT_ACCESS.minor.safetyModeOnly).toBe(true);
+  });
+
+  it('"minor" tier requires WA rest nudge', () => {
+    expect(TIER_CONTENT_ACCESS.minor.waRestNudgeRequired).toBe(true);
+  });
+
+  it('"minor" tier does not have standardFeatures', () => {
+    expect(TIER_CONTENT_ACCESS.minor.standardFeatures).toBe(false);
+  });
+
+  it('"minor" tier does not have advancedPersonas', () => {
+    expect(TIER_CONTENT_ACCESS.minor.advancedPersonas).toBe(false);
+  });
+
+  it('"unknown" tier has safetyModeOnly=true', () => {
+    expect(TIER_CONTENT_ACCESS.unknown.safetyModeOnly).toBe(true);
+  });
+
+  it('"unknown" tier does not require WA rest nudge', () => {
+    expect(TIER_CONTENT_ACCESS.unknown.waRestNudgeRequired).toBe(false);
+  });
+
+  it('"adult_unverified" has standardFeatures but not advancedPersonas', () => {
+    expect(TIER_CONTENT_ACCESS.adult_unverified.standardFeatures).toBe(true);
+    expect(TIER_CONTENT_ACCESS.adult_unverified.advancedPersonas).toBe(false);
+  });
+
+  it('"adult_verified" has full access including advancedPersonas', () => {
+    expect(TIER_CONTENT_ACCESS.adult_verified.safetyModeOnly).toBe(false);
+    expect(TIER_CONTENT_ACCESS.adult_verified.standardFeatures).toBe(true);
+    expect(TIER_CONTENT_ACCESS.adult_verified.advancedPersonas).toBe(true);
+  });
+
+  it('"adult_verified" does not require WA rest nudge', () => {
+    expect(TIER_CONTENT_ACCESS.adult_verified.waRestNudgeRequired).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────
+// TIER_LABELS & TIER_DESCRIPTIONS coverage
+// ──────────────────────────────────────────────
+
+describe('TIER_LABELS', () => {
+  it('all four tiers have non-empty labels', () => {
+    const tiers = ['unknown', 'minor', 'adult_unverified', 'adult_verified'] as const;
+    for (const t of tiers) {
+      expect(TIER_LABELS[t].length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('TIER_DESCRIPTIONS', () => {
+  it('"adult_unverified" description mentions verifying age', () => {
+    expect(TIER_DESCRIPTIONS.adult_unverified.toLowerCase()).toMatch(/verify/);
+  });
+
+  it('"minor" description mentions WA HB 2822', () => {
+    expect(TIER_DESCRIPTIONS.minor).toMatch(/WA HB 2822/);
+  });
+});
+
+// ──────────────────────────────────────────────
+// AgeVerificationTierBadge component
+// ──────────────────────────────────────────────
+
+describe('AgeVerificationTierBadge', () => {
+  it('renders tier badge for adult_verified', async () => {
+    const { AgeVerificationTierBadge } = await import(
+      '../../../components/age-verification/AgeVerificationTierBadge'
+    );
+
+    await act(async () => {
+      render(<AgeVerificationTierBadge tier="adult_verified" />);
+    });
+
+    expect(screen.getByTestId('age-verification-tier-badge')).toBeInTheDocument();
+    expect(screen.getByText(TIER_LABELS.adult_verified)).toBeInTheDocument();
+  });
+
+  it('renders tier badge for minor and shows WA compliance note', async () => {
+    const { AgeVerificationTierBadge } = await import(
+      '../../../components/age-verification/AgeVerificationTierBadge'
+    );
+
+    await act(async () => {
+      render(<AgeVerificationTierBadge tier="minor" />);
+    });
+
+    expect(screen.getByTestId('wa-compliance-note')).toBeInTheDocument();
+    expect(screen.getByTestId('wa-compliance-note')).toHaveAttribute(
+      'data-wa-compliance',
+      'WA_HB_2822'
+    );
+  });
+
+  it('does not show WA compliance note for adult_verified', async () => {
+    const { AgeVerificationTierBadge } = await import(
+      '../../../components/age-verification/AgeVerificationTierBadge'
+    );
+
+    await act(async () => {
+      render(<AgeVerificationTierBadge tier="adult_verified" />);
+    });
+
+    expect(screen.queryByTestId('wa-compliance-note')).not.toBeInTheDocument();
+  });
+
+  it('renders correct data-tier attribute', async () => {
+    const { AgeVerificationTierBadge } = await import(
+      '../../../components/age-verification/AgeVerificationTierBadge'
+    );
+
+    await act(async () => {
+      render(<AgeVerificationTierBadge tier="adult_unverified" />);
+    });
+
+    expect(screen.getByTestId('age-verification-tier-badge')).toHaveAttribute(
+      'data-tier',
+      'adult_unverified'
+    );
+  });
+});
+
+// ──────────────────────────────────────────────
+// AgeVerificationUpgradeCTA component
+// ──────────────────────────────────────────────
+
+describe('AgeVerificationUpgradeCTA', () => {
+  it('renders CTA for adult_unverified tier', async () => {
+    const { AgeVerificationUpgradeCTA } = await import(
+      '../../../components/age-verification/AgeVerificationUpgradeCTA'
+    );
+
+    await act(async () => {
+      render(<AgeVerificationUpgradeCTA tier="adult_unverified" />);
+    });
+
+    expect(
+      screen.getByTestId('age-verification-upgrade-cta')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /verify age now/i })).toHaveAttribute(
+      'href',
+      '/dashboard/settings'
+    );
+  });
+
+  it('does not render CTA for adult_verified tier', async () => {
+    const { AgeVerificationUpgradeCTA } = await import(
+      '../../../components/age-verification/AgeVerificationUpgradeCTA'
+    );
+
+    await act(async () => {
+      render(<AgeVerificationUpgradeCTA tier="adult_verified" />);
+    });
+
+    expect(
+      screen.queryByTestId('age-verification-upgrade-cta')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render CTA for minor tier', async () => {
+    const { AgeVerificationUpgradeCTA } = await import(
+      '../../../components/age-verification/AgeVerificationUpgradeCTA'
+    );
+
+    await act(async () => {
+      render(<AgeVerificationUpgradeCTA tier="minor" />);
+    });
+
+    expect(
+      screen.queryByTestId('age-verification-upgrade-cta')
+    ).not.toBeInTheDocument();
+  });
+
+  it('upgrade CTA copy mentions no biometric data', async () => {
+    const { AgeVerificationUpgradeCTA } = await import(
+      '../../../components/age-verification/AgeVerificationUpgradeCTA'
+    );
+
+    await act(async () => {
+      render(<AgeVerificationUpgradeCTA tier="adult_unverified" />);
+    });
+
+    expect(screen.getByText(/no biometric data/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/age-verification/AgeVerificationTierBadge.tsx
+++ b/apps/web/components/age-verification/AgeVerificationTierBadge.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useEffect, startTransition } from 'react';
+import { ShieldAlert, ShieldCheck, ShieldQuestion, Clock } from 'lucide-react';
+import {
+  TIER_LABELS,
+  TIER_DESCRIPTIONS,
+  TIER_CONTENT_ACCESS,
+  type AgeVerificationTier,
+} from '@/lib/age-verification-tier';
+import { wa_chatbot_safety as WA_FLAG } from '@/lib/minor-safe-mode';
+
+const TIER_ICON: Record<AgeVerificationTier, React.ReactNode> = {
+  unknown: <Clock className="h-4 w-4 text-muted-foreground" aria-hidden="true" />,
+  minor: <ShieldAlert className="h-4 w-4 text-amber-500" aria-hidden="true" />,
+  adult_unverified: (
+    <ShieldQuestion className="h-4 w-4 text-sky-400" aria-hidden="true" />
+  ),
+  adult_verified: (
+    <ShieldCheck className="h-4 w-4 text-emerald-500" aria-hidden="true" />
+  ),
+};
+
+const TIER_BADGE_CLASS: Record<AgeVerificationTier, string> = {
+  unknown: 'border-border text-muted-foreground bg-muted/40',
+  minor: 'border-amber-500/40 text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/40',
+  adult_unverified:
+    'border-sky-400/40 text-sky-700 dark:text-sky-400 bg-sky-50 dark:bg-sky-950/40',
+  adult_verified:
+    'border-emerald-500/40 text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-950/40',
+};
+
+type AgeVerificationTierBadgeProps = {
+  tier: AgeVerificationTier;
+};
+
+export function AgeVerificationTierBadge({ tier }: AgeVerificationTierBadgeProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    startTransition(() => setMounted(true));
+  }, []);
+
+  if (!mounted) return null;
+
+  const access = TIER_CONTENT_ACCESS[tier];
+  const isWaActive = access.waRestNudgeRequired;
+
+  return (
+    <div
+      className="space-y-2"
+      data-testid="age-verification-tier-badge"
+      data-tier={tier}
+    >
+      <div
+        className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium ${TIER_BADGE_CLASS[tier]}`}
+      >
+        {TIER_ICON[tier]}
+        <span>{TIER_LABELS[tier]}</span>
+      </div>
+      <p className="text-xs text-muted-foreground">{TIER_DESCRIPTIONS[tier]}</p>
+      {isWaActive && (
+        <p
+          className="text-xs text-amber-600/80 dark:text-amber-400/70"
+          data-testid="wa-compliance-note"
+          data-wa-compliance={WA_FLAG}
+        >
+          WA HB 2822 compliant — rest reminders active
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/age-verification/AgeVerificationUpgradeCTA.tsx
+++ b/apps/web/components/age-verification/AgeVerificationUpgradeCTA.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState, useEffect, startTransition } from 'react';
+import Link from 'next/link';
+import { ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { AgeVerificationTier } from '@/lib/age-verification-tier';
+
+type AgeVerificationUpgradeCTAProps = {
+  tier: AgeVerificationTier;
+};
+
+/** Renders a "Verify age to unlock advanced features" CTA for adult_unverified users.
+ *  Returns null for minor, unknown, and adult_verified tiers. */
+export function AgeVerificationUpgradeCTA({ tier }: AgeVerificationUpgradeCTAProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    startTransition(() => setMounted(true));
+  }, []);
+
+  if (!mounted || tier !== 'adult_unverified') return null;
+
+  return (
+    <div
+      className="flex items-start gap-3 rounded-xl border border-sky-400/30 bg-sky-50 dark:bg-sky-950/40 px-4 py-3"
+      data-testid="age-verification-upgrade-cta"
+    >
+      <ShieldCheck
+        className="mt-0.5 h-5 w-5 shrink-0 text-sky-500"
+        aria-hidden="true"
+      />
+      <div className="flex-1 space-y-2">
+        <p className="text-sm font-medium text-sky-900 dark:text-sky-100">
+          Unlock advanced features
+        </p>
+        <p className="text-xs text-sky-800/80 dark:text-sky-200/70">
+          Verify your age to access all persona modes and advanced companion
+          features. Verification is private and instant — no biometric data
+          collected.
+        </p>
+        <Button asChild size="sm" className="mt-1">
+          <Link href="/dashboard/settings">Verify Age Now</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/hooks/use-age-verification-tier.ts
+++ b/apps/web/hooks/use-age-verification-tier.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useMinorSafeProfile } from '@/hooks/use-minor-safe-profile';
+import {
+  getAgeVerificationTier,
+  TIER_CONTENT_ACCESS,
+  type AgeVerificationTier,
+  type TierContentAccess,
+} from '@/lib/age-verification-tier';
+
+export type UseAgeVerificationTierResult = {
+  tier: AgeVerificationTier;
+  access: TierContentAccess;
+};
+
+export function useAgeVerificationTier(): UseAgeVerificationTierResult {
+  const profile = useMinorSafeProfile();
+  const tier = getAgeVerificationTier(profile);
+  return { tier, access: TIER_CONTENT_ACCESS[tier] };
+}

--- a/apps/web/lib/age-verification-tier.ts
+++ b/apps/web/lib/age-verification-tier.ts
@@ -1,0 +1,81 @@
+import type { UserProfile } from '@/lib/minor-safe-mode';
+
+export type AgeVerificationTier = 'unknown' | 'minor' | 'adult_unverified' | 'adult_verified';
+
+export const TIER_LABELS: Record<AgeVerificationTier, string> = {
+  unknown: 'Verifying…',
+  minor: 'Minor (Under 18)',
+  adult_unverified: 'Adult — Unverified',
+  adult_verified: 'Adult — Verified',
+};
+
+export const TIER_DESCRIPTIONS: Record<AgeVerificationTier, string> = {
+  unknown: 'Loading your verification status.',
+  minor:
+    'Safety-mode features only. Periodic rest reminders are active per WA HB 2822.',
+  adult_unverified:
+    'Standard features available. Verify your age to unlock all content and persona modes.',
+  adult_verified: 'Full access — all features and persona modes unlocked.',
+};
+
+/** Derive a user's AgeVerificationTier from their profile.
+ *
+ * Rules:
+ *   null profile          → 'unknown'
+ *   age_verified falsy    → 'adult_unverified'
+ *   verified + dob < 18   → 'minor'
+ *   verified otherwise    → 'adult_verified'
+ */
+export function getAgeVerificationTier(
+  profile: UserProfile | null
+): AgeVerificationTier {
+  if (!profile) return 'unknown';
+
+  const { age_verified, date_of_birth } = profile;
+
+  if (!age_verified) return 'adult_unverified';
+
+  if (date_of_birth) {
+    const dob = new Date(date_of_birth);
+    const cutoff = new Date();
+    cutoff.setFullYear(cutoff.getFullYear() - 18);
+    if (dob > cutoff) return 'minor';
+  }
+
+  return 'adult_verified';
+}
+
+export type TierContentAccess = {
+  safetyModeOnly: boolean;
+  standardFeatures: boolean;
+  advancedPersonas: boolean;
+  waRestNudgeRequired: boolean;
+};
+
+export const TIER_CONTENT_ACCESS: Record<AgeVerificationTier, TierContentAccess> =
+  {
+    unknown: {
+      safetyModeOnly: true,
+      standardFeatures: false,
+      advancedPersonas: false,
+      waRestNudgeRequired: false,
+    },
+    minor: {
+      safetyModeOnly: true,
+      standardFeatures: false,
+      advancedPersonas: false,
+      waRestNudgeRequired: true,
+    },
+    adult_unverified: {
+      safetyModeOnly: false,
+      standardFeatures: true,
+      advancedPersonas: false,
+      waRestNudgeRequired: false,
+    },
+    adult_verified: {
+      safetyModeOnly: false,
+      standardFeatures: true,
+      advancedPersonas: true,
+      waRestNudgeRequired: false,
+    },
+  };

--- a/docs/pr-evidence/age-verification-tiering.md
+++ b/docs/pr-evidence/age-verification-tiering.md
@@ -1,0 +1,47 @@
+# Age Verification Tiering — PR Evidence
+
+## Tier Definitions
+
+| Tier | Condition | Safety Mode | Standard Features | Advanced Personas | WA Rest Nudge |
+|------|-----------|-------------|-------------------|-------------------|---------------|
+| `unknown` | Profile not loaded | ✅ only | ❌ | ❌ | ❌ |
+| `minor` | `age_verified=true` + DoB < 18 | ✅ only | ❌ | ❌ | ✅ |
+| `adult_unverified` | `age_verified` falsy | ❌ | ✅ | ❌ | ❌ |
+| `adult_verified` | `age_verified=true` + DoB ≥ 18 (or no DoB) | ❌ | ✅ | ✅ | ❌ |
+
+## Compliance Notes
+
+### WA HB 2822 (Washington State AI Chatbot Safety)
+- Applied to the `minor` tier only.
+- `waRestNudgeRequired: true` triggers the 30-minute `WaRestNudge` component inherited from PR #709 / PR #669.
+- Badge component surfaces `data-wa-compliance="WA_HB_2822"` attribute for automated compliance audits.
+
+### 27-State Regulatory Wave
+- `adult_unverified` tier deliberately gates advanced persona modes. Unverified users cannot self-escalate to `adult_verified` features, matching the requirement model of SB 243 (CA), NY AI Companion Law, and the emerging uniform minor-protection statutes in the 27-state wave.
+- Age verification must be actively asserted (`age_verified=true` from the auth metadata pipeline) — passive/implicit verification is not accepted.
+
+## Integration Points
+
+| Prior PR | Pattern Used |
+|----------|-------------|
+| PR #669 (MinorSafeGate) | `WaRestNudge`, `WA_REST_NUDGE_THRESHOLD_MS`, `wa_chatbot_safety` constant |
+| PR #699 (AdultVerifiedPersonaGate) | `isAdultVerified` logic mirrored in `getAgeVerificationTier` |
+| PR #709 (rest-notification) | `waRestNudgeRequired` flag wires into same rest-notification infrastructure |
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `apps/web/lib/age-verification-tier.ts` | Core types, `getAgeVerificationTier()`, `TIER_CONTENT_ACCESS` |
+| `apps/web/hooks/use-age-verification-tier.ts` | `useAgeVerificationTier()` hook (wraps `useMinorSafeProfile`) |
+| `apps/web/components/age-verification/AgeVerificationTierBadge.tsx` | Profile/settings tier badge |
+| `apps/web/components/age-verification/AgeVerificationUpgradeCTA.tsx` | Upgrade CTA for `adult_unverified` users |
+| `apps/web/__tests__/components/age-verification/age-verification-tier.test.tsx` | 29 unit tests |
+
+## Test Results
+
+29 tests passing — zero failing — covering:
+- `getAgeVerificationTier` all four branches + boundary conditions
+- `TIER_CONTENT_ACCESS` access rules per tier
+- `AgeVerificationTierBadge` rendering + WA compliance attribute
+- `AgeVerificationUpgradeCTA` show/hide per tier + copy assertions


### PR DESCRIPTION
Source: backlog.md:264

## Summary

- Defines `AgeVerificationTier` type: `'unknown' | 'minor' | 'adult_unverified' | 'adult_verified'`
- `getAgeVerificationTier(profile)` pure function with per-tier `TIER_CONTENT_ACCESS` rules
- `useAgeVerificationTier()` hook returning tier + access object from live session
- `AgeVerificationTierBadge` — settings/profile badge showing current tier + WA HB 2822 compliance note for minors
- `AgeVerificationUpgradeCTA` — "Verify Age Now" CTA shown only to `adult_unverified` users
- 29 unit tests (zero failures) covering tier logic, access rules, and component rendering

## Evidence

docs/pr-evidence/age-verification-tiering.md

## Compliance

| Tier | WA HB 2822 | SB 243 / NY AI Law |
|------|------------|---------------------|
| `minor` | ✅ rest-nudge active | blocked from advanced personas |
| `adult_unverified` | — | blocked from advanced personas |
| `adult_verified` | — | full access |

Builds on PR #669 (MinorSafeGate), PR #699 (AdultVerifiedPersonaGate), PR #709 (rest-notification).

## Auth-only Proof

N/A — authentication-gated feature, no public URL required

## Test plan

- [ ] Run `npx vitest run __tests__/components/age-verification/` — all 29 pass
- [ ] Verify `AgeVerificationTierBadge` renders correct badge color and WA note for minor profile
- [ ] Verify `AgeVerificationUpgradeCTA` appears for unverified adult, hidden for verified adult
- [ ] Verify `useAgeVerificationTier()` returns `adult_unverified` for fresh signup (no age_verified metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)