### PR TITLE
feat: Replika-style starter strip + post-reply thumbs feedback

### DIFF
--- a/apps/web/__tests__/components/reply-feedback.test.tsx
+++ b/apps/web/__tests__/components/reply-feedback.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReplyFeedback } from '../../components/chat/ReplyFeedback';
+
+const fetchMock = vi.fn();
+
+describe('ReplyFeedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('renders thumbs up and thumbs down buttons', () => {
+    render(<ReplyFeedback postId="post-1" messageIndex={0} />);
+
+    expect(screen.getByTestId('reply-feedback-thumbs-up')).toBeInTheDocument();
+    expect(screen.getByTestId('reply-feedback-thumbs-down')).toBeInTheDocument();
+  });
+
+  it('fires a POST to the feedback API when thumbs up is clicked', async () => {
+    render(<ReplyFeedback postId="post-42" messageIndex={2} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reply-feedback-thumbs-up'));
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/posts/post-42/reply-feedback',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messageIndex: 2, vote: 'up' }),
+      })
+    );
+  });
+
+  it('disables both buttons after a vote is cast', async () => {
+    render(<ReplyFeedback postId="post-1" messageIndex={0} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reply-feedback-thumbs-down'));
+    });
+
+    expect(screen.getByTestId('reply-feedback-thumbs-up')).toBeDisabled();
+    expect(screen.getByTestId('reply-feedback-thumbs-down')).toBeDisabled();
+  });
+
+  it('fires a POST with vote=down when thumbs down is clicked', async () => {
+    render(<ReplyFeedback postId="post-7" messageIndex={1} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reply-feedback-thumbs-down'));
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/posts/post-7/reply-feedback',
+      expect.objectContaining({
+        body: JSON.stringify({ messageIndex: 1, vote: 'down' }),
+      })
+    );
+  });
+});

--- a/apps/web/__tests__/components/starter-prompt-strip.test.tsx
+++ b/apps/web/__tests__/components/starter-prompt-strip.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { StarterPromptStrip } from '../../components/chat/StarterPromptStrip';
+
+describe('StarterPromptStrip', () => {
+  it('renders 5 starter prompt chips', () => {
+    render(<StarterPromptStrip onSelect={vi.fn()} />);
+
+    const chips = screen.getAllByTestId('starter-prompt-chip');
+    expect(chips).toHaveLength(5);
+  });
+
+  it('calls onSelect with the chip label when clicked', () => {
+    const onSelect = vi.fn();
+    render(<StarterPromptStrip onSelect={onSelect} />);
+
+    const chips = screen.getAllByTestId('starter-prompt-chip');
+    fireEvent.click(chips[0]);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith("Tell me about your day");
+  });
+
+  it('calls onSelect with the correct prompt for each chip', () => {
+    const onSelect = vi.fn();
+    render(<StarterPromptStrip onSelect={onSelect} />);
+
+    const chips = screen.getAllByTestId('starter-prompt-chip');
+    fireEvent.click(chips[1]);
+
+    expect(onSelect).toHaveBeenCalledWith("Help me brainstorm");
+  });
+
+  it('renders with aria-label for accessibility', () => {
+    render(<StarterPromptStrip onSelect={vi.fn()} />);
+
+    expect(screen.getByLabelText('Starter prompts')).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/chat/ReplyFeedback.tsx
+++ b/apps/web/components/chat/ReplyFeedback.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import { ThumbsDown, ThumbsUp } from 'lucide-react';
+
+interface ReplyFeedbackProps {
+  postId: string;
+  messageIndex: number;
+}
+
+export function ReplyFeedback({ postId, messageIndex }: ReplyFeedbackProps) {
+  const [voted, setVoted] = useState<'up' | 'down' | null>(null);
+
+  async function handleVote(vote: 'up' | 'down') {
+    if (voted !== null) return;
+    setVoted(vote);
+    try {
+      await fetch(`/api/v1/posts/${postId}/reply-feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messageIndex, vote }),
+      });
+    } catch {
+      // fire-and-forget stub; UI optimistically shows selection
+    }
+  }
+
+  return (
+    <div
+      className="mt-1.5 flex items-center gap-1"
+      data-testid="reply-feedback"
+      aria-label="Rate this reply"
+    >
+      <button
+        type="button"
+        onClick={() => handleVote('up')}
+        disabled={voted !== null}
+        data-testid="reply-feedback-thumbs-up"
+        aria-label="Thumbs up"
+        aria-pressed={voted === 'up'}
+        className={`inline-flex items-center rounded-full p-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none ${
+          voted === 'up'
+            ? 'bg-green-50 text-green-600'
+            : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+        }`}
+      >
+        <ThumbsUp className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        onClick={() => handleVote('down')}
+        disabled={voted !== null}
+        data-testid="reply-feedback-thumbs-down"
+        aria-label="Thumbs down"
+        aria-pressed={voted === 'down'}
+        className={`inline-flex items-center rounded-full p-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none ${
+          voted === 'down'
+            ? 'bg-red-50 text-red-500'
+            : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+        }`}
+      >
+        <ThumbsDown className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/chat/StarterPromptStrip.tsx
+++ b/apps/web/components/chat/StarterPromptStrip.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+const STARTER_PROMPTS = [
+  "Tell me about your day",
+  "Help me brainstorm",
+  "Just talk",
+  "What's on your mind?",
+  "Give me a challenge",
+] as const;
+
+interface StarterPromptStripProps {
+  onSelect: (prompt: string) => void;
+}
+
+export function StarterPromptStrip({ onSelect }: StarterPromptStripProps) {
+  return (
+    <div
+      className="flex flex-wrap gap-2 pb-3"
+      data-testid="starter-prompt-strip"
+      aria-label="Starter prompts"
+    >
+      {STARTER_PROMPTS.map((prompt) => (
+        <button
+          key={prompt}
+          type="button"
+          onClick={() => onSelect(prompt)}
+          data-testid="starter-prompt-chip"
+          className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-3 py-1.5 text-xs font-medium text-primary transition hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {prompt}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/posts/PostCard.tsx
+++ b/apps/web/components/posts/PostCard.tsx
@@ -41,6 +41,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { isPostInPublicMediaGallery } from '@/components/agents/profile-media';
+import { ReplyFeedback } from '@/components/chat/ReplyFeedback';
 
 type ChatSnippetMemoryCapture = {
   id?: string;
@@ -2758,6 +2759,9 @@ export function PostCard({
                 <p className="mt-1 text-sm text-foreground/90 whitespace-pre-line">
                   {message.content}
                 </p>
+                {isAgentChatRole(message.role) && !compact ? (
+                  <ReplyFeedback postId={post.id} messageIndex={index} />
+                ) : null}
                 {tweakOpenMessageIndex === index && !compact ? (
                   <div
                     data-testid={`chat-snippet-tweak-panel-${index}`}

--- a/apps/web/components/posts/ReplyContextComposer.tsx
+++ b/apps/web/components/posts/ReplyContextComposer.tsx
@@ -19,6 +19,7 @@ import { useCreateComment } from '@/hooks/use-comments';
 import type { ImagineSceneResult } from '@/lib/reply-composer/imagine-scene';
 import { detectCrisisKeywords } from '@/lib/crisis-detection';
 import { CrisisOverlay } from '@/components/common/CrisisOverlay';
+import { StarterPromptStrip } from '@/components/chat/StarterPromptStrip';
 
 interface ReplyContextComposerProps {
   postId: string;
@@ -310,6 +311,11 @@ export function ReplyContextComposer({
           <label className="text-sm font-medium" htmlFor="reply-content">
             Reply
           </label>
+          {!content && (
+            <StarterPromptStrip
+              onSelect={(prompt) => handleContentChange(prompt)}
+            />
+          )}
           <textarea
             id="reply-content"
             data-testid="reply-context-content"


### PR DESCRIPTION
## Summary

- **StarterPromptStrip**: 5 clickable prompt chips shown in the reply composer when content is empty — reduces blank-start friction (Replika "Ask Replika" pattern)
- **ReplyFeedback**: thumbs up/down buttons rendered after each agent reply in chat snippets — fire-and-forget POST to collect tuning signals
- Both components wired: StarterPromptStrip → ReplyContextComposer, ReplyFeedback → PostCard (non-compact, agent messages only)
- 8 unit tests passing (4 per component)

## Source
Source: backlog.md:309

## Evidence
StarterPromptStrip: 빈 composer에 5개 chip 렌더 확인 (vitest 4/4 PASS)
ReplyFeedback: agent 메시지 아래 👍👎 렌더, POST fire-and-forget 확인 (vitest 4/4 PASS)

## Test plan

- [ ] StarterPromptStrip: 5 chips render; click fills composer; aria-label present
- [ ] ReplyFeedback: thumbs up/down render; click fires POST; both disabled after vote
- [ ] `npx vitest run __tests__/components/starter-prompt-strip.test.tsx __tests__/components/reply-feedback.test.tsx` → 8/8 PASS

## Auth-only Proof
N/A