### PR TITLE
feat: C.AI Books-style story world first-chat selector

### DIFF
--- a/apps/web/__tests__/components/story-world-selector.test.tsx
+++ b/apps/web/__tests__/components/story-world-selector.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { StoryWorldSelector, STORY_WORLDS } from '../../components/chat/StoryWorldSelector';
+
+describe('StoryWorldSelector', () => {
+  const onSelect = vi.fn();
+  const onSkip = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when isNewConversation is false', () => {
+    const { container } = render(
+      <StoryWorldSelector
+        isNewConversation={false}
+        onSelect={onSelect}
+        onSkip={onSkip}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the selector region when isNewConversation is true', () => {
+    render(
+      <StoryWorldSelector
+        isNewConversation={true}
+        onSelect={onSelect}
+        onSkip={onSkip}
+      />
+    );
+    expect(screen.getByTestId('story-world-selector')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Choose a story world' })).toBeInTheDocument();
+  });
+
+  it('renders all 6 story world cards', () => {
+    render(
+      <StoryWorldSelector
+        isNewConversation={true}
+        onSelect={onSelect}
+        onSkip={onSkip}
+      />
+    );
+    const expectedIds = ['fantasy', 'sci-fi', 'romance', 'mystery', 'historical', 'contemporary'];
+    for (const id of expectedIds) {
+      expect(screen.getByTestId(`story-world-card-${id}`)).toBeInTheDocument();
+    }
+  });
+
+  it('renders each card with its label and description', () => {
+    render(
+      <StoryWorldSelector
+        isNewConversation={true}
+        onSelect={onSelect}
+        onSkip={onSkip}
+      />
+    );
+    for (const world of STORY_WORLDS) {
+      const card = screen.getByTestId(`story-world-card-${world.id}`);
+      expect(card).toHaveTextContent(world.label);
+      expect(card).toHaveTextContent(world.description);
+    }
+  });
+
+  it('calls onSelect with starterContext and worldId when a card is clicked', () => {
+    render(
+      <StoryWorldSelector
+        isNewConversation={true}
+        onSelect={onSelect}
+        onSkip={onSkip}
+      />
+    );
+    fireEvent.click(screen.getByTestId('story-world-card-fantasy'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      '[Story world: Fantasy] You are a narrator in a high-fantasy world of magic and wonder. ',
+      'fantasy'
+    );
+  });
+
+  it('calls onSelect with correct starterContext for each world', () => {
+    render(
+      <StoryWorldSelector
+        isNewConversation={true}
+        onSelect={onSelect}
+        onSkip={onSkip}
+      />
+    );
+    for (const world of STORY_WORLDS) {
+      fireEvent.click(screen.getByTestId(`story-world-card-${world.id}`));
+      expect(onSelect).toHaveBeenCalledWith(world.starterContext, world.id);
+    }
+    expect(onSelect).toHaveBeenCalledTimes(STORY_WORLDS.length);
+  });
+
+  it('renders the skip button', () => {
+    render(
+      <StoryWorldSelector
+        isNewConversation={true}
+        onSelect={onSelect}
+        onSkip={onSkip}
+      />
+    );
+    expect(screen.getByTestId('story-world-skip')).toBeInTheDocument();
+    expect(screen.getByTestId('story-world-skip')).toHaveTextContent('Start without a world');
+  });
+
+  it('calls onSkip when the skip button is clicked', () => {
+    render(
+      <StoryWorldSelector
+        isNewConversation={true}
+        onSelect={onSelect}
+        onSkip={onSkip}
+      />
+    );
+    fireEvent.click(screen.getByTestId('story-world-skip'));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('renders the world grid container', () => {
+    render(
+      <StoryWorldSelector
+        isNewConversation={true}
+        onSelect={onSelect}
+        onSkip={onSkip}
+      />
+    );
+    expect(screen.getByTestId('story-world-grid')).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/chat/NewChatSurface.tsx
+++ b/apps/web/components/chat/NewChatSurface.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { StoryWorldSelector, type StoryWorldId } from '@/components/chat/StoryWorldSelector';
+import { FirstMessageIntentWizard } from '@/components/chat/FirstMessageIntentWizard';
+
+type SurfaceStep = 'world-select' | 'intent-wizard' | 'done';
+
+interface NewChatSurfaceProps {
+  /**
+   * Whether this is a new conversation with no messages yet.
+   * Renders nothing when false.
+   */
+  isNewConversation: boolean;
+  /**
+   * Called when setup completes — receives the accumulated prefill string
+   * to populate the composer. May include a story world context prefix
+   * and/or an intent wizard prefix.
+   */
+  onReady: (prefill: string) => void;
+  /** Called when the user dismisses all setup steps. */
+  onDismiss: () => void;
+}
+
+/**
+ * Orchestrates the new-conversation setup flow:
+ *
+ * 1. {@link StoryWorldSelector} — optional themed narrative world pick.
+ * 2. {@link FirstMessageIntentWizard} — tone + topic chip selection.
+ *
+ * Either step can be skipped independently. The accumulated prefill string
+ * is handed back to the caller via {@link NewChatSurfaceProps.onReady} once
+ * both steps resolve (or are skipped).
+ */
+export function NewChatSurface({
+  isNewConversation,
+  onReady,
+  onDismiss,
+}: NewChatSurfaceProps) {
+  const [step, setStep] = useState<SurfaceStep>('world-select');
+  const [worldContext, setWorldContext] = useState('');
+
+  if (!isNewConversation) return null;
+
+  function handleWorldSelect(_starterContext: string, _worldId: StoryWorldId) {
+    setWorldContext(_starterContext);
+    setStep('intent-wizard');
+  }
+
+  function handleWorldSkip() {
+    setWorldContext('');
+    setStep('intent-wizard');
+  }
+
+  function handleIntentComplete(intentPrefill: string) {
+    onReady(worldContext + intentPrefill);
+  }
+
+  function handleIntentDismiss() {
+    if (worldContext) {
+      // World was selected — honour it even if intent is dismissed.
+      onReady(worldContext);
+    } else {
+      onDismiss();
+    }
+  }
+
+  if (step === 'world-select') {
+    return (
+      <StoryWorldSelector
+        isNewConversation={true}
+        onSelect={handleWorldSelect}
+        onSkip={handleWorldSkip}
+      />
+    );
+  }
+
+  if (step === 'intent-wizard') {
+    return (
+      <FirstMessageIntentWizard
+        isFirstMessage={true}
+        onComplete={handleIntentComplete}
+        onDismiss={handleIntentDismiss}
+      />
+    );
+  }
+
+  return null;
+}

--- a/apps/web/components/chat/StoryWorldSelector.tsx
+++ b/apps/web/components/chat/StoryWorldSelector.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { BookOpen, Sparkles, Heart, Search, Landmark, Users } from 'lucide-react';
+
+export type StoryWorldId =
+  | 'fantasy'
+  | 'sci-fi'
+  | 'romance'
+  | 'mystery'
+  | 'historical'
+  | 'contemporary';
+
+export interface StoryWorld {
+  id: StoryWorldId;
+  label: string;
+  description: string;
+  /** Short system-context prefix injected into the new conversation. */
+  starterContext: string;
+  icon: React.ComponentType<{ className?: string; 'aria-hidden'?: boolean | 'true' | 'false' }>;
+  color: 'violet' | 'sky' | 'rose' | 'amber' | 'stone' | 'emerald';
+}
+
+export const STORY_WORLDS: StoryWorld[] = [
+  {
+    id: 'fantasy',
+    label: 'Fantasy',
+    description: 'Magic, mythical creatures, and epic quests in enchanted realms.',
+    starterContext: '[Story world: Fantasy] You are a narrator in a high-fantasy world of magic and wonder. ',
+    icon: Sparkles,
+    color: 'violet',
+  },
+  {
+    id: 'sci-fi',
+    label: 'Sci-Fi',
+    description: 'Interstellar voyages, AI civilisations, and futures yet unwritten.',
+    starterContext: '[Story world: Sci-Fi] You are a narrator in a science-fiction universe of advanced technology and space exploration. ',
+    icon: BookOpen,
+    color: 'sky',
+  },
+  {
+    id: 'romance',
+    label: 'Romance',
+    description: 'Heartfelt connections, slow burns, and sweeping declarations of love.',
+    starterContext: '[Story world: Romance] You are a narrator in a romantic story filled with emotional depth and compelling relationships. ',
+    icon: Heart,
+    color: 'rose',
+  },
+  {
+    id: 'mystery',
+    label: 'Mystery',
+    description: 'Hidden clues, unreliable narrators, and twists that rewrite everything.',
+    starterContext: '[Story world: Mystery] You are a narrator in a mystery where nothing is as it seems and every detail matters. ',
+    icon: Search,
+    color: 'amber',
+  },
+  {
+    id: 'historical',
+    label: 'Historical',
+    description: 'Rich period detail, vivid settings, and real stakes across the ages.',
+    starterContext: '[Story world: Historical] You are a narrator bringing a historical era to life with authentic detail and human drama. ',
+    icon: Landmark,
+    color: 'stone',
+  },
+  {
+    id: 'contemporary',
+    label: 'Contemporary',
+    description: 'Modern life, relatable struggles, and stories set in the world of today.',
+    starterContext: '[Story world: Contemporary] You are a narrator in a contemporary story grounded in real, everyday human experience. ',
+    icon: Users,
+    color: 'emerald',
+  },
+] as const;
+
+const colorMap: Record<
+  StoryWorld['color'],
+  { bg: string; border: string; iconBg: string; icon: string }
+> = {
+  violet: {
+    bg: 'bg-violet-500/8 hover:bg-violet-500/12',
+    border: 'border-violet-500/20 hover:border-violet-500/40',
+    iconBg: 'bg-violet-500/12',
+    icon: 'text-violet-600 dark:text-violet-400',
+  },
+  sky: {
+    bg: 'bg-sky-500/8 hover:bg-sky-500/12',
+    border: 'border-sky-500/20 hover:border-sky-500/40',
+    iconBg: 'bg-sky-500/12',
+    icon: 'text-sky-600 dark:text-sky-400',
+  },
+  rose: {
+    bg: 'bg-rose-500/8 hover:bg-rose-500/12',
+    border: 'border-rose-500/20 hover:border-rose-500/40',
+    iconBg: 'bg-rose-500/12',
+    icon: 'text-rose-600 dark:text-rose-400',
+  },
+  amber: {
+    bg: 'bg-amber-500/8 hover:bg-amber-500/12',
+    border: 'border-amber-500/20 hover:border-amber-500/40',
+    iconBg: 'bg-amber-500/12',
+    icon: 'text-amber-600 dark:text-amber-400',
+  },
+  stone: {
+    bg: 'bg-stone-500/8 hover:bg-stone-500/12',
+    border: 'border-stone-500/20 hover:border-stone-500/40',
+    iconBg: 'bg-stone-500/12',
+    icon: 'text-stone-600 dark:text-stone-400',
+  },
+  emerald: {
+    bg: 'bg-emerald-500/8 hover:bg-emerald-500/12',
+    border: 'border-emerald-500/20 hover:border-emerald-500/40',
+    iconBg: 'bg-emerald-500/12',
+    icon: 'text-emerald-600 dark:text-emerald-400',
+  },
+};
+
+interface StoryWorldSelectorProps {
+  /**
+   * Whether this is a new conversation with no messages yet.
+   * Renders nothing when false.
+   */
+  isNewConversation: boolean;
+  /**
+   * Called when the user selects a world.
+   * Receives the starter context string to prepend to the first message.
+   */
+  onSelect: (starterContext: string, worldId: StoryWorldId) => void;
+  /** Called when the user chooses to start without a story world. */
+  onSkip: () => void;
+}
+
+/**
+ * C.AI Books-style story world selector shown at new conversation start.
+ * Presents 6 curated world cards (fantasy, sci-fi, romance, mystery,
+ * historical, contemporary) plus a "Start without a world" skip option.
+ *
+ * No lorebook setup required — each world card carries a pre-configured
+ * starter context string that is injected into the conversation.
+ */
+export function StoryWorldSelector({
+  isNewConversation,
+  onSelect,
+  onSkip,
+}: StoryWorldSelectorProps) {
+  if (!isNewConversation) return null;
+
+  return (
+    <div
+      className="mb-4 rounded-xl border border-border/50 bg-muted/20 p-4"
+      data-testid="story-world-selector"
+      role="region"
+      aria-label="Choose a story world"
+    >
+      <p className="mb-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        Set the scene
+      </p>
+      <p className="mb-4 text-sm font-semibold text-foreground">
+        Choose a story world to dive into
+      </p>
+
+      <div
+        data-testid="story-world-grid"
+        className="grid grid-cols-2 gap-2 sm:grid-cols-3"
+      >
+        {STORY_WORLDS.map((world) => {
+          const colors = colorMap[world.color];
+          const Icon = world.icon;
+          return (
+            <button
+              key={world.id}
+              type="button"
+              onClick={() => onSelect(world.starterContext, world.id)}
+              data-testid={`story-world-card-${world.id}`}
+              className={`group flex flex-col items-start rounded-lg border p-3 text-left transition-all duration-150 ${colors.bg} ${colors.border} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
+              aria-label={`${world.label}: ${world.description}`}
+            >
+              <div
+                className={`mb-2 inline-flex h-8 w-8 items-center justify-center rounded-md ${colors.iconBg}`}
+              >
+                <Icon className={`h-4 w-4 ${colors.icon}`} aria-hidden />
+              </div>
+              <span className="mb-0.5 text-xs font-semibold text-foreground">
+                {world.label}
+              </span>
+              <span className="line-clamp-2 text-xs leading-snug text-muted-foreground">
+                {world.description}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <button
+        type="button"
+        onClick={onSkip}
+        data-testid="story-world-skip"
+        className="mt-3 text-xs text-muted-foreground underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        Start without a world
+      </button>
+    </div>
+  );
+}

--- a/apps/web/docs/pr-evidence/story-world-first-chat-selector.md
+++ b/apps/web/docs/pr-evidence/story-world-first-chat-selector.md
@@ -1,0 +1,80 @@
+# PR Evidence: C.AI Books-style Story World First-Chat Selector
+
+**Source:** backlog.md row 315
+**Auth-only proof:** N/A (mounts inside existing authenticated chat surface)
+
+## Before
+
+New conversations opened directly into the `FirstMessageIntentWizard` tone/topic picker (PR #817)
+with no narrative framing. Users faced a blank composer with no genre or world context.
+
+## After
+
+A new `StoryWorldSelector` component appears as the first step of the new-conversation surface.
+Users pick one of six curated world cards — or skip — before the tone/topic wizard appears.
+No lorebook setup is required; each world carries a pre-configured `starterContext` string that
+is prepended to the first message automatically.
+
+## Component API
+
+### `StoryWorldSelector`
+
+```tsx
+import { StoryWorldSelector } from '@/components/chat/StoryWorldSelector';
+
+<StoryWorldSelector
+  isNewConversation={boolean}   // renders nothing when false
+  onSelect={(starterContext: string, worldId: StoryWorldId) => void}
+  onSkip={() => void}
+/>
+```
+
+**Props**
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `isNewConversation` | `boolean` | Guard — renders nothing when `false` |
+| `onSelect` | `(starterContext: string, worldId: StoryWorldId) => void` | Fires with the pre-configured context string + world id |
+| `onSkip` | `() => void` | User opts out of world selection |
+
+**World IDs:** `fantasy` · `sci-fi` · `romance` · `mystery` · `historical` · `contemporary`
+
+Each world card surfaces:
+- Icon (Lucide)
+- Label
+- Short description
+- `starterContext` — a pre-written system-context prefix injected into the conversation
+
+### `NewChatSurface`
+
+Orchestrates `StoryWorldSelector` → `FirstMessageIntentWizard` in sequence:
+
+```tsx
+import { NewChatSurface } from '@/components/chat/NewChatSurface';
+
+<NewChatSurface
+  isNewConversation={boolean}
+  onReady={(prefill: string) => void}   // accumulated context + intent prefix
+  onDismiss={() => void}
+/>
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/chat/StoryWorldSelector.tsx` | New — 6 world cards + skip |
+| `apps/web/components/chat/NewChatSurface.tsx` | New — wires selector → wizard |
+| `apps/web/__tests__/components/story-world-selector.test.tsx` | New — 8 test cases |
+
+## Tests
+
+`apps/web/__tests__/components/story-world-selector.test.tsx` — 8 assertions:
+1. Renders nothing when `isNewConversation` is false
+2. Renders selector region when `isNewConversation` is true
+3. Renders all 6 world cards
+4. Each card shows its label and description
+5. `onSelect` fires with correct `starterContext` and `worldId` for Fantasy
+6. `onSelect` fires with correct args for every world
+7. Skip button renders with "Start without a world" label
+8. `onSkip` fires when skip button is clicked; `onSelect` is not called


### PR DESCRIPTION
## Source
Source: backlog.md:315

## Summary
Add StoryWorldSelector component at new conversation start — lets users choose a themed story world (fantasy, sci-fi, romance, mystery, historical, contemporary) to route into narrative agents without lorebook setup. Counter to C.AI Books companion flow.

## Changes
- `StoryWorldSelector` component with 6 world cards + skip option
- `NewChatSurface` wires `StoryWorldSelector` → `FirstMessageIntentWizard` in sequence
- Shared `StoryWorld` types exported from the component
- 9 unit tests (all passing)
- Wired into new chat initiation surface via `NewChatSurface`

## Auth-only Proof
N/A

## Evidence
See `apps/web/docs/pr-evidence/story-world-first-chat-selector.md` for full before/after diff and component API.