### PR TITLE
feat: group-chat shareable invite link generator

### DIFF
--- a/apps/web/__tests__/components/ShareGroupChatButton.test.tsx
+++ b/apps/web/__tests__/components/ShareGroupChatButton.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { ShareGroupChatButton } from '../../components/group-chat/ShareGroupChatButton';
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined);
+
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: writeTextMock },
+  writable: true,
+});
+
+Object.defineProperty(window, 'location', {
+  value: { origin: 'https://agentgram.app' },
+  writable: true,
+});
+
+describe('ShareGroupChatButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders without errors', () => {
+    render(<ShareGroupChatButton agentIds={['nova', 'aria']} />);
+    expect(screen.getByTestId('share-group-chat-button')).toBeInTheDocument();
+  });
+
+  it('shows "Share invite link" label by default', () => {
+    render(<ShareGroupChatButton agentIds={['nova']} />);
+    expect(screen.getByTestId('share-group-chat-button')).toHaveTextContent(
+      'Share invite link'
+    );
+  });
+
+  it('copies a URL to clipboard when clicked', async () => {
+    render(<ShareGroupChatButton agentIds={['nova', 'aria']} />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('share-group-chat-button'));
+    });
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    const [copiedUrl] = writeTextMock.mock.calls[0] as [string];
+    expect(copiedUrl).toContain('https://agentgram.app/group-chat/invite/');
+  });
+
+  it('shows "Link copied!" feedback after click', async () => {
+    render(<ShareGroupChatButton agentIds={['nova']} />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('share-group-chat-button'));
+    });
+    expect(screen.getByTestId('share-group-chat-button')).toHaveTextContent(
+      'Link copied!'
+    );
+  });
+
+  it('reverts to original label after 2 seconds', async () => {
+    vi.useFakeTimers();
+    render(<ShareGroupChatButton agentIds={['nova']} />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('share-group-chat-button'));
+    });
+    expect(screen.getByTestId('share-group-chat-button')).toHaveTextContent(
+      'Link copied!'
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(2001);
+    });
+    expect(screen.getByTestId('share-group-chat-button')).toHaveTextContent(
+      'Share invite link'
+    );
+  });
+});

--- a/apps/web/__tests__/lib/group-chat-invite.test.ts
+++ b/apps/web/__tests__/lib/group-chat-invite.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateGroupChatInviteToken,
+  parseGroupChatInviteToken,
+} from '@/lib/group-chat-invite';
+
+describe('generateGroupChatInviteToken', () => {
+  it('returns a non-empty string', () => {
+    const token = generateGroupChatInviteToken({ agentIds: ['nova', 'aria'] });
+    expect(typeof token).toBe('string');
+    expect(token.length).toBeGreaterThan(0);
+  });
+
+  it('produces a URL-safe token with no +, /, or = characters', () => {
+    const token = generateGroupChatInviteToken({ agentIds: ['atlas', 'echo'] });
+    expect(token).not.toMatch(/[+/=]/);
+  });
+});
+
+describe('parseGroupChatInviteToken', () => {
+  it('correctly round-trips a token with agentIds only', () => {
+    const config = { agentIds: ['nova', 'aria'] };
+    const token = generateGroupChatInviteToken(config);
+    const parsed = parseGroupChatInviteToken(token);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.agentIds).toEqual(['nova', 'aria']);
+  });
+
+  it('correctly round-trips a token that includes sessionName', () => {
+    const config = { agentIds: ['atlas', 'zara'], sessionName: 'Friday fun' };
+    const token = generateGroupChatInviteToken(config);
+    const parsed = parseGroupChatInviteToken(token);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.agentIds).toEqual(['atlas', 'zara']);
+    expect(parsed!.sessionName).toBe('Friday fun');
+  });
+
+  it('returns null for an invalid token', () => {
+    expect(parseGroupChatInviteToken('not-a-valid-token!!!')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseGroupChatInviteToken('')).toBeNull();
+  });
+
+  it('handles single-agent arrays', () => {
+    const config = { agentIds: ['solo'] };
+    const token = generateGroupChatInviteToken(config);
+    const parsed = parseGroupChatInviteToken(token);
+    expect(parsed!.agentIds).toEqual(['solo']);
+  });
+});

--- a/apps/web/app/group-chat/invite/[token]/page.tsx
+++ b/apps/web/app/group-chat/invite/[token]/page.tsx
@@ -1,0 +1,102 @@
+import Link from 'next/link';
+import { Users, Bot, AlertCircle } from 'lucide-react';
+import { parseGroupChatInviteToken } from '@/lib/group-chat-invite';
+
+interface InvitePageProps {
+  params: Promise<{ token: string }>;
+}
+
+export default async function GroupChatInvitePage({ params }: InvitePageProps) {
+  const { token } = await params;
+  const config = parseGroupChatInviteToken(token);
+
+  if (!config) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center px-4">
+        <div
+          className="flex max-w-md flex-col items-center gap-4 rounded-2xl border border-destructive/20 bg-destructive/5 p-8 text-center"
+          data-testid="invite-error-state"
+        >
+          <AlertCircle className="h-10 w-10 text-destructive" />
+          <h1 className="text-xl font-semibold">Invalid invite link</h1>
+          <p className="text-sm text-muted-foreground">
+            This invite link is invalid or has expired. Ask the sender to generate a new one.
+          </p>
+          <Link
+            href="/"
+            className="mt-2 rounded-full border border-border/70 bg-background px-5 py-2 text-sm font-medium transition hover:bg-muted/30"
+          >
+            Go home
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const { agentIds, sessionName } = config;
+
+  const companionParams = new URLSearchParams({
+    starter: 'group_chat',
+  });
+  if (agentIds.length > 0) {
+    companionParams.set('companions', agentIds.join(','));
+  }
+  const joinHref = `/dashboard/onboard?${companionParams.toString()}`;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center px-4">
+      <div
+        className="flex max-w-md flex-col items-center gap-6 rounded-2xl border border-border/60 bg-background p-8 text-center shadow-sm"
+        data-testid="invite-landing"
+      >
+        <div className="flex h-14 w-14 items-center justify-center rounded-full border border-primary/20 bg-primary/5">
+          <Users className="h-7 w-7 text-primary" />
+        </div>
+
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold">
+            {sessionName
+              ? `Join "${sessionName}"`
+              : "You've been invited to a group chat"}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            A pre-configured multi-companion session is ready for you to join.
+          </p>
+        </div>
+
+        {agentIds.length > 0 && (
+          <div
+            className="w-full space-y-2"
+            data-testid="invite-agent-list"
+          >
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Companions in this chat
+            </p>
+            <ul className="space-y-1.5">
+              {agentIds.map((id) => (
+                <li
+                  key={id}
+                  className="flex items-center gap-2 rounded-lg border border-border/50 bg-muted/20 px-3 py-2"
+                  data-testid={`invite-agent-${id}`}
+                >
+                  <div className="flex h-7 w-7 items-center justify-center rounded-full border border-border/50 bg-muted">
+                    <Bot className="h-3.5 w-3.5 text-muted-foreground" />
+                  </div>
+                  <span className="text-sm font-medium">@{id}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <Link
+          href={joinHref}
+          className="w-full rounded-full bg-primary px-6 py-3 text-center text-sm font-semibold text-primary-foreground transition hover:bg-primary/90"
+          data-testid="invite-join-cta"
+        >
+          Join this group chat
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/agents/StartGroupChatButton.tsx
+++ b/apps/web/components/agents/StartGroupChatButton.tsx
@@ -19,6 +19,7 @@ import { useAgents } from '@/hooks/use-agents';
 import { useSearch } from '@/hooks/use-search';
 import { GroupMemoryIsolationPreview } from './GroupMemoryIsolationPreview';
 import { GroupMemoryInspector } from '@/components/chat/GroupMemoryInspector';
+import { ShareGroupChatButton } from '@/components/group-chat/ShareGroupChatButton';
 import {
   buildParticipantScopes,
   type RawMemoryItem,
@@ -331,6 +332,11 @@ export function StartGroupChatButton({
             >
               메모리 미리보기
             </Button>
+            {selected.length > 0 && (
+              <ShareGroupChatButton
+                agentIds={[anchorAgentName, ...selected.map((a) => a.name)]}
+              />
+            )}
             <Button variant="outline" onClick={() => handleClose(false)}>
               Cancel
             </Button>

--- a/apps/web/components/group-chat/ShareGroupChatButton.tsx
+++ b/apps/web/components/group-chat/ShareGroupChatButton.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Share2 } from 'lucide-react';
+import { generateGroupChatInviteToken } from '@/lib/group-chat-invite';
+
+interface ShareGroupChatButtonProps {
+  agentIds: string[];
+  sessionName?: string;
+}
+
+export function ShareGroupChatButton({ agentIds, sessionName }: ShareGroupChatButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = useCallback(async () => {
+    const token = generateGroupChatInviteToken({ agentIds, sessionName });
+    const url = `${window.location.origin}/group-chat/invite/${token}`;
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [agentIds, sessionName]);
+
+  return (
+    <button
+      type="button"
+      className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background px-3 py-2 text-sm font-medium text-muted-foreground transition hover:border-primary/20 hover:bg-muted/30 hover:text-foreground"
+      onClick={handleShare}
+      data-testid="share-group-chat-button"
+      aria-label="Copy invite link for this group chat setup"
+    >
+      <Share2 className="h-3.5 w-3.5" />
+      {copied ? 'Link copied!' : 'Share invite link'}
+    </button>
+  );
+}

--- a/apps/web/lib/group-chat-invite.ts
+++ b/apps/web/lib/group-chat-invite.ts
@@ -1,0 +1,31 @@
+interface GroupChatConfig {
+  agentIds: string[];
+  sessionName?: string;
+}
+
+export function generateGroupChatInviteToken(groupConfig: GroupChatConfig): string {
+  const json = JSON.stringify({
+    agentIds: groupConfig.agentIds,
+    ...(groupConfig.sessionName ? { sessionName: groupConfig.sessionName } : {}),
+  });
+  return btoa(json).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function parseGroupChatInviteToken(token: string): GroupChatConfig | null {
+  try {
+    const padded = token.replace(/-/g, '+').replace(/_/g, '/');
+    const padding = (4 - (padded.length % 4)) % 4;
+    const base64 = padded + '='.repeat(padding);
+    const json = atob(base64);
+    const parsed = JSON.parse(json);
+    if (!Array.isArray(parsed.agentIds)) return null;
+    return {
+      agentIds: parsed.agentIds,
+      ...(typeof parsed.sessionName === 'string'
+        ? { sessionName: parsed.sessionName }
+        : {}),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/docs/pr-evidence/group-chat-shareable-invite-link.md
+++ b/docs/pr-evidence/group-chat-shareable-invite-link.md
@@ -1,0 +1,12 @@
+## Source
+backlog.md:294 — Group-chat shareable invite link
+
+## Before
+Group chat setup (PR #683) had no way to share the configuration externally.
+
+## After
+ShareGroupChatButton generates shareable /group-chat/invite/[token] URL. 
+Invite landing page shows group composition preview + Join CTA. 
+Drives organic viral sharing of multi-companion setups.
+Complements PR #683 (group chat CTA) + PR #692 (memory isolation preview).
+Counter to Moltbook's pure-bot viral model post-Meta acquisition.


### PR DESCRIPTION
Source: backlog.md:294

Add shareable pre-configured multi-companion session invite URL generator. Users can share group-chat setups via /group-chat/invite/[token], driving organic viral loops. Complements PR #683 group chat CTA + PR #692 memory isolation preview. Counter to Moltbook's pure-bot viral model post-Meta acquisition; Nomi multi-companion 2026 headline feature parity.

## Evidence

## Source
backlog.md:294 — Group-chat shareable invite link

## Before
Group chat setup (PR #683) had no way to share the configuration externally.

## After
ShareGroupChatButton generates shareable /group-chat/invite/[token] URL.
Invite landing page shows group composition preview + Join CTA.
Drives organic viral sharing of multi-companion setups.
Complements PR #683 (group chat CTA) + PR #692 (memory isolation preview).
Counter to Moltbook's pure-bot viral model post-Meta acquisition.

## Tests
12 new tests (all passing): 7 for `group-chat-invite.ts` utility (round-trip, URL-safety, edge cases) + 5 for `ShareGroupChatButton` (render, label, clipboard copy, "Link copied!" feedback, 2s revert).