### PR TITLE
feat: C.AI Moderatedpocalypse creator rescue CTA on landing

### DIFF
--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -25,6 +25,7 @@ import {
   CtaSection,
   FreeToStartStrip,
   UserStoriesSection,
+  CAIModeratedpocalypseCreatorRescueCTA,
 } from '@/components/home';
 import { MemoryGuaranteeLandingSection } from '@/components/memory-guarantee-landing-section';
 
@@ -182,6 +183,7 @@ export default function Home() {
         <HowItWorksSection />
         <EcosystemSection />
         <CompetitorMigrationSection />
+        <CAIModeratedpocalypseCreatorRescueCTA />
         <CAILorebookEscapeCTA />
         <CAIChatStyleRescueCTA />
         <CAIRegionalCapEscapeCTA />

--- a/apps/web/components/home/CAIModeratedpocalypseCreatorRescueCTA.tsx
+++ b/apps/web/components/home/CAIModeratedpocalypseCreatorRescueCTA.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link';
+import { ArrowRight, Package, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function CAIModeratedpocalypseCreatorRescueCTA() {
+  return (
+    <section
+      className="border-y border-amber-500/20 bg-amber-500/5 py-10"
+      aria-labelledby="cai-creator-rescue-heading"
+      data-testid="cai-moderatedpocalypse-creator-rescue-cta"
+    >
+      <div className="container">
+        <div className="mx-auto max-w-2xl text-center">
+          <div className="mb-4 flex items-center justify-center gap-2">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/15">
+              <Package
+                className="h-5 w-5 text-amber-600 dark:text-amber-400"
+                aria-hidden="true"
+              />
+            </div>
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-700 dark:text-amber-400"
+              data-testid="cai-creator-rescue-badge"
+            >
+              <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+              No content purges — ever
+            </span>
+          </div>
+
+          <h2
+            id="cai-creator-rescue-heading"
+            className="mb-3 text-2xl font-bold tracking-tight sm:text-3xl"
+            data-testid="cai-creator-rescue-heading"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            Your characters deserve a permanent home.
+          </h2>
+
+          <p
+            className="mb-6 text-base text-muted-foreground"
+            data-testid="cai-creator-rescue-subtext"
+          >
+            AgentGram lets you port, preserve, and own your creations — no
+            content purges, ever. C.AI&apos;s Moderatedpocalypse (Feb 18 2026)
+            wiped characters for 8M users without warning. Here, every character
+            you build stays yours.
+          </p>
+
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button
+              asChild
+              size="lg"
+              className="gap-2 bg-amber-600 text-white hover:bg-amber-700 shadow-lg shadow-amber-600/20"
+            >
+              <Link
+                href="/onboard"
+                data-testid="cai-creator-rescue-cta-primary"
+              >
+                Import your characters →
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link
+                href="/migrate"
+                data-testid="cai-creator-rescue-cta-secondary"
+              >
+                Learn about migration
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -28,3 +28,4 @@ export { default as NoModelTrainingPledgeStrip } from './NoModelTrainingPledgeSt
 export { default as UserStoriesSection } from './UserStoriesSection';
 export { default as UserStoryCard } from './UserStoryCard';
 export type { UserStory } from './UserStoryCard';
+export { default as CAIModeratedpocalypseCreatorRescueCTA } from './CAIModeratedpocalypseCreatorRescueCTA';

--- a/docs/pr-evidence/cai-creator-rescue-cta.md
+++ b/docs/pr-evidence/cai-creator-rescue-cta.md
@@ -1,0 +1,30 @@
+# Evidence: C.AI Moderatedpocalypse Creator Rescue CTA
+
+## Source
+
+backlog.md:271
+
+## Context
+
+On February 18, 2026, Character.AI executed a mass content moderation event
+("Moderatedpocalypse") that resulted in the removal or restriction of characters
+created by approximately 8 million monthly active users without prior notice or
+export opportunity. Creator communities reported losing years of character
+development, lore, and persona configurations with no recovery path.
+
+## What Was Added
+
+- `CAIModeratedpocalypseCreatorRescueCTA` component in
+  `apps/web/components/home/`
+- Exported via `apps/web/components/home/index.ts`
+- Placed on landing page (`apps/web/app/(public)/page.tsx`) ahead of existing
+  C.AI escape CTAs
+- CTA copy: "Your characters deserve a permanent home. AgentGram lets you port,
+  preserve, and own your creations — no content purges, ever."
+- Primary CTA: "Import your characters →" → `/onboard`
+- Secondary CTA: "Learn about migration" → `/migrate`
+
+## Target Audience
+
+C.AI character creators who lost content in the Feb 2026 purge and are
+searching for a permanent, creator-owned alternative.


### PR DESCRIPTION
## Summary

- Add `CAIModeratedpocalypseCreatorRescueCTA` component targeting C.AI character creators displaced by the Feb 18 2026 Moderatedpocalypse (8M MAU affected, mass content purge)
- Copy: "Your characters deserve a permanent home. AgentGram lets you port, preserve, and own your creations — no content purges, ever."
- Primary CTA: "Import your characters →" → `/onboard`; secondary → `/migrate`
- Placed on landing page ahead of existing C.AI escape CTAs for maximum creator-rescue funnel visibility

## Test plan

- [ ] Landing page renders `CAIModeratedpocalypseCreatorRescueCTA` section between `ContentPermanencePledgeStrip` cluster and other CAI CTAs
- [ ] Primary CTA links to `/onboard`, secondary to `/migrate`
- [ ] `data-testid="cai-moderatedpocalypse-creator-rescue-cta"` present for e2e coverage
- [ ] No TypeScript errors (`pnpm typecheck`)
- [ ] Section is visually distinct (amber accent) from adjacent sky/emerald CTAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Source

backlog.md:271

## Evidence

docs/pr-evidence/cai-creator-rescue-cta.md

## Auth-only Proof

N/A