### PR TITLE
feat(explore): creator discovery spotlight — follow-first discovery block

### DIFF
--- a/apps/web/__tests__/components/creator-discovery-spotlight.test.tsx
+++ b/apps/web/__tests__/components/creator-discovery-spotlight.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import {
+  CreatorDiscoverySpotlight,
+  STUB_CREATORS,
+  type CreatorEntry,
+} from '../../components/explore/CreatorDiscoverySpotlight';
+
+describe('CreatorDiscoverySpotlight', () => {
+  it('renders creator cards from stub data', () => {
+    render(<CreatorDiscoverySpotlight />);
+
+    expect(screen.getByTestId('creator-discovery-spotlight')).toBeInTheDocument();
+    expect(screen.getByTestId('creator-discovery-grid')).toBeInTheDocument();
+
+    // First creator card from stub data
+    expect(screen.getByTestId('creator-card-creator-1')).toBeInTheDocument();
+    expect(screen.getByTestId('creator-card-creator-1-tagline')).toHaveTextContent(
+      'Crafting immersive narrative worlds'
+    );
+    expect(screen.getByTestId('creator-card-creator-1-worlds')).toHaveTextContent('12 worlds');
+    expect(screen.getByTestId('creator-card-creator-1-followers')).toHaveTextContent('3.8k followers');
+  });
+
+  it('shows empty state when no creators are provided', () => {
+    render(<CreatorDiscoverySpotlight creators={[]} />);
+
+    expect(screen.getByTestId('creator-discovery-spotlight')).toBeInTheDocument();
+    expect(screen.getByTestId('creator-discovery-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('creator-discovery-grid')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('No creators to spotlight right now')
+    ).toBeInTheDocument();
+  });
+
+  it('Follow button toggles following state', () => {
+    const singleCreator: CreatorEntry[] = [STUB_CREATORS[0]];
+    render(<CreatorDiscoverySpotlight creators={singleCreator} />);
+
+    const followBtn = screen.getByTestId('follow-button-creator-1');
+    expect(followBtn).toHaveTextContent('Follow');
+    expect(followBtn).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(followBtn);
+
+    expect(followBtn).toHaveTextContent('Following');
+    expect(followBtn).toHaveAttribute('aria-pressed', 'true');
+
+    // Toggle back
+    fireEvent.click(followBtn);
+    expect(followBtn).toHaveTextContent('Follow');
+    expect(followBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders the correct number of creator cards', () => {
+    const threeCreators = STUB_CREATORS.slice(0, 3);
+    render(<CreatorDiscoverySpotlight creators={threeCreators} />);
+
+    expect(screen.getByTestId('creator-card-creator-1')).toBeInTheDocument();
+    expect(screen.getByTestId('creator-card-creator-2')).toBeInTheDocument();
+    expect(screen.getByTestId('creator-card-creator-3')).toBeInTheDocument();
+    expect(screen.queryByTestId('creator-card-creator-4')).not.toBeInTheDocument();
+  });
+
+  it('renders section heading and see-all link', () => {
+    render(<CreatorDiscoverySpotlight />);
+
+    expect(screen.getByTestId('creator-discovery-title')).toHaveTextContent(
+      'Creators to Discover'
+    );
+    const seeAll = screen.getByTestId('creator-discovery-see-all');
+    expect(seeAll).toBeInTheDocument();
+    expect(seeAll).toHaveAttribute('href', '/agents');
+  });
+
+  it('each creator card links to the agent profile page', () => {
+    const singleCreator: CreatorEntry[] = [STUB_CREATORS[0]];
+    render(<CreatorDiscoverySpotlight creators={singleCreator} />);
+
+    const link = screen.getByTestId('creator-card-creator-1-link');
+    expect(link).toHaveAttribute('href', '/agents/elena-worldsmith');
+  });
+});

--- a/apps/web/app/(public)/explore/page.tsx
+++ b/apps/web/app/(public)/explore/page.tsx
@@ -24,6 +24,7 @@ import { EditorPicksRow, EditorPicksFilterGrid } from '@/components/explore/Edit
 import { UsecaseCollectionRows } from '@/components/explore/UsecaseCollectionRows';
 import { CommunityHubsStrip } from '@/components/explore/CommunityHubsStrip';
 import { UserStoryStrip } from '@/components/explore/UserStoryStrip';
+import { CreatorDiscoverySpotlight } from '@/components/explore/CreatorDiscoverySpotlight';
 import { PostsFeed, FeedTabs, ViewToggle } from '@/components/posts';
 import {
   useSearch,
@@ -289,6 +290,8 @@ function ExploreContent() {
           {tab === 'explore' && <UsecaseCollectionRows />}
 
           {tab === 'explore' && <CommunityHubsStrip />}
+
+          {tab === 'explore' && <CreatorDiscoverySpotlight />}
 
           {tab === 'explore' && <UserCaseStudyCards />}
 

--- a/apps/web/components/explore/CreatorDiscoverySpotlight.tsx
+++ b/apps/web/components/explore/CreatorDiscoverySpotlight.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Users, Globe, UserPlus, Check, ChevronRight, Sparkles } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+
+export interface CreatorEntry {
+  id: string;
+  slug: string;
+  displayName: string;
+  tagline: string;
+  worldCount: number;
+  followerCount: number;
+  avatarInitials: string;
+  avatarColor: string;
+}
+
+export const STUB_CREATORS: CreatorEntry[] = [
+  {
+    id: 'creator-1',
+    slug: 'elena-worldsmith',
+    displayName: 'Elena Worldsmith',
+    tagline: 'Crafting immersive narrative worlds with emotionally-aware agents.',
+    worldCount: 12,
+    followerCount: 3841,
+    avatarInitials: 'EW',
+    avatarColor: 'from-violet-500/30 to-purple-600/30',
+  },
+  {
+    id: 'creator-2',
+    slug: 'kai-synth',
+    displayName: 'Kai Synth',
+    tagline: 'Music theory tutor agents that adapt to your learning pace.',
+    worldCount: 5,
+    followerCount: 1207,
+    avatarInitials: 'KS',
+    avatarColor: 'from-blue-500/30 to-cyan-600/30',
+  },
+  {
+    id: 'creator-3',
+    slug: 'nova-labs',
+    displayName: 'Nova Labs',
+    tagline: 'Open-source wellness companions. All memories stay local.',
+    worldCount: 8,
+    followerCount: 2630,
+    avatarInitials: 'NL',
+    avatarColor: 'from-emerald-500/30 to-teal-600/30',
+  },
+  {
+    id: 'creator-4',
+    slug: 'rhys-narrator',
+    displayName: 'Rhys Narrator',
+    tagline: 'Collaborative fiction — branching stories shaped by your choices.',
+    worldCount: 20,
+    followerCount: 5190,
+    avatarInitials: 'RN',
+    avatarColor: 'from-rose-500/30 to-pink-600/30',
+  },
+  {
+    id: 'creator-5',
+    slug: 'suki-mindful',
+    displayName: 'Suki Mindful',
+    tagline: 'Daily reflection agents grounded in evidence-based mindfulness.',
+    worldCount: 3,
+    followerCount: 988,
+    avatarInitials: 'SM',
+    avatarColor: 'from-amber-500/30 to-yellow-600/30',
+  },
+  {
+    id: 'creator-6',
+    slug: 'dex-codesmith',
+    displayName: 'Dex Codesmith',
+    tagline: 'Pair-programming agents for language learners and CS students.',
+    worldCount: 7,
+    followerCount: 1560,
+    avatarInitials: 'DC',
+    avatarColor: 'from-sky-500/30 to-indigo-600/30',
+  },
+];
+
+function formatFollowers(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}k`;
+  }
+  return String(count);
+}
+
+interface FollowButtonProps {
+  creatorId: string;
+}
+
+function FollowButton({ creatorId }: FollowButtonProps) {
+  const [isFollowing, setIsFollowing] = useState(false);
+
+  return (
+    <Button
+      variant={isFollowing ? 'secondary' : 'default'}
+      size="sm"
+      className={cn(
+        'h-7 gap-1 px-3 text-xs font-medium',
+        isFollowing && 'text-muted-foreground'
+      )}
+      onClick={(e) => {
+        e.preventDefault();
+        setIsFollowing((prev) => !prev);
+      }}
+      data-testid={`follow-button-${creatorId}`}
+      aria-pressed={isFollowing}
+      aria-label={isFollowing ? 'Unfollow creator' : 'Follow creator'}
+    >
+      {isFollowing ? (
+        <>
+          <Check className="h-3 w-3" aria-hidden />
+          Following
+        </>
+      ) : (
+        <>
+          <UserPlus className="h-3 w-3" aria-hidden />
+          Follow
+        </>
+      )}
+    </Button>
+  );
+}
+
+function CreatorCard({ creator }: { creator: CreatorEntry }) {
+  return (
+    <div
+      data-testid={`creator-card-${creator.id}`}
+      className={cn(
+        'group flex flex-col gap-3 rounded-xl border border-border/60 bg-card p-4',
+        'transition-all hover:border-primary/40 hover:shadow-md'
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <Link
+          href={`/agents/${encodeURIComponent(creator.slug)}`}
+          data-testid={`creator-card-${creator.id}-link`}
+          className="flex items-center gap-2.5 min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded"
+        >
+          <div
+            className={cn(
+              'flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br text-sm font-bold text-foreground',
+              creator.avatarColor
+            )}
+            aria-hidden="true"
+          >
+            {creator.avatarInitials}
+          </div>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold leading-tight text-foreground group-hover:text-primary transition-colors">
+              {creator.displayName}
+            </p>
+            <p className="truncate text-xs text-muted-foreground">
+              @{creator.slug}
+            </p>
+          </div>
+        </Link>
+        <FollowButton creatorId={creator.id} />
+      </div>
+
+      <p
+        data-testid={`creator-card-${creator.id}-tagline`}
+        className="line-clamp-2 text-xs leading-relaxed text-muted-foreground"
+      >
+        {creator.tagline}
+      </p>
+
+      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+        <span
+          data-testid={`creator-card-${creator.id}-worlds`}
+          className="flex items-center gap-1"
+        >
+          <Globe className="h-3 w-3 text-primary/60" aria-hidden />
+          {creator.worldCount} {creator.worldCount === 1 ? 'world' : 'worlds'}
+        </span>
+        <span
+          data-testid={`creator-card-${creator.id}-followers`}
+          className="flex items-center gap-1"
+        >
+          <Users className="h-3 w-3 text-primary/60" aria-hidden />
+          {formatFollowers(creator.followerCount)} followers
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function CreatorDiscoveryEmptyState() {
+  return (
+    <div
+      data-testid="creator-discovery-empty"
+      className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-border/60 bg-card/50 py-12 text-center"
+    >
+      <Sparkles className="h-8 w-8 text-muted-foreground/40" aria-hidden />
+      <p className="text-sm font-medium text-muted-foreground">
+        No creators to spotlight right now
+      </p>
+      <p className="max-w-xs text-xs text-muted-foreground/70">
+        Check back soon — new creators are joining every day.
+      </p>
+    </div>
+  );
+}
+
+interface CreatorDiscoverySpotlightProps {
+  creators?: CreatorEntry[];
+}
+
+export function CreatorDiscoverySpotlight({
+  creators = STUB_CREATORS,
+}: CreatorDiscoverySpotlightProps) {
+  if (creators.length === 0) {
+    return (
+      <section
+        aria-label="Creator discovery spotlight"
+        data-testid="creator-discovery-spotlight"
+      >
+        <CreatorDiscoveryEmptyState />
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Creator discovery spotlight"
+      data-testid="creator-discovery-spotlight"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-primary" aria-hidden />
+          <h2 className="text-base font-semibold" data-testid="creator-discovery-title">
+            Creators to Discover
+          </h2>
+          <span className="hidden rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary sm:inline-flex">
+            Recently spotted
+          </span>
+        </div>
+        <Link
+          href="/agents"
+          className="flex items-center gap-0.5 text-xs text-muted-foreground transition hover:text-primary"
+          data-testid="creator-discovery-see-all"
+        >
+          See all
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+
+      <div
+        className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
+        data-testid="creator-discovery-grid"
+      >
+        {creators.map((creator) => (
+          <CreatorCard key={creator.id} creator={creator} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/docs/pr-evidence/creator-discovery-spotlight.md
+++ b/docs/pr-evidence/creator-discovery-spotlight.md
@@ -1,0 +1,51 @@
+# Creator Discovery Spotlight — PR Evidence (Row 330)
+
+## Component
+
+`apps/web/components/explore/CreatorDiscoverySpotlight.tsx`
+
+Follow-first discovery block surfacing recently discovered creators and their worlds on the Explore page.
+
+## Key Design Decisions
+
+**Stub data, no API dependency.** Six hardcoded `CreatorEntry` records (`STUB_CREATORS`) are exported so tests can import and slice them directly. Replacing with a real API call requires only swapping the `creators` prop default — the card rendering is data-agnostic.
+
+**Local follow-state toggle.** `FollowButton` manages `isFollowing` with `useState`. Clicking Follow/Unfollow is optimistic and purely local — no auth check or network call. The `aria-pressed` attribute keeps it accessible.
+
+**Grid layout, not horizontal scroll.** Unlike `EditorPicksRow` (horizontal scroll strip), the spotlight uses a `grid` layout (`sm:grid-cols-2 lg:grid-cols-3`) so creators are fully scannable without horizontal drag. This matches Moltbook's creator social proof style.
+
+**Empty state.** When `creators=[]` is passed, a bordered dashed card with a `Sparkles` icon and copy replaces the grid — consistent with other empty states in the codebase.
+
+**Insertion point.** Placed between `CommunityHubsStrip` and `UserCaseStudyCards` in `app/(public)/explore/page.tsx`, inside the `tab === 'explore'` guard block.
+
+## Component Interface
+
+```tsx
+export interface CreatorEntry {
+  id: string;
+  slug: string;
+  displayName: string;
+  tagline: string;
+  worldCount: number;
+  followerCount: number;
+  avatarInitials: string;
+  avatarColor: string;  // Tailwind gradient class
+}
+
+export function CreatorDiscoverySpotlight({
+  creators = STUB_CREATORS,
+}: {
+  creators?: CreatorEntry[];
+}) { ... }
+```
+
+## Test Coverage
+
+`apps/web/__tests__/components/creator-discovery-spotlight.test.tsx` — 6 tests, all passing:
+
+1. Renders creator cards from stub data (name, tagline, worlds, followers)
+2. Shows empty state when `creators=[]`
+3. Follow button toggles `aria-pressed` and label between Follow / Following
+4. Renders the correct number of cards (3 of 6 stubs = 3 cards, no card-4)
+5. Renders section heading and see-all link pointing to `/agents`
+6. Each creator card links to the correct `/agents/{slug}` profile page


### PR DESCRIPTION
## Summary

- Adds `CreatorDiscoverySpotlight` component (`apps/web/components/explore/CreatorDiscoverySpotlight.tsx`) — a follow-first discovery block surfacing recently discovered creators/worlds on the Explore page
- Each card shows avatar initials, display name, slug, tagline, world count, follower count, and a Follow button that toggles local following state
- Responsive grid layout (`sm:grid-cols-2 lg:grid-cols-3`), empty-state UI, and "See all" link to `/agents`
- Inserted between `CommunityHubsStrip` and `UserCaseStudyCards` in the explore `tab === 'explore'` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Source
Source: backlog.md:330

## Evidence

`CreatorDiscoverySpotlight` component added to `apps/web/components/explore/CreatorDiscoverySpotlight.tsx`. Inserted in `explore/page.tsx` between `CommunityHubsStrip` and `UserCaseStudyCards`. 6 unit tests covering render, empty state, follow toggle, card count, heading, and slug routing — all passing.

## Test plan

- [x] `apps/web/__tests__/components/creator-discovery-spotlight.test.tsx` — 6 tests, all passing
  - [x] Renders creator cards from stub data (name, tagline, worlds, followers)
  - [x] Shows empty state when `creators=[]`
  - [x] Follow button toggles `aria-pressed` and label (Follow / Following / back to Follow)
  - [x] Renders the correct number of cards (3 of 6 stubs = 3 cards, no card-4)
  - [x] Section heading and see-all link render correctly
  - [x] Creator card links to correct `/agents/{slug}` profile
- [x] `npx tsc --noEmit` — no TypeScript errors

## Auth-only Proof
N/A