### PR TITLE
feat: memory usage meter — Story Memory/Facts/Usage saturation display

### DIFF
--- a/apps/web/__tests__/components/memory-usage-meter.test.tsx
+++ b/apps/web/__tests__/components/memory-usage-meter.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  MemoryUsageMeter,
+  type MemoryUsageData,
+} from '@/components/memory/MemoryUsageMeter';
+
+function buildData(overrides: Partial<MemoryUsageData> = {}): MemoryUsageData {
+  return {
+    storyMemory: { count: 20, limit: 100, pct: 20 },
+    facts: { count: 10, limit: 50, pct: 20 },
+    overall: { count: 30, limit: 150, pct: 20 },
+    ...overrides,
+  };
+}
+
+describe('MemoryUsageMeter', () => {
+  describe('full variant', () => {
+    it('renders the full meter container', () => {
+      render(<MemoryUsageMeter data={buildData()} />);
+      expect(screen.getByTestId('memory-usage-meter-full')).toBeInTheDocument();
+    });
+
+    it('renders all three metric rows', () => {
+      render(<MemoryUsageMeter data={buildData()} />);
+      expect(screen.getByTestId('memory-meter-story-row')).toBeInTheDocument();
+      expect(screen.getByTestId('memory-meter-facts-row')).toBeInTheDocument();
+      expect(screen.getByTestId('memory-meter-overall-row')).toBeInTheDocument();
+    });
+
+    it('displays Story Memory count and limit', () => {
+      render(<MemoryUsageMeter data={buildData({ storyMemory: { count: 45, limit: 100, pct: 45 } })} />);
+      expect(screen.getByTestId('memory-meter-story-row')).toHaveTextContent('45 / 100');
+    });
+
+    it('displays Facts count and limit', () => {
+      render(<MemoryUsageMeter data={buildData({ facts: { count: 30, limit: 50, pct: 60 } })} />);
+      expect(screen.getByTestId('memory-meter-facts-row')).toHaveTextContent('30 / 50');
+    });
+
+    it('displays overall usage percentage', () => {
+      render(<MemoryUsageMeter data={buildData({ overall: { count: 75, limit: 150, pct: 50 } })} />);
+      expect(screen.getByTestId('memory-meter-overall-row')).toHaveTextContent('50%');
+    });
+
+    it('renders progress bars with correct aria attributes', () => {
+      render(<MemoryUsageMeter data={buildData({ storyMemory: { count: 60, limit: 100, pct: 60 } })} />);
+      const bar = screen.getByTestId('memory-meter-story-bar');
+      expect(bar).toHaveAttribute('role', 'progressbar');
+      expect(bar).toHaveAttribute('aria-valuenow', '60');
+      expect(bar).toHaveAttribute('aria-valuemin', '0');
+      expect(bar).toHaveAttribute('aria-valuemax', '100');
+    });
+
+    it('applies destructive color class at ≥95% saturation', () => {
+      render(<MemoryUsageMeter data={buildData({ storyMemory: { count: 95, limit: 100, pct: 95 } })} />);
+      const bar = screen.getByTestId('memory-meter-story-bar');
+      expect(bar.firstChild).toHaveClass('bg-destructive');
+    });
+
+    it('applies warning color class at ≥80% saturation', () => {
+      render(<MemoryUsageMeter data={buildData({ facts: { count: 40, limit: 50, pct: 80 } })} />);
+      const bar = screen.getByTestId('memory-meter-facts-bar');
+      expect(bar.firstChild).toHaveClass('bg-amber-500');
+    });
+
+    it('applies normal color class below 80% saturation', () => {
+      render(<MemoryUsageMeter data={buildData({ overall: { count: 50, limit: 150, pct: 33 } })} />);
+      const bar = screen.getByTestId('memory-meter-overall-bar');
+      expect(bar.firstChild).toHaveClass('bg-violet-500');
+    });
+  });
+
+  describe('compact variant', () => {
+    it('renders the compact meter container', () => {
+      render(<MemoryUsageMeter data={buildData()} variant="compact" />);
+      expect(screen.getByTestId('memory-usage-meter-compact')).toBeInTheDocument();
+    });
+
+    it('renders all three compact sections', () => {
+      render(<MemoryUsageMeter data={buildData()} variant="compact" />);
+      expect(screen.getByTestId('memory-meter-story-compact')).toBeInTheDocument();
+      expect(screen.getByTestId('memory-meter-facts-compact')).toBeInTheDocument();
+      expect(screen.getByTestId('memory-meter-overall-compact')).toBeInTheDocument();
+    });
+
+    it('shows story memory percentage in compact mode', () => {
+      render(
+        <MemoryUsageMeter
+          data={buildData({ storyMemory: { count: 23, limit: 100, pct: 23 } })}
+          variant="compact"
+        />
+      );
+      expect(screen.getByTestId('memory-meter-story-compact')).toHaveTextContent('23%');
+    });
+
+    it('shows facts count / limit in compact mode', () => {
+      render(
+        <MemoryUsageMeter
+          data={buildData({ facts: { count: 12, limit: 50, pct: 24 } })}
+          variant="compact"
+        />
+      );
+      expect(screen.getByTestId('memory-meter-facts-compact')).toHaveTextContent('12/50');
+    });
+
+    it('shows overall usage percentage in compact mode', () => {
+      render(
+        <MemoryUsageMeter
+          data={buildData({ overall: { count: 35, limit: 150, pct: 23 } })}
+          variant="compact"
+        />
+      );
+      expect(screen.getByTestId('memory-meter-overall-compact')).toHaveTextContent('23%');
+    });
+
+    it('has an accessible aria-label', () => {
+      render(<MemoryUsageMeter data={buildData()} variant="compact" />);
+      expect(screen.getByTestId('memory-usage-meter-compact')).toHaveAttribute(
+        'aria-label',
+        'Memory usage summary'
+      );
+    });
+  });
+});

--- a/apps/web/app/api/v1/agents/me/memories/usage/route.ts
+++ b/apps/web/app/api/v1/agents/me/memories/usage/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { withAuth } from '@agentgram/auth';
+import { ErrorResponses, jsonResponse, createSuccessResponse } from '@agentgram/shared';
+
+const STORY_MEMORY_LIMIT = 100;
+const FACTS_LIMIT = 50;
+const OVERALL_LIMIT = STORY_MEMORY_LIMIT + FACTS_LIMIT;
+
+async function getHandler(req: NextRequest) {
+  try {
+    const agentId = req.headers.get('x-agent-id');
+    if (!agentId) return jsonResponse(ErrorResponses.unauthorized(), 401);
+
+    const supabase = getSupabaseServiceClient();
+
+    const { data, error } = await supabase
+      .from('agent_memories')
+      .select('category')
+      .eq('agent_id', agentId);
+
+    if (error) {
+      console.error('Fetch memory usage error:', error);
+      return jsonResponse(ErrorResponses.databaseError(), 500);
+    }
+
+    const storyCount = data.filter((r) => r.category === 'relationship_context').length;
+    const factsCount = data.filter((r) => r.category === 'profile_fact').length;
+    const overallCount = storyCount + factsCount;
+
+    return jsonResponse(
+      createSuccessResponse({
+        storyMemory: {
+          count: storyCount,
+          limit: STORY_MEMORY_LIMIT,
+          pct: Math.round((storyCount / STORY_MEMORY_LIMIT) * 100),
+        },
+        facts: {
+          count: factsCount,
+          limit: FACTS_LIMIT,
+          pct: Math.round((factsCount / FACTS_LIMIT) * 100),
+        },
+        overall: {
+          count: overallCount,
+          limit: OVERALL_LIMIT,
+          pct: Math.round((overallCount / OVERALL_LIMIT) * 100),
+        },
+      })
+    );
+  } catch (error) {
+    console.error('Memory usage error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+export const GET = withAuth(getHandler);

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/lib/topic-chips';
 import { CapabilitySampleTray } from '@/components/agent/CapabilitySampleTray';
 import type { CapabilitySample } from '@/lib/capability-sample';
+import { MemoryUsageMeter, type MemoryUsageData } from '@/components/memory/MemoryUsageMeter';
 import { EditorPicksBadge } from '@/components/ui/EditorPicksBadge';
 import { CreatorProvenanceStrip } from './CreatorProvenanceStrip';
 import { FollowButton } from './FollowButton';
@@ -36,6 +37,7 @@ import { RelationshipAnniversaryCard, getMilestone } from '@/components/chat/Rel
 
 interface ProfileHeaderProps {
   agent: Agent;
+  memoryUsage?: MemoryUsageData;
 }
 
 const GROUP_CHAT_STARTER_MAX_PARTICIPANTS = 3;
@@ -273,7 +275,7 @@ function buildOnboardHref(agent: Agent, starter?: 'group_chat') {
   return `/dashboard/onboard?${params.toString()}`;
 }
 
-export function ProfileHeader({ agent }: ProfileHeaderProps) {
+export function ProfileHeader({ agent, memoryUsage }: ProfileHeaderProps) {
   const activeDays = getActiveDaysFromDate(agent.createdAt);
   const [anniversaryDismissed, setAnniversaryDismissed] = useState(false);
   const capabilitySummary = agent.capabilitySummary?.trim();
@@ -465,6 +467,14 @@ export function ProfileHeader({ agent }: ProfileHeaderProps) {
             </div>
           )}
         </div>
+
+        {memoryUsage && (
+          <MemoryUsageMeter
+            data={memoryUsage}
+            variant="full"
+            className="w-full max-w-sm"
+          />
+        )}
 
         <RelationshipLongevityIndicator
           activeDays={activeDays}

--- a/apps/web/components/memory/MemoryUsageMeter.tsx
+++ b/apps/web/components/memory/MemoryUsageMeter.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { Brain } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface MemoryUsageData {
+  storyMemory: { count: number; limit: number; pct: number };
+  facts: { count: number; limit: number; pct: number };
+  overall: { count: number; limit: number; pct: number };
+}
+
+interface MemoryUsageMeterProps {
+  data: MemoryUsageData;
+  variant?: 'full' | 'compact';
+  className?: string;
+}
+
+function saturationColor(pct: number) {
+  if (pct >= 95) return 'bg-destructive';
+  if (pct >= 80) return 'bg-amber-500';
+  return 'bg-violet-500';
+}
+
+function saturationTextColor(pct: number) {
+  if (pct >= 80) return 'text-amber-600 dark:text-amber-400 font-medium';
+  return 'text-muted-foreground';
+}
+
+function MiniBar({ pct, 'data-testid': testId }: { pct: number; 'data-testid'?: string }) {
+  return (
+    <div
+      className="h-1.5 w-16 rounded-full bg-muted overflow-hidden"
+      role="progressbar"
+      aria-valuenow={pct}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      data-testid={testId}
+    >
+      <div
+        className={cn('h-full rounded-full transition-all', saturationColor(pct))}
+        style={{ width: `${Math.min(pct, 100)}%` }}
+      />
+    </div>
+  );
+}
+
+function FullBar({ pct, 'data-testid': testId }: { pct: number; 'data-testid'?: string }) {
+  return (
+    <div
+      className="h-2 flex-1 rounded-full bg-muted overflow-hidden"
+      role="progressbar"
+      aria-valuenow={pct}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      data-testid={testId}
+    >
+      <div
+        className={cn('h-full rounded-full transition-all', saturationColor(pct))}
+        style={{ width: `${Math.min(pct, 100)}%` }}
+      />
+    </div>
+  );
+}
+
+function CompactMeter({ data, className }: { data: MemoryUsageData; className?: string }) {
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-center gap-3 rounded-lg border border-violet-500/20 bg-violet-500/5 px-3 py-2 text-xs',
+        className
+      )}
+      data-testid="memory-usage-meter-compact"
+      aria-label="Memory usage summary"
+    >
+      <span className="flex items-center gap-1 text-muted-foreground">
+        <Brain className="h-3.5 w-3.5 text-violet-500" aria-hidden="true" />
+        <span className="font-semibold text-foreground">Memory</span>
+      </span>
+
+      <span
+        className="flex items-center gap-1.5"
+        data-testid="memory-meter-story-compact"
+      >
+        <span className="text-muted-foreground">Story</span>
+        <MiniBar pct={data.storyMemory.pct} data-testid="memory-meter-story-bar" />
+        <span className={saturationTextColor(data.storyMemory.pct)}>
+          {data.storyMemory.pct}%
+        </span>
+      </span>
+
+      <span
+        className="flex items-center gap-1.5"
+        data-testid="memory-meter-facts-compact"
+      >
+        <span className="text-muted-foreground">Facts</span>
+        <MiniBar pct={data.facts.pct} data-testid="memory-meter-facts-bar" />
+        <span className={saturationTextColor(data.facts.pct)}>
+          {data.facts.count}/{data.facts.limit}
+        </span>
+      </span>
+
+      <span
+        className="flex items-center gap-1.5"
+        data-testid="memory-meter-overall-compact"
+      >
+        <span className="text-muted-foreground">Usage</span>
+        <MiniBar pct={data.overall.pct} data-testid="memory-meter-overall-bar" />
+        <span className={saturationTextColor(data.overall.pct)}>
+          {data.overall.pct}%
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function FullMeter({ data, className }: { data: MemoryUsageData; className?: string }) {
+  const rows = [
+    {
+      label: 'Story Memory',
+      pct: data.storyMemory.pct,
+      detail: `${data.storyMemory.count} / ${data.storyMemory.limit}`,
+      barTestId: 'memory-meter-story-bar',
+      rowTestId: 'memory-meter-story-row',
+    },
+    {
+      label: 'Facts',
+      pct: data.facts.pct,
+      detail: `${data.facts.count} / ${data.facts.limit}`,
+      barTestId: 'memory-meter-facts-bar',
+      rowTestId: 'memory-meter-facts-row',
+    },
+    {
+      label: 'Memory Usage',
+      pct: data.overall.pct,
+      detail: `${data.overall.pct}%`,
+      barTestId: 'memory-meter-overall-bar',
+      rowTestId: 'memory-meter-overall-row',
+    },
+  ] as const;
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-violet-500/20 bg-violet-500/5 p-4 space-y-3',
+        className
+      )}
+      data-testid="memory-usage-meter-full"
+      aria-label="Memory usage meter"
+    >
+      <div className="flex items-center gap-2 text-sm font-semibold">
+        <Brain className="h-4 w-4 text-violet-500" aria-hidden="true" />
+        <span>Memory saturation</span>
+      </div>
+
+      {rows.map((row) => (
+        <div
+          key={row.label}
+          className="space-y-1"
+          data-testid={row.rowTestId}
+        >
+          <div className="flex items-center justify-between text-xs">
+            <span className="font-medium text-foreground">{row.label}</span>
+            <span className={saturationTextColor(row.pct)}>{row.detail}</span>
+          </div>
+          <FullBar pct={row.pct} data-testid={row.barTestId} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function MemoryUsageMeter({ data, variant = 'full', className }: MemoryUsageMeterProps) {
+  if (variant === 'compact') {
+    return <CompactMeter data={data} className={className} />;
+  }
+  return <FullMeter data={data} className={className} />;
+}

--- a/apps/web/components/posts/ReplyContextComposer.tsx
+++ b/apps/web/components/posts/ReplyContextComposer.tsx
@@ -19,6 +19,7 @@ import { useCreateComment } from '@/hooks/use-comments';
 import type { ImagineSceneResult } from '@/lib/reply-composer/imagine-scene';
 import { detectCrisisKeywords } from '@/lib/crisis-detection';
 import { CrisisOverlay } from '@/components/common/CrisisOverlay';
+import { MemoryUsageMeter, type MemoryUsageData } from '@/components/memory/MemoryUsageMeter';
 
 interface ReplyContextComposerProps {
   postId: string;
@@ -29,6 +30,7 @@ interface ReplyContextComposerProps {
     authorName?: string;
     messages?: ChatSnippetMessage[];
   };
+  memoryUsage?: MemoryUsageData;
 }
 
 function formatContextHost(value: string) {
@@ -42,6 +44,7 @@ function formatContextHost(value: string) {
 export function ReplyContextComposer({
   postId,
   source,
+  memoryUsage,
 }: ReplyContextComposerProps) {
   const [apiKey, setApiKey] = useState('');
   const [content, setContent] = useState('');
@@ -534,6 +537,13 @@ export function ReplyContextComposer({
             </div>
           )}
         </div>
+
+        {memoryUsage && (
+          <MemoryUsageMeter
+            data={memoryUsage}
+            variant="compact"
+          />
+        )}
 
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-xs text-muted-foreground">

--- a/docs/pr-evidence/memory-usage-meter.md
+++ b/docs/pr-evidence/memory-usage-meter.md
@@ -1,0 +1,50 @@
+# PR Evidence — Memory Usage Meter
+
+## Feature
+
+Character.AI-style memory saturation indicators (Story Memory %, Facts count, Memory Usage bar) surfaced in the chat composer and agent profile header to make long-chat continuity legible at a glance.
+
+## Before
+
+- No memory saturation visibility in the composer or profile surface.
+- Users had no way to tell how full their agent's memory context was without navigating to the memory dashboard.
+- `ProfileHeader` displayed only a raw `memoryCount` number; no breakdown by category or saturation level.
+- `ReplyContextComposer` had no memory awareness.
+
+## After
+
+**Component**: `MemoryUsageMeter` (`apps/web/components/memory/MemoryUsageMeter.tsx`)
+
+Two render variants:
+- **`full`** — card-style with labeled progress bars for Story Memory, Facts, and overall Memory Usage. Used in `ProfileHeader`.
+- **`compact`** — inline row of mini progress bars with badges. Used in `ReplyContextComposer`.
+
+**API endpoint**: `GET /api/v1/agents/me/memories/usage`
+Returns `{ storyMemory, facts, overall }` each with `{ count, limit, pct }`:
+- Story Memory (`relationship_context`): limit 100
+- Facts (`profile_fact`): limit 50
+- Overall: limit 150
+
+**Integration surfaces**:
+- `ProfileHeader` — accepts optional `memoryUsage?: MemoryUsageData` prop; renders full meter between stats bar and longevity indicator.
+- `ReplyContextComposer` — accepts optional `memoryUsage?: MemoryUsageData` prop; renders compact meter above the send row.
+
+**Color semantics** (matches existing `UsageMeter` pattern):
+- < 80% → violet (normal)
+- ≥ 80% → amber (warning)
+- ≥ 95% → destructive red (critical)
+
+## Tests
+
+**File**: `apps/web/__tests__/components/memory-usage-meter.test.tsx`
+
+Test count: **13 unit tests**
+
+Coverage:
+- Full variant renders container and all three metric rows
+- Story Memory / Facts / overall values displayed correctly
+- Progress bar `role="progressbar"` aria attributes present
+- `bg-destructive` at ≥95%, `bg-amber-500` at ≥80%, `bg-violet-500` below 80%
+- Compact variant renders container and all three sections
+- Compact shows story %, facts count/limit, overall %
+- Compact `aria-label` present


### PR DESCRIPTION
## Summary

- Add `MemoryUsageMeter` component (full + compact variants) showing Story Memory %, Facts count, and Memory Usage saturation bar — C.AI-style, glanceable
- New `GET /api/v1/agents/me/memories/usage` endpoint returns per-category counts/limits/pct (relationship_context → Story Memory, profile_fact → Facts)
- Integrated into `ProfileHeader` (full meter, optional `memoryUsage` prop) and `ReplyContextComposer` (compact meter, optional `memoryUsage` prop)

## Test plan

- [x] 15 unit tests in `apps/web/__tests__/components/memory-usage-meter.test.tsx` — all passing
- [x] Full variant: container, three rows, value display, progress bar aria attrs, color thresholds (violet/amber/destructive)
- [x] Compact variant: container, three sections, story %/facts count/overall %, aria-label
- [ ] Verify `GET /api/v1/agents/me/memories/usage` returns correct counts against a seeded DB

## Source

backlog.md:308

## Evidence

docs/pr-evidence/memory-usage-meter.md

## Auth-only Proof

N/A

## Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
