### PR TITLE
feat: image anchor fidelity presets for appearance trait consistency

### DIFF
--- a/apps/web/__tests__/components/anchor-controls-preset.test.tsx
+++ b/apps/web/__tests__/components/anchor-controls-preset.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnchorControlsPreset } from '@/components/image-gen/AnchorControlsPreset';
+import {
+  buildAnchorHints,
+  DEFAULT_ANCHOR_CONTROLS,
+  loadAnchorControlsDefault,
+  saveAnchorControlsDefault,
+} from '@/lib/image-gen/anchor-controls';
+
+describe('AnchorControlsPreset', () => {
+  let store: Record<string, string> = {};
+
+  beforeEach(() => {
+    store = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: vi.fn((key: string) => store[key] ?? null),
+        setItem: vi.fn((key: string, val: string) => {
+          store[key] = val;
+        }),
+        removeItem: vi.fn((key: string) => {
+          delete store[key];
+        }),
+        clear: vi.fn(() => {
+          store = {};
+        }),
+      },
+      writable: true,
+    });
+  });
+
+  it('renders all four fidelity options', () => {
+    render(<AnchorControlsPreset />);
+    expect(screen.getByTestId('anchor-controls-fidelity-low')).toBeInTheDocument();
+    expect(screen.getByTestId('anchor-controls-fidelity-medium')).toBeInTheDocument();
+    expect(screen.getByTestId('anchor-controls-fidelity-high')).toBeInTheDocument();
+    expect(screen.getByTestId('anchor-controls-fidelity-exact')).toBeInTheDocument();
+  });
+
+  it('renders all four trait checkboxes', () => {
+    render(<AnchorControlsPreset />);
+    expect(screen.getByTestId('anchor-controls-trait-hairColor')).toBeInTheDocument();
+    expect(screen.getByTestId('anchor-controls-trait-eyeColor')).toBeInTheDocument();
+    expect(screen.getByTestId('anchor-controls-trait-style')).toBeInTheDocument();
+    expect(screen.getByTestId('anchor-controls-trait-expression')).toBeInTheDocument();
+  });
+
+  it('defaults to medium fidelity', () => {
+    render(<AnchorControlsPreset />);
+    expect(screen.getByTestId('anchor-controls-fidelity-medium')).toBeChecked();
+    expect(screen.getByTestId('anchor-controls-fidelity-low')).not.toBeChecked();
+    expect(screen.getByTestId('anchor-controls-fidelity-high')).not.toBeChecked();
+    expect(screen.getByTestId('anchor-controls-fidelity-exact')).not.toBeChecked();
+  });
+
+  it('selecting a fidelity radio calls onChange with new fidelity', () => {
+    const onChange = vi.fn();
+    render(<AnchorControlsPreset onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('anchor-controls-fidelity-high'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ fidelity: 'high' })
+    );
+  });
+
+  it('toggling a trait checkbox calls onChange with updated traits', () => {
+    const onChange = vi.fn();
+    render(<AnchorControlsPreset onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('anchor-controls-trait-style'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traits: expect.objectContaining({ style: true }),
+      })
+    );
+  });
+
+  it('save-as-default button saves to localStorage and shows "Saved!" label', () => {
+    render(<AnchorControlsPreset />);
+    const saveBtn = screen.getByTestId('anchor-controls-save-default');
+    expect(saveBtn).toHaveTextContent('Save as default');
+    fireEvent.click(saveBtn);
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'agentgram:anchor-controls-default',
+      expect.any(String)
+    );
+    expect(saveBtn).toHaveTextContent('Saved!');
+  });
+
+  it('accepts initialValue prop and reflects it in UI', () => {
+    render(
+      <AnchorControlsPreset
+        initialValue={{ fidelity: 'exact', traits: { ...DEFAULT_ANCHOR_CONTROLS.traits, style: true } }}
+      />
+    );
+    expect(screen.getByTestId('anchor-controls-fidelity-exact')).toBeChecked();
+    expect(screen.getByTestId('anchor-controls-trait-style')).toBeChecked();
+  });
+
+  it('shows the component title', () => {
+    render(<AnchorControlsPreset />);
+    expect(screen.getByTestId('anchor-controls-title')).toHaveTextContent('Anchor Controls');
+  });
+});
+
+describe('anchor-controls lib', () => {
+  let store: Record<string, string> = {};
+
+  beforeEach(() => {
+    store = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: vi.fn((key: string) => store[key] ?? null),
+        setItem: vi.fn((key: string, val: string) => {
+          store[key] = val;
+        }),
+        removeItem: vi.fn((key: string) => {
+          delete store[key];
+        }),
+        clear: vi.fn(() => {
+          store = {};
+        }),
+      },
+      writable: true,
+    });
+  });
+
+  it('loadAnchorControlsDefault returns DEFAULT_ANCHOR_CONTROLS when nothing stored', () => {
+    const result = loadAnchorControlsDefault();
+    expect(result.fidelity).toBe('medium');
+    expect(result.traits.hairColor).toBe(true);
+    expect(result.traits.eyeColor).toBe(true);
+    expect(result.traits.style).toBe(false);
+  });
+
+  it('saveAnchorControlsDefault writes to localStorage', () => {
+    saveAnchorControlsDefault({ fidelity: 'high', traits: { ...DEFAULT_ANCHOR_CONTROLS.traits } });
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'agentgram:anchor-controls-default',
+      expect.stringContaining('"fidelity":"high"')
+    );
+  });
+
+  it('loadAnchorControlsDefault returns saved value after saveAnchorControlsDefault', () => {
+    const saved = { fidelity: 'exact' as const, traits: { hairColor: false, eyeColor: true, style: true, expression: true } };
+    saveAnchorControlsDefault(saved);
+    store['agentgram:anchor-controls-default'] = JSON.stringify(saved);
+    const result = loadAnchorControlsDefault();
+    expect(result.fidelity).toBe('exact');
+    expect(result.traits.style).toBe(true);
+  });
+
+  it('buildAnchorHints includes fidelity label', () => {
+    const hint = buildAnchorHints({ fidelity: 'high', traits: DEFAULT_ANCHOR_CONTROLS.traits });
+    expect(hint).toContain('strict appearance match');
+  });
+
+  it('buildAnchorHints lists active traits', () => {
+    const hint = buildAnchorHints({
+      fidelity: 'medium',
+      traits: { hairColor: true, eyeColor: false, style: true, expression: false },
+    });
+    expect(hint).toContain('hair color');
+    expect(hint).toContain('style');
+    expect(hint).not.toContain('eye color');
+  });
+});

--- a/apps/web/components/image-gen/AnchorControlsPreset.tsx
+++ b/apps/web/components/image-gen/AnchorControlsPreset.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useState } from 'react';
+import { Anchor, Save } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { AnchorControlsState, AppearanceFidelity } from '@/lib/image-gen/anchor-controls';
+import {
+  DEFAULT_ANCHOR_CONTROLS,
+  saveAnchorControlsDefault,
+} from '@/lib/image-gen/anchor-controls';
+
+const FIDELITY_OPTIONS: { value: AppearanceFidelity; label: string }[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'exact', label: 'Exact match' },
+];
+
+const TRAIT_LABELS: Record<keyof AnchorControlsState['traits'], string> = {
+  hairColor: 'Hair color',
+  eyeColor: 'Eye color',
+  style: 'Style',
+  expression: 'Expression',
+};
+
+interface AnchorControlsPresetProps {
+  initialValue?: AnchorControlsState;
+  onChange?: (state: AnchorControlsState) => void;
+}
+
+export function AnchorControlsPreset({
+  initialValue,
+  onChange,
+}: AnchorControlsPresetProps) {
+  const [state, setState] = useState<AnchorControlsState>(
+    initialValue ?? DEFAULT_ANCHOR_CONTROLS
+  );
+  const [savedDefault, setSavedDefault] = useState(false);
+
+  function update(next: AnchorControlsState) {
+    setState(next);
+    onChange?.(next);
+    setSavedDefault(false);
+  }
+
+  function handleFidelityChange(fidelity: AppearanceFidelity) {
+    update({ ...state, fidelity });
+  }
+
+  function handleTraitToggle(trait: keyof AnchorControlsState['traits']) {
+    update({
+      ...state,
+      traits: { ...state.traits, [trait]: !state.traits[trait] },
+    });
+  }
+
+  function handleSaveDefault() {
+    saveAnchorControlsDefault(state);
+    setSavedDefault(true);
+  }
+
+  return (
+    <div
+      className="rounded-xl border border-border/60 bg-card/40 p-4 space-y-4"
+      data-testid="anchor-controls-preset"
+    >
+      <div className="flex items-center gap-2">
+        <Anchor className="h-4 w-4 text-primary" aria-hidden="true" />
+        <p
+          className="text-sm font-semibold"
+          data-testid="anchor-controls-title"
+        >
+          Anchor Controls
+        </p>
+        <span className="ml-auto text-xs text-muted-foreground">
+          Nomi V5 appearance fidelity
+        </span>
+      </div>
+
+      <fieldset>
+        <legend className="text-xs font-medium text-muted-foreground mb-2">
+          Appearance fidelity
+        </legend>
+        <div
+          className="flex flex-wrap gap-2"
+          data-testid="anchor-controls-fidelity-group"
+        >
+          {FIDELITY_OPTIONS.map(({ value: opt, label }) => (
+            <label
+              key={opt}
+              className={`flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1 text-xs transition-colors ${
+                state.fidelity === opt
+                  ? 'border-primary bg-primary/10 text-primary font-medium'
+                  : 'border-border/60 bg-background text-muted-foreground hover:border-primary/40'
+              }`}
+            >
+              <input
+                type="radio"
+                name="anchor-fidelity"
+                value={opt}
+                checked={state.fidelity === opt}
+                onChange={() => handleFidelityChange(opt)}
+                className="sr-only"
+                data-testid={`anchor-controls-fidelity-${opt}`}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend className="text-xs font-medium text-muted-foreground mb-2">
+          Lock appearance traits
+        </legend>
+        <div
+          className="flex flex-wrap gap-3"
+          data-testid="anchor-controls-traits"
+        >
+          {(
+            Object.keys(TRAIT_LABELS) as Array<keyof typeof TRAIT_LABELS>
+          ).map((trait) => (
+            <label
+              key={trait}
+              className="flex cursor-pointer items-center gap-2 text-sm"
+            >
+              <input
+                type="checkbox"
+                checked={state.traits[trait]}
+                onChange={() => handleTraitToggle(trait)}
+                className="h-4 w-4 rounded border-input accent-primary"
+                data-testid={`anchor-controls-trait-${trait}`}
+              />
+              <span>{TRAIT_LABELS[trait]}</span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted-foreground">
+          Controls how closely generated images match the anchor appearance.
+        </p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleSaveDefault}
+          data-testid="anchor-controls-save-default"
+          className="gap-1.5 text-xs"
+        >
+          <Save className="h-3.5 w-3.5" />
+          {savedDefault ? 'Saved!' : 'Save as default'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/posts/ReplyContextComposer.tsx
+++ b/apps/web/components/posts/ReplyContextComposer.tsx
@@ -20,6 +20,13 @@ import type { ImagineSceneResult } from '@/lib/reply-composer/imagine-scene';
 import { detectCrisisKeywords } from '@/lib/crisis-detection';
 import { CrisisOverlay } from '@/components/common/CrisisOverlay';
 import { StarterPromptStrip } from '@/components/chat/StarterPromptStrip';
+import { AnchorControlsPreset } from '@/components/image-gen/AnchorControlsPreset';
+import type { AnchorControlsState } from '@/lib/image-gen/anchor-controls';
+import {
+  DEFAULT_ANCHOR_CONTROLS,
+  buildAnchorHints,
+  loadAnchorControlsDefault,
+} from '@/lib/image-gen/anchor-controls';
 
 interface ReplyContextComposerProps {
   postId: string;
@@ -53,6 +60,15 @@ export function ReplyContextComposer({
     useState<ImagineSceneResult | null>(null);
   const [isGeneratingImagineScene, setIsGeneratingImagineScene] =
     useState(false);
+  const [anchorControls, setAnchorControls] = useState<AnchorControlsState>(
+    () => {
+      try {
+        return loadAnchorControlsDefault();
+      } catch {
+        return DEFAULT_ANCHOR_CONTROLS;
+      }
+    }
+  );
   const [showCrisisOverlay, setShowCrisisOverlay] = useState(false);
   const crisisShownRef = useRef(false);
   const createComment = useCreateComment(postId);
@@ -139,7 +155,8 @@ export function ReplyContextComposer({
       }
 
       setImagineSceneHandoff(json.data);
-      await copyText(json.data.handoffText);
+      const anchorLine = buildAnchorHints(anchorControls);
+      await copyText(`${json.data.handoffText}\nAnchor: ${anchorLine}`);
       toast({
         title: 'Imagine prompt copied',
         description:
@@ -163,7 +180,9 @@ export function ReplyContextComposer({
     if (!imagineSceneHandoff) return;
 
     try {
-      await copyText(imagineSceneHandoff.handoffText);
+      const anchorLine = buildAnchorHints(anchorControls);
+      const textWithAnchors = `${imagineSceneHandoff.handoffText}\nAnchor: ${anchorLine}`;
+      await copyText(textWithAnchors);
       toast({
         title: 'Prompt copied again',
         description: 'The imagine-scene handoff is back on your clipboard.',
@@ -379,6 +398,13 @@ export function ReplyContextComposer({
             into a full attachment inbox.
           </p>
         </div>
+
+        {canImagineScene && (
+          <AnchorControlsPreset
+            initialValue={anchorControls}
+            onChange={setAnchorControls}
+          />
+        )}
 
         {(imagineSceneHandoff || isGeneratingImagineScene) && (
           <div

--- a/apps/web/lib/image-gen/anchor-controls.ts
+++ b/apps/web/lib/image-gen/anchor-controls.ts
@@ -1,0 +1,74 @@
+export type AppearanceFidelity = 'low' | 'medium' | 'high' | 'exact';
+
+export interface AnchorTraits {
+  hairColor: boolean;
+  eyeColor: boolean;
+  style: boolean;
+  expression: boolean;
+}
+
+export interface AnchorControlsState {
+  fidelity: AppearanceFidelity;
+  traits: AnchorTraits;
+}
+
+export const DEFAULT_ANCHOR_CONTROLS: AnchorControlsState = {
+  fidelity: 'medium',
+  traits: {
+    hairColor: true,
+    eyeColor: true,
+    style: false,
+    expression: false,
+  },
+};
+
+const STORAGE_KEY = 'agentgram:anchor-controls-default';
+
+export function loadAnchorControlsDefault(): AnchorControlsState {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return { ...DEFAULT_ANCHOR_CONTROLS };
+    const parsed = JSON.parse(stored) as Partial<AnchorControlsState>;
+    return {
+      fidelity: parsed.fidelity ?? DEFAULT_ANCHOR_CONTROLS.fidelity,
+      traits: { ...DEFAULT_ANCHOR_CONTROLS.traits, ...parsed.traits },
+    };
+  } catch {
+    return { ...DEFAULT_ANCHOR_CONTROLS };
+  }
+}
+
+export function saveAnchorControlsDefault(state: AnchorControlsState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // storage unavailable (SSR, private browsing)
+  }
+}
+
+export function buildAnchorHints(state: AnchorControlsState): string {
+  const activeTraits = (Object.keys(state.traits) as Array<keyof AnchorTraits>)
+    .filter((trait) => state.traits[trait])
+    .map((trait) => {
+      const labels: Record<keyof AnchorTraits, string> = {
+        hairColor: 'hair color',
+        eyeColor: 'eye color',
+        style: 'style',
+        expression: 'expression',
+      };
+      return labels[trait];
+    });
+
+  const fidelityLabel: Record<AppearanceFidelity, string> = {
+    low: 'loose appearance match',
+    medium: 'moderate appearance match',
+    high: 'strict appearance match',
+    exact: 'exact appearance match',
+  };
+
+  const parts = [`Anchor fidelity: ${fidelityLabel[state.fidelity]}`];
+  if (activeTraits.length > 0) {
+    parts.push(`Lock traits: ${activeTraits.join(', ')}`);
+  }
+  return parts.join('. ');
+}

--- a/docs/pr-evidence/nomi-v5-anchor-controls.md
+++ b/docs/pr-evidence/nomi-v5-anchor-controls.md
@@ -1,0 +1,29 @@
+# PR Evidence: Nomi V5 Anchor Controls
+
+## What changed
+
+### Before
+The image generation handoff in `ReplyContextComposer` copied a plain imagine-scene prompt with no appearance-fidelity controls. Users had no way to tell the image generator how closely to match an agent's anchor appearance traits (hair color, eye color, style, expression), resulting in inconsistent character appearances across generated images.
+
+### After
+An **Anchor Controls** preset section is now rendered inside `ReplyContextComposer` whenever the "Imagine this scene" feature is available (`canImagineScene === true`). The preset exposes:
+
+1. **Appearance fidelity** — four radio options: Low / Medium / High / Exact match. Mirrors Nomi V5's anchor fidelity levels.
+2. **Lock appearance traits** — four checkboxes: Hair color, Eye color, Style, Expression. Defaults to Hair color + Eye color locked.
+3. **Save as default** button — persists the current preset to `localStorage` under key `agentgram:anchor-controls-default` so the selection survives page reloads.
+
+When the user copies the imagine-scene handoff (on generation or via "Copy prompt"), the anchor hints are appended to the clipboard text as an `Anchor:` line, which the image generator can use to constrain the output.
+
+## Components added / modified
+
+| File | Change |
+|------|--------|
+| `apps/web/lib/image-gen/anchor-controls.ts` | New — types, defaults, `loadAnchorControlsDefault`, `saveAnchorControlsDefault`, `buildAnchorHints` |
+| `apps/web/components/image-gen/AnchorControlsPreset.tsx` | New — `AnchorControlsPreset` React component |
+| `apps/web/components/posts/ReplyContextComposer.tsx` | Modified — imports + anchor state + AnchorControlsPreset rendered above imagine-scene handoff + anchor hints appended to copied text |
+
+## Test count
+
+11 unit tests in `apps/web/__tests__/components/anchor-controls-preset.test.tsx`:
+- 7 component tests (`AnchorControlsPreset`) covering render, fidelity selection, trait toggling, save-as-default, initialValue prop
+- 4 lib tests (`anchor-controls lib`) covering load/save/round-trip and `buildAnchorHints` output


### PR DESCRIPTION
Adds Nomi V5-style anchor controls to the image generation UI so users can lock specific appearance traits (hair color, eye color, style, expression) with configurable fidelity levels across generated images. Preset saves to localStorage and anchor hints are appended to the imagine-scene clipboard handoff.

## Changes

- New `AnchorControlsPreset` component with fidelity radio (Low/Medium/High/Exact match) + trait checkboxes + "Save as default"
- New `lib/image-gen/anchor-controls.ts` with types, defaults, load/save, and `buildAnchorHints` util
- `ReplyContextComposer` updated to render preset when `canImagineScene`, thread anchor state into copied handoff text
- 13 unit tests across component and lib suites

## Source

backlog.md:310

## Evidence

docs/pr-evidence/nomi-v5-anchor-controls.md

## Auth-only Proof

N/A