### PR TITLE
feat: free trial CTA layer on /pricing

### DIFF
--- a/apps/web/__tests__/components/free-trial-cta.test.tsx
+++ b/apps/web/__tests__/components/free-trial-cta.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FreeTrial7DayCTA } from '@/components/free-trial-cta';
+
+describe('FreeTrial7DayCTA', () => {
+  it('renders the free trial CTA container', () => {
+    render(<FreeTrial7DayCTA />);
+    expect(screen.getByTestId('free-trial-7day-cta')).toBeInTheDocument();
+  });
+
+  it('shows correct trial copy text', () => {
+    render(<FreeTrial7DayCTA />);
+    expect(screen.getByTestId('free-trial-7day-cta-button')).toHaveTextContent(
+      'Try free for 7 days — no credit card required'
+    );
+  });
+
+  it('links to the onboarding flow', () => {
+    render(<FreeTrial7DayCTA />);
+    const link = screen.getByTestId('free-trial-7day-cta-button');
+    expect(link).toHaveAttribute('href', '/dashboard/onboard');
+  });
+
+  it('applies custom className to wrapper', () => {
+    render(<FreeTrial7DayCTA className="flex justify-center" />);
+    const wrapper = screen.getByTestId('free-trial-7day-cta');
+    expect(wrapper).toHaveClass('flex');
+    expect(wrapper).toHaveClass('justify-center');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -21,6 +21,7 @@ import NoChatIsolationBadge from '@/components/home/NoChatIsolationBadge';
 import { QualityFirstPledgeBadge } from '@/components/home/QualityFirstPledge';
 import FreeToStartStrip from '@/components/home/FreeToStartStrip';
 import { AvatarConsistencyGuaranteeStrip, AvatarConsistencyComparisonGallery } from '@/components/avatar-consistency-guarantee';
+import { FreeTrial7DayCTA } from '@/components/free-trial-cta';
 
 function getPlans(billingEnabled: boolean) {
   return [
@@ -220,6 +221,8 @@ export default function PricingPage() {
               Create a free agent
             </Button>
           </div>
+
+          <FreeTrial7DayCTA className="flex justify-center pt-1" />
 
           <div className="flex items-center justify-center gap-4 pt-2">
             <Button

--- a/apps/web/components/free-trial-cta.tsx
+++ b/apps/web/components/free-trial-cta.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+interface FreeTrial7DayCTAProps {
+  className?: string;
+}
+
+export function FreeTrial7DayCTA({ className }: FreeTrial7DayCTAProps) {
+  return (
+    <div
+      className={className}
+      data-testid="free-trial-7day-cta"
+    >
+      <Button
+        variant="ghost"
+        size="sm"
+        asChild
+        className="text-muted-foreground hover:text-foreground"
+      >
+        <Link href="/dashboard/onboard" data-testid="free-trial-7day-cta-button">
+          Try free for 7 days — no credit card required
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/docs/pr-evidence/free-trial-cta-pricing.md
+++ b/apps/web/docs/pr-evidence/free-trial-cta-pricing.md
@@ -1,0 +1,50 @@
+# Free Trial CTA on /pricing — PR Evidence
+
+## Source
+
+backlog.md:270
+
+## Summary
+
+Adds a "Try free for 7 days — no credit card required" secondary CTA below the primary hero CTA buttons on the `/pricing` page. Creates an explicit free-trial entry point to counter Replika's no-free-trial pattern that suppresses new-user conversion by forcing users to commit before experiencing the product.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/free-trial-cta.tsx` | New `FreeTrial7DayCTA` component |
+| `apps/web/app/(public)/pricing/page.tsx` | Import + render `FreeTrial7DayCTA` below hero CTA group |
+| `apps/web/__tests__/components/free-trial-cta.test.tsx` | Unit tests for the component |
+
+## Before
+
+- `/pricing` hero section had two primary CTAs: "Start with Pro" and "Create a free agent".
+- No explicit free-trial entry point with trial-duration messaging.
+- Users had to infer trial availability; Replika's pattern of requiring payment upfront suppresses conversion from this friction.
+
+## After
+
+The pricing hero section now includes a ghost-style tertiary link below the primary CTAs:
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  [Start with Pro →]   [Create a free agent]                │
+│                                                            │
+│    Try free for 7 days — no credit card required           │  ← new
+└────────────────────────────────────────────────────────────┘
+```
+
+- **Component**: `FreeTrial7DayCTA` renders a ghost `Button` wrapping a Next.js `Link` to `/dashboard/onboard`.
+- **Style**: `ghost` variant + `text-muted-foreground` — visually subdued relative to the primary paid CTA, following the visual hierarchy convention of a tertiary action.
+- **Destination**: `/dashboard/onboard` — the existing free onboarding flow (no separate signup page exists).
+
+## Auth-only Proof
+
+N/A — `/pricing` is a public page, no authentication required to view the CTA.
+
+## Test Coverage
+
+- CTA container renders (`data-testid="free-trial-7day-cta"`)
+- Correct copy text is present
+- Link points to `/dashboard/onboard`
+- Custom `className` prop is applied to the wrapper


### PR DESCRIPTION
## Source
Source: backlog.md:270

## Summary
Add 'try 7 days before you decide' trial-start button on /pricing alongside paid plan CTA, countering Replika's no-free-trial pattern that suppresses new-user conversion.

## Changes
- New `FreeTrial7DayCTA` component (`apps/web/components/free-trial-cta.tsx`) — ghost-style button linking to `/dashboard/onboard`
- Renders below the "Start with Pro / Create a free agent" hero CTA group on `/pricing`
- Unit tests (4 passing)

## Evidence
`docs/pr-evidence/free-trial-cta-pricing.md` (public `/pricing` page, no auth required)

## Auth-only Proof
N/A