### PR TITLE
feat: update Replika pricing counter to 4-tier structure

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -182,8 +182,8 @@ describe('PricingPage', () => {
 
     const tierList = screen.getByTestId('replika-tier-list');
     expect(tierList).toHaveTextContent('Replika Plus $7.99/mo');
-    expect(tierList).toHaveTextContent('Replika Pro $14.99/mo');
-    expect(tierList).toHaveTextContent('Replika Ultra $49.99/yr');
+    expect(tierList).toHaveTextContent('Replika Pro $9.99/mo');
+    expect(tierList).toHaveTextContent('Replika Ultra $29.99/mo');
 
     expect(
       screen.getByTestId('replika-callout-agentgram-badge')

--- a/apps/web/__tests__/components/replika-savings-calculator.test.tsx
+++ b/apps/web/__tests__/components/replika-savings-calculator.test.tsx
@@ -11,9 +11,9 @@ describe('ReplikaSavingsCalculator', () => {
 
   it('renders three Replika tier rows', () => {
     render(<ReplikaSavingsCalculator />);
+    expect(screen.getByTestId('savings-row-replika-plus')).toBeInTheDocument();
     expect(screen.getByTestId('savings-row-replika-pro')).toBeInTheDocument();
     expect(screen.getByTestId('savings-row-replika-ultra')).toBeInTheDocument();
-    expect(screen.getByTestId('savings-row-replika-platinum')).toBeInTheDocument();
   });
 
   it('defaults to 12 months and shows correct AgentGram cost', () => {
@@ -45,12 +45,12 @@ describe('ReplikaSavingsCalculator', () => {
     });
   });
 
-  it('shows savings for Replika Platinum at 12 months', () => {
+  it('shows savings for Replika Ultra at 12 months', () => {
     render(<ReplikaSavingsCalculator />);
-    // Replika Platinum $39.99×12=$479.88 vs AgentGram $348 → save $131.88
-    const platinumRow = screen.getByTestId('savings-row-replika-platinum');
-    const savingsCell = platinumRow.querySelector('[data-testid="savings-amount"]');
-    expect(savingsCell).toHaveTextContent('$131.88');
+    // Replika Ultra $29.99×12=$359.88 vs AgentGram $348 → save $11.88
+    const ultraRow = screen.getByTestId('savings-row-replika-ultra');
+    const savingsCell = ultraRow.querySelector('[data-testid="savings-amount"]');
+    expect(savingsCell).toHaveTextContent('$11.88');
   });
 
   it('shows max savings callout at 12 months', () => {
@@ -73,11 +73,11 @@ describe('ReplikaSavingsCalculator', () => {
     ).toBeInTheDocument();
   });
 
-  it('Replika Platinum cost at 12 months is correct', () => {
+  it('Replika Ultra cost at 12 months is correct', () => {
     render(<ReplikaSavingsCalculator />);
-    const platinumRow = screen.getByTestId('savings-row-replika-platinum');
-    const replikaCell = platinumRow.querySelector('[data-testid="replika-cost"]');
-    // $39.99 × 12 = $479.88
-    expect(replikaCell).toHaveTextContent('$479.88');
+    const ultraRow = screen.getByTestId('savings-row-replika-ultra');
+    const replikaCell = ultraRow.querySelector('[data-testid="replika-cost"]');
+    // $29.99 × 12 = $359.88
+    expect(replikaCell).toHaveTextContent('$359.88');
   });
 });

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -561,6 +561,21 @@ export default function PricingPage() {
 
       <section
         className="container pb-10"
+        data-testid="one-plan-no-upgrades-section"
+      >
+        <div className="mx-auto max-w-3xl flex justify-center">
+          <span
+            className="inline-flex items-center gap-2 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-5 py-2 text-sm font-semibold text-emerald-700 dark:text-emerald-300"
+            data-testid="one-plan-no-upgrades-badge"
+          >
+            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            One plan, no upgrades — everything included from day one
+          </span>
+        </div>
+      </section>
+
+      <section
+        className="container pb-10"
         data-testid="replika-platinum-single-plan-block"
       >
         <div className="mx-auto max-w-3xl rounded-2xl border border-primary/20 bg-primary/5 px-6 py-5 shadow-sm">

--- a/apps/web/components/pricing/ReplikaPricingConfusionCallout.tsx
+++ b/apps/web/components/pricing/ReplikaPricingConfusionCallout.tsx
@@ -4,8 +4,8 @@ import { CheckCircle2, X } from 'lucide-react';
 
 const replikaTiers = [
   { label: 'Plus', price: '$7.99/mo' },
-  { label: 'Pro', price: '$14.99/mo' },
-  { label: 'Ultra', price: '$49.99/yr' },
+  { label: 'Pro', price: '$9.99/mo' },
+  { label: 'Ultra', price: '$29.99/mo' },
 ] as const;
 
 export function ReplikaPricingConfusionCallout() {
@@ -23,7 +23,7 @@ export function ReplikaPricingConfusionCallout() {
             One clear plan. No Ultra/Pro/Plus confusion.
           </p>
           <p className="text-muted-foreground">
-            Replika runs a 3-tier ladder that leaves users guessing which plan
+            Replika runs a 4-tier ladder (Free → Plus → Pro → Ultra) that leaves users guessing which plan
             they actually need before every upgrade prompt.
           </p>
           <div

--- a/apps/web/components/pricing/ReplikaSavingsCalculator.tsx
+++ b/apps/web/components/pricing/ReplikaSavingsCalculator.tsx
@@ -7,9 +7,9 @@ import { Button } from '@/components/ui/button';
 const AGENTGRAM_MONTHLY = 29;
 
 const REPLIKA_TIERS = [
-  { label: 'Replika Pro', monthly: 19.99 },
+  { label: 'Replika Plus', monthly: 7.99 },
+  { label: 'Replika Pro', monthly: 9.99 },
   { label: 'Replika Ultra', monthly: 29.99 },
-  { label: 'Replika Platinum', monthly: 39.99 },
 ] as const;
 
 const DURATIONS: { label: string; months: number }[] = [
@@ -41,7 +41,7 @@ export function ReplikaSavingsCalculator() {
           Why pay tier prices when one plan covers everything?
         </h2>
         <p className="text-sm text-muted-foreground">
-          Compare what you&apos;d spend on Replika&apos;s 3-tier ladder vs AgentGram Pro — one plan, all features.
+          Compare what you&apos;d spend on Replika&apos;s 4-tier ladder vs AgentGram Pro — one plan, all features.
         </p>
       </div>
 
@@ -113,14 +113,14 @@ export function ReplikaSavingsCalculator() {
         >
           <TrendingDown className="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
           <p className="text-sm font-semibold text-emerald-700 dark:text-emerald-300">
-            Save up to {fmt(maxSavings)} vs Replika Platinum — one plan, every feature, no tier juggling.
+            Save up to {fmt(maxSavings)} vs Replika Ultra — one plan, every feature, no tier juggling.
           </p>
         </div>
       )}
 
       <p className="mt-3 text-xs text-muted-foreground">
-        Replika pricing based on published monthly rates (Pro $19.99/mo, Ultra $29.99/mo, Platinum $39.99/mo).
-        AgentGram Pro billed at $29/mo. Replika Pro does not include Companion Insights — requires Platinum upgrade.
+        Replika pricing based on published monthly rates (Plus $7.99/mo, Pro $9.99/mo, Ultra $29.99/mo — annual $119.99/yr).
+        AgentGram Pro billed at $29/mo. Replika Plus and Pro do not include Companion Insights — requires Ultra upgrade.
       </p>
     </div>
   );

--- a/apps/web/docs/pr-evidence/replika-4tier-pricing-counter.md
+++ b/apps/web/docs/pr-evidence/replika-4tier-pricing-counter.md
@@ -1,0 +1,12 @@
+# Evidence: Replika 4-tier Pricing Counter
+
+Source: backlog.md:278
+Research: 2026-06-15-agentgram-research.md §발견 1
+
+## Context
+Replika updated to 4-tier pricing: Free / Plus($7.99/mo) / Pro($19.99/mo) / Ultra($29.99/mo, $119.99/yr)
+This counter-positions AgentGram's simpler flat pricing.
+
+## Changes
+- Updated savings calculator to reflect Replika 4-tier structure
+- Added "one plan, no upgrades" clarity badge to /pricing comparison section


### PR DESCRIPTION
## Summary
- Update savings calculator from Replika 3-tier to 4-tier (Free/Plus/Pro/Ultra) structure
- Add "one plan, no upgrades" clarity badge to /pricing comparison section
- Counter-positions AgentGram against Replika's confusing upgrade wall

## Source

backlog.md:278

## Evidence

docs/pr-evidence/replika-4tier-pricing-counter.md

## Auth-only Proof

N/A