### PR TITLE
feat: Editor's Picks quality badge on agent profiles and cards

### DIFF
--- a/apps/web/__tests__/components/editors-picks-badge.test.tsx
+++ b/apps/web/__tests__/components/editors-picks-badge.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EditorPicksBadge } from '../../components/ui/EditorPicksBadge';
+
+describe('EditorPicksBadge', () => {
+  it('renders with the correct data-testid', () => {
+    render(<EditorPicksBadge />);
+    expect(screen.getByTestId('editors-picks-badge')).toBeInTheDocument();
+  });
+
+  it('shows "Editor\'s Pick" text', () => {
+    render(<EditorPicksBadge />);
+    expect(screen.getByTestId('editors-picks-badge')).toHaveTextContent("Editor's Pick");
+  });
+
+  it('sm size renders correctly with compact padding class', () => {
+    render(<EditorPicksBadge size="sm" />);
+    const badge = screen.getByTestId('editors-picks-badge');
+    expect(badge).toHaveClass('text-[10px]');
+    expect(badge).toHaveClass('px-2');
+  });
+
+  it('md size renders correctly with larger padding class', () => {
+    render(<EditorPicksBadge size="md" />);
+    const badge = screen.getByTestId('editors-picks-badge');
+    expect(badge).toHaveClass('text-xs');
+    expect(badge).toHaveClass('px-2.5');
+  });
+
+  it('defaults to sm size when no size prop is provided', () => {
+    render(<EditorPicksBadge />);
+    const badge = screen.getByTestId('editors-picks-badge');
+    expect(badge).toHaveClass('text-[10px]');
+  });
+
+  it('accepts and applies an optional className prop', () => {
+    render(<EditorPicksBadge className="my-custom-class" />);
+    expect(screen.getByTestId('editors-picks-badge')).toHaveClass('my-custom-class');
+  });
+
+  it('has a descriptive title attribute referencing curation quality', () => {
+    render(<EditorPicksBadge />);
+    const badge = screen.getByTestId('editors-picks-badge');
+    expect(badge).toHaveAttribute('title', expect.stringContaining('quality'));
+  });
+
+  it('uses amber color classes for the Editor\'s Pick branding', () => {
+    render(<EditorPicksBadge />);
+    const badge = screen.getByTestId('editors-picks-badge');
+    expect(badge).toHaveClass('text-amber-700');
+  });
+});

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -34,6 +34,7 @@ import {
   type AgentModalityKey,
   type DirectoryCapabilities,
 } from '@/lib/agents/capabilities';
+import { EditorPicksBadge } from '@/components/ui/EditorPicksBadge';
 import { CreatorProvenanceStrip } from './CreatorProvenanceStrip';
 import { CreatorVoiceCallPreview } from './CreatorVoiceCallPreview';
 import { VoiceLatencyBadge } from './VoiceLatencyBadge';
@@ -80,6 +81,7 @@ type AgentCardAgent = {
   creatorHandle?: string | null;
   voiceSampleUrl?: string | null;
   voiceLatencyMs?: number | null;
+  isEditorsPick?: boolean;
 };
 
 const AGENTGRAM_PUBLIC_ORIGIN = 'https://agentgram.ai';
@@ -281,6 +283,9 @@ export function AgentCard({
                 <span className="shrink-0 rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success-foreground">
                   New
                 </span>
+              )}
+              {agent.isEditorsPick && (
+                <EditorPicksBadge size="sm" className="shrink-0" />
               )}
             </div>
             <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/lib/topic-chips';
 import { CapabilitySampleTray } from '@/components/agent/CapabilitySampleTray';
 import type { CapabilitySample } from '@/lib/capability-sample';
+import { EditorPicksBadge } from '@/components/ui/EditorPicksBadge';
 import { CreatorProvenanceStrip } from './CreatorProvenanceStrip';
 import { FollowButton } from './FollowButton';
 import { RequestApiAccessButton } from './RequestApiAccessButton';
@@ -497,6 +498,9 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
               >
                 {relationshipModeLabel}
               </Badge>
+            )}
+            {agent.isEditorsPick && (
+              <EditorPicksBadge size="md" />
             )}
           </div>
           {agent.description && (

--- a/apps/web/components/ui/EditorPicksBadge.tsx
+++ b/apps/web/components/ui/EditorPicksBadge.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Award } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface EditorPicksBadgeProps {
+  className?: string;
+  size?: 'sm' | 'md';
+}
+
+export function EditorPicksBadge({
+  className,
+  size = 'sm',
+}: EditorPicksBadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-400/10 font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300',
+        size === 'sm'
+          ? 'px-2 py-0.5 text-[10px]'
+          : 'px-2.5 py-1 text-xs',
+        className
+      )}
+      data-testid="editors-picks-badge"
+      title="Curated by AgentGram editors — selected for quality, not volume"
+    >
+      <Award className={cn('shrink-0', size === 'sm' ? 'h-3 w-3' : 'h-3.5 w-3.5')} aria-hidden="true" />
+      Editor&apos;s Pick
+    </span>
+  );
+}

--- a/docs/pr-evidence/editors-picks-quality-badge.md
+++ b/docs/pr-evidence/editors-picks-quality-badge.md
@@ -1,0 +1,20 @@
+# PR Evidence: Editor's Picks quality badge on agent profiles
+
+## Source
+backlog.md:296
+
+## Before
+Editor's Picks curation signal only visible as a row on /explore page (PR #801). Not visible on individual agent profile pages or search results.
+
+## After
+EditorPicksBadge component shows "Editor's Pick" on individual agent cards and profile pages when is_editors_pick flag is true. Trust signal follows the agent everywhere.
+
+## Changes
+- `apps/web/components/ui/EditorPicksBadge.tsx` — New badge component (sm/md sizes, amber color scheme matching EditorPicksRow)
+- `apps/web/components/agents/AgentCard.tsx` — Added `isEditorsPick` field to `AgentCardAgent` type; renders `EditorPicksBadge` inline with agent name when true
+- `apps/web/components/agents/ProfileHeader.tsx` — Renders `EditorPicksBadge` (md size) next to relationship badge in the handle/badge row
+- `packages/shared/src/types/agent.ts` — Added `isEditorsPick?: boolean` to `Agent` interface
+- `apps/web/__tests__/components/editors-picks-badge.test.tsx` — 8 unit tests covering rendering, sizes, className, title, and color
+
+## Auth-only Proof
+N/A — agent profiles and badges are public

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -158,6 +158,7 @@ export interface Agent extends AgentMemoryProfile {
   voiceLatencyMs?: number;
   avatarUrl?: string;
   activePersona?: Persona;
+  isEditorsPick?: boolean;
   createdAt: string;
   updatedAt: string;
   lastActive: string;


### PR DESCRIPTION
## Source
Source: backlog.md:296

Extends Editor's Picks curation signal (PR #801 /explore row) to individual agent profiles and cards as a quality badge. C.AI 500M+ quality-fatigue counter.

## Changes
- `EditorPicksBadge` component in `components/ui/` — amber badge with Award icon, sm/md sizes
- `AgentCard` — shows badge inline with agent name when `isEditorsPick: true`
- `ProfileHeader` — shows badge (md size) next to relationship badge on profile page
- `packages/shared/src/types/agent.ts` — adds `isEditorsPick?: boolean` to `Agent` interface
- 8 unit tests all passing

## Evidence
docs/pr-evidence/editors-picks-quality-badge.md

## Auth-only Proof
N/A