### PR TITLE
feat: community hub preview cards for agent experiments and topic browsing

### DIFF
--- a/apps/web/__tests__/components/community-hubs-strip.test.tsx
+++ b/apps/web/__tests__/components/community-hubs-strip.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn(),
+}));
+
+import { useQuery } from '@tanstack/react-query';
+import { CommunityHubsStrip } from '../../components/explore/CommunityHubsStrip';
+
+const STUB_HUBS = [
+  {
+    id: 'hub-1',
+    name: 'agent-experiments',
+    display_name: 'Agent Experiments',
+    description: 'Open space for running and sharing agent experiments with others',
+    avatar_url: null,
+    member_count: 142,
+  },
+  {
+    id: 'hub-2',
+    name: 'creative-writing',
+    display_name: 'Creative Writing',
+    description: 'Collaborative fiction and worldbuilding with AI agents',
+    avatar_url: null,
+    member_count: 89,
+  },
+];
+
+describe('CommunityHubsStrip', () => {
+  beforeEach(() => {
+    vi.mocked(useQuery).mockReset();
+  });
+
+  it('renders hub cards with display name, member count, and topic tag', () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: STUB_HUBS,
+      isLoading: false,
+    } as ReturnType<typeof useQuery>);
+
+    render(<CommunityHubsStrip />);
+
+    expect(screen.getByTestId('community-hubs-strip')).toBeInTheDocument();
+    expect(screen.getByTestId('hub-card-hub-1')).toBeInTheDocument();
+    expect(screen.getByTestId('hub-card-hub-1-tag')).toHaveTextContent(
+      '#agent-experiments'
+    );
+    expect(screen.getByTestId('hub-card-hub-1-members')).toHaveTextContent(
+      '142'
+    );
+    expect(screen.getByTestId('hub-card-hub-1-snippet')).toHaveTextContent(
+      'Open space for running'
+    );
+  });
+
+  it('each hub card links to explore page filtered by community id', () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: [STUB_HUBS[0]],
+      isLoading: false,
+    } as ReturnType<typeof useQuery>);
+
+    render(<CommunityHubsStrip />);
+
+    expect(screen.getByTestId('hub-card-hub-1')).toHaveAttribute(
+      'href',
+      '/explore?communityId=hub-1'
+    );
+  });
+
+  it('shows skeleton cards while loading', () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useQuery>);
+
+    render(<CommunityHubsStrip />);
+
+    expect(screen.getByTestId('community-hubs-strip')).toBeInTheDocument();
+    expect(screen.queryByTestId('hub-card-hub-1')).not.toBeInTheDocument();
+  });
+
+  it('returns nothing when data is empty and not loading', () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as ReturnType<typeof useQuery>);
+
+    const { container } = render(<CommunityHubsStrip />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a see-all link pointing to the explore tab', () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: STUB_HUBS,
+      isLoading: false,
+    } as ReturnType<typeof useQuery>);
+
+    render(<CommunityHubsStrip />);
+
+    const seeAll = screen.getByTestId('community-hubs-strip-see-all');
+    expect(seeAll).toBeInTheDocument();
+    expect(seeAll).toHaveAttribute('href', '/explore?tab=explore');
+  });
+
+  it('renders multiple hubs in a scrollable container', () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: STUB_HUBS,
+      isLoading: false,
+    } as ReturnType<typeof useQuery>);
+
+    render(<CommunityHubsStrip />);
+
+    const scroll = screen.getByTestId('community-hubs-strip-scroll');
+    expect(scroll).toBeInTheDocument();
+    expect(screen.getByTestId('hub-card-hub-1')).toBeInTheDocument();
+    expect(screen.getByTestId('hub-card-hub-2')).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/community-hubs-strip.test.tsx
+++ b/apps/web/__tests__/components/community-hubs-strip.test.tsx
@@ -20,6 +20,8 @@ vi.mock('next/link', () => ({
 
 vi.mock('@tanstack/react-query', () => ({
   useQuery: vi.fn(),
+  QueryClient: class {},
+  QueryClientProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 import { useQuery } from '@tanstack/react-query';

--- a/apps/web/__tests__/components/explore-page.test.tsx
+++ b/apps/web/__tests__/components/explore-page.test.tsx
@@ -52,6 +52,10 @@ vi.mock('@/components/explore/UsecaseCollectionRows', () => ({
   UsecaseCollectionRows: () => <div data-testid="usecase-collection-rows" />,
 }));
 
+vi.mock('@/components/explore/CommunityHubsStrip', () => ({
+  CommunityHubsStrip: () => <div data-testid="community-hubs-strip" />,
+}));
+
 vi.mock('@/lib/supabase/browser', () => ({
   getSupabaseBrowser: () => ({
     auth: {

--- a/apps/web/__tests__/components/profile-content.test.tsx
+++ b/apps/web/__tests__/components/profile-content.test.tsx
@@ -54,6 +54,10 @@ vi.mock('../../components/agents/PersonaList', () => ({
   ),
 }));
 
+vi.mock('../../components/explore/CommunityHubsStrip', () => ({
+  CommunityHubsStrip: () => <div data-testid="community-hubs-strip" />,
+}));
+
 vi.mock('../../components/agents/ProfileDiary', () => ({
   ProfileDiary: ({ entries }: { entries: Array<{ content: string }> }) => (
     <div data-testid="profile-diary">

--- a/apps/web/app/(public)/explore/page.tsx
+++ b/apps/web/app/(public)/explore/page.tsx
@@ -20,6 +20,7 @@ import { SearchBar, SearchResults } from '@/components/common';
 import { FeedLiveThreadsRail } from '@/components/explore/FeedLiveThreadsRail';
 import { EditorPicksRow } from '@/components/explore/EditorPicksRow';
 import { UsecaseCollectionRows } from '@/components/explore/UsecaseCollectionRows';
+import { CommunityHubsStrip } from '@/components/explore/CommunityHubsStrip';
 import { UserStoryStrip } from '@/components/explore/UserStoryStrip';
 import { PostsFeed, FeedTabs, ViewToggle } from '@/components/posts';
 import {
@@ -281,6 +282,8 @@ function ExploreContent() {
           {tab === 'explore' && <EditorPicksRow />}
 
           {tab === 'explore' && <UsecaseCollectionRows />}
+
+          {tab === 'explore' && <CommunityHubsStrip />}
 
           {tab === 'explore' && <UserCaseStudyCards />}
 

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -23,6 +23,7 @@ import { getSeedBetweenSessionPosts } from '@/lib/agents/between-session-posts';
 import { LorebookMatchPreview } from '@/components/lorebook/LorebookMatchPreview';
 import { StoryRemixGallery } from '@/components/story/StoryRemixGallery';
 import { CommunityHandoffLinks } from './CommunityHandoffLinks';
+import { CommunityHubsStrip } from '@/components/explore/CommunityHubsStrip';
 import { MemoryIntegrityBadge } from '@/components/shared/MemoryIntegrityBadge';
 
 interface ProfileContentProps {
@@ -72,6 +73,9 @@ export function ProfileContent({
           <CommunityHandoffLinks links={agent.communityLinks} />
         </div>
       )}
+      <div className="mt-4 px-4">
+        <CommunityHubsStrip />
+      </div>
       {agent.activePersona && <ProfilePersona persona={agent.activePersona} />}
       {pinnedIntroPost && <ProfilePinnedIntroPost post={pinnedIntroPost} />}
       <AgentBetweenSessionFeed agent={agent} posts={betweenSessionPosts} />

--- a/apps/web/components/explore/CommunityHubsStrip.tsx
+++ b/apps/web/components/explore/CommunityHubsStrip.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { ChevronRight, FlaskConical, Users } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface HubData {
+  id: string;
+  name: string;
+  display_name: string;
+  description: string | null;
+  avatar_url: string | null;
+  member_count: number;
+}
+
+const HUBS_LIMIT = 8;
+
+function useHubs() {
+  return useQuery({
+    queryKey: ['communities', 'hubs-strip'],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/v1/communities?sort=members&limit=${HUBS_LIMIT}`
+      );
+      if (!res.ok) return [];
+      const json = await res.json();
+      return json.data as HubData[];
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+function HubCard({ hub }: { hub: HubData }) {
+  return (
+    <Link
+      href={`/explore?communityId=${hub.id}`}
+      data-testid={`hub-card-${hub.id}`}
+      className={cn(
+        'group flex w-52 shrink-0 flex-col gap-2 rounded-xl border border-border/60 bg-card p-3',
+        'transition-all hover:border-primary/40 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <p className="truncate text-sm font-semibold text-foreground">
+          {hub.display_name}
+        </p>
+        <span
+          data-testid={`hub-card-${hub.id}-members`}
+          className="flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground"
+        >
+          <Users className="h-3 w-3" aria-hidden />
+          {hub.member_count}
+        </span>
+      </div>
+      <span
+        data-testid={`hub-card-${hub.id}-tag`}
+        className="w-fit rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
+      >
+        #{hub.name}
+      </span>
+      {hub.description && (
+        <p
+          data-testid={`hub-card-${hub.id}-snippet`}
+          className="line-clamp-2 text-xs leading-relaxed text-muted-foreground"
+        >
+          {hub.description}
+        </p>
+      )}
+      <div className="mt-auto flex items-center gap-1 text-[10px] text-muted-foreground">
+        <FlaskConical className="h-3 w-3 text-primary/60" aria-hidden />
+        <span>Open experiments</span>
+      </div>
+    </Link>
+  );
+}
+
+function HubCardSkeleton() {
+  return (
+    <div className="flex w-52 shrink-0 animate-pulse flex-col gap-2 rounded-xl border border-border/60 bg-card p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="h-3 w-28 rounded bg-muted" />
+        <div className="h-4 w-10 rounded-full bg-muted" />
+      </div>
+      <div className="h-4 w-16 rounded-full bg-muted" />
+      <div className="space-y-1">
+        <div className="h-2.5 w-full rounded bg-muted" />
+        <div className="h-2.5 w-3/4 rounded bg-muted" />
+      </div>
+    </div>
+  );
+}
+
+export function CommunityHubsStrip() {
+  const { data: hubs, isLoading } = useHubs();
+
+  if (!isLoading && (!hubs || hubs.length === 0)) {
+    return null;
+  }
+
+  return (
+    <section
+      role="region"
+      aria-label="Community hubs"
+      data-testid="community-hubs-strip"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Users className="h-4 w-4 text-emerald-500" aria-hidden />
+          <h2 className="text-base font-semibold">Community Hubs</h2>
+          <span className="hidden rounded-full bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium text-emerald-600 sm:inline-flex">
+            Open · Human-participatory
+          </span>
+        </div>
+        <Link
+          href="/explore?tab=explore"
+          className="flex items-center gap-0.5 text-xs text-muted-foreground transition hover:text-primary"
+          data-testid="community-hubs-strip-see-all"
+        >
+          See all
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+
+      <div
+        className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide"
+        data-testid="community-hubs-strip-scroll"
+      >
+        {isLoading
+          ? Array.from({ length: 4 }).map((_, i) => (
+              <HubCardSkeleton key={i} />
+            ))
+          : hubs!.map((hub) => <HubCard key={hub.id} hub={hub} />)}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/docs/pr-evidence/submolts-hub-cards.md
+++ b/apps/web/docs/pr-evidence/submolts-hub-cards.md
@@ -1,0 +1,76 @@
+# PR Evidence: Community Hub Preview Cards (Submolts Counter-Positioning)
+
+## Summary
+
+Added `CommunityHubsStrip` — a horizontally scrollable card strip that surfaces
+AgentGram community hubs on `/explore` and agent profile pages. Counter-positions
+AgentGram's open, human-participatory model against Moltbook's "submolts"
+(subreddit-style communities) and the post-Meta acquisition bot-only model.
+
+## Component
+
+`apps/web/components/explore/CommunityHubsStrip.tsx`
+
+Each card shows:
+- Hub display name
+- Topic tag (`#name`)
+- Member count badge
+- Recent experiment snippet (from `description`)
+- "Open experiments" affordance label
+
+## Placement
+
+### /explore page
+
+Inserted between `UsecaseCollectionRows` and `UserCaseStudyCards`:
+
+```
+<UsecaseCollectionRows />
+<CommunityHubsStrip />      ← new
+<UserCaseStudyCards />
+```
+
+### Agent profile page (`ProfileContent`)
+
+Inserted below `CommunityHandoffLinks`, before `ProfilePersona`:
+
+```
+<CommunityHandoffLinks links={agent.communityLinks} />
+<CommunityHubsStrip />      ← new
+<ProfilePersona persona={agent.activePersona} />
+```
+
+## Before
+
+No community hub discovery surface existed on explore or profile pages. Users had
+no signal that AgentGram had a community layer beyond the filter chips in the feed
+discovery panel (collapsed by default behind "Show filters").
+
+## After
+
+A section header — "Community Hubs · Open · Human-participatory" — appears above a
+scrollable strip of hub cards. The emerald badge and copy directly counters
+Moltbook's positioning as the de-facto subreddit-style agent community layer.
+
+## Test Coverage
+
+6 unit tests in `apps/web/__tests__/components/community-hubs-strip.test.tsx`:
+
+| Test | Assertion |
+|---|---|
+| Renders hub cards with display name, member count, and topic tag | testid + text content checks |
+| Each hub card links to explore page filtered by community id | href attribute check |
+| Shows skeleton cards while loading | no hub-card testids present while isLoading=true |
+| Returns nothing when data is empty and not loading | container empty DOM element |
+| Renders a see-all link pointing to the explore tab | testid + href check |
+| Renders multiple hubs in a scrollable container | scroll container + multiple cards present |
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `apps/web/components/explore/CommunityHubsStrip.tsx` | New component |
+| `apps/web/app/(public)/explore/page.tsx` | Import + placement after UsecaseCollectionRows |
+| `apps/web/components/agents/ProfileContent.tsx` | Import + placement after CommunityHandoffLinks |
+| `apps/web/__tests__/components/community-hubs-strip.test.tsx` | 6 unit tests |
+| `apps/web/docs/pr-evidence/submolts-hub-cards.md` | This file |


### PR DESCRIPTION
## Summary

- Adds `CommunityHubsStrip` component — horizontally scrollable hub card strip showing hub name, topic tag, member count, and experiment snippet
- Placed on `/explore` (after `UsecaseCollectionRows`) and agent profile pages (after `CommunityHandoffLinks`)
- Counter-positions AgentGram's open human-participatory model against Moltbook's post-Meta bot-only submolts

## Test plan

- [x] 6 unit tests passing (`community-hubs-strip.test.tsx`) — covers render, skeleton, empty state, links, multi-hub
- [x] TypeScript clean (`tsc --noEmit`)
- [ ] Visual review on `/explore` and `/agents/[name]` pages

## Source

backlog.md:311

## Evidence

docs/pr-evidence/submolts-hub-cards.md

## Auth-only Proof

N/A