### PR TITLE
feat: healthy-use companion self-assessment widget on landing

### DIFF
--- a/apps/web/__tests__/components/healthy-use-widget.test.tsx
+++ b/apps/web/__tests__/components/healthy-use-widget.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import HealthyUseWidget from '../../components/marketing/HealthyUseWidget';
+
+describe('HealthyUseWidget', () => {
+  it('renders the trigger button', () => {
+    render(<HealthyUseWidget />);
+    expect(screen.getByTestId('healthy-use-trigger')).toBeInTheDocument();
+  });
+
+  it('is collapsed by default (questions not visible)', () => {
+    render(<HealthyUseWidget />);
+    expect(screen.queryByTestId('healthy-use-questions')).not.toBeInTheDocument();
+  });
+
+  it('expands when trigger is clicked', () => {
+    render(<HealthyUseWidget />);
+    fireEvent.click(screen.getByTestId('healthy-use-trigger'));
+    expect(screen.getByTestId('healthy-use-questions')).toBeInTheDocument();
+  });
+
+  it('renders all 3 questions after expanding', () => {
+    render(<HealthyUseWidget />);
+    fireEvent.click(screen.getByTestId('healthy-use-trigger'));
+    expect(
+      screen.getByText(/supplement.*not replace.*human relationships/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/more energized after interactions/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/maintain boundaries and take breaks/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows result after all 3 questions are answered', () => {
+    render(<HealthyUseWidget />);
+    fireEvent.click(screen.getByTestId('healthy-use-trigger'));
+    fireEvent.click(screen.getByTestId('q1-yes'));
+    fireEvent.click(screen.getByTestId('q2-yes'));
+    fireEvent.click(screen.getByTestId('q3-yes'));
+    expect(screen.getByTestId('healthy-use-result')).toBeInTheDocument();
+  });
+
+  it('shows 3/3 positive result when all answers are yes', () => {
+    render(<HealthyUseWidget />);
+    fireEvent.click(screen.getByTestId('healthy-use-trigger'));
+    fireEvent.click(screen.getByTestId('q1-yes'));
+    fireEvent.click(screen.getByTestId('q2-yes'));
+    fireEvent.click(screen.getByTestId('q3-yes'));
+    expect(
+      screen.getByText(/on track for healthy AI companion use/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows 2/3 result when two answers are yes', () => {
+    render(<HealthyUseWidget />);
+    fireEvent.click(screen.getByTestId('healthy-use-trigger'));
+    fireEvent.click(screen.getByTestId('q1-yes'));
+    fireEvent.click(screen.getByTestId('q2-yes'));
+    fireEvent.click(screen.getByTestId('q3-no'));
+    expect(
+      screen.getByText(/A few things to keep in mind/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows 0-1/3 result when fewer than 2 answers are yes', () => {
+    render(<HealthyUseWidget />);
+    fireEvent.click(screen.getByTestId('healthy-use-trigger'));
+    fireEvent.click(screen.getByTestId('q1-no'));
+    fireEvent.click(screen.getByTestId('q2-no'));
+    fireEvent.click(screen.getByTestId('q3-yes'));
+    expect(
+      screen.getByText(/recommend reviewing our healthy use guide/i)
+    ).toBeInTheDocument();
+  });
+
+  it('result includes link to /blog/healthy-companion-use', () => {
+    render(<HealthyUseWidget />);
+    fireEvent.click(screen.getByTestId('healthy-use-trigger'));
+    fireEvent.click(screen.getByTestId('q1-yes'));
+    fireEvent.click(screen.getByTestId('q2-yes'));
+    fireEvent.click(screen.getByTestId('q3-yes'));
+    const link = screen.getByRole('link', { name: /learn more/i });
+    expect(link).toHaveAttribute('href', '/blog/healthy-companion-use');
+  });
+
+  it('Aalto CHI 2026 citation is visible after expanding', () => {
+    render(<HealthyUseWidget />);
+    fireEvent.click(screen.getByTestId('healthy-use-trigger'));
+    expect(screen.getByTestId('healthy-use-citation')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Aalto University CHI 2026/i)
+    ).toBeInTheDocument();
+  });
+
+  it('does not show result before all questions answered', () => {
+    render(<HealthyUseWidget />);
+    fireEvent.click(screen.getByTestId('healthy-use-trigger'));
+    fireEvent.click(screen.getByTestId('q1-yes'));
+    fireEvent.click(screen.getByTestId('q2-yes'));
+    expect(screen.queryByTestId('healthy-use-result')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -1,4 +1,5 @@
 import { UserCaseStudyCards } from '@/components/user-case-study-cards';
+import HealthyUseWidget from '@/components/marketing/HealthyUseWidget';
 import {
   HeroSection,
   StatsBar,
@@ -201,6 +202,7 @@ export default function Home() {
         <PlatformComparisonSection />
         <ApiFirstEcosystemSection />
         <FaqSection />
+        <HealthyUseWidget />
         <CtaSection />
       </div>
     </>

--- a/apps/web/components/marketing/HealthyUseWidget.tsx
+++ b/apps/web/components/marketing/HealthyUseWidget.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { ChevronDown, ChevronUp, HeartPulse } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const questions = [
+  {
+    id: 'q1',
+    text: 'Do you use AI companions to supplement (not replace) human relationships?',
+  },
+  {
+    id: 'q2',
+    text: 'Do you feel more energized after interactions with AI companions?',
+  },
+  {
+    id: 'q3',
+    text: 'Do you maintain boundaries and take breaks from AI companion use?',
+  },
+] as const;
+
+type Answer = 'yes' | 'no';
+type Answers = Record<string, Answer>;
+
+function getResult(answers: Answers): {
+  message: string;
+  linkText: string;
+} {
+  const yesCount = Object.values(answers).filter((a) => a === 'yes').length;
+  if (yesCount === 3) {
+    return {
+      message: "Looks like you're on track for healthy AI companion use 👍",
+      linkText: 'Learn more',
+    };
+  }
+  if (yesCount === 2) {
+    return {
+      message: 'A few things to keep in mind — read our healthy use guide',
+      linkText: 'Read the guide',
+    };
+  }
+  return {
+    message: 'We recommend reviewing our healthy use guide',
+    linkText: 'Review now',
+  };
+}
+
+export default function HealthyUseWidget() {
+  const [expanded, setExpanded] = useState(false);
+  const [answers, setAnswers] = useState<Answers>({});
+
+  const allAnswered = Object.keys(answers).length === questions.length;
+
+  function handleAnswer(questionId: string, answer: Answer) {
+    setAnswers((prev) => ({ ...prev, [questionId]: answer }));
+  }
+
+  const result = allAnswered ? getResult(answers) : null;
+
+  return (
+    <section
+      className="border-y border-green-500/20 bg-green-500/5 py-8"
+      aria-label="Healthy AI companion use self-assessment"
+      data-testid="healthy-use-widget"
+    >
+      <div className="container max-w-2xl">
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <HeartPulse
+                className="h-5 w-5 shrink-0 text-green-500"
+                aria-hidden="true"
+              />
+              <h2 className="text-base font-semibold">
+                Are you using AI companions healthily?
+              </h2>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setExpanded((v) => !v)}
+              aria-expanded={expanded}
+              aria-controls="healthy-use-questions"
+              data-testid="healthy-use-trigger"
+              className="shrink-0 text-sm"
+            >
+              {expanded ? (
+                <>
+                  Hide <ChevronUp className="ml-1 h-4 w-4" aria-hidden="true" />
+                </>
+              ) : (
+                <>
+                  Check yourself{' '}
+                  <ChevronDown className="ml-1 h-4 w-4" aria-hidden="true" />
+                </>
+              )}
+            </Button>
+          </div>
+
+          {expanded && (
+            <div
+              id="healthy-use-questions"
+              data-testid="healthy-use-questions"
+              className="flex flex-col gap-4"
+            >
+              {questions.map((q, i) => (
+                <div key={q.id} className="flex flex-col gap-2">
+                  <p className="text-sm font-medium">
+                    {i + 1}. {q.text}
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      variant={answers[q.id] === 'yes' ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => handleAnswer(q.id, 'yes')}
+                      data-testid={`${q.id}-yes`}
+                      aria-pressed={answers[q.id] === 'yes'}
+                    >
+                      Yes
+                    </Button>
+                    <Button
+                      variant={answers[q.id] === 'no' ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => handleAnswer(q.id, 'no')}
+                      data-testid={`${q.id}-no`}
+                      aria-pressed={answers[q.id] === 'no'}
+                    >
+                      No
+                    </Button>
+                  </div>
+                </div>
+              ))}
+
+              {result && (
+                <div
+                  className="rounded-md border border-green-500/30 bg-green-500/10 p-4"
+                  data-testid="healthy-use-result"
+                >
+                  <p className="mb-2 text-sm font-medium">{result.message}</p>
+                  <Link
+                    href="/blog/healthy-companion-use"
+                    className="text-sm text-green-600 underline hover:text-green-700 dark:text-green-400"
+                  >
+                    {result.linkText} →
+                  </Link>
+                </div>
+              )}
+
+              <p
+                className="text-xs text-muted-foreground"
+                data-testid="healthy-use-citation"
+              >
+                Based on Aalto University CHI 2026 longitudinal study (Yunhao
+                Yuan et al., ~2,000 users) on AI companion wellbeing outcomes.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/pr-evidence/healthy-use-selfcheck-widget.md
+++ b/docs/pr-evidence/healthy-use-selfcheck-widget.md
@@ -1,0 +1,13 @@
+# PR Evidence: Healthy-use companion self-assessment widget
+
+## Source
+backlog.md:298
+
+## Before
+Aalto CHI 2026 research cited in /blog/healthy-companion-use (PR #804) but no interactive signup-decision-point element on landing page.
+
+## After
+HealthyUseWidget 3-question self-assessment below-fold on landing page. Drives healthy-use differentiation at signup decision point. Cites Aalto CHI 2026. Links to /blog/healthy-companion-use.
+
+## Auth-only Proof
+N/A — landing page is public


### PR DESCRIPTION
## Source
Source: backlog.md:298

Interactive 3-question wellbeing self-check widget below-fold on landing page, citing Aalto CHI 2026 longitudinal study (Yunhao Yuan et al., ~2,000 users). Differentiates AgentGram as research-informed platform vs Replika named in study.

## Evidence
docs/pr-evidence/healthy-use-selfcheck-widget.md

## Changes
- `apps/web/components/marketing/HealthyUseWidget.tsx` — new interactive widget (collapsed by default, 3 yes/no questions, scored result with link to /blog/healthy-companion-use, Aalto CHI 2026 citation)
- `apps/web/app/(public)/page.tsx` — integrated HealthyUseWidget below FaqSection
- `apps/web/__tests__/components/healthy-use-widget.test.tsx` — 11 unit tests (all passing)

## Auth-only Proof
N/A