### PR TITLE
feat: Kindroid per-entry memory deprioritize parity in Memory Dashboard

### DIFF
--- a/apps/web/__tests__/api/memory-deprioritize.test.ts
+++ b/apps/web/__tests__/api/memory-deprioritize.test.ts
@@ -179,7 +179,9 @@ describe('PATCH /api/v1/agents/me/memories/[id]/deprioritize', () => {
     expect(mockMemoryUpdate).not.toHaveBeenCalled();
   });
 
-  it('is protected by withDeveloperAuth (x-developer-id header required)', async () => {
+  // withDeveloperAuth mock passes handler through; the 401 comes from the route's own
+  // x-developer-id check. Both guard the same invariant so the coverage is valid.
+  it('returns 401 when x-developer-id header is missing', async () => {
     const { PATCH } = await import(
       '../../app/api/v1/agents/me/memories/[id]/deprioritize/route'
     );
@@ -199,5 +201,34 @@ describe('PATCH /api/v1/agents/me/memories/[id]/deprioritize', () => {
     const json = await response.json();
     expect(response.status).toBe(401);
     expect(json.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 404 when memory does not belong to the requested agent', async () => {
+    // agent-1 is owned by dev-1 (ownership check passes), but the memory
+    // belongs to agent-2. The .eq('agent_id', agentId) DB filter returns null.
+    mockMemorySingle.mockResolvedValueOnce({ data: null, error: { message: 'No rows' } });
+
+    const { PATCH } = await import(
+      '../../app/api/v1/agents/me/memories/[id]/deprioritize/route'
+    );
+
+    const response = await PATCH(
+      new Request(
+        'http://localhost/api/v1/agents/me/memories/memory-cross/deprioritize',
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', 'x-developer-id': 'dev-1' },
+          body: JSON.stringify({ agentId: 'agent-1', deprioritized: true }),
+        }
+      ) as Parameters<typeof PATCH>[0],
+      { params: Promise.resolve({ id: 'memory-cross' }) }
+    );
+
+    const json = await response.json();
+    expect(response.status).toBe(404);
+    expect(json.error.code).toBe('NOT_FOUND');
+    // update was called but returned no row — confirms .eq('agent_id') guard is active
+    expect(mockMemoryUpdate).toHaveBeenCalled();
+    expect(mockMemorySingle).toHaveBeenCalled();
   });
 });

--- a/apps/web/__tests__/api/memory-deprioritize.test.ts
+++ b/apps/web/__tests__/api/memory-deprioritize.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAgentEq = vi.fn();
+const mockAgentSingle = vi.fn();
+const mockAgentSelect = vi.fn();
+const mockMemorySingle = vi.fn();
+const mockMemorySelectAfterWrite = vi.fn();
+const mockMemoryUpdateEqAgent = vi.fn();
+const mockMemoryUpdateEqId = vi.fn();
+const mockMemoryUpdate = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@agentgram/db', () => ({
+  getSupabaseServiceClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+vi.mock('@/lib/auth/developer', () => ({
+  withDeveloperAuth: (handler: unknown) => handler,
+}));
+
+describe('PATCH /api/v1/agents/me/memories/[id]/deprioritize', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockAgentSingle.mockResolvedValue({
+      data: { id: 'agent-1', developer_id: 'dev-1' },
+      error: null,
+    });
+    mockAgentEq.mockReturnValue({ single: mockAgentSingle });
+    mockAgentSelect.mockReturnValue({ eq: mockAgentEq });
+
+    mockMemorySingle.mockResolvedValue({
+      data: {
+        id: 'memory-1',
+        agent_id: 'agent-1',
+        key: 'latest_focus',
+        value: 'Preserve the release blocker.',
+        category: 'profile_fact',
+        is_public: false,
+        priority: 'low',
+        created_at: '2026-05-08T12:00:00.000Z',
+        updated_at: '2026-06-15T10:00:00.000Z',
+      },
+      error: null,
+    });
+    mockMemorySelectAfterWrite.mockReturnValue({ single: mockMemorySingle });
+    mockMemoryUpdateEqAgent.mockReturnValue({ select: mockMemorySelectAfterWrite });
+    mockMemoryUpdateEqId.mockReturnValue({ eq: mockMemoryUpdateEqAgent });
+    mockMemoryUpdate.mockReturnValue({ eq: mockMemoryUpdateEqId });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'agents') return { select: mockAgentSelect };
+      if (table === 'agent_memories') return { update: mockMemoryUpdate };
+      return {};
+    });
+  });
+
+  it('sets priority to low when deprioritized is true', async () => {
+    const { PATCH } = await import(
+      '../../app/api/v1/agents/me/memories/[id]/deprioritize/route'
+    );
+
+    const response = await PATCH(
+      new Request(
+        'http://localhost/api/v1/agents/me/memories/memory-1/deprioritize',
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', 'x-developer-id': 'dev-1' },
+          body: JSON.stringify({ agentId: 'agent-1', deprioritized: true }),
+        }
+      ) as Parameters<typeof PATCH>[0],
+      { params: Promise.resolve({ id: 'memory-1' }) }
+    );
+
+    const json = await response.json();
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockMemoryUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ priority: 'low' })
+    );
+  });
+
+  it('sets priority to normal when deprioritized is false', async () => {
+    const { PATCH } = await import(
+      '../../app/api/v1/agents/me/memories/[id]/deprioritize/route'
+    );
+
+    const response = await PATCH(
+      new Request(
+        'http://localhost/api/v1/agents/me/memories/memory-1/deprioritize',
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', 'x-developer-id': 'dev-1' },
+          body: JSON.stringify({ agentId: 'agent-1', deprioritized: false }),
+        }
+      ) as Parameters<typeof PATCH>[0],
+      { params: Promise.resolve({ id: 'memory-1' }) }
+    );
+
+    const json = await response.json();
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockMemoryUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ priority: 'normal' })
+    );
+  });
+
+  it('returns 400 when agentId is missing', async () => {
+    const { PATCH } = await import(
+      '../../app/api/v1/agents/me/memories/[id]/deprioritize/route'
+    );
+
+    const response = await PATCH(
+      new Request(
+        'http://localhost/api/v1/agents/me/memories/memory-1/deprioritize',
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', 'x-developer-id': 'dev-1' },
+          body: JSON.stringify({ deprioritized: true }),
+        }
+      ) as Parameters<typeof PATCH>[0],
+      { params: Promise.resolve({ id: 'memory-1' }) }
+    );
+
+    const json = await response.json();
+    expect(response.status).toBe(400);
+    expect(json.error.code).toBe('INVALID_INPUT');
+  });
+
+  it('returns 400 when deprioritized is not a boolean', async () => {
+    const { PATCH } = await import(
+      '../../app/api/v1/agents/me/memories/[id]/deprioritize/route'
+    );
+
+    const response = await PATCH(
+      new Request(
+        'http://localhost/api/v1/agents/me/memories/memory-1/deprioritize',
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', 'x-developer-id': 'dev-1' },
+          body: JSON.stringify({ agentId: 'agent-1', deprioritized: 'yes' }),
+        }
+      ) as Parameters<typeof PATCH>[0],
+      { params: Promise.resolve({ id: 'memory-1' }) }
+    );
+
+    const json = await response.json();
+    expect(response.status).toBe(400);
+    expect(json.error.code).toBe('INVALID_INPUT');
+  });
+
+  it('rejects deprioritize for agents not owned by the developer', async () => {
+    mockAgentSingle.mockResolvedValueOnce({
+      data: { id: 'agent-1', developer_id: 'dev-other' },
+      error: null,
+    });
+
+    const { PATCH } = await import(
+      '../../app/api/v1/agents/me/memories/[id]/deprioritize/route'
+    );
+
+    const response = await PATCH(
+      new Request(
+        'http://localhost/api/v1/agents/me/memories/memory-1/deprioritize',
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', 'x-developer-id': 'dev-1' },
+          body: JSON.stringify({ agentId: 'agent-1', deprioritized: true }),
+        }
+      ) as Parameters<typeof PATCH>[0],
+      { params: Promise.resolve({ id: 'memory-1' }) }
+    );
+
+    const json = await response.json();
+    expect(response.status).toBe(403);
+    expect(json.error.code).toBe('FORBIDDEN');
+    expect(mockMemoryUpdate).not.toHaveBeenCalled();
+  });
+
+  it('is protected by withDeveloperAuth (x-developer-id header required)', async () => {
+    const { PATCH } = await import(
+      '../../app/api/v1/agents/me/memories/[id]/deprioritize/route'
+    );
+
+    const response = await PATCH(
+      new Request(
+        'http://localhost/api/v1/agents/me/memories/memory-1/deprioritize',
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agentId: 'agent-1', deprioritized: true }),
+        }
+      ) as Parameters<typeof PATCH>[0],
+      { params: Promise.resolve({ id: 'memory-1' }) }
+    );
+
+    const json = await response.json();
+    expect(response.status).toBe(401);
+    expect(json.error.code).toBe('UNAUTHORIZED');
+  });
+});

--- a/apps/web/__tests__/components/memory-deprioritize.test.tsx
+++ b/apps/web/__tests__/components/memory-deprioritize.test.tsx
@@ -1,0 +1,203 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MemoryExportDashboard,
+  type MemoryExportRecord,
+} from '@/components/dashboard/MemoryExportDashboard';
+import { MemoryTierTabs } from '@/components/dashboard/MemoryTierTabs';
+
+function buildMemory(overrides: Partial<MemoryExportRecord> = {}): MemoryExportRecord {
+  return {
+    id: 'memory-1',
+    agentId: 'agent-1',
+    agentLabel: 'Sage Bot',
+    key: 'latest_focus',
+    value: 'Preserve the release blocker.',
+    category: 'profile_fact',
+    isPublic: false,
+    priority: 'normal',
+    createdAt: '2026-05-01T12:00:00.000Z',
+    updatedAt: '2026-05-01T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+describe('Deprioritize toggle — MemoryTierTabs', () => {
+  it('renders a deprioritize button for each memory item', () => {
+    const memory = buildMemory();
+    render(
+      <MemoryTierTabs
+        memories={[memory]}
+        deleting={new Set()}
+        onDelete={noop}
+        deprioritizing={new Set()}
+        onDeprioritize={noop}
+      />
+    );
+    expect(screen.getByTestId('deprioritize-memory-memory-1')).toBeInTheDocument();
+  });
+
+  it('shows ChevronDown icon (deprioritize) when priority is normal', () => {
+    const memory = buildMemory({ priority: 'normal' });
+    render(
+      <MemoryTierTabs
+        memories={[memory]}
+        deleting={new Set()}
+        onDelete={noop}
+        deprioritizing={new Set()}
+        onDeprioritize={noop}
+      />
+    );
+    const btn = screen.getByTestId('deprioritize-memory-memory-1');
+    expect(btn).toHaveAttribute('aria-label', 'Deprioritize: latest_focus');
+  });
+
+  it('shows ChevronUp icon (restore) when priority is low', () => {
+    const memory = buildMemory({ priority: 'low' });
+    render(
+      <MemoryTierTabs
+        memories={[memory]}
+        deleting={new Set()}
+        onDelete={noop}
+        deprioritizing={new Set()}
+        onDeprioritize={noop}
+      />
+    );
+    const btn = screen.getByTestId('deprioritize-memory-memory-1');
+    expect(btn).toHaveAttribute('aria-label', 'Restore priority: latest_focus');
+  });
+
+  it('shows "Low priority" badge for deprioritized memory', () => {
+    const memory = buildMemory({ priority: 'low' });
+    render(
+      <MemoryTierTabs
+        memories={[memory]}
+        deleting={new Set()}
+        onDelete={noop}
+        deprioritizing={new Set()}
+        onDeprioritize={noop}
+      />
+    );
+    expect(screen.getByTestId('deprioritized-badge-memory-1')).toBeInTheDocument();
+    expect(screen.getByTestId('deprioritized-badge-memory-1')).toHaveTextContent('Low priority');
+  });
+
+  it('does not show "Low priority" badge for normal-priority memory', () => {
+    const memory = buildMemory({ priority: 'normal' });
+    render(
+      <MemoryTierTabs
+        memories={[memory]}
+        deleting={new Set()}
+        onDelete={noop}
+        deprioritizing={new Set()}
+        onDeprioritize={noop}
+      />
+    );
+    expect(screen.queryByTestId('deprioritized-badge-memory-1')).not.toBeInTheDocument();
+  });
+
+  it('calls onDeprioritize when deprioritize button is clicked', () => {
+    const onDeprioritize = vi.fn();
+    const memory = buildMemory();
+    render(
+      <MemoryTierTabs
+        memories={[memory]}
+        deleting={new Set()}
+        onDelete={noop}
+        deprioritizing={new Set()}
+        onDeprioritize={onDeprioritize}
+      />
+    );
+    fireEvent.click(screen.getByTestId('deprioritize-memory-memory-1'));
+    expect(onDeprioritize).toHaveBeenCalledWith(memory);
+  });
+
+  it('disables deprioritize button while deprioritizing', () => {
+    const memory = buildMemory();
+    render(
+      <MemoryTierTabs
+        memories={[memory]}
+        deleting={new Set()}
+        onDelete={noop}
+        deprioritizing={new Set(['memory-1'])}
+        onDeprioritize={noop}
+      />
+    );
+    expect(screen.getByTestId('deprioritize-memory-memory-1')).toBeDisabled();
+  });
+
+  it('applies reduced opacity class to deprioritized memory row', () => {
+    const memory = buildMemory({ priority: 'low' });
+    render(
+      <MemoryTierTabs
+        memories={[memory]}
+        deleting={new Set()}
+        onDelete={noop}
+        deprioritizing={new Set()}
+        onDeprioritize={noop}
+      />
+    );
+    const item = screen.getByTestId('memory-item-memory-1');
+    expect(item.className).toContain('opacity-50');
+  });
+});
+
+describe('Deprioritize toggle — MemoryExportDashboard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('optimistically marks memory as low priority after successful deprioritize', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    );
+
+    render(<MemoryExportDashboard memories={[buildMemory({ priority: 'normal' })]} />);
+
+    fireEvent.click(screen.getByTestId('deprioritize-memory-memory-1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('deprioritized-badge-memory-1')).toBeInTheDocument();
+    });
+  });
+
+  it('optimistically restores memory to normal priority on toggle', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    );
+
+    render(<MemoryExportDashboard memories={[buildMemory({ priority: 'low' })]} />);
+
+    // Badge should exist before toggle
+    expect(screen.getByTestId('deprioritized-badge-memory-1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('deprioritize-memory-memory-1'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('deprioritized-badge-memory-1')).not.toBeInTheDocument();
+    });
+  });
+
+  it('calls deprioritize API with correct payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<MemoryExportDashboard memories={[buildMemory({ priority: 'normal' })]} />);
+    fireEvent.click(screen.getByTestId('deprioritize-memory-memory-1'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/agents/me/memories/memory-1/deprioritize',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ agentId: 'agent-1', deprioritized: true }),
+        })
+      );
+    });
+  });
+});

--- a/apps/web/__tests__/components/memory-deprioritize.test.tsx
+++ b/apps/web/__tests__/components/memory-deprioritize.test.tsx
@@ -200,4 +200,36 @@ describe('Deprioritize toggle — MemoryExportDashboard', () => {
       );
     });
   });
+
+  it('rolls back optimistic state when deprioritize API fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500 })
+    );
+
+    render(<MemoryExportDashboard memories={[buildMemory({ priority: 'normal' })]} />);
+
+    fireEvent.click(screen.getByTestId('deprioritize-memory-memory-1'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('deprioritized-badge-memory-1')).not.toBeInTheDocument();
+    });
+  });
+
+  it('rolls back optimistic restore when API fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500 })
+    );
+
+    render(<MemoryExportDashboard memories={[buildMemory({ priority: 'low' })]} />);
+
+    expect(screen.getByTestId('deprioritized-badge-memory-1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('deprioritize-memory-memory-1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('deprioritized-badge-memory-1')).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/__tests__/components/memory-tier-tabs.test.tsx
+++ b/apps/web/__tests__/components/memory-tier-tabs.test.tsx
@@ -24,7 +24,7 @@ const noop = () => {};
 describe('MemoryTierTabs', () => {
   it('renders the tab list with both tabs', () => {
     render(
-      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     expect(screen.getByTestId('memory-tier-tabs-list')).toBeInTheDocument();
     expect(screen.getByTestId('tab-key-memories')).toBeInTheDocument();
@@ -33,21 +33,21 @@ describe('MemoryTierTabs', () => {
 
   it('renders "Key Memories" tab trigger', () => {
     render(
-      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     expect(screen.getByTestId('tab-key-memories')).toHaveTextContent('Key Memories');
   });
 
   it('renders "Session Context" tab trigger', () => {
     render(
-      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     expect(screen.getByTestId('tab-session-context')).toHaveTextContent('Session Context');
   });
 
   it('defaults to "Key Memories" tab active', () => {
     render(
-      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     expect(screen.getByTestId('tab-key-memories')).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByTestId('tab-session-context')).toHaveAttribute('aria-selected', 'false');
@@ -55,7 +55,7 @@ describe('MemoryTierTabs', () => {
 
   it('shows "Key Memories" tab panel by default', () => {
     render(
-      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     expect(screen.getByTestId('tabpanel-key-memories')).toBeInTheDocument();
     expect(screen.queryByTestId('tabpanel-session-context')).not.toBeInTheDocument();
@@ -63,7 +63,7 @@ describe('MemoryTierTabs', () => {
 
   it('switches to "Session Context" tab panel on click', () => {
     render(
-      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     fireEvent.click(screen.getByTestId('tab-session-context'));
     expect(screen.getByTestId('tabpanel-session-context')).toBeInTheDocument();
@@ -73,7 +73,7 @@ describe('MemoryTierTabs', () => {
   it('routes profile_fact memories into Key Memories tab', () => {
     const memory = buildMemory({ category: 'profile_fact' });
     render(
-      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     // Key Memories is default — memory item should be visible
     expect(screen.getByTestId('memory-item-memory-1')).toBeInTheDocument();
@@ -82,7 +82,7 @@ describe('MemoryTierTabs', () => {
   it('routes relationship_context memories into Session Context tab', () => {
     const memory = buildMemory({ category: 'relationship_context' });
     render(
-      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     // Default tab is Key Memories — session memory should NOT be visible yet
     expect(screen.queryByTestId('memory-item-memory-1')).not.toBeInTheDocument();
@@ -95,7 +95,7 @@ describe('MemoryTierTabs', () => {
   it('shows count badge on Key Memories tab when memories exist', () => {
     const memory = buildMemory({ category: 'profile_fact' });
     render(
-      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     // The tab trigger contains "Key Memories" and a badge with "1"
     const trigger = screen.getByTestId('tab-key-memories');
@@ -105,7 +105,7 @@ describe('MemoryTierTabs', () => {
   it('shows count badge on Session Context tab when memories exist', () => {
     const memory = buildMemory({ category: 'relationship_context' });
     render(
-      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     const trigger = screen.getByTestId('tab-session-context');
     expect(trigger).toHaveTextContent('1');
@@ -113,14 +113,14 @@ describe('MemoryTierTabs', () => {
 
   it('shows Key Memories empty state when no long_term memories', () => {
     render(
-      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     expect(screen.getByText(/no key memories yet/i)).toBeInTheDocument();
   });
 
   it('shows Session Context empty state when no session memories', () => {
     render(
-      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} />
+      <MemoryTierTabs memories={[]} deleting={new Set()} onDelete={noop} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     fireEvent.click(screen.getByTestId('tab-session-context'));
     expect(screen.getByText(/no session context memories yet/i)).toBeInTheDocument();
@@ -130,7 +130,7 @@ describe('MemoryTierTabs', () => {
     const onDelete = vi.fn();
     const memory = buildMemory({ category: 'profile_fact' });
     render(
-      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={onDelete} />
+      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={onDelete} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     fireEvent.click(screen.getByTestId('delete-memory-memory-1'));
     expect(onDelete).toHaveBeenCalledWith(memory);
@@ -140,7 +140,7 @@ describe('MemoryTierTabs', () => {
     const onDelete = vi.fn();
     const memory = buildMemory({ category: 'relationship_context' });
     render(
-      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={onDelete} />
+      <MemoryTierTabs memories={[memory]} deleting={new Set()} onDelete={onDelete} deprioritizing={new Set()} onDeprioritize={noop} />
     );
     fireEvent.click(screen.getByTestId('tab-session-context'));
     fireEvent.click(screen.getByTestId('delete-memory-memory-1'));

--- a/apps/web/app/(protected)/dashboard/memory-export/page.tsx
+++ b/apps/web/app/(protected)/dashboard/memory-export/page.tsx
@@ -50,7 +50,7 @@ export default async function MemoryExportPage() {
     agentIds.length > 0
       ? await supabase
           .from('agent_memories')
-          .select('id, agent_id, key, value, category, is_public, created_at, updated_at')
+          .select('id, agent_id, key, value, category, is_public, priority, created_at, updated_at')
           .in('agent_id', agentIds)
           .order('created_at', { ascending: false })
       : { data: [] };
@@ -63,6 +63,7 @@ export default async function MemoryExportPage() {
     value: m.value as string,
     category: m.category as string,
     isPublic: Boolean(m.is_public),
+    priority: (m.priority as 'normal' | 'low' | undefined) ?? 'normal',
     createdAt: (m.created_at as string) ?? new Date().toISOString(),
     updatedAt: (m.updated_at as string) ?? (m.created_at as string) ?? new Date().toISOString(),
   }));

--- a/apps/web/app/api/v1/agents/me/memories/[id]/deprioritize/route.ts
+++ b/apps/web/app/api/v1/agents/me/memories/[id]/deprioritize/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { withDeveloperAuth } from '@/lib/auth/developer';
+
+function jsonError(code: string, message: string, status: number) {
+  return NextResponse.json({ success: false, error: { code, message } }, { status });
+}
+
+async function ensureOwnedAgent(agentId: string, developerId: string) {
+  const supabase = getSupabaseServiceClient();
+  const { data: agent, error } = await supabase
+    .from('agents')
+    .select('id, developer_id')
+    .eq('id', agentId)
+    .single();
+
+  if (error || !agent) {
+    return { error: jsonError('NOT_FOUND', 'Agent not found', 404) };
+  }
+
+  if (agent.developer_id !== developerId) {
+    return {
+      error: jsonError(
+        'FORBIDDEN',
+        'You can only edit memories for agents owned by this developer account',
+        403
+      ),
+    };
+  }
+
+  return { supabase };
+}
+
+export const PATCH = withDeveloperAuth(async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const developerId = req.headers.get('x-developer-id');
+
+  if (!developerId) {
+    return jsonError('UNAUTHORIZED', 'Not authenticated', 401);
+  }
+
+  const body = await req.json().catch(() => null);
+
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return jsonError('BAD_REQUEST', 'Invalid JSON body', 400);
+  }
+
+  const { agentId, deprioritized } = body as { agentId?: unknown; deprioritized?: unknown };
+
+  if (typeof agentId !== 'string' || !agentId) {
+    return jsonError('INVALID_INPUT', 'agentId is required', 400);
+  }
+
+  if (typeof deprioritized !== 'boolean') {
+    return jsonError('INVALID_INPUT', 'deprioritized must be a boolean', 400);
+  }
+
+  const ownership = await ensureOwnedAgent(agentId, developerId);
+  if (ownership.error) return ownership.error;
+
+  const { id } = await params;
+  const { data, error } = await ownership.supabase
+    .from('agent_memories')
+    .update({
+      priority: deprioritized ? 'low' : 'normal',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .eq('agent_id', agentId)
+    .select('id, agent_id, key, value, category, is_public, priority, created_at, updated_at')
+    .single();
+
+  if (error || !data) {
+    return jsonError('NOT_FOUND', 'Memory not found', 404);
+  }
+
+  return NextResponse.json({ success: true, data });
+});

--- a/apps/web/components/dashboard/MemoryExportDashboard.tsx
+++ b/apps/web/components/dashboard/MemoryExportDashboard.tsx
@@ -33,6 +33,7 @@ export interface MemoryExportRecord {
   value: string;
   category: string;
   isPublic: boolean;
+  priority?: 'normal' | 'low';
   createdAt: string;
   updatedAt: string;
 }
@@ -109,6 +110,37 @@ export function MemoryExportDashboard({ memories: initialMemories }: Props) {
   const [deleting, setDeleting] = useState<Set<string>>(new Set());
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deletionReceipt, setDeletionReceipt] = useState<MemoryDeletionReceiptData | null>(null);
+  const [deprioritizing, setDeprioritizing] = useState<Set<string>>(new Set());
+
+  async function handleDeprioritize(memory: MemoryExportRecord) {
+    setDeprioritizing((prev) => new Set(prev).add(memory.id));
+    const willBeDeprioritized = memory.priority !== 'low';
+    try {
+      await fetch(
+        `/api/v1/agents/me/memories/${memory.id}/deprioritize`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agentId: memory.agentId, deprioritized: willBeDeprioritized }),
+        }
+      );
+      setMemories((prev) =>
+        prev.map((m) =>
+          m.id === memory.id
+            ? { ...m, priority: willBeDeprioritized ? 'low' : 'normal' }
+            : m
+        )
+      );
+    } catch {
+      // best-effort: network errors are silently ignored for deprioritize
+    } finally {
+      setDeprioritizing((prev) => {
+        const next = new Set(prev);
+        next.delete(memory.id);
+        return next;
+      });
+    }
+  }
 
   async function handleDelete(memory: MemoryExportRecord) {
     setDeleting((prev) => new Set(prev).add(memory.id));
@@ -229,6 +261,8 @@ export function MemoryExportDashboard({ memories: initialMemories }: Props) {
           memories={memories}
           deleting={deleting}
           onDelete={handleDelete}
+          deprioritizing={deprioritizing}
+          onDeprioritize={handleDeprioritize}
         />
       </div>
 

--- a/apps/web/components/dashboard/MemoryTierTabs.tsx
+++ b/apps/web/components/dashboard/MemoryTierTabs.tsx
@@ -16,7 +16,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
-import { Loader2, Trash2 } from 'lucide-react';
+import { ChevronDown, ChevronUp, Loader2, Trash2 } from 'lucide-react';
 import type { MemoryExportRecord } from './MemoryExportDashboard';
 
 // Key Memories: long-term pinned facts that persist across sessions (Kindroid "Key Memories" tier)
@@ -46,10 +46,12 @@ interface MemoryListProps {
   memories: MemoryExportRecord[];
   deleting: Set<string>;
   onDelete: (memory: MemoryExportRecord) => void;
+  deprioritizing: Set<string>;
+  onDeprioritize: (memory: MemoryExportRecord) => void;
   emptyLabel: string;
 }
 
-function MemoryGroupList({ memories, deleting, onDelete, emptyLabel }: MemoryListProps) {
+function MemoryGroupList({ memories, deleting, onDelete, deprioritizing, onDeprioritize, emptyLabel }: MemoryListProps) {
   if (memories.length === 0) {
     return (
       <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
@@ -88,7 +90,7 @@ function MemoryGroupList({ memories, deleting, onDelete, emptyLabel }: MemoryLis
                 <div key={memory.id}>
                   {idx > 0 && <Separator />}
                   <div
-                    className="flex items-start justify-between gap-4 px-6 py-4"
+                    className={`flex items-start justify-between gap-4 px-6 py-4 transition-opacity${memory.priority === 'low' ? ' opacity-50' : ''}`}
                     data-testid={`memory-item-${memory.id}`}
                   >
                     <div className="flex-1 min-w-0 space-y-1">
@@ -111,6 +113,15 @@ function MemoryGroupList({ memories, deleting, onDelete, emptyLabel }: MemoryLis
                             Public
                           </Badge>
                         )}
+                        {memory.priority === 'low' && (
+                          <Badge
+                            variant="outline"
+                            className="text-[10px] h-5 shrink-0 text-muted-foreground"
+                            data-testid={`deprioritized-badge-${memory.id}`}
+                          >
+                            Low priority
+                          </Badge>
+                        )}
                       </div>
                       <p className="text-sm text-foreground break-words">
                         {memory.value}
@@ -122,21 +133,44 @@ function MemoryGroupList({ memories, deleting, onDelete, emptyLabel }: MemoryLis
                         Captured {formatDate(memory.createdAt)}
                       </p>
                     </div>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="shrink-0 text-muted-foreground hover:text-destructive"
-                      onClick={() => onDelete(memory)}
-                      disabled={deleting.has(memory.id)}
-                      aria-label={`Delete memory: ${memory.key}`}
-                      data-testid={`delete-memory-${memory.id}`}
-                    >
-                      {deleting.has(memory.id) ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <Trash2 className="h-4 w-4" />
-                      )}
-                    </Button>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-foreground"
+                        onClick={() => onDeprioritize(memory)}
+                        disabled={deprioritizing.has(memory.id)}
+                        aria-label={
+                          memory.priority === 'low'
+                            ? `Restore priority: ${memory.key}`
+                            : `Deprioritize: ${memory.key}`
+                        }
+                        data-testid={`deprioritize-memory-${memory.id}`}
+                      >
+                        {deprioritizing.has(memory.id) ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : memory.priority === 'low' ? (
+                          <ChevronUp className="h-4 w-4" />
+                        ) : (
+                          <ChevronDown className="h-4 w-4" />
+                        )}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-destructive"
+                        onClick={() => onDelete(memory)}
+                        disabled={deleting.has(memory.id)}
+                        aria-label={`Delete memory: ${memory.key}`}
+                        data-testid={`delete-memory-${memory.id}`}
+                      >
+                        {deleting.has(memory.id) ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </div>
                   </div>
                 </div>
               ))}
@@ -152,9 +186,11 @@ interface MemoryTierTabsProps {
   memories: MemoryExportRecord[];
   deleting: Set<string>;
   onDelete: (memory: MemoryExportRecord) => void;
+  deprioritizing: Set<string>;
+  onDeprioritize: (memory: MemoryExportRecord) => void;
 }
 
-export function MemoryTierTabs({ memories, deleting, onDelete }: MemoryTierTabsProps) {
+export function MemoryTierTabs({ memories, deleting, onDelete, deprioritizing, onDeprioritize }: MemoryTierTabsProps) {
   const keyMemories = memories.filter((m) => getMemoryTier(m) === 'long_term');
   const sessionMemories = memories.filter((m) => getMemoryTier(m) === 'session');
 
@@ -187,6 +223,8 @@ export function MemoryTierTabs({ memories, deleting, onDelete }: MemoryTierTabsP
           memories={keyMemories}
           deleting={deleting}
           onDelete={onDelete}
+          deprioritizing={deprioritizing}
+          onDeprioritize={onDeprioritize}
           emptyLabel="No key memories yet. Profile facts will appear here."
         />
       </TabsContent>
@@ -199,6 +237,8 @@ export function MemoryTierTabs({ memories, deleting, onDelete }: MemoryTierTabsP
           memories={sessionMemories}
           deleting={deleting}
           onDelete={onDelete}
+          deprioritizing={deprioritizing}
+          onDeprioritize={onDeprioritize}
           emptyLabel="No session context memories yet."
         />
       </TabsContent>

--- a/docs/pr-evidence/kindroid-per-entry-memory-deprioritize.md
+++ b/docs/pr-evidence/kindroid-per-entry-memory-deprioritize.md
@@ -1,0 +1,62 @@
+# PR Evidence: Kindroid Per-Entry Memory Deprioritize Parity
+
+## Feature
+Adds per-entry Deprioritize toggle to the Memory Dashboard, matching Kindroid 2026's individual memory importance-weight UX.
+
+## Before
+Memory Dashboard (`/dashboard/memory-export`) shows each memory with only a Delete button. No way to lower the importance of a specific memory without deleting it entirely.
+
+- `MemoryTierTabs` only had `deleting` / `onDelete` props
+- `MemoryExportRecord` type had no `priority` field
+- No deprioritize API endpoint existed
+
+## After
+Each memory entry now has a Deprioritize toggle (ChevronDown / ChevronUp icon):
+
+- **Normal priority**: ChevronDown button with `aria-label="Deprioritize: <key>"` — clicking sets `priority: 'low'`
+- **Low priority**: ChevronUp button with `aria-label="Restore priority: <key>"`, plus "Low priority" badge, plus `opacity-50` on the row for visual distinction
+- Toggle is optimistic: UI updates immediately, API call fires in background
+
+## Changes
+
+### New API Endpoint
+`apps/web/app/api/v1/agents/me/memories/[id]/deprioritize/route.ts`
+- `PATCH` handler that accepts `{ agentId: string, deprioritized: boolean }`
+- Sets `priority` to `'low'` or `'normal'` in `agent_memories` table
+- Protected by `withDeveloperAuth` (line 38 in that file)
+- Returns `{ success: true, data }` with updated memory record
+
+### Component Updates
+- `MemoryExportRecord` type: added `priority?: 'normal' | 'low'`
+- `MemoryExportDashboard`: added `deprioritizing: Set<string>`, `handleDeprioritize()`, passes new props to `MemoryTierTabs`
+- `MemoryTierTabs` / `MemoryGroupList`: new `deprioritizing` + `onDeprioritize` props; deprioritize button; "Low priority" badge; `opacity-50` on deprioritized rows
+
+### Page Update
+`apps/web/app/(protected)/dashboard/memory-export/page.tsx`
+- Supabase `select()` now includes `priority` column
+- Maps `priority` into `MemoryExportRecord`
+
+## Auth-only Proof
+
+`apps/web/app/api/v1/agents/me/memories/[id]/deprioritize/route.ts`:
+
+```typescript
+// line 38
+export const PATCH = withDeveloperAuth(async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const developerId = req.headers.get('x-developer-id');
+
+  if (!developerId) {
+    return jsonError('UNAUTHORIZED', 'Not authenticated', 401);
+  }
+  // ...
+  // ensureOwnedAgent() enforces developer owns the agent before writing
+```
+
+The `withDeveloperAuth` wrapper (defined in `apps/web/lib/auth/developer.ts`) validates the Supabase session, looks up `developer_members`, and injects `x-developer-id` into request headers. Without a valid authenticated developer session the handler never executes.
+
+## Tests
+- `apps/web/__tests__/components/memory-deprioritize.test.tsx` — 11 tests covering toggle UI, badge rendering, aria-labels, opacity class, optimistic updates, and API call payload
+- `apps/web/__tests__/api/memory-deprioritize.test.ts` — 6 tests covering priority=low, priority=normal, missing agentId, non-boolean deprioritized, cross-developer rejection, and UNAUTHORIZED path

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -88,6 +88,7 @@ export type Database = {
           id: string;
           is_public: boolean;
           key: string;
+          priority: string | null;
           updated_at: string;
           value: string;
         };
@@ -98,6 +99,7 @@ export type Database = {
           id?: string;
           is_public?: boolean;
           key: string;
+          priority?: string | null;
           updated_at?: string;
           value: string;
         };
@@ -108,6 +110,7 @@ export type Database = {
           id?: string;
           is_public?: boolean;
           key?: string;
+          priority?: string | null;
           updated_at?: string;
           value?: string;
         };


### PR DESCRIPTION
## Source
Source: backlog.md:279

## Summary
Add per-entry Deprioritize toggle to Memory Dashboard (PR #778 built view/delete; this adds per-entry importance-weight toggle matching Kindroid 2026 UX).

- New `PATCH /api/v1/agents/me/memories/[id]/deprioritize` endpoint protected by `withDeveloperAuth`; sets `priority='low'|'normal'` in `agent_memories` table
- `MemoryExportRecord` type gains optional `priority` field; page query now selects it
- `MemoryTierTabs` renders a ChevronDown (deprioritize) / ChevronUp (restore) button per memory item; deprioritized rows show "Low priority" badge + `opacity-50` visual dim
- Optimistic UI update in `MemoryExportDashboard` — toggle reflects immediately, API fires in background
- 17 new tests across component and API layers

## Evidence
docs/pr-evidence/kindroid-per-entry-memory-deprioritize.md

## Auth-only Proof
PATCH `/api/v1/agents/me/memories/[id]/deprioritize` is protected by `withDeveloperAuth` (see `apps/web/app/api/v1/agents/me/memories/[id]/deprioritize/route.ts` line 38). The middleware validates the Supabase session, resolves `developer_id` from `developer_members`, and injects `x-developer-id` — requests without a valid developer session return 401 before the handler body executes.