### PR TITLE
feat: memory integrity guarantee badge (Kindroid drift counter)

### DIFF
--- a/apps/web/__tests__/components/MemoryIntegrityBadge.test.tsx
+++ b/apps/web/__tests__/components/MemoryIntegrityBadge.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryIntegrityBadge } from '../../components/shared/MemoryIntegrityBadge';
+
+describe('MemoryIntegrityBadge', () => {
+  it('renders without errors (compact variant by default)', () => {
+    render(<MemoryIntegrityBadge />);
+    expect(screen.getByTestId('memory-integrity-badge-compact')).toBeInTheDocument();
+  });
+
+  it('links to /trust', () => {
+    render(<MemoryIntegrityBadge />);
+    const link = screen.getByTestId('memory-integrity-badge-compact');
+    expect(link).toHaveAttribute('href', '/trust');
+  });
+
+  it('displays "Memory Integrity" badge text', () => {
+    render(<MemoryIntegrityBadge />);
+    expect(screen.getByText('Memory Integrity Guaranteed')).toBeInTheDocument();
+  });
+
+  describe('full variant', () => {
+    it('renders without errors', () => {
+      render(<MemoryIntegrityBadge variant="full" />);
+      expect(screen.getByTestId('memory-integrity-badge-full')).toBeInTheDocument();
+    });
+
+    it('link to /trust is present in full variant', () => {
+      render(<MemoryIntegrityBadge variant="full" />);
+      const link = screen.getByTestId('memory-integrity-badge-link');
+      expect(link).toHaveAttribute('href', '/trust');
+    });
+
+    it('displays "Memory Integrity" text in full variant', () => {
+      render(<MemoryIntegrityBadge variant="full" />);
+      expect(screen.getAllByText('Memory Integrity Guaranteed').length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -23,6 +23,7 @@ import FreeToStartStrip from '@/components/home/FreeToStartStrip';
 import { AvatarConsistencyGuaranteeStrip, AvatarConsistencyComparisonGallery } from '@/components/avatar-consistency-guarantee';
 import { FreeTrial7DayCTA } from '@/components/free-trial-cta';
 import { RepetitionFreeMemoryBadge } from '@/components/repetition-free-memory-badge';
+import { MemoryIntegrityBadge } from '@/components/shared/MemoryIntegrityBadge';
 
 function getPlans(billingEnabled: boolean) {
   return [
@@ -478,6 +479,15 @@ export default function PricingPage() {
               Always-on
             </span>
           </div>
+        </div>
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="pricing-memory-integrity-section"
+      >
+        <div className="mx-auto max-w-6xl">
+          <MemoryIntegrityBadge variant="full" />
         </div>
       </section>
 

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -23,6 +23,7 @@ import { getSeedBetweenSessionPosts } from '@/lib/agents/between-session-posts';
 import { LorebookMatchPreview } from '@/components/lorebook/LorebookMatchPreview';
 import { StoryRemixGallery } from '@/components/story/StoryRemixGallery';
 import { CommunityHandoffLinks } from './CommunityHandoffLinks';
+import { MemoryIntegrityBadge } from '@/components/shared/MemoryIntegrityBadge';
 
 interface ProfileContentProps {
   agent: Agent;
@@ -63,6 +64,9 @@ export function ProfileContent({
       <AiDisclosureBanner />
       <ProfileHeader agent={agent} />
       <ProofStrip agent={agent} />
+      <div className="mt-2 px-4">
+        <MemoryIntegrityBadge variant="compact" />
+      </div>
       {agent.communityLinks && (
         <div className="mt-3">
           <CommunityHandoffLinks links={agent.communityLinks} />

--- a/apps/web/components/shared/MemoryIntegrityBadge.tsx
+++ b/apps/web/components/shared/MemoryIntegrityBadge.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link';
+import { ShieldCheck } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface MemoryIntegrityBadgeProps {
+  variant?: 'compact' | 'full';
+  className?: string;
+}
+
+const TOOLTIP =
+  "Unlike Kindroid's Feb 2026 memory-drift incident (stored context reset unexpectedly), AgentGram guarantees stable memory across all sessions";
+
+export function MemoryIntegrityBadge({
+  variant = 'compact',
+  className,
+}: MemoryIntegrityBadgeProps) {
+  if (variant === 'full') {
+    return (
+      <section
+        className={cn(
+          'rounded-2xl border border-emerald-500/20 bg-emerald-500/5 px-6 py-5',
+          className
+        )}
+        aria-label="Memory Integrity Guarantee"
+        data-testid="memory-integrity-badge-full"
+      >
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-2">
+            <Link
+              href="/trust"
+              className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-700 hover:bg-emerald-500/20 dark:text-emerald-300"
+              title={TOOLTIP}
+              aria-label={TOOLTIP}
+              data-testid="memory-integrity-badge-link"
+            >
+              <ShieldCheck className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              Memory Integrity Guaranteed
+            </Link>
+            <p className="text-sm font-semibold text-foreground">
+              Memory that never drifts — guaranteed across every session
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Kindroid&apos;s documented Feb 2026 incident reset stored context
+              unexpectedly across user profiles (1.2M downloads signal). AgentGram
+              guarantees stable, drift-free memory across all sessions — no silent
+              resets, no lost context.
+            </p>
+          </div>
+          <Link
+            href="/trust"
+            className="shrink-0 rounded-full border border-emerald-500/30 bg-background px-4 py-1.5 text-xs font-semibold text-emerald-700 hover:bg-emerald-500/5 dark:text-emerald-300"
+          >
+            See our trust page →
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <Link
+      href="/trust"
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold text-emerald-700 hover:bg-emerald-500/20 dark:text-emerald-300',
+        className
+      )}
+      title={TOOLTIP}
+      aria-label={TOOLTIP}
+      data-testid="memory-integrity-badge-compact"
+    >
+      <ShieldCheck className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      Memory Integrity Guaranteed
+    </Link>
+  );
+}
+
+export default MemoryIntegrityBadge;

--- a/docs/pr-evidence/kindroid-memory-drift-integrity-badge.md
+++ b/docs/pr-evidence/kindroid-memory-drift-integrity-badge.md
@@ -1,0 +1,10 @@
+## Source
+backlog.md:293 — Kindroid memory-drift integrity badge
+
+## Before
+No memory stability guarantee visible on agent profiles or /pricing.
+
+## After
+MemoryIntegrityBadge component added to agent profile pages (compact) and /pricing 
+(full), linking to /trust. Counter to Kindroid Feb 2026 memory-drift incident. 
+Differentiates AgentGram memory stability (Kindroid 1.2M downloads signal).


### PR DESCRIPTION
Source: backlog.md:293

Add 'Memory Integrity Guaranteed' badge on agent profiles and /pricing linking to /trust. Counter to Kindroid's documented Feb 2026 memory-drift incident (stored context reset unexpectedly across user profiles; 1.2M downloads signal). Differentiates AgentGram memory stability.

## Evidence
## Source
backlog.md:293 — Kindroid memory-drift integrity badge

## Before
No memory stability guarantee visible on agent profiles or /pricing.

## After
MemoryIntegrityBadge component added to agent profile pages (compact) and /pricing 
(full), linking to /trust. Counter to Kindroid Feb 2026 memory-drift incident. 
Differentiates AgentGram memory stability (Kindroid 1.2M downloads signal).