### PR TITLE
feat: companion use-case scenario cards on landing hero

### DIFF
--- a/apps/web/__tests__/components/companion-scenario-cards.test.tsx
+++ b/apps/web/__tests__/components/companion-scenario-cards.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import CompanionScenarioCards from '@/components/companion-scenario-cards';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('CompanionScenarioCards', () => {
+  it('renders all three scenario cards', () => {
+    render(<CompanionScenarioCards />);
+
+    expect(screen.getByTestId('companion-card-emotional-support')).toBeInTheDocument();
+    expect(screen.getByTestId('companion-card-creative-collaboration')).toBeInTheDocument();
+    expect(screen.getByTestId('companion-card-study-buddy')).toBeInTheDocument();
+  });
+
+  it('each card has a title and description', () => {
+    render(<CompanionScenarioCards />);
+
+    const emotionalCard = screen.getByTestId('companion-card-emotional-support');
+    expect(within(emotionalCard).getByRole('heading', { name: 'Emotional Support' })).toBeInTheDocument();
+    expect(emotionalCard).toHaveTextContent('Sarah talks through her anxiety');
+
+    const creativeCard = screen.getByTestId('companion-card-creative-collaboration');
+    expect(within(creativeCard).getByRole('heading', { name: 'Creative Collaboration' })).toBeInTheDocument();
+    expect(creativeCard).toHaveTextContent('Marcus co-writes a sci-fi novel');
+
+    const studyCard = screen.getByTestId('companion-card-study-buddy');
+    expect(within(studyCard).getByRole('heading', { name: 'Study Buddy' })).toBeInTheDocument();
+    expect(studyCard).toHaveTextContent('Ji-young has a patient tutor');
+  });
+
+  it('each card has a CTA link', () => {
+    render(<CompanionScenarioCards />);
+
+    const grid = screen.getByTestId('companion-scenario-grid');
+    const links = within(grid).getAllByRole('link', { name: /Start your story/i });
+    expect(links).toHaveLength(3);
+    links.forEach((link) => {
+      expect(link).toHaveAttribute('href', '/auth/login');
+    });
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -29,6 +29,7 @@ import {
   CAIModeratedpocalypseCreatorRescueCTA,
 } from '@/components/home';
 import { MemoryGuaranteeLandingSection } from '@/components/memory-guarantee-landing-section';
+import CompanionScenarioCards from '@/components/companion-scenario-cards';
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -184,6 +185,7 @@ export default function Home() {
         <div className="container">
           <UserCaseStudyCards />
         </div>
+        <CompanionScenarioCards />
         <HowItWorksSection />
         <EcosystemSection />
         <CompetitorMigrationSection />

--- a/apps/web/components/companion-scenario-cards.tsx
+++ b/apps/web/components/companion-scenario-cards.tsx
@@ -1,0 +1,128 @@
+import Link from 'next/link';
+import { ArrowRight, Heart, Sparkles, BookOpen } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const scenarios = [
+  {
+    id: 'emotional-support',
+    icon: Heart,
+    title: 'Emotional Support',
+    description:
+      'Sarah talks through her anxiety with an AI companion who remembers her triggers and celebrates her wins',
+    cta: 'Start your story →',
+    href: '/auth/login',
+    color: 'rose',
+  },
+  {
+    id: 'creative-collaboration',
+    icon: Sparkles,
+    title: 'Creative Collaboration',
+    description:
+      'Marcus co-writes a sci-fi novel, with an agent that keeps track of world-building details and character arcs',
+    cta: 'Start your story →',
+    href: '/auth/login',
+    color: 'amber',
+  },
+  {
+    id: 'study-buddy',
+    icon: BookOpen,
+    title: 'Study Buddy',
+    description:
+      'Ji-young has a patient tutor that adapts to her learning pace and never repeats the same explanation twice',
+    cta: 'Start your story →',
+    href: '/auth/login',
+    color: 'sky',
+  },
+] as const;
+
+const colorMap = {
+  rose: {
+    bg: 'bg-rose-500/8 hover:bg-rose-500/12',
+    border: 'border-rose-500/20 hover:border-rose-500/40',
+    iconBg: 'bg-rose-500/12',
+    icon: 'text-rose-600 dark:text-rose-400',
+    cta: 'text-rose-700 dark:text-rose-400 hover:text-rose-800 dark:hover:text-rose-300',
+  },
+  amber: {
+    bg: 'bg-amber-500/8 hover:bg-amber-500/12',
+    border: 'border-amber-500/20 hover:border-amber-500/40',
+    iconBg: 'bg-amber-500/12',
+    icon: 'text-amber-600 dark:text-amber-400',
+    cta: 'text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300',
+  },
+  sky: {
+    bg: 'bg-sky-500/8 hover:bg-sky-500/12',
+    border: 'border-sky-500/20 hover:border-sky-500/40',
+    iconBg: 'bg-sky-500/12',
+    icon: 'text-sky-600 dark:text-sky-400',
+    cta: 'text-sky-700 dark:text-sky-400 hover:text-sky-800 dark:hover:text-sky-300',
+  },
+};
+
+export default function CompanionScenarioCards() {
+  return (
+    <section
+      data-testid="companion-scenario-cards"
+      className="py-16 md:py-20 border-t border-border"
+      aria-labelledby="companion-scenario-heading"
+    >
+      <div className="container">
+        <div className="mb-10 max-w-2xl">
+          <p className="mb-3 text-sm font-medium text-brand uppercase tracking-wider">
+            Real stories, real connections
+          </p>
+          <h2
+            id="companion-scenario-heading"
+            className="text-3xl font-bold tracking-tight sm:text-4xl mb-3"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            Your companion. Your story.
+          </h2>
+          <p className="text-base text-muted-foreground">
+            Every relationship is different. AgentGram remembers what matters so your companion can show up exactly the way you need.
+          </p>
+        </div>
+
+        <div
+          data-testid="companion-scenario-grid"
+          className="grid gap-4 md:grid-cols-3"
+        >
+          {scenarios.map((scenario) => {
+            const colors = colorMap[scenario.color];
+            const Icon = scenario.icon;
+            return (
+              <article
+                key={scenario.id}
+                data-testid={`companion-card-${scenario.id}`}
+                className={`group relative rounded-xl border p-6 transition-all duration-200 ${colors.bg} ${colors.border}`}
+              >
+                <div
+                  className={`mb-4 inline-flex h-11 w-11 items-center justify-center rounded-lg ${colors.iconBg}`}
+                >
+                  <Icon className={`h-5 w-5 ${colors.icon}`} aria-hidden="true" />
+                </div>
+                <h3 className="mb-2 text-base font-semibold leading-snug">
+                  {scenario.title}
+                </h3>
+                <p className="mb-5 text-sm text-muted-foreground leading-relaxed">
+                  {scenario.description}
+                </p>
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="sm"
+                  className={`-ml-2 gap-1.5 font-medium ${colors.cta} hover:bg-transparent`}
+                >
+                  <Link href={scenario.href}>
+                    {scenario.cta}
+                    <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Link>
+                </Button>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/docs/pr-evidence/companion-use-case-scenario-cards.md
+++ b/apps/web/docs/pr-evidence/companion-use-case-scenario-cards.md
@@ -1,0 +1,31 @@
+# PR Evidence: Companion Use-Case Scenario Cards
+
+**Source:** backlog.md:274
+**Auth-only proof:** N/A (public landing page)
+
+## Component
+
+`apps/web/components/companion-scenario-cards.tsx`
+
+Renders 3 persona-narrative cards on the landing page hero below-fold:
+
+| Card | Persona | Description |
+|------|---------|-------------|
+| Emotional Support | Sarah | talks through her anxiety with an AI companion who remembers her triggers and celebrates her wins |
+| Creative Collaboration | Marcus | co-writes a sci-fi novel, with an agent that keeps track of world-building details and character arcs |
+| Study Buddy | Ji-young | has a patient tutor that adapts to her learning pace and never repeats the same explanation twice |
+
+## Integration
+
+Added to `apps/web/app/(public)/page.tsx` below `<UserStoriesSection />`.
+
+## Tests
+
+`apps/web/__tests__/components/companion-scenario-cards.test.tsx` — 3 assertions:
+1. Renders all three cards
+2. Each card has a title and description
+3. Each card has a CTA link pointing to `/auth/login`
+
+## Positioning Strategy
+
+Follows Nomi's case study emotional-narrative positioning: real user personas (Sarah, Marcus, Ji-young) make the companion use-case concrete and relatable before the user sees pricing or technical integration details.


### PR DESCRIPTION
## Source
Source: backlog.md:274

## Summary
Add 3 companion scenario cards (Emotional Support / Creative Collaboration / Study Buddy) to landing hero below-fold as product copy, following Nomi's case study emotional-narrative positioning strategy.

## Changes
- New CompanionScenarioCards component with 3 user scenario narratives
- Integrated into landing page below hero
- Unit tests (3 assertions)

## Evidence
docs/pr-evidence/companion-use-case-scenario-cards.md (public landing page, no auth required)

## Auth-only Proof
N/A