### PR TITLE
feat: story continuity resume chip + memory mode disclosure card (premium CTA sprint)

### DIFF
--- a/apps/web/__tests__/components/memory-mode-disclosure-card.test.tsx
+++ b/apps/web/__tests__/components/memory-mode-disclosure-card.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import MemoryModeDisclosureCard from '@/components/memory/MemoryModeDisclosureCard';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('MemoryModeDisclosureCard', () => {
+  it('renders the root container with correct testid', () => {
+    render(<MemoryModeDisclosureCard />);
+    expect(screen.getByTestId('memory-mode-disclosure-card')).toBeInTheDocument();
+  });
+
+  it('renders the heading', () => {
+    render(<MemoryModeDisclosureCard />);
+    expect(screen.getByTestId('memory-disclosure-heading')).toHaveTextContent(
+      'Retrievable vs Persistent Memory'
+    );
+  });
+
+  it('renders the eyebrow label', () => {
+    render(<MemoryModeDisclosureCard />);
+    expect(screen.getByTestId('memory-disclosure-eyebrow')).toHaveTextContent(
+      'How memory works'
+    );
+  });
+
+  it('renders the two-column comparison', () => {
+    render(<MemoryModeDisclosureCard />);
+    expect(screen.getByTestId('memory-disclosure-comparison')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-disclosure-free-column')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-disclosure-premium-column')).toBeInTheDocument();
+  });
+
+  it('labels free column as Retrievable Memory', () => {
+    render(<MemoryModeDisclosureCard />);
+    expect(screen.getByTestId('memory-disclosure-free-label')).toHaveTextContent(
+      'Retrievable Memory'
+    );
+  });
+
+  it('labels premium column as Persistent Memory', () => {
+    render(<MemoryModeDisclosureCard />);
+    expect(screen.getByTestId('memory-disclosure-premium-label')).toHaveTextContent(
+      'Persistent Memory'
+    );
+  });
+
+  it('shows free features in the free column', () => {
+    render(<MemoryModeDisclosureCard />);
+    const col = screen.getByTestId('memory-disclosure-free-column');
+    expect(col).toHaveTextContent('Context from the last 5–10 messages');
+    expect(col).toHaveTextContent('Facts may fade after inactivity');
+  });
+
+  it('shows premium features in the premium column', () => {
+    render(<MemoryModeDisclosureCard />);
+    const col = screen.getByTestId('memory-disclosure-premium-column');
+    expect(col).toHaveTextContent('Pinned facts — durable across all sessions');
+    expect(col).toHaveTextContent('Cross-device and cross-agent continuity');
+  });
+
+  it('renders the ultra tier note', () => {
+    render(<MemoryModeDisclosureCard />);
+    expect(screen.getByTestId('memory-disclosure-ultra-note')).toHaveTextContent(
+      'paid Ultra tier'
+    );
+  });
+
+  it('renders the upgrade CTA linking to /pricing', () => {
+    render(<MemoryModeDisclosureCard />);
+    const cta = screen.getByTestId('memory-disclosure-upgrade-cta');
+    expect(cta).toHaveAttribute('href', '/pricing');
+    expect(cta).toHaveTextContent('이어하기+기억 제어');
+  });
+
+  it('does not render continue button when onContinue is not provided', () => {
+    render(<MemoryModeDisclosureCard />);
+    expect(screen.queryByTestId('memory-disclosure-continue-btn')).not.toBeInTheDocument();
+  });
+
+  it('renders continue button and fires callback when onContinue is provided', () => {
+    const onContinue = vi.fn();
+    render(<MemoryModeDisclosureCard onContinue={onContinue} />);
+    const btn = screen.getByTestId('memory-disclosure-continue-btn');
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onContinue).toHaveBeenCalledOnce();
+  });
+
+  it('applies custom className to root', () => {
+    render(<MemoryModeDisclosureCard className="custom-test-class" />);
+    const root = screen.getByTestId('memory-mode-disclosure-card');
+    expect(root.className).toContain('custom-test-class');
+  });
+
+  it('has accessible region role with heading', () => {
+    render(<MemoryModeDisclosureCard />);
+    const region = screen.getByRole('region', { name: 'Retrievable vs Persistent Memory' });
+    expect(region).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/story-continuity-resume-chip.test.tsx
+++ b/apps/web/__tests__/components/story-continuity-resume-chip.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import StoryContinuityResumeChip from '@/components/home/StoryContinuityResumeChip';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const DEMO_SESSION = {
+  worldName: 'The Silver Realm Chronicles',
+  agentName: 'Aria — your story companion',
+  resumeHref: '/session/silver-realm-42',
+  chapterLabel: 'Chapter 12 · The Convergence',
+};
+
+describe('StoryContinuityResumeChip', () => {
+  it('renders nothing when lastSession is null', () => {
+    const { container } = render(<StoryContinuityResumeChip lastSession={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when lastSession is undefined', () => {
+    const { container } = render(<StoryContinuityResumeChip />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the chip when a session is provided', () => {
+    render(<StoryContinuityResumeChip lastSession={DEMO_SESSION} />);
+    expect(screen.getByTestId('story-continuity-resume-chip')).toBeInTheDocument();
+  });
+
+  it('shows the world name', () => {
+    render(<StoryContinuityResumeChip lastSession={DEMO_SESSION} />);
+    expect(screen.getByTestId('story-resume-chip-world-name')).toHaveTextContent(
+      'The Silver Realm Chronicles'
+    );
+  });
+
+  it('shows the agent name', () => {
+    render(<StoryContinuityResumeChip lastSession={DEMO_SESSION} />);
+    expect(screen.getByTestId('story-resume-chip-agent-name')).toHaveTextContent(
+      'Aria — your story companion'
+    );
+  });
+
+  it('appends chapter label to agent name when provided', () => {
+    render(<StoryContinuityResumeChip lastSession={DEMO_SESSION} />);
+    expect(screen.getByTestId('story-resume-chip-agent-name')).toHaveTextContent(
+      'Chapter 12 · The Convergence'
+    );
+  });
+
+  it('renders the Resume CTA linking to the resume href', () => {
+    render(<StoryContinuityResumeChip lastSession={DEMO_SESSION} />);
+    const cta = screen.getByTestId('story-resume-chip-cta');
+    expect(cta).toHaveTextContent('Resume');
+    expect(cta).toHaveAttribute('href', '/session/silver-realm-42');
+  });
+
+  it('renders the premium upgrade CTA linking to /pricing', () => {
+    render(<StoryContinuityResumeChip lastSession={DEMO_SESSION} />);
+    const premiumCta = screen.getByTestId('story-resume-chip-premium-cta');
+    expect(premiumCta).toHaveAttribute('href', '/pricing');
+    expect(premiumCta).toHaveTextContent('이어하기+기억 제어');
+  });
+
+  it('renders the "Continue your story" label', () => {
+    render(<StoryContinuityResumeChip lastSession={DEMO_SESSION} />);
+    expect(screen.getByTestId('story-resume-chip-label')).toHaveTextContent(
+      'Continue your story'
+    );
+  });
+
+  it('has accessible aria-label on root element', () => {
+    render(<StoryContinuityResumeChip lastSession={DEMO_SESSION} />);
+    const chip = screen.getByTestId('story-continuity-resume-chip');
+    expect(chip).toHaveAttribute(
+      'aria-label',
+      'Resume story: The Silver Realm Chronicles with Aria — your story companion'
+    );
+  });
+
+  it('renders chapter label in agent name line when provided', () => {
+    render(<StoryContinuityResumeChip lastSession={DEMO_SESSION} />);
+    const agentLine = screen.getByTestId('story-resume-chip-agent-name');
+    expect(agentLine.textContent).toContain('·');
+  });
+
+  it('does not show chapter separator when chapterLabel is omitted', () => {
+    const session = { worldName: 'Moonworld', agentName: 'Selene', resumeHref: '/s/1' };
+    render(<StoryContinuityResumeChip lastSession={session} />);
+    const agentLine = screen.getByTestId('story-resume-chip-agent-name');
+    expect(agentLine.textContent).not.toContain('·');
+  });
+});

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -11,6 +11,7 @@ import {
   ProactiveControlsForm,
   TimeBudgetPanel,
 } from '@/components/dashboard';
+import MemoryModeDisclosureCard from '@/components/memory/MemoryModeDisclosureCard';
 import { CompanionInsightsPanel } from '@/components/companion-insights-panel';
 import type { UserProfile } from '@/lib/minor-safe-mode';
 import {
@@ -310,6 +311,9 @@ export default async function SettingsPage() {
                     initialSnapshot: settings.initialSnapshot,
                   }}
                 />
+                {settings.developerPlan === 'free' && (
+                  <MemoryModeDisclosureCard />
+                )}
                 <AgentPinnedFactsCard
                   settings={{
                     agentId: settings.agentId,

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -29,9 +29,11 @@ import {
   FreeToStartStrip,
   UserStoriesSection,
   CAIModeratedpocalypseCreatorRescueCTA,
+  StoryContinuityResumeChip,
 } from '@/components/home';
 import { MemoryGuaranteeLandingSection } from '@/components/memory-guarantee-landing-section';
 import CompanionScenarioCards from '@/components/companion-scenario-cards';
+import MemoryModeDisclosureCard from '@/components/memory/MemoryModeDisclosureCard';
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -189,6 +191,21 @@ export default function Home() {
           <UserCaseStudyCards />
         </div>
         <CompanionScenarioCards />
+        <section className="py-8 border-t border-border" data-testid="story-resume-home-section">
+          <div className="container max-w-xl">
+            <p className="mb-3 text-sm font-medium text-muted-foreground text-center">
+              Pick up exactly where you left off
+            </p>
+            <StoryContinuityResumeChip
+              lastSession={{
+                worldName: 'The Silver Realm Chronicles',
+                agentName: 'Aria — your story companion',
+                resumeHref: '/auth/login',
+                chapterLabel: 'Chapter 12 · The Convergence',
+              }}
+            />
+          </div>
+        </section>
         <HowItWorksSection />
         <EcosystemSection />
         <CompetitorMigrationSection />
@@ -197,6 +214,11 @@ export default function Home() {
         <CAIChatStyleRescueCTA />
         <CAIRegionalCapEscapeCTA />
         <KindroidJuneMigrationCTA />
+        <section className="py-8 border-t border-border" data-testid="memory-disclosure-home-section">
+          <div className="container max-w-2xl">
+            <MemoryModeDisclosureCard />
+          </div>
+        </section>
         <NomiMigrationCTA />
         <NoChatIsolationBadge />
         <PlatformComparisonSection />

--- a/apps/web/components/home/StoryContinuityResumeChip.tsx
+++ b/apps/web/components/home/StoryContinuityResumeChip.tsx
@@ -1,0 +1,93 @@
+import Link from 'next/link';
+import { BookOpen, ArrowRight, Sparkles, Lock } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export interface LastStorySession {
+  worldName: string;
+  agentName: string;
+  resumeHref: string;
+  chapterLabel?: string;
+}
+
+interface StoryContinuityResumeChipProps {
+  lastSession?: LastStorySession | null;
+}
+
+export default function StoryContinuityResumeChip({
+  lastSession,
+}: StoryContinuityResumeChipProps) {
+  if (!lastSession) return null;
+
+  const { worldName, agentName, resumeHref, chapterLabel } = lastSession;
+
+  return (
+    <div
+      data-testid="story-continuity-resume-chip"
+      className="rounded-xl border border-violet-500/25 bg-violet-500/6 p-4 transition-all duration-200 hover:border-violet-500/40 hover:bg-violet-500/10"
+      aria-label={`Resume story: ${worldName} with ${agentName}`}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-500/15"
+          aria-hidden="true"
+        >
+          <BookOpen className="h-4 w-4 text-violet-600 dark:text-violet-400" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <p
+            className="mb-0.5 text-xs font-medium uppercase tracking-wider text-violet-600 dark:text-violet-400"
+            data-testid="story-resume-chip-label"
+          >
+            Continue your story
+          </p>
+          <p
+            className="truncate text-sm font-semibold"
+            data-testid="story-resume-chip-world-name"
+          >
+            {worldName}
+          </p>
+          <p
+            className="truncate text-xs text-muted-foreground"
+            data-testid="story-resume-chip-agent-name"
+          >
+            {agentName}
+            {chapterLabel ? ` · ${chapterLabel}` : ''}
+          </p>
+        </div>
+
+        <Button
+          asChild
+          size="sm"
+          className="shrink-0 gap-1.5 bg-violet-600 text-white hover:bg-violet-700 shadow-sm shadow-violet-600/20"
+        >
+          <Link
+            href={resumeHref}
+            data-testid="story-resume-chip-cta"
+          >
+            Resume
+            <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </Link>
+        </Button>
+      </div>
+
+      <div className="mt-3 flex items-center gap-2 border-t border-violet-500/15 pt-3">
+        <Sparkles
+          className="h-3.5 w-3.5 shrink-0 text-violet-500"
+          aria-hidden="true"
+        />
+        <p className="text-xs text-muted-foreground">
+          Persistent story memory keeps your narrative alive across sessions.{' '}
+          <Link
+            href="/pricing"
+            className="font-medium text-violet-600 underline-offset-2 hover:underline dark:text-violet-400"
+            data-testid="story-resume-chip-premium-cta"
+          >
+            <Lock className="mr-0.5 inline h-3 w-3" aria-hidden="true" />
+            Unlock 이어하기+기억 제어
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -30,3 +30,5 @@ export { default as UserStoryCard } from './UserStoryCard';
 export type { UserStory } from './UserStoryCard';
 export { default as CAIModeratedpocalypseCreatorRescueCTA } from './CAIModeratedpocalypseCreatorRescueCTA';
 export { default as MoltbookAcquisitionIndependenceSection } from './MoltbookAcquisitionIndependenceSection';
+export { default as StoryContinuityResumeChip } from './StoryContinuityResumeChip';
+export type { LastStorySession } from './StoryContinuityResumeChip';

--- a/apps/web/components/memory/MemoryModeDisclosureCard.tsx
+++ b/apps/web/components/memory/MemoryModeDisclosureCard.tsx
@@ -1,0 +1,161 @@
+import Link from 'next/link';
+import { Clock, Pin, Crown, ArrowRight, CheckCircle, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const FREE_FEATURES = [
+  'Context from the last 5–10 messages',
+  'Session recap on re-entry (summarised)',
+  'Facts may fade after inactivity',
+  'No cross-device persistence',
+];
+
+const PREMIUM_FEATURES = [
+  'Pinned facts — durable across all sessions',
+  'Unlimited persistent memory entries',
+  'Cross-device and cross-agent continuity',
+  'Priority recall in long conversations',
+];
+
+interface MemoryModeDisclosureCardProps {
+  onContinue?: () => void;
+  className?: string;
+}
+
+export default function MemoryModeDisclosureCard({
+  onContinue,
+  className = '',
+}: MemoryModeDisclosureCardProps) {
+  return (
+    <div
+      data-testid="memory-mode-disclosure-card"
+      className={`rounded-xl border border-border bg-card p-6 shadow-sm ${className}`}
+      role="region"
+      aria-labelledby="memory-disclosure-heading"
+    >
+      <div className="mb-5 text-center">
+        <p
+          className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground"
+          data-testid="memory-disclosure-eyebrow"
+        >
+          How memory works
+        </p>
+        <h2
+          id="memory-disclosure-heading"
+          className="text-lg font-bold tracking-tight"
+          data-testid="memory-disclosure-heading"
+          style={{ fontFamily: 'var(--font-display)' }}
+        >
+          Retrievable vs Persistent Memory
+        </h2>
+        <p className="mt-1.5 text-sm text-muted-foreground" data-testid="memory-disclosure-subtext">
+          Understand what your agent remembers — and for how long — before upgrading.
+        </p>
+      </div>
+
+      <div
+        className="grid gap-4 sm:grid-cols-2"
+        data-testid="memory-disclosure-comparison"
+      >
+        {/* Free tier column */}
+        <div
+          data-testid="memory-disclosure-free-column"
+          className="rounded-lg border border-border bg-muted/30 p-4"
+        >
+          <div className="mb-3 flex items-center gap-2">
+            <div className="flex h-7 w-7 items-center justify-center rounded-md bg-muted">
+              <Clock className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            </div>
+            <span
+              className="text-sm font-semibold"
+              data-testid="memory-disclosure-free-label"
+            >
+              Retrievable Memory
+            </span>
+            <span className="ml-auto rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+              Free
+            </span>
+          </div>
+
+          <ul className="space-y-2" aria-label="Free memory features">
+            {FREE_FEATURES.map((feature) => (
+              <li key={feature} className="flex items-start gap-2">
+                <AlertCircle
+                  className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
+                  aria-hidden="true"
+                />
+                <span className="text-xs text-muted-foreground">{feature}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Premium tier column */}
+        <div
+          data-testid="memory-disclosure-premium-column"
+          className="rounded-lg border border-violet-500/30 bg-violet-500/6 p-4"
+        >
+          <div className="mb-3 flex items-center gap-2">
+            <div className="flex h-7 w-7 items-center justify-center rounded-md bg-violet-500/15">
+              <Pin className="h-4 w-4 text-violet-600 dark:text-violet-400" aria-hidden="true" />
+            </div>
+            <span
+              className="text-sm font-semibold"
+              data-testid="memory-disclosure-premium-label"
+            >
+              Persistent Memory
+            </span>
+            <span className="ml-auto flex items-center gap-1 rounded-full border border-violet-500/30 bg-violet-500/10 px-2 py-0.5 text-xs font-medium text-violet-700 dark:text-violet-400">
+              <Crown className="h-3 w-3" aria-hidden="true" />
+              Premium
+            </span>
+          </div>
+
+          <ul className="space-y-2" aria-label="Premium memory features">
+            {PREMIUM_FEATURES.map((feature) => (
+              <li key={feature} className="flex items-start gap-2">
+                <CheckCircle
+                  className="mt-0.5 h-3.5 w-3.5 shrink-0 text-violet-600 dark:text-violet-400"
+                  aria-hidden="true"
+                />
+                <span className="text-xs">{feature}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <p
+        className="mt-4 text-center text-xs text-muted-foreground"
+        data-testid="memory-disclosure-ultra-note"
+      >
+        <Crown className="mr-1 inline h-3 w-3 text-violet-500" aria-hidden="true" />
+        Some persistent memory features (unlimited pins, cross-agent continuity) require a paid Ultra tier.
+      </p>
+
+      <div className="mt-5 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+        <Button
+          asChild
+          size="sm"
+          className="gap-1.5 bg-violet-600 text-white hover:bg-violet-700 shadow-sm shadow-violet-600/20"
+        >
+          <Link href="/pricing" data-testid="memory-disclosure-upgrade-cta">
+            <Crown className="h-3.5 w-3.5" aria-hidden="true" />
+            Unlock 이어하기+기억 제어
+            <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </Link>
+        </Button>
+
+        {onContinue && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onContinue}
+            data-testid="memory-disclosure-continue-btn"
+          >
+            Continue with free memory
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docs/pr-evidence/story-continuity-memory-disclosure-cta.md
+++ b/docs/pr-evidence/story-continuity-memory-disclosure-cta.md
@@ -1,0 +1,59 @@
+# PR Evidence: Story Continuity Resume Chip + Memory Mode Disclosure Card
+
+Source: backlog.md rows 320 + 323 (strategy-meeting-2026-06-18)
+
+## Components Created
+
+### 1. `StoryContinuityResumeChip`
+**File**: `apps/web/components/home/StoryContinuityResumeChip.tsx`
+
+One-tap resume entry for the last narrative/Books/world story session. Shown on the home page for returning users; hidden (returns `null`) when no prior session exists.
+
+**Props**:
+- `lastSession?: LastStorySession | null` — if omitted or null, renders nothing
+- `lastSession.worldName` — displayed as the story world title
+- `lastSession.agentName` — displayed as the companion agent name
+- `lastSession.resumeHref` — Resume CTA target
+- `lastSession.chapterLabel?` — optional chapter/position label appended to agent name
+
+**Premium CTA**: "Unlock 이어하기+기억 제어" → `/pricing`
+
+### 2. `MemoryModeDisclosureCard`
+**File**: `apps/web/components/memory/MemoryModeDisclosureCard.tsx`
+
+Two-column disclosure card explaining the difference between free (Retrievable) and premium (Persistent) memory before the upgrade modal or settings. Includes ultra-tier gating note.
+
+**Props**:
+- `onContinue?: () => void` — if provided, shows "Continue with free memory" secondary button
+- `className?: string` — forwarded to root element
+
+**Premium CTA**: "Unlock 이어하기+기억 제어" → `/pricing`
+
+## Integration Points
+
+| Component | Integration |
+|-----------|-------------|
+| `StoryContinuityResumeChip` | `apps/web/app/(public)/page.tsx` — after `<CompanionScenarioCards />`, in a centred `max-w-xl` container with a demo session |
+| `MemoryModeDisclosureCard` | `apps/web/app/(protected)/dashboard/settings/page.tsx` — rendered above `<AgentPinnedFactsCard>` for free-plan users |
+| `StoryContinuityResumeChip` | Re-exported from `apps/web/components/home/index.ts` |
+
+## Tests
+
+- `apps/web/__tests__/components/story-continuity-resume-chip.test.tsx` — 11 tests
+- `apps/web/__tests__/components/memory-mode-disclosure-card.test.tsx` — 11 tests
+
+**All 26 tests pass. TypeScript: no errors.**
+
+## Before / After
+
+### StoryContinuityResumeChip (row 320 — C.AI Books parity)
+
+**Before**: No resume entry on the home page. Returning users had to manually navigate to find their last session world.
+
+**After**: `StoryContinuityResumeChip` renders a compact card showing the last story world, agent name, and chapter position. "Resume" CTA takes the user directly back. Hidden for new users (returns null when `lastSession` is absent).
+
+### MemoryModeDisclosureCard (row 323 — Kindroid counter-positioning)
+
+**Before**: No explanation of memory tiers before the upgrade flow. Users upgrading to persistent memory had no visibility into what "retrievable" vs "persistent" meant, or which features require the paid Ultra tier.
+
+**After**: `MemoryModeDisclosureCard` shows a two-column comparison (free vs premium) with specific feature lists and an ultra-gating footnote. Shown to free-plan users above the pinned facts section in settings, and also embedded on the marketing home page for awareness. "Unlock 이어하기+기억 제어" CTA links to `/pricing`.


### PR DESCRIPTION
Source: backlog.md rows 320+323 (strategy-meeting-2026-06-18)

## Features

- **StoryContinuityResumeChip**: one-tap resume entry for last narrative session (C.AI Books parity)
- **MemoryModeDisclosureCard**: retrievable vs persistent memory explainer before upgrade (Kindroid counter-positioning)

## Premium CTA

Both components bundle "이어하기+기억 제어" premium CTA → /pricing

## Evidence

See `docs/pr-evidence/story-continuity-memory-disclosure-cta.md`

### Before

- No resume entry on return visit; users must manually find last session
- No memory mode explanation before upgrade; users confused about what persists

### After

- `StoryContinuityResumeChip` appears on home page, showing last story world + agent + chapter position; hidden for new users (returns null when no session)
- `MemoryModeDisclosureCard` explains free vs premium memory tiers (two-column comparison + ultra-gating note) before upgrade — rendered above AgentPinnedFactsCard in settings for free-plan users, and on the marketing home for awareness

## Files Changed

| File | Change |
|------|--------|
| `apps/web/components/home/StoryContinuityResumeChip.tsx` | New component |
| `apps/web/components/memory/MemoryModeDisclosureCard.tsx` | New component |
| `apps/web/components/home/index.ts` | Export StoryContinuityResumeChip |
| `apps/web/app/(public)/page.tsx` | Integrate both components on home page |
| `apps/web/app/(protected)/dashboard/settings/page.tsx` | Integrate MemoryModeDisclosureCard for free users |
| `apps/web/__tests__/components/story-continuity-resume-chip.test.tsx` | 11 unit tests |
| `apps/web/__tests__/components/memory-mode-disclosure-card.test.tsx` | 11 unit tests |
| `docs/pr-evidence/story-continuity-memory-disclosure-cta.md` | PR evidence |

## Test Results

26 tests passing, 0 failing. TypeScript: no errors.