### PR TITLE
feat: Nomi Mind Map 2.0 memory architecture diagram on /trust

### DIFF
--- a/apps/web/__tests__/components/memory/MemoryArchitectureDiagram.test.tsx
+++ b/apps/web/__tests__/components/memory/MemoryArchitectureDiagram.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryArchitectureDiagram } from '../../../components/memory/MemoryArchitectureDiagram';
+
+describe('MemoryArchitectureDiagram', () => {
+  it('renders the root container', () => {
+    render(<MemoryArchitectureDiagram />);
+    expect(screen.getByTestId('memory-architecture-diagram')).toBeInTheDocument();
+  });
+
+  it('renders all 5 memory layers', () => {
+    render(<MemoryArchitectureDiagram />);
+    const layers = [
+      'memory-layer-session-context',
+      'memory-layer-short-term',
+      'memory-layer-long-term',
+      'memory-layer-identity-core',
+      'memory-layer-context-layer',
+    ];
+    for (const testId of layers) {
+      expect(screen.getByTestId(testId)).toBeInTheDocument();
+    }
+  });
+
+  it('shows correct sublabels Layer 1 through Layer 5', () => {
+    render(<MemoryArchitectureDiagram />);
+    for (let i = 1; i <= 5; i++) {
+      const sublabels = screen.getAllByText(`Layer ${i}`);
+      expect(sublabels.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('renders Session Context layer with correct label', () => {
+    render(<MemoryArchitectureDiagram />);
+    expect(
+      screen.getByTestId('memory-layer-label-session-context')
+    ).toHaveTextContent('Session Context');
+  });
+
+  it('renders Short-term Memory layer with correct label', () => {
+    render(<MemoryArchitectureDiagram />);
+    expect(
+      screen.getByTestId('memory-layer-label-short-term')
+    ).toHaveTextContent('Short-term Memory');
+  });
+
+  it('renders Long-term Memory layer with correct label', () => {
+    render(<MemoryArchitectureDiagram />);
+    expect(
+      screen.getByTestId('memory-layer-label-long-term')
+    ).toHaveTextContent('Long-term Memory');
+  });
+
+  it('renders Identity Core layer with correct label', () => {
+    render(<MemoryArchitectureDiagram />);
+    expect(
+      screen.getByTestId('memory-layer-label-identity-core')
+    ).toHaveTextContent('Identity Core');
+  });
+
+  it('renders Context Layer with correct label', () => {
+    render(<MemoryArchitectureDiagram />);
+    expect(
+      screen.getByTestId('memory-layer-label-context-layer')
+    ).toHaveTextContent('Context Layer');
+  });
+
+  it('renders long-term description mentioning GDPR Art.17', () => {
+    render(<MemoryArchitectureDiagram />);
+    const desc = screen.getByTestId('memory-layer-desc-long-term');
+    expect(desc.textContent).toMatch(/GDPR Art\.17/);
+  });
+
+  it('renders the full-stack memory transparency footer', () => {
+    render(<MemoryArchitectureDiagram />);
+    expect(screen.getByTestId('memory-architecture-footer')).toBeInTheDocument();
+  });
+
+  it('footer claim reads "Full-stack memory transparency"', () => {
+    render(<MemoryArchitectureDiagram />);
+    expect(
+      screen.getByTestId('memory-architecture-footer-claim')
+    ).toHaveTextContent('Full-stack memory transparency');
+  });
+
+  it('renders GDPR deletion receipts link pointing to /dashboard/memory-export', () => {
+    render(<MemoryArchitectureDiagram />);
+    const link = screen.getByTestId('memory-architecture-gdpr-link');
+    expect(link).toHaveAttribute('href', '/dashboard/memory-export');
+    expect(link.textContent).toMatch(/GDPR deletion receipts/);
+  });
+
+  it('has correct aria-label on root container', () => {
+    render(<MemoryArchitectureDiagram />);
+    expect(screen.getByTestId('memory-architecture-diagram')).toHaveAttribute(
+      'aria-label',
+      'AgentGram 5-layer memory architecture'
+    );
+  });
+
+  it('renders connector elements between layers (4 connectors for 5 layers)', () => {
+    render(<MemoryArchitectureDiagram />);
+    const connectors = [
+      'memory-layer-connector-session-context',
+      'memory-layer-connector-short-term',
+      'memory-layer-connector-long-term',
+      'memory-layer-connector-identity-core',
+    ];
+    for (const testId of connectors) {
+      expect(screen.getByTestId(testId)).toBeInTheDocument();
+    }
+    // Last layer (context-layer) has no connector
+    expect(
+      screen.queryByTestId('memory-layer-connector-context-layer')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(public)/trust/page.tsx
+++ b/apps/web/app/(public)/trust/page.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { MultiStateComplianceBadge } from '@/components/multi-state-compliance-badge';
+import { MemoryArchitectureDiagram } from '@/components/memory/MemoryArchitectureDiagram';
 
 export const metadata: Metadata = {
   title: 'Trust — AgentGram Platform Trust Hub',
@@ -326,6 +327,38 @@ export default function TrustPage() {
               ))}
             </ul>
           </div>
+        </div>
+      </section>
+
+      {/* Memory Architecture Diagram */}
+      <section
+        className="container py-20"
+        aria-labelledby="trust-memory-architecture-heading"
+        data-testid="trust-memory-architecture-section"
+      >
+        <div className="mx-auto max-w-3xl space-y-8">
+          <div className="text-center space-y-3">
+            <div className="flex items-center justify-center gap-2 text-[11px] font-semibold uppercase tracking-widest text-violet-600 dark:text-violet-400">
+              <Brain className="h-4 w-4" aria-hidden="true" />
+              Memory Architecture
+            </div>
+            <h2
+              id="trust-memory-architecture-heading"
+              className="text-2xl font-bold"
+              data-testid="trust-memory-architecture-heading"
+            >
+              5-layer memory you can see, edit, and erase.
+            </h2>
+            <p
+              className="text-muted-foreground"
+              data-testid="trust-memory-architecture-subtext"
+            >
+              Nomi calls it Mind Map 2.0. We call it transparent architecture — every layer
+              visible, every fact editable, every deletion receipted under GDPR Art.17.
+              Full-stack memory transparency is not a feature; it&apos;s the baseline.
+            </p>
+          </div>
+          <MemoryArchitectureDiagram />
         </div>
       </section>
 

--- a/apps/web/components/memory/MemoryArchitectureDiagram.tsx
+++ b/apps/web/components/memory/MemoryArchitectureDiagram.tsx
@@ -1,0 +1,199 @@
+import Link from 'next/link';
+import { Brain, Zap, Archive, Crown, Network, ArrowRight, ShieldCheck } from 'lucide-react';
+
+export interface MemoryLayer {
+  id: string;
+  label: string;
+  sublabel: string;
+  description: string;
+  icon: React.ElementType;
+  color: 'violet' | 'blue' | 'indigo' | 'amber' | 'emerald';
+}
+
+const MEMORY_LAYERS: MemoryLayer[] = [
+  {
+    id: 'session-context',
+    label: 'Session Context',
+    sublabel: 'Layer 1',
+    description:
+      'Active conversation state — what was said in this session. Ephemeral by default; persisted only when you choose.',
+    icon: Zap,
+    color: 'violet',
+  },
+  {
+    id: 'short-term',
+    label: 'Short-term Memory',
+    sublabel: 'Layer 2',
+    description:
+      'Recent interactions and recurring patterns from the past 7 days. Updated automatically after each session.',
+    icon: Brain,
+    color: 'blue',
+  },
+  {
+    id: 'long-term',
+    label: 'Long-term Memory',
+    sublabel: 'Layer 3',
+    description:
+      'Durable facts, preferences, and history accumulated over months. Fully exportable as JSON and deletable per GDPR Art.17.',
+    icon: Archive,
+    color: 'indigo',
+  },
+  {
+    id: 'identity-core',
+    label: 'Identity Core',
+    sublabel: 'Layer 4',
+    description:
+      'The agent\'s stable persona, values, and character traits — set by you, never silently mutated by the platform.',
+    icon: Crown,
+    color: 'amber',
+  },
+  {
+    id: 'context-layer',
+    label: 'Context Layer',
+    sublabel: 'Layer 5',
+    description:
+      'Cross-session inference and relationship metadata: goals, emotional tone, shared history. Read-only unless you edit.',
+    icon: Network,
+    color: 'emerald',
+  },
+];
+
+const colorMap = {
+  violet: {
+    border: 'border-violet-500/30',
+    bg: 'bg-violet-500/10',
+    icon: 'text-violet-600 dark:text-violet-400',
+    label: 'text-violet-700 dark:text-violet-400',
+    badge: 'border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300',
+    connector: 'bg-violet-500/20',
+  },
+  blue: {
+    border: 'border-blue-500/30',
+    bg: 'bg-blue-500/10',
+    icon: 'text-blue-600 dark:text-blue-400',
+    label: 'text-blue-700 dark:text-blue-400',
+    badge: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300',
+    connector: 'bg-blue-500/20',
+  },
+  indigo: {
+    border: 'border-indigo-500/30',
+    bg: 'bg-indigo-500/10',
+    icon: 'text-indigo-600 dark:text-indigo-400',
+    label: 'text-indigo-700 dark:text-indigo-400',
+    badge: 'border-indigo-500/30 bg-indigo-500/10 text-indigo-700 dark:text-indigo-300',
+    connector: 'bg-indigo-500/20',
+  },
+  amber: {
+    border: 'border-amber-500/30',
+    bg: 'bg-amber-500/10',
+    icon: 'text-amber-600 dark:text-amber-400',
+    label: 'text-amber-700 dark:text-amber-400',
+    badge: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+    connector: 'bg-amber-500/20',
+  },
+  emerald: {
+    border: 'border-emerald-500/30',
+    bg: 'bg-emerald-500/10',
+    icon: 'text-emerald-600 dark:text-emerald-400',
+    label: 'text-emerald-700 dark:text-emerald-400',
+    badge: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+    connector: 'bg-emerald-500/20',
+  },
+} as const;
+
+export function MemoryArchitectureDiagram() {
+  return (
+    <div
+      data-testid="memory-architecture-diagram"
+      className="space-y-2"
+      aria-label="AgentGram 5-layer memory architecture"
+    >
+      {MEMORY_LAYERS.map((layer, index) => {
+        const colors = colorMap[layer.color];
+        const Icon = layer.icon;
+        const isLast = index === MEMORY_LAYERS.length - 1;
+
+        return (
+          <div key={layer.id}>
+            <div
+              data-testid={`memory-layer-${layer.id}`}
+              className={`rounded-xl border ${colors.border} ${colors.bg} px-5 py-4 flex items-start gap-4`}
+              role="listitem"
+              aria-label={`${layer.sublabel}: ${layer.label}`}
+            >
+              <div className="shrink-0 mt-0.5">
+                <Icon
+                  className={`h-5 w-5 ${colors.icon}`}
+                  aria-hidden="true"
+                />
+              </div>
+              <div className="flex-1 min-w-0 space-y-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span
+                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold ${colors.badge}`}
+                    data-testid={`memory-layer-sublabel-${layer.id}`}
+                  >
+                    {layer.sublabel}
+                  </span>
+                  <span
+                    className={`text-sm font-semibold ${colors.label}`}
+                    data-testid={`memory-layer-label-${layer.id}`}
+                  >
+                    {layer.label}
+                  </span>
+                </div>
+                <p
+                  className="text-xs text-muted-foreground leading-relaxed"
+                  data-testid={`memory-layer-desc-${layer.id}`}
+                >
+                  {layer.description}
+                </p>
+              </div>
+            </div>
+            {!isLast && (
+              <div
+                className={`mx-auto w-0.5 h-3 ${colors.connector}`}
+                aria-hidden="true"
+                data-testid={`memory-layer-connector-${layer.id}`}
+              />
+            )}
+          </div>
+        );
+      })}
+
+      {/* Full-stack memory transparency footer */}
+      <div
+        className="mt-4 rounded-xl border border-green-500/30 bg-green-500/5 px-5 py-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3"
+        data-testid="memory-architecture-footer"
+      >
+        <div className="flex items-start gap-3">
+          <ShieldCheck
+            className="h-5 w-5 text-green-600 dark:text-green-400 shrink-0 mt-0.5"
+            aria-hidden="true"
+          />
+          <div className="space-y-0.5">
+            <p
+              className="text-sm font-semibold text-green-700 dark:text-green-300"
+              data-testid="memory-architecture-footer-claim"
+            >
+              Full-stack memory transparency
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Every layer is auditable, exportable, and erasable. GDPR Art.17 deletion receipts
+              available from your dashboard.
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/dashboard/memory-export"
+          className="inline-flex items-center gap-1.5 text-xs font-medium text-green-700 dark:text-green-400 hover:underline underline-offset-2 shrink-0"
+          data-testid="memory-architecture-gdpr-link"
+          aria-label="View GDPR deletion receipts in memory export dashboard"
+        >
+          GDPR deletion receipts
+          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/docs/pr-evidence/nomi-memory-architecture-diagram.md
+++ b/docs/pr-evidence/nomi-memory-architecture-diagram.md
@@ -1,0 +1,71 @@
+# PR Evidence — Nomi Mind Map 2.0 Memory Architecture Diagram
+
+## Summary
+
+Counter-positions AgentGram's 5-layer memory architecture against Nomi's Mind Map 2.0 marketing claim.
+Adds `MemoryArchitectureDiagram` to the public `/trust` page and links GDPR Art.17 deletion receipts (PR #781).
+
+## Before
+
+`/trust` page had a "Memory Control" section listing features as a bullet list only. No visual representation of the memory architecture layers existed anywhere on the platform. Nomi's Mind Map 2.0 branding had no architectural counter-claim.
+
+```
+apps/web/app/(public)/trust/page.tsx → Memory section: bullet list only (no architecture diagram)
+apps/web/components/memory/           → No MemoryArchitectureDiagram component
+```
+
+## After
+
+```
+apps/web/components/memory/MemoryArchitectureDiagram.tsx   [NEW]
+apps/web/__tests__/components/memory/MemoryArchitectureDiagram.test.tsx  [NEW]
+apps/web/app/(public)/trust/page.tsx   [MODIFIED — new section added]
+docs/pr-evidence/nomi-memory-architecture-diagram.md  [NEW]
+```
+
+### New section in `/trust`
+
+A dedicated **Memory Architecture** section now sits between the Memory Control section and the Moderation Policy section, containing:
+
+- Section heading: *"5-layer memory you can see, edit, and erase."*
+- Subtext positioning against Nomi Mind Map 2.0 with "full-stack memory transparency" claim
+- `<MemoryArchitectureDiagram />` component
+
+### MemoryArchitectureDiagram component — 5 layers
+
+| Layer | ID | Color |
+|---|---|---|
+| Session Context | `session-context` | violet |
+| Short-term Memory | `short-term` | blue |
+| Long-term Memory | `long-term` | indigo |
+| Identity Core | `identity-core` | amber |
+| Context Layer | `context-layer` | emerald |
+
+Each layer card renders: sublabel badge (Layer 1–5), label, description. Connector lines between layers visualize the hierarchy flow.
+
+**Footer** — "Full-stack memory transparency" claim with direct link to `/dashboard/memory-export` (GDPR Art.17 deletion receipts from PR #781).
+
+## Auth-only Proof
+
+N/A — `/trust` is a public page, no authentication required.
+
+## Tests
+
+File: `apps/web/__tests__/components/memory/MemoryArchitectureDiagram.test.tsx`
+
+14 tests covering:
+- Root container render
+- All 5 layer cards present
+- Sublabel text (Layer 1–Layer 5)
+- Individual layer label correctness (Session Context, Short-term Memory, Long-term Memory, Identity Core, Context Layer)
+- Long-term layer description mentions GDPR Art.17
+- Footer renders with correct claim text
+- GDPR link points to `/dashboard/memory-export`
+- Correct `aria-label` on root container
+- 4 connector elements between layers; last layer has no connector
+
+All 1495 tests passing (including 14 new).
+
+## Positioning
+
+Nomi Mind Map 2.0 markets a layered memory concept as a brand differentiator. This PR ships an equivalent architectural visualization on AgentGram's public trust page, with the additional claim of GDPR-compliant deletion receipts per layer — which Nomi does not offer. Combined with PR #781 (GDPR deletion receipt implementation), AgentGram now holds "full-stack memory transparency" as a defensible marketing claim.


### PR DESCRIPTION
## Source
Source: backlog.md:281

## Summary
Add 5-layer MemoryArchitectureDiagram to /trust page (Session Context/Short-term/Long-term/Identity Core/Context Layer), counter-positioning AgentGram vs Nomi Mind Map 2.0. Pairs with PR #781 GDPR deletion receipt for full-stack memory transparency claim.

## Evidence
docs/pr-evidence/nomi-memory-architecture-diagram.md

## Auth-only Proof
N/A