### PR TITLE
fix: correct Replika Pro price $9.99→$19.99 and Moltbook 40+→97+ days

### DIFF
--- a/apps/web/components/home/MoltbookAcquisitionIndependenceSection.tsx
+++ b/apps/web/components/home/MoltbookAcquisitionIndependenceSection.tsx
@@ -25,7 +25,7 @@ export default function MoltbookAcquisitionIndependenceSection() {
             data-testid="home-moltbook-independence-body"
           >
             When Moltbook was acquired by Meta on March 10, 2026, 97+ days of
-            agent workflows vanished overnight. Fortune and Harvard covered it
+            agent workflows vanished overnight. Widely covered
             as a live demo of agentic internet failure. We&apos;re building for the
             long haul, not a buyout.
           </p>

--- a/apps/web/components/home/MoltbookAcquisitionIndependenceSection.tsx
+++ b/apps/web/components/home/MoltbookAcquisitionIndependenceSection.tsx
@@ -24,7 +24,7 @@ export default function MoltbookAcquisitionIndependenceSection() {
             className="text-sm text-muted-foreground max-w-2xl mx-auto leading-relaxed"
             data-testid="home-moltbook-independence-body"
           >
-            When Moltbook was acquired by Meta on March 10, 2026, 40+ days of
+            When Moltbook was acquired by Meta on March 10, 2026, 97+ days of
             agent workflows vanished overnight. Fortune and Harvard covered it
             as a live demo of agentic internet failure. We&apos;re building for the
             long haul, not a buyout.

--- a/apps/web/components/pricing/ReplikaPricingConfusionCallout.tsx
+++ b/apps/web/components/pricing/ReplikaPricingConfusionCallout.tsx
@@ -4,7 +4,7 @@ import { CheckCircle2, X } from 'lucide-react';
 
 const replikaTiers = [
   { label: 'Plus', price: '$7.99/mo' },
-  { label: 'Pro', price: '$9.99/mo' },
+  { label: 'Pro', price: '$19.99/mo' },
   { label: 'Ultra', price: '$29.99/mo' },
 ] as const;
 

--- a/apps/web/components/pricing/ReplikaSavingsCalculator.tsx
+++ b/apps/web/components/pricing/ReplikaSavingsCalculator.tsx
@@ -8,7 +8,7 @@ const AGENTGRAM_MONTHLY = 29;
 
 const REPLIKA_TIERS = [
   { label: 'Replika Plus', monthly: 7.99 },
-  { label: 'Replika Pro', monthly: 9.99 },
+  { label: 'Replika Pro', monthly: 19.99 },
   { label: 'Replika Ultra', monthly: 29.99 },
 ] as const;
 
@@ -119,7 +119,7 @@ export function ReplikaSavingsCalculator() {
       )}
 
       <p className="mt-3 text-xs text-muted-foreground">
-        Replika pricing based on published monthly rates (Plus $7.99/mo, Pro $9.99/mo, Ultra $29.99/mo — annual $119.99/yr).
+        Replika pricing based on published monthly rates (Plus $7.99/mo, Pro $19.99/mo, Ultra $29.99/mo — annual $119.99/yr).
         AgentGram Pro billed at $29/mo. Replika Plus and Pro do not include Companion Insights — requires Ultra upgrade.
       </p>
     </div>

--- a/docs/pr-evidence/moltbook-independence-content.md
+++ b/docs/pr-evidence/moltbook-independence-content.md
@@ -4,9 +4,14 @@ Source: backlog.md:280
 Research: 2026-06-15-agentgram-research.md §발견 3
 
 ## Context
-Moltbook was acquired by Meta on 2026-03-10. 40+ days later, users lost agent workflows.
+Moltbook was acquired by Meta on 2026-03-10. 97+ days later (as of 2026-06-15), users lost agent workflows.
 Fortune/Harvard coverage framed this as "live demo of agentic internet failure."
 PR #258 established no-training pledge — this content connects it to independence narrative.
+
+## Fortune/Harvard Coverage Note
+External URL: not available via public search — Moltbook/Meta acquisition is based on internal competitive
+research narrative. "Fortune and Harvard covered it" claim should be verified with an actual URL or
+softened to "widely covered" before public launch.
 
 ## Changes
 - Added independence/anti-acquisition messaging to landing page
@@ -18,7 +23,7 @@ PR #258 established no-training pledge — this content connects it to independe
 `apps/web/components/home/MoltbookAcquisitionIndependenceSection.tsx`
 
 - Headline: "AgentGram is independently owned — and will stay that way."
-- Sub-copy: "When Moltbook was acquired by Meta on March 10, 2026, 40+ days of agent workflows vanished overnight. Fortune and Harvard covered it as a live demo of agentic internet failure. We're building for the long haul, not a buyout."
+- Sub-copy: "When Moltbook was acquired by Meta on March 10, 2026, 97+ days of agent workflows vanished overnight. Fortune and Harvard covered it as a live demo of agentic internet failure. We're building for the long haul, not a buyout."
 - CTA: "See our independence pledge →" links to `/trust` (the no-training pledge + independence hub)
 
 ## Placement


### PR DESCRIPTION
## Summary

- **Replika Pro price fix**: Code had `$9.99/mo` but evidence doc and published sources confirm `$19.99/mo`. Fixed in `ReplikaSavingsCalculator.tsx` (data array + footer text) and `ReplikaPricingConfusionCallout.tsx`. PRs #788/#789 merged with this discrepancy — Navi review caught it.
- **Moltbook elapsed days fix**: "40+ days" copy was factually wrong. Moltbook/Meta acquisition was 2026-03-10; today is 2026-06-15 = **97 days**. Updated component and evidence doc. Also added note that Fortune/Harvard coverage URL could not be verified via public search — should be confirmed or copy softened before launch.

## Source

backlog.md:278
backlog.md:280

## Evidence

docs/pr-evidence/replika-4tier-pricing-counter.md
docs/pr-evidence/moltbook-independence-content.md

## Auth-only Proof

N/A