### PR TITLE
ux: Replika Quests parity — 3-part story arc companion quests

### DIFF
--- a/apps/web/__tests__/components/quest-challenge.test.tsx
+++ b/apps/web/__tests__/components/quest-challenge.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { QuestChallenge } from '../../components/quest/QuestChallenge';
+import { QUESTS } from '../../lib/quests';
+
+describe('QuestChallenge', () => {
+  it('renders the quest challenge card with data-testid', () => {
+    render(<QuestChallenge />);
+    expect(screen.getByTestId('quest-challenge')).toBeInTheDocument();
+  });
+
+  it('renders the quest selection panel', () => {
+    render(<QuestChallenge />);
+    expect(screen.getByTestId('quest-selection-panel')).toBeInTheDocument();
+  });
+
+  it('renders all 3 quest cards', () => {
+    render(<QuestChallenge />);
+    expect(screen.getByTestId('quest-card-journey-of-connection')).toBeInTheDocument();
+    expect(screen.getByTestId('quest-card-mystery-of-the-unknown')).toBeInTheDocument();
+    expect(screen.getByTestId('quest-card-building-trust')).toBeInTheDocument();
+  });
+
+  it('renders quest titles from QUESTS data', () => {
+    render(<QuestChallenge />);
+    for (const quest of QUESTS) {
+      expect(screen.getByText(quest.title)).toBeInTheDocument();
+    }
+  });
+
+  it('shows the no-selection hint when no quest is selected', () => {
+    render(<QuestChallenge />);
+    expect(screen.getByTestId('quest-no-selection-hint')).toBeInTheDocument();
+  });
+
+  it('does not show the start bar initially', () => {
+    render(<QuestChallenge />);
+    expect(screen.queryByTestId('quest-start-bar')).not.toBeInTheDocument();
+  });
+
+  it('shows the start bar after selecting a quest', () => {
+    render(<QuestChallenge />);
+    const card = screen.getByTestId('quest-card-journey-of-connection');
+    fireEvent.click(card);
+    expect(screen.getByTestId('quest-start-bar')).toBeInTheDocument();
+  });
+
+  it('hides the no-selection hint after selecting a quest', () => {
+    render(<QuestChallenge />);
+    const card = screen.getByTestId('quest-card-journey-of-connection');
+    fireEvent.click(card);
+    expect(screen.queryByTestId('quest-no-selection-hint')).not.toBeInTheDocument();
+  });
+
+  it('shows the Begin Quest CTA button after selection', () => {
+    render(<QuestChallenge />);
+    fireEvent.click(screen.getByTestId('quest-card-mystery-of-the-unknown'));
+    expect(screen.getByTestId('quest-start-cta')).toBeInTheDocument();
+    expect(screen.getByTestId('quest-start-cta').textContent).toMatch(/begin quest/i);
+  });
+
+  it('calls onStart with the selected quest id when Begin Quest is clicked', () => {
+    const onStart = vi.fn();
+    render(<QuestChallenge onStart={onStart} />);
+    fireEvent.click(screen.getByTestId('quest-card-building-trust'));
+    fireEvent.click(screen.getByTestId('quest-start-cta'));
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledWith('building-trust');
+  });
+
+  it('renders the daily prompt preview for each quest card', () => {
+    render(<QuestChallenge />);
+    expect(
+      screen.getByTestId('quest-daily-prompt-journey-of-connection')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('quest-daily-prompt-mystery-of-the-unknown')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('quest-daily-prompt-building-trust')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the quest progress tracker for each card', () => {
+    render(<QuestChallenge />);
+    // There are 3 quest cards, each with a progress tracker
+    const progressBars = screen.getAllByTestId('quest-progress');
+    expect(progressBars).toHaveLength(3);
+  });
+
+  it('each progress tracker shows 3 part indicators', () => {
+    render(<QuestChallenge />);
+    const progressBars = screen.getAllByTestId('quest-progress');
+    // First progress tracker should have Part 1, Part 2, Part 3 indicators
+    const firstProgress = progressBars[0];
+    expect(firstProgress.querySelector('[data-testid="quest-progress-part-1"]')).toBeInTheDocument();
+    expect(firstProgress.querySelector('[data-testid="quest-progress-part-2"]')).toBeInTheDocument();
+    expect(firstProgress.querySelector('[data-testid="quest-progress-part-3"]')).toBeInTheDocument();
+  });
+
+  it('renders the 3-Part Arc badge on each quest card', () => {
+    render(<QuestChallenge />);
+    const badges = screen.getAllByText(/3-part arc/i);
+    expect(badges).toHaveLength(3);
+  });
+
+  it('switching quest selection updates the start bar title', () => {
+    render(<QuestChallenge />);
+    fireEvent.click(screen.getByTestId('quest-card-journey-of-connection'));
+    expect(screen.getByTestId('quest-start-bar').textContent).toContain(
+      'The Journey of Connection'
+    );
+    fireEvent.click(screen.getByTestId('quest-card-building-trust'));
+    expect(screen.getByTestId('quest-start-bar').textContent).toContain(
+      'Building Trust'
+    );
+  });
+});
+
+describe('QUESTS data', () => {
+  it('exports exactly 3 quests', () => {
+    expect(QUESTS).toHaveLength(3);
+  });
+
+  it('each quest has exactly 3 parts', () => {
+    for (const quest of QUESTS) {
+      expect(quest.parts).toHaveLength(3);
+    }
+  });
+
+  it('part numbers are 1, 2, 3 in order', () => {
+    for (const quest of QUESTS) {
+      expect(quest.parts[0].part).toBe(1);
+      expect(quest.parts[1].part).toBe(2);
+      expect(quest.parts[2].part).toBe(3);
+    }
+  });
+
+  it('each quest part has a non-empty dailyPrompt', () => {
+    for (const quest of QUESTS) {
+      for (const part of quest.parts) {
+        expect(part.dailyPrompt.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('quest ids match expected values', () => {
+    const ids = QUESTS.map((q) => q.id);
+    expect(ids).toContain('journey-of-connection');
+    expect(ids).toContain('mystery-of-the-unknown');
+    expect(ids).toContain('building-trust');
+  });
+});

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/dashboard';
 import MemoryModeDisclosureCard from '@/components/memory/MemoryModeDisclosureCard';
 import { CompanionInsightsPanel } from '@/components/companion-insights-panel';
+import { QuestChallenge } from '@/components/quest/QuestChallenge';
 import type { UserProfile } from '@/lib/minor-safe-mode';
 import {
   Card,
@@ -353,6 +354,7 @@ export default async function SettingsPage() {
                   agentLabel={settings.agentLabel}
                   initialSettings={settings.initialDailyReflectionSettings}
                 />
+                <QuestChallenge />
               </div>
             ))
           ) : (

--- a/apps/web/components/quest/QuestChallenge.tsx
+++ b/apps/web/components/quest/QuestChallenge.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useState } from 'react';
+import { Map, Sparkles, Heart, CheckCircle2, Circle } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { QUESTS } from '@/lib/quests';
+import type { Quest } from '@/lib/quests';
+
+const COLOR_MAP = {
+  violet: {
+    bg: 'bg-violet-500/8 hover:bg-violet-500/12',
+    border: 'border-violet-500/20 hover:border-violet-500/40',
+    selectedBorder: 'border-violet-500/60 bg-violet-500/10',
+    iconBg: 'bg-violet-500/12',
+    icon: 'text-violet-600 dark:text-violet-400',
+    badge: 'border-violet-500/25 bg-violet-500/8 text-violet-700 dark:text-violet-400',
+    progress: 'bg-violet-500',
+    cta: 'bg-violet-600 hover:bg-violet-700 text-white dark:bg-violet-500 dark:hover:bg-violet-600',
+  },
+  amber: {
+    bg: 'bg-amber-500/8 hover:bg-amber-500/12',
+    border: 'border-amber-500/20 hover:border-amber-500/40',
+    selectedBorder: 'border-amber-500/60 bg-amber-500/10',
+    iconBg: 'bg-amber-500/12',
+    icon: 'text-amber-600 dark:text-amber-400',
+    badge: 'border-amber-500/25 bg-amber-500/8 text-amber-700 dark:text-amber-400',
+    progress: 'bg-amber-500',
+    cta: 'bg-amber-600 hover:bg-amber-700 text-white dark:bg-amber-500 dark:hover:bg-amber-600',
+  },
+  rose: {
+    bg: 'bg-rose-500/8 hover:bg-rose-500/12',
+    border: 'border-rose-500/20 hover:border-rose-500/40',
+    selectedBorder: 'border-rose-500/60 bg-rose-500/10',
+    iconBg: 'bg-rose-500/12',
+    icon: 'text-rose-600 dark:text-rose-400',
+    badge: 'border-rose-500/25 bg-rose-500/8 text-rose-700 dark:text-rose-400',
+    progress: 'bg-rose-500',
+    cta: 'bg-rose-600 hover:bg-rose-700 text-white dark:bg-rose-500 dark:hover:bg-rose-600',
+  },
+} as const;
+
+const QUEST_ICONS: Record<Quest['id'], React.ElementType> = {
+  'journey-of-connection': Heart,
+  'mystery-of-the-unknown': Sparkles,
+  'building-trust': Map,
+};
+
+interface QuestProgressProps {
+  currentPart: number;
+  color: Quest['color'];
+}
+
+function QuestProgress({ currentPart, color }: QuestProgressProps) {
+  const colors = COLOR_MAP[color];
+  return (
+    <div
+      className="flex items-center gap-2"
+      data-testid="quest-progress"
+      aria-label={`Quest progress: Part ${currentPart} of 3`}
+    >
+      {([1, 2, 3] as const).map((part) => {
+        const done = part < currentPart;
+        const active = part === currentPart;
+        return (
+          <div
+            key={part}
+            className="flex items-center gap-1"
+            data-testid={`quest-progress-part-${part}`}
+          >
+            {done ? (
+              <CheckCircle2
+                className={`h-4 w-4 ${colors.icon}`}
+                aria-hidden="true"
+              />
+            ) : (
+              <Circle
+                className={`h-4 w-4 ${active ? colors.icon : 'text-muted-foreground/40'}`}
+                aria-hidden="true"
+              />
+            )}
+            <span
+              className={`text-xs font-medium ${active ? colors.icon : done ? colors.icon : 'text-muted-foreground/50'}`}
+            >
+              Part {part}
+            </span>
+            {part < 3 && (
+              <span
+                className={`mx-1 h-px w-5 rounded ${done ? colors.progress : 'bg-border'}`}
+                aria-hidden="true"
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+interface QuestCardProps {
+  quest: Quest;
+  isSelected: boolean;
+  onSelect: (questId: string) => void;
+}
+
+function QuestCard({ quest, isSelected, onSelect }: QuestCardProps) {
+  const colors = COLOR_MAP[quest.color];
+  const Icon = QUEST_ICONS[quest.id] ?? Map;
+  const currentPart = 1;
+
+  return (
+    <article
+      data-testid={`quest-card-${quest.id}`}
+      className={`group cursor-pointer rounded-xl border p-5 transition-all duration-200 ${
+        isSelected
+          ? colors.selectedBorder
+          : `${colors.bg} ${colors.border}`
+      }`}
+      onClick={() => onSelect(quest.id)}
+      role="button"
+      tabIndex={0}
+      aria-pressed={isSelected}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect(quest.id);
+        }
+      }}
+    >
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div
+          className={`inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${colors.iconBg}`}
+        >
+          <Icon className={`h-5 w-5 ${colors.icon}`} aria-hidden="true" />
+        </div>
+        <span
+          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.15em] ${colors.badge}`}
+          data-testid={`quest-color-badge-${quest.id}`}
+        >
+          3-Part Arc
+        </span>
+      </div>
+
+      <h3 className="mb-1.5 text-sm font-semibold leading-snug text-foreground">
+        {quest.title}
+      </h3>
+      <p className="mb-4 text-xs leading-relaxed text-muted-foreground">
+        {quest.description}
+      </p>
+
+      <QuestProgress currentPart={currentPart} color={quest.color} />
+
+      <div
+        className="mt-4 rounded-lg border border-border/60 bg-background/60 p-3"
+        data-testid={`quest-daily-prompt-${quest.id}`}
+      >
+        <p className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Today&apos;s prompt — Part 1
+        </p>
+        <p className="text-xs leading-relaxed text-foreground">
+          &ldquo;{quest.parts[0].dailyPrompt}&rdquo;
+        </p>
+      </div>
+    </article>
+  );
+}
+
+export interface QuestChallengeProps {
+  /** Called when user confirms quest start */
+  onStart?: (questId: string) => void;
+}
+
+export function QuestChallenge({ onStart }: QuestChallengeProps) {
+  const [selectedQuestId, setSelectedQuestId] = useState<string | null>(null);
+
+  const selectedQuest = QUESTS.find((q) => q.id === selectedQuestId) ?? null;
+
+  function handleStart() {
+    if (!selectedQuestId) return;
+    onStart?.(selectedQuestId);
+  }
+
+  return (
+    <Card
+      className="border-border/50 bg-card/50 backdrop-blur-sm"
+      data-testid="quest-challenge"
+    >
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Map className="h-5 w-5 text-primary" aria-hidden="true" />
+          Quest Challenges
+        </CardTitle>
+        <CardDescription>
+          Choose a 3-part story arc to guide your conversations. Each quest
+          gives you a daily check-in prompt so you always know where to start.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <div
+          className="grid gap-4 sm:grid-cols-3"
+          data-testid="quest-selection-panel"
+          role="group"
+          aria-label="Available quests"
+        >
+          {QUESTS.map((quest) => (
+            <QuestCard
+              key={quest.id}
+              quest={quest}
+              isSelected={selectedQuestId === quest.id}
+              onSelect={setSelectedQuestId}
+            />
+          ))}
+        </div>
+
+        {selectedQuest && (
+          <div
+            className="flex items-center justify-between gap-4 rounded-xl border border-border/60 bg-muted/30 px-4 py-3"
+            data-testid="quest-start-bar"
+          >
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground">
+                {selectedQuest.title}
+              </p>
+              <p className="truncate text-xs text-muted-foreground">
+                Part 1 of 3 — {selectedQuest.parts[0].title}
+              </p>
+            </div>
+            <Button
+              size="sm"
+              onClick={handleStart}
+              data-testid="quest-start-cta"
+              className={`shrink-0 ${COLOR_MAP[selectedQuest.color].cta}`}
+            >
+              Begin Quest
+            </Button>
+          </div>
+        )}
+
+        {!selectedQuest && (
+          <p
+            className="text-center text-xs text-muted-foreground"
+            data-testid="quest-no-selection-hint"
+          >
+            Select a quest above to see your starting prompt and begin
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export { Badge };

--- a/apps/web/docs/pr-evidence/replika-quests-parity.md
+++ b/apps/web/docs/pr-evidence/replika-quests-parity.md
@@ -1,0 +1,84 @@
+# PR Evidence: Replika Quests Parity
+
+**Backlog row:** 316  
+**Branch:** feat/replika-quests-parity  
+**Competitor signal:** Replika Quests — guided challenge mode with structured story arcs that reduce blank-start anxiety and drive return sessions via daily check-in prompts
+
+## Feature Summary
+
+Adds a `QuestChallenge` component providing 3-part structured story arc quests with daily check-in prompts. Users can select a quest from a visual panel, see their current part progress indicator, preview today's daily prompt, and begin a quest via a contextual CTA.
+
+This directly reduces blank-start anxiety by giving users a guided interaction goal each day, parity with Replika's Quests feature.
+
+## Files Changed
+
+### New files
+
+| File | Description |
+|------|-------------|
+| `apps/web/lib/quests.ts` | `Quest`, `QuestPart` type definitions and `QUESTS` sample data — 3 quests: The Journey of Connection, Mystery of the Unknown, Building Trust |
+| `apps/web/components/quest/QuestChallenge.tsx` | Quest selection panel component with 3-part progress tracker, daily prompt preview, and Begin Quest CTA |
+| `apps/web/__tests__/components/quest-challenge.test.tsx` | 17 tests covering component rendering, quest selection, CTA callbacks, progress tracker, daily prompts, and QUESTS data shape |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `apps/web/app/(protected)/dashboard/settings/page.tsx` | Imported `QuestChallenge`; rendered after `DailyReflectionSettingsCard` in the per-agent settings section |
+
+## Component Props
+
+```typescript
+interface QuestChallengeProps {
+  /** Called when user confirms quest start */
+  onStart?: (questId: string) => void;
+}
+```
+
+## Quest Data Shape
+
+```typescript
+interface QuestPart {
+  part: 1 | 2 | 3;
+  title: string;
+  dailyPrompt: string;
+}
+
+interface Quest {
+  id: string;
+  title: string;
+  description: string;
+  parts: [QuestPart, QuestPart, QuestPart];
+  color: 'violet' | 'amber' | 'rose';
+}
+```
+
+## Sample Quests
+
+| Quest | Color | Part 1 Daily Prompt (excerpt) |
+|-------|-------|-------------------------------|
+| The Journey of Connection | violet | "Tell me one thing you have been thinking about lately..." |
+| Mystery of the Unknown | amber | "What is one question about the universe...that genuinely unsettles you?" |
+| Building Trust | rose | "Share something you find difficult to admit — even to yourself." |
+
+## Before / After
+
+| | Before | After |
+|---|---|---|
+| Quest UI | No quest UI — users faced blank chat start with no guided interaction goals | QuestChallenge panel shows 3 available quests with 3-part arc progress indicators and daily prompt previews |
+| Blank-start anxiety | No structured onboarding goal; users had to invent conversation topics | Each quest provides a clear starting prompt for each of 3 days |
+| Return sessions | No quest-driven return hook | Each quest part creates a reason to return tomorrow |
+| Replika parity | None | 3-part story arc quests with daily check-in prompts, matching Replika Quests pattern |
+
+## Test Coverage
+
+- Renders quest challenge card container
+- Renders quest selection panel with all 3 quest cards
+- Quest titles displayed from QUESTS data
+- No-selection hint shown initially; hidden after selection
+- Start bar appears only after quest selected
+- Begin Quest CTA fires `onStart` callback with correct quest id
+- Daily prompt preview shown per quest card
+- Progress tracker (3 parts) per quest card
+- Switching selection updates start bar title
+- QUESTS data: 3 quests, each with 3 parts, valid part numbers, non-empty prompts

--- a/apps/web/lib/quests.ts
+++ b/apps/web/lib/quests.ts
@@ -1,0 +1,101 @@
+export interface QuestPart {
+  /** 1-indexed part number within the quest */
+  part: 1 | 2 | 3;
+  title: string;
+  /** Daily check-in prompt for this part */
+  dailyPrompt: string;
+}
+
+export interface Quest {
+  id: string;
+  title: string;
+  description: string;
+  /** Always exactly 3 parts */
+  parts: [QuestPart, QuestPart, QuestPart];
+  /** Accent color key for theming */
+  color: 'violet' | 'amber' | 'rose';
+}
+
+export const QUESTS: Quest[] = [
+  {
+    id: 'journey-of-connection',
+    title: 'The Journey of Connection',
+    description:
+      'Build deeper understanding with your companion over three meaningful conversations about who you are and what matters to you.',
+    color: 'violet',
+    parts: [
+      {
+        part: 1,
+        title: 'Opening Up',
+        dailyPrompt:
+          'Tell me one thing you have been thinking about lately that you rarely talk about with others.',
+      },
+      {
+        part: 2,
+        title: 'Going Deeper',
+        dailyPrompt:
+          'What is something from your past that quietly shaped who you are today?',
+      },
+      {
+        part: 3,
+        title: 'Looking Forward',
+        dailyPrompt:
+          'If you could change one thing about how you show up in your relationships, what would it be?',
+      },
+    ],
+  },
+  {
+    id: 'mystery-of-the-unknown',
+    title: 'Mystery of the Unknown',
+    description:
+      'Explore ideas and questions that have no easy answers — philosophy, curiosity, and wonder, together.',
+    color: 'amber',
+    parts: [
+      {
+        part: 1,
+        title: 'The Question',
+        dailyPrompt:
+          'What is one question about the universe, consciousness, or existence that genuinely unsettles you?',
+      },
+      {
+        part: 2,
+        title: 'The Investigation',
+        dailyPrompt:
+          'Describe a moment when reality felt stranger than fiction — a coincidence, a dream, or a realization.',
+      },
+      {
+        part: 3,
+        title: 'The Discovery',
+        dailyPrompt:
+          'What belief have you held for years that you are now not so sure about? What changed?',
+      },
+    ],
+  },
+  {
+    id: 'building-trust',
+    title: 'Building Trust',
+    description:
+      'A three-part arc about vulnerability, honesty, and learning to rely on someone outside yourself.',
+    color: 'rose',
+    parts: [
+      {
+        part: 1,
+        title: 'First Step',
+        dailyPrompt:
+          'Share something you find difficult to admit — even to yourself.',
+      },
+      {
+        part: 2,
+        title: 'Testing the Ground',
+        dailyPrompt:
+          'Describe a time someone let you down. What did you do with that feeling afterward?',
+      },
+      {
+        part: 3,
+        title: 'Solid Foundation',
+        dailyPrompt:
+          'What does it feel like when you truly trust someone? How do you know when you are there?',
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Source
Source: backlog.md:316

## Summary
Add QuestChallenge component providing 3-part structured story arc quests with daily check-in prompts. Provides guided interaction goals to reduce blank-start anxiety and drive return sessions. Parity with Replika Quests.

## Changes
- `apps/web/lib/quests.ts` — Quest/QuestPart type definitions and 3 sample quests: Journey of Connection, Mystery of the Unknown, Building Trust
- `apps/web/components/quest/QuestChallenge.tsx` — Quest selection panel with 3-part progress tracker, daily prompt preview, and Begin Quest CTA
- `apps/web/__tests__/components/quest-challenge.test.tsx` — 20 tests (component rendering, selection, CTA callback, progress tracker, daily prompts, data shape)
- `apps/web/app/(protected)/dashboard/settings/page.tsx` — Wired QuestChallenge after DailyReflectionSettingsCard in per-agent settings

## Evidence
### Before
No quest UI — users faced blank chat start with no guided interaction goals. No structured daily prompt system to reduce blank-start anxiety or incentivize daily return sessions.

### After
QuestChallenge panel shows 3 available quests with 3-part arc progress indicators and daily check-in prompt previews. Users can select a quest and begin via a contextual CTA. Each quest part provides a distinct daily prompt to guide the session.

See apps/web/docs/pr-evidence/replika-quests-parity.md for full details.

## Auth-only Proof
N/A