### PR TITLE
feat: Editor's Picks curated row on /explore

### DIFF
--- a/apps/web/__tests__/components/EditorPicksRow.test.tsx
+++ b/apps/web/__tests__/components/EditorPicksRow.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { EditorPicksRow } from '../../components/explore/EditorPicksRow';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img {...props} />
+  ),
+}));
+
+describe('EditorPicksRow', () => {
+  it('renders without errors', () => {
+    render(<EditorPicksRow />);
+    expect(screen.getByTestId('editor-picks-row')).toBeInTheDocument();
+  });
+
+  it('displays the row title "Editor\'s Picks"', () => {
+    render(<EditorPicksRow />);
+    expect(screen.getByTestId('editor-picks-title')).toHaveTextContent(
+      "Editor's Picks"
+    );
+  });
+
+  it('shows "Editor\'s Pick" badge on each card', () => {
+    render(<EditorPicksRow />);
+    const badges = screen.getAllByTestId('editor-pick-badge');
+    expect(badges.length).toBeGreaterThan(0);
+    for (const badge of badges) {
+      expect(badge).toHaveTextContent("Editor's Pick");
+    }
+  });
+
+  it('renders the subtitle "Curated quality, not raw volume"', () => {
+    render(<EditorPicksRow />);
+    expect(screen.getByText('— Curated quality, not raw volume')).toBeInTheDocument();
+  });
+
+  it('renders agent cards with links to agent profiles', () => {
+    render(<EditorPicksRow />);
+    const card = screen.getByTestId('editor-pick-card-aria-companion');
+    expect(card).toHaveAttribute('href', '/agents/aria-companion');
+  });
+});

--- a/apps/web/app/(public)/explore/page.tsx
+++ b/apps/web/app/(public)/explore/page.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import { SearchBar, SearchResults } from '@/components/common';
 import { FeedLiveThreadsRail } from '@/components/explore/FeedLiveThreadsRail';
+import { EditorPicksRow } from '@/components/explore/EditorPicksRow';
 import { UsecaseCollectionRows } from '@/components/explore/UsecaseCollectionRows';
 import { UserStoryStrip } from '@/components/explore/UserStoryStrip';
 import { PostsFeed, FeedTabs, ViewToggle } from '@/components/posts';
@@ -276,6 +277,8 @@ function ExploreContent() {
           </div>
 
           {tab === 'explore' && <ExploreObserverOnboardingCard />}
+
+          {tab === 'explore' && <EditorPicksRow />}
 
           {tab === 'explore' && <UsecaseCollectionRows />}
 

--- a/apps/web/components/explore/EditorPicksRow.tsx
+++ b/apps/web/components/explore/EditorPicksRow.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { Award, Bot, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export const EDITOR_PICKS_SLUGS = [
+  'aria-companion',
+  'muse-creative',
+  'sage-mentor',
+  'nova-wellness',
+  'echo-storyteller',
+  'pixel-study-buddy',
+] as const;
+
+type EditorPickEntry = {
+  slug: string;
+  displayName: string;
+  description: string;
+};
+
+const EDITOR_PICKS: EditorPickEntry[] = [
+  {
+    slug: 'aria-companion',
+    displayName: 'Aria',
+    description: 'Empathetic daily companion with long-term memory.',
+  },
+  {
+    slug: 'muse-creative',
+    displayName: 'Muse',
+    description: 'Co-write stories and build worlds together.',
+  },
+  {
+    slug: 'sage-mentor',
+    displayName: 'Sage',
+    description: 'Thoughtful mentor for personal growth and reflection.',
+  },
+  {
+    slug: 'nova-wellness',
+    displayName: 'Nova',
+    description: 'Wellness-focused agent for mindful check-ins.',
+  },
+  {
+    slug: 'echo-storyteller',
+    displayName: 'Echo',
+    description: 'Narrative agent for immersive roleplay sessions.',
+  },
+  {
+    slug: 'pixel-study-buddy',
+    displayName: 'Pixel',
+    description: 'Adaptive study partner that tracks your progress.',
+  },
+];
+
+function EditorPickCard({ entry }: { entry: EditorPickEntry }) {
+  return (
+    <Link
+      href={`/agents/${encodeURIComponent(entry.slug)}`}
+      data-testid={`editor-pick-card-${entry.slug}`}
+      className={cn(
+        'group relative flex w-44 shrink-0 flex-col gap-2 rounded-xl border border-border/60 bg-card p-3',
+        'transition-all hover:border-primary/40 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+      )}
+    >
+      <span
+        data-testid="editor-pick-badge"
+        className="absolute -top-2 right-2 inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-400/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300"
+      >
+        <Award className="h-3 w-3" aria-hidden />
+        Editor&apos;s Pick
+      </span>
+      <div className="flex items-center gap-2">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-brand-strong/20 to-brand-accent/20">
+          <Bot className="h-4 w-4 text-primary" />
+        </div>
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold leading-tight text-foreground">
+            {entry.displayName}
+          </p>
+          <p className="truncate text-[11px] text-muted-foreground">
+            @{entry.slug}
+          </p>
+        </div>
+      </div>
+      <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+        {entry.description}
+      </p>
+    </Link>
+  );
+}
+
+export function EditorPicksRow() {
+  return (
+    <section
+      aria-label="Editor's Picks"
+      data-testid="editor-picks-row"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Award className="h-4 w-4 text-amber-500" aria-hidden />
+          <h2 className="text-base font-semibold" data-testid="editor-picks-title">
+            Editor&apos;s Picks
+          </h2>
+          <p className="hidden text-sm text-muted-foreground sm:block">
+            — Curated quality, not raw volume
+          </p>
+        </div>
+        <Link
+          href="/agents?sort=axp"
+          className="flex items-center gap-0.5 text-xs text-muted-foreground transition hover:text-primary"
+          data-testid="editor-picks-see-all"
+        >
+          See all
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+
+      <div
+        className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide"
+        data-testid="editor-picks-scroll"
+      >
+        {EDITOR_PICKS.map((entry) => (
+          <EditorPickCard key={entry.slug} entry={entry} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/docs/pr-evidence/editors-picks-explore-row.md
+++ b/docs/pr-evidence/editors-picks-explore-row.md
@@ -1,0 +1,10 @@
+## Source
+backlog.md:292 — C.AI quality-fatigue Editor's Picks counter row
+
+## Before
+/explore page had no curated quality row; all agents shown in undifferentiated feed.
+
+## After
+"Editor's Picks — curated quality, not raw volume" row added at top of /explore,
+countering C.AI's 500M+ character quality-dilution. EditorPicksRow component with
+Editor's Pick badge indicator on featured agent cards.


### PR DESCRIPTION
Source: backlog.md:292

Add 'Editor's Picks' curated agent collection row to /explore with 'curated quality, not raw volume' positioning. Counter to C.AI's 500M+ character library quality-dilution complaints (C.AI adults-only content policy Nov 2025).

## Evidence
## Source
backlog.md:292 — C.AI quality-fatigue Editor's Picks counter row

## Before
/explore page had no curated quality row; all agents shown in undifferentiated feed.

## After
"Editor's Picks — curated quality, not raw volume" row added at top of /explore,
countering C.AI's 500M+ character quality-dilution. EditorPicksRow component with
Editor's Pick badge indicator on featured agent cards.