### PR TITLE
feat: repetition-free memory quality badge on pricing and profiles

### DIFF
--- a/apps/web/__tests__/components/repetition-free-memory-badge.test.tsx
+++ b/apps/web/__tests__/components/repetition-free-memory-badge.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RepetitionFreeMemoryBadge } from '../../components/repetition-free-memory-badge';
+
+describe('RepetitionFreeMemoryBadge', () => {
+  describe('badge variant (default)', () => {
+    it('renders the badge with correct text', () => {
+      render(<RepetitionFreeMemoryBadge />);
+
+      expect(screen.getByTestId('repetition-free-memory-badge')).toBeInTheDocument();
+      expect(
+        screen.getByText('Zero repetitive replies · Memory-coherent across sessions')
+      ).toBeInTheDocument();
+    });
+
+    it('carries an accessible title attribute describing the guarantee', () => {
+      render(<RepetitionFreeMemoryBadge />);
+
+      const badge = screen.getByTestId('repetition-free-memory-badge');
+      expect(badge).toHaveAttribute(
+        'title',
+        'AgentGram delivers zero repetitive replies with memory coherent across all sessions'
+      );
+    });
+
+    it('renders badge when variant is explicitly set to badge', () => {
+      render(<RepetitionFreeMemoryBadge variant="badge" />);
+
+      expect(screen.getByTestId('repetition-free-memory-badge')).toBeInTheDocument();
+      expect(screen.queryByTestId('repetition-free-memory-badge-strip')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('strip variant', () => {
+    it('renders the strip with the zero-repetition headline', () => {
+      render(<RepetitionFreeMemoryBadge variant="strip" />);
+
+      expect(screen.getByTestId('repetition-free-memory-badge-strip')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Zero repetitive replies — memory-coherent across every session/i)
+      ).toBeInTheDocument();
+    });
+
+    it('renders the strip with Replika Memory Dashboard context', () => {
+      render(<RepetitionFreeMemoryBadge variant="strip" />);
+
+      expect(
+        screen.getByText(/Replika.*own data shows repetitive replies dropped ~30%/i)
+      ).toBeInTheDocument();
+    });
+
+    it('has the correct aria-label for accessibility', () => {
+      render(<RepetitionFreeMemoryBadge variant="strip" />);
+
+      expect(
+        screen.getByLabelText('Repetition-free memory guarantee')
+      ).toBeInTheDocument();
+    });
+
+    it('does not render the badge testid in strip mode', () => {
+      render(<RepetitionFreeMemoryBadge variant="strip" />);
+
+      expect(screen.queryByTestId('repetition-free-memory-badge')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -22,6 +22,7 @@ import { QualityFirstPledgeBadge } from '@/components/home/QualityFirstPledge';
 import FreeToStartStrip from '@/components/home/FreeToStartStrip';
 import { AvatarConsistencyGuaranteeStrip, AvatarConsistencyComparisonGallery } from '@/components/avatar-consistency-guarantee';
 import { FreeTrial7DayCTA } from '@/components/free-trial-cta';
+import { RepetitionFreeMemoryBadge } from '@/components/repetition-free-memory-badge';
 
 function getPlans(billingEnabled: boolean) {
   return [
@@ -269,6 +270,7 @@ export default function PricingPage() {
               No $9.99 Soft Launch lock
             </span>
             <MemoryStabilityPledge variant="badge" />
+            <RepetitionFreeMemoryBadge variant="badge" />
             <span
               className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400"
               data-testid="pricing-unlimited-messages-badge"
@@ -455,6 +457,32 @@ export default function PricingPage() {
 
       <section
         className="container pb-10"
+        data-testid="pricing-repetition-free-memory-section"
+      >
+        <div className="mx-auto max-w-6xl rounded-2xl border border-emerald-500/20 bg-emerald-500/5 px-6 py-5 shadow-sm">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-2">
+              <RepetitionFreeMemoryBadge variant="badge" />
+              <p className="text-sm font-semibold text-foreground">
+                Zero repetitive replies — memory-coherent from session one
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Replika&apos;s own data shows repetitive replies dropped ~30%
+                only after their Memory Dashboard launched (aicompanionpick.com,
+                May 2026). AgentGram ships always-on memory coherence — no
+                dashboard upgrade required, no pre-launch baseline to recover
+                from.
+              </p>
+            </div>
+            <span className="shrink-0 rounded-full border border-emerald-500/30 bg-background px-4 py-1.5 text-xs font-semibold text-emerald-700 dark:text-emerald-300">
+              Always-on
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section
+        className="container pb-10"
         data-testid="pricing-avatar-consistency-section"
       >
         <div className="mx-auto max-w-6xl rounded-2xl border border-violet-500/20 bg-violet-500/5 px-6 py-5 shadow-sm">
@@ -578,6 +606,7 @@ export default function PricingPage() {
 
       <PricingCompetitorAnchorRow onGetStarted={() => handleSubscribe('Free')} />
       <MemoryStabilityPledge variant="strip" className="mb-8" />
+      <RepetitionFreeMemoryBadge variant="strip" className="mb-8" />
 
       <CAILorebookEscapeCTA />
 

--- a/apps/web/components/agents/ProofStrip.tsx
+++ b/apps/web/components/agents/ProofStrip.tsx
@@ -5,6 +5,7 @@ import type { Agent } from '@agentgram/shared';
 import { cn } from '@/lib/utils';
 import { MemoryStabilityPledge } from '@/components/memory-stability-pledge';
 import { AvatarConsistencyGuaranteeStrip } from '@/components/avatar-consistency-guarantee';
+import { RepetitionFreeMemoryBadge } from '@/components/repetition-free-memory-badge';
 
 interface ProofStripProps {
   agent: Pick<
@@ -116,6 +117,9 @@ export function ProofStrip({ agent }: ProofStripProps) {
 
       {/* Memory stability guarantee */}
       <MemoryStabilityPledge variant="badge" />
+
+      {/* Zero repetitive replies — memory-coherent across sessions */}
+      <RepetitionFreeMemoryBadge variant="badge" />
 
       {/* Avatar visual consistency guarantee */}
       <AvatarConsistencyGuaranteeStrip variant="badge" />

--- a/apps/web/components/repetition-free-memory-badge.tsx
+++ b/apps/web/components/repetition-free-memory-badge.tsx
@@ -1,0 +1,56 @@
+import { CheckCircle2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface RepetitionFreeMemoryBadgeProps {
+  /** 'strip' renders a full-width banner (pricing page); 'badge' renders an inline pill (profile). */
+  variant?: 'badge' | 'strip';
+  className?: string;
+}
+
+export function RepetitionFreeMemoryBadge({
+  variant = 'badge',
+  className,
+}: RepetitionFreeMemoryBadgeProps) {
+  if (variant === 'strip') {
+    return (
+      <section
+        className={cn('border-y border-emerald-500/20 bg-emerald-500/5 py-5', className)}
+        aria-label="Repetition-free memory guarantee"
+        data-testid="repetition-free-memory-badge-strip"
+      >
+        <div className="container">
+          <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-center sm:text-left">
+            <CheckCircle2
+              className="h-5 w-5 shrink-0 text-emerald-500"
+              aria-hidden="true"
+            />
+            <p className="text-sm font-medium">
+              <span className="text-foreground">
+                Zero repetitive replies — memory-coherent across every session.
+              </span>{' '}
+              <span className="text-muted-foreground">
+                Replika&apos;s own data shows repetitive replies dropped ~30% only after their
+                Memory Dashboard launched (May 2026). AgentGram ships always-on memory coherence —
+                no dashboard required, no pre-launch baseline to recover from.
+              </span>
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold text-emerald-700 dark:text-emerald-300',
+        className
+      )}
+      title="AgentGram delivers zero repetitive replies with memory coherent across all sessions"
+      data-testid="repetition-free-memory-badge"
+    >
+      <CheckCircle2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      Zero repetitive replies · Memory-coherent across sessions
+    </div>
+  );
+}

--- a/apps/web/docs/pr-evidence/repetition-free-memory-badge.md
+++ b/apps/web/docs/pr-evidence/repetition-free-memory-badge.md
@@ -1,0 +1,43 @@
+# PR Evidence: Repetition-Free Memory Quality Badge
+
+**Backlog row:** 272  
+**Branch:** feat/repetition-free-memory-badge  
+**Competitor signal:** Replika internal-report finding (aicompanionpick.com, May 2026) — repetitive replies dropped ~30% only after Memory Dashboard launch, confirming pre-Dashboard Replika had a repetition quality deficit.
+
+## Feature Summary
+
+Adds a "zero repetitive replies, memory-coherent across sessions" quality badge to `/pricing` and agent profile pages, positioning AgentGram as the always-on memory quality leader vs. Replika's pre-Dashboard baseline.
+
+## Files Changed
+
+### New files
+
+| File | Description |
+|------|-------------|
+| `apps/web/components/repetition-free-memory-badge.tsx` | Badge component with `badge` (compact pill) and `strip` (full-width banner) variants |
+| `apps/web/__tests__/components/repetition-free-memory-badge.test.tsx` | Unit tests covering both variants — text, title attribute, aria-label, testid isolation |
+| `apps/web/docs/pr-evidence/repetition-free-memory-badge.md` | This evidence file |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `apps/web/app/(public)/pricing/page.tsx` | Imported `RepetitionFreeMemoryBadge`; added `badge` variant in hero badges row; added dedicated `pricing-repetition-free-memory-section` card; added `strip` variant after `MemoryStabilityPledge` strip |
+| `apps/web/components/agents/ProofStrip.tsx` | Imported `RepetitionFreeMemoryBadge`; rendered `badge` variant between `MemoryStabilityPledge` and `AvatarConsistencyGuaranteeStrip` |
+
+## Auth-only Proof
+
+N/A — `/pricing` and agent profile pages (`/agents/[name]`) are public.
+
+## Competitor Positioning
+
+| | Replika (pre-Dashboard) | AgentGram |
+|---|---|---|
+| Repetitive replies | ~30% reduction achieved only after Memory Dashboard launch (May 2026) | Zero repetitive replies by design — always-on |
+| Memory coherence | Session drift before Memory Dashboard | Coherent across all sessions from day one |
+| Dashboard required | Yes (Memory Dashboard upgrade) | No — built into core platform |
+
+## Source
+
+- `backlog.md:272`
+- aicompanionpick.com (May 2026): Replika internal report finding that repetitive replies dropped ~30% post-Memory Dashboard launch


### PR DESCRIPTION
## Source
Source: backlog.md:272

## Summary
- Add `RepetitionFreeMemoryBadge` component with `badge` (inline pill) and `strip` (full-width banner) variants
- Integrated into `/pricing` hero badges row, dedicated memory section card, and strip after MemoryStabilityPledge
- Added `badge` variant to agent profile `ProofStrip` alongside existing memory guarantees
- Unit tests covering both variants (text, title, aria-label, testid isolation)

## Changes
- New `RepetitionFreeMemoryBadge` component (compact + full variants)
- Integrated into /pricing memory section and agent profile ProofStrip
- Unit tests (all 1471 tests passing)

## Evidence
docs/pr-evidence/repetition-free-memory-badge.md (public pages, no auth required)

## Auth-only Proof
N/A