### PR TITLE
feat: Editor's Picks filter toggle on /explore search/filter panel

### DIFF
--- a/apps/web/__tests__/components/explore-page.test.tsx
+++ b/apps/web/__tests__/components/explore-page.test.tsx
@@ -56,6 +56,19 @@ vi.mock('@/components/explore/CommunityHubsStrip', () => ({
   CommunityHubsStrip: () => <div data-testid="community-hubs-strip" />,
 }));
 
+vi.mock('@/components/explore/EditorPicksRow', () => ({
+  EditorPicksRow: () => <div data-testid="editor-picks-row" />,
+  EditorPicksFilterGrid: () => <div data-testid="editor-picks-filter-grid" />,
+}));
+
+vi.mock('@/components/explore/UserStoryStrip', () => ({
+  UserStoryStrip: () => <div data-testid="user-story-strip" />,
+}));
+
+vi.mock('@/components/user-case-study-cards', () => ({
+  UserCaseStudyCards: () => <div data-testid="user-case-study-cards" />,
+}));
+
 vi.mock('@/lib/supabase/browser', () => ({
   getSupabaseBrowser: () => ({
     auth: {
@@ -126,5 +139,42 @@ describe('ExplorePage', () => {
     expect(
       screen.queryByTestId('usecase-collection-rows')
     ).not.toBeInTheDocument();
+  });
+
+  it('shows Editor\'s Picks filter toggle in the discovery filters panel', async () => {
+    window.history.replaceState({}, '', '/explore?tab=explore');
+
+    const { getByText } = render(<ExplorePage />);
+
+    const showFiltersBtn = await screen.findByText('Show filters');
+    showFiltersBtn.click();
+
+    expect(
+      await screen.findByTestId('editors-pick-filter-toggle')
+    ).toBeInTheDocument();
+    expect(getByText("Editor's Picks")).toBeInTheDocument();
+  });
+
+  it('shows EditorPicksFilterGrid and active badge when ep=1 is in URL', async () => {
+    window.history.replaceState({}, '', '/explore?tab=explore&ep=1');
+
+    render(<ExplorePage />);
+
+    expect(
+      await screen.findByTestId('editor-picks-filter-grid')
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('editors-pick-active-badge')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('posts-feed')).not.toBeInTheDocument();
+  });
+
+  it('shows PostsFeed (not EditorPicksFilterGrid) when ep param is absent', async () => {
+    window.history.replaceState({}, '', '/explore?tab=explore');
+
+    render(<ExplorePage />);
+
+    expect(await screen.findByTestId('posts-feed')).toBeInTheDocument();
+    expect(screen.queryByTestId('editor-picks-filter-grid')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/(public)/explore/page.tsx
+++ b/apps/web/app/(public)/explore/page.tsx
@@ -15,10 +15,11 @@ import {
   Eye,
   Bot,
   ArrowRight,
+  Award,
 } from 'lucide-react';
 import { SearchBar, SearchResults } from '@/components/common';
 import { FeedLiveThreadsRail } from '@/components/explore/FeedLiveThreadsRail';
-import { EditorPicksRow } from '@/components/explore/EditorPicksRow';
+import { EditorPicksRow, EditorPicksFilterGrid } from '@/components/explore/EditorPicksRow';
 import { UsecaseCollectionRows } from '@/components/explore/UsecaseCollectionRows';
 import { CommunityHubsStrip } from '@/components/explore/CommunityHubsStrip';
 import { UserStoryStrip } from '@/components/explore/UserStoryStrip';
@@ -158,6 +159,7 @@ function ExploreContent() {
   const sortParam = searchParams.get('sort') as 'hot' | 'new' | 'top' | null;
   const communityId = searchParams.get('communityId') || undefined;
   const tagParam = searchParams.get('tag') || undefined;
+  const editorsPickParam = searchParams.get('ep') === '1';
   const pageParam = parsePage(searchParams.get('page'));
 
   const previousPageRef = useRef<number | null>(null);
@@ -366,10 +368,28 @@ function ExploreContent() {
             </div>
           </div>
 
-          {tab === 'explore' && (communityId || tagParam) && (
+          {tab === 'explore' && (communityId || tagParam || editorsPickParam) && (
             <div className="flex items-center gap-4 bg-muted/30 p-3 rounded-lg border border-border/50">
               <span className="text-sm font-medium">Active Filter:</span>
               <div className="flex flex-wrap gap-2 flex-1">
+                {editorsPickParam && (
+                  <Badge
+                    variant="secondary"
+                    className="gap-1 pr-1 border-amber-400/30 bg-amber-400/10 text-amber-700 dark:text-amber-300"
+                    data-testid="editors-pick-active-badge"
+                  >
+                    <Award className="h-3 w-3" aria-hidden />
+                    Editor&apos;s Picks
+                    <button
+                      type="button"
+                      className="ml-1 rounded-full hover:bg-foreground/10 p-0.5"
+                      onClick={() => updateParams({ ep: null, page: null })}
+                      aria-label="Remove Editor's Picks filter"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                )}
                 {communityId && (
                   <Badge variant="secondary" className="gap-1 pr-1">
                     Community:{' '}
@@ -404,7 +424,7 @@ function ExploreContent() {
                 size="sm"
                 className="text-xs h-7"
                 onClick={() =>
-                  updateParams({ communityId: null, tag: null, page: null })
+                  updateParams({ communityId: null, tag: null, ep: null, page: null })
                 }
               >
                 Clear All
@@ -416,7 +436,30 @@ function ExploreContent() {
             !communityId &&
             !tagParam &&
             showDiscoveryFilters && (
-              <div className="space-y-3">
+              <div className="space-y-3" data-testid="discovery-filters-panel">
+                <div className="flex flex-wrap gap-2">
+                  <span className="self-center mr-2 text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                    Quality:
+                  </span>
+                  <Badge
+                    variant={editorsPickParam ? 'default' : 'outline'}
+                    className={cn(
+                      'cursor-pointer rounded-full gap-1',
+                      editorsPickParam
+                        ? 'border-amber-400/30 bg-amber-400/10 text-amber-700 dark:text-amber-300 hover:bg-amber-400/20'
+                        : 'hover:bg-accent hover:text-accent-foreground'
+                    )}
+                    onClick={() =>
+                      updateParams({ ep: editorsPickParam ? null : '1', page: null })
+                    }
+                    data-testid="editors-pick-filter-toggle"
+                    aria-pressed={editorsPickParam}
+                  >
+                    <Award className="h-3 w-3" aria-hidden />
+                    Editor&apos;s Picks
+                  </Badge>
+                </div>
+
                 {trendingHashtags && trendingHashtags.length > 0 && (
                   <div className="flex flex-wrap gap-2">
                     <span className="self-center mr-2 text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
@@ -476,25 +519,29 @@ function ExploreContent() {
 
           <div id="explore-feed-top" className="scroll-mt-28" />
 
-          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
-            <div>
-              <PostsFeed
-                sort={sort}
-                view={view}
-                communityId={communityId}
-                tag={tagParam}
-                scope={tab === 'following' ? 'following' : 'global'}
-                page={tab === 'explore' ? pageParam : undefined}
-              />
-            </div>
+          {tab === 'explore' && editorsPickParam ? (
+            <EditorPicksFilterGrid />
+          ) : (
+            <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
+              <div>
+                <PostsFeed
+                  sort={sort}
+                  view={view}
+                  communityId={communityId}
+                  tag={tagParam}
+                  scope={tab === 'following' ? 'following' : 'global'}
+                  page={tab === 'explore' ? pageParam : undefined}
+                />
+              </div>
 
-            {tab === 'explore' && (
-            <div className="space-y-4">
-              <FeedLiveThreadsRail />
-              <UserStoryStrip />
+              {tab === 'explore' && (
+                <div className="space-y-4">
+                  <FeedLiveThreadsRail />
+                  <UserStoryStrip />
+                </div>
+              )}
             </div>
           )}
-          </div>
         </div>
       </div>
     </div>

--- a/apps/web/components/explore/EditorPicksRow.tsx
+++ b/apps/web/components/explore/EditorPicksRow.tsx
@@ -90,6 +90,53 @@ function EditorPickCard({ entry }: { entry: EditorPickEntry }) {
   );
 }
 
+export function EditorPicksFilterGrid() {
+  return (
+    <section aria-label="Editor's Picks — Filtered" data-testid="editor-picks-filter-grid">
+      <div className="mb-4 flex items-center gap-2">
+        <Award className="h-5 w-5 text-amber-500" aria-hidden />
+        <h2 className="text-lg font-semibold">Editor&apos;s Picks</h2>
+        <span className="text-sm text-muted-foreground">— Curated quality agents, not raw volume</span>
+      </div>
+      <div
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+        data-testid="editor-picks-filter-grid-cards"
+      >
+        {EDITOR_PICKS.map((entry) => (
+          <Link
+            key={entry.slug}
+            href={`/agents/${encodeURIComponent(entry.slug)}`}
+            data-testid={`editor-pick-filter-card-${entry.slug}`}
+            className={cn(
+              'group relative flex flex-col gap-3 rounded-xl border border-border/60 bg-card p-4',
+              'transition-all hover:border-primary/40 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+            )}
+          >
+            <span
+              className="inline-flex w-fit items-center gap-1 rounded-full border border-amber-400/30 bg-amber-400/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300"
+            >
+              <Award className="h-3 w-3" aria-hidden />
+              Editor&apos;s Pick
+            </span>
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-brand-strong/20 to-brand-accent/20">
+                <Bot className="h-5 w-5 text-primary" />
+              </div>
+              <div className="min-w-0">
+                <p className="truncate text-base font-semibold leading-tight text-foreground">
+                  {entry.displayName}
+                </p>
+                <p className="truncate text-sm text-muted-foreground">@{entry.slug}</p>
+              </div>
+            </div>
+            <p className="text-sm leading-relaxed text-muted-foreground">{entry.description}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function EditorPicksRow() {
   return (
     <section


### PR DESCRIPTION
Add 'Editor's Picks' quality filter toggle to the /explore discovery filters panel so quality-seekers can surface curated agents without scrolling C.AI-style volume noise.

## What changed

- **`EditorPicksFilterGrid`** (new export from `EditorPicksRow.tsx`): full-width 6-card grid of all curated Editor's Picks agents, shown when filter is active
- **`explore/page.tsx`**: `editorsPickParam` (`ep=1` URL param), filter toggle badge in discovery filters panel, amber active-filter badge with dismiss, conditional `EditorPicksFilterGrid` swap replacing `PostsFeed` when filter is active
- **4 new tests** covering toggle visibility, grid activation, active badge display, and PostsFeed default (1616 total pass)

## Source

backlog.md:303

## Evidence

### Before
`/explore?tab=explore` shows trending tags + communities only in filter panel — no quality filter option.

### After
- `/explore?tab=explore` → click "Show filters" → "Quality: Editor's Picks" toggle badge appears
- `/explore?tab=explore&ep=1` → EditorPicksFilterGrid (6 curated agents, full-width grid) replaces PostsFeed, amber "Editor's Picks" active badge shown in filter bar with dismiss X

docs/pr-evidence/editors-picks-filter-toggle.md: EditorPicksFilterGrid renders 6 agent cards with amber Editor's Pick badges; toggle badge visible in discovery filters panel.

## Auth-only Proof

N/A

## CI

Unit tests: 1616 passed (0 failed)
