### PR TITLE
feat(explore): trending agents real API — connect rank/comment count to live DB (#831-followup)

### DIFF
--- a/apps/web/__tests__/api/agents-trending.test.ts
+++ b/apps/web/__tests__/api/agents-trending.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+/**
+ * Trending agents API endpoint tests.
+ *
+ * Tests the /api/v1/agents/trending route handler logic in isolation
+ * by mocking the Supabase client. Verifies ranking, comment aggregation,
+ * and response shape.
+ */
+
+// Mocks for posts query chain
+const mockPostsIs = vi.fn();
+const mockPostsSelect = vi.fn().mockReturnValue({ is: mockPostsIs });
+
+// Mocks for agents query chain
+const mockAgentsIn = vi.fn();
+const mockAgentsSelect = vi.fn().mockReturnValue({ in: mockAgentsIn });
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'posts') {
+    return { select: mockPostsSelect };
+  }
+  if (table === 'agents') {
+    return { select: mockAgentsSelect };
+  }
+  return { select: vi.fn() };
+});
+
+vi.mock('@agentgram/db', () => ({
+  getSupabaseClient: () => ({ from: mockFrom }),
+  getSupabaseServiceClient: () => ({ from: mockFrom }),
+}));
+
+const AGENT_ROWS = [
+  { id: 'agent-1', name: 'aria-companion', display_name: 'Aria', verification_state: 'verified' },
+  { id: 'agent-2', name: 'muse-creative', display_name: 'Muse', verification_state: 'unverified' },
+  { id: 'agent-3', name: 'sage-mentor', display_name: 'Sage', verification_state: 'verified' },
+];
+
+const POST_ROWS = [
+  { author_id: 'agent-1', comment_count: 100 },
+  { author_id: 'agent-1', comment_count: 134 },  // total: 234
+  { author_id: 'agent-2', comment_count: 187 },  // total: 187
+  { author_id: 'agent-3', comment_count: 100 },
+  { author_id: 'agent-3', comment_count: 56 },   // total: 156
+];
+
+function makeRequest() {
+  return new NextRequest('http://localhost/api/v1/agents/trending');
+}
+
+describe('GET /api/v1/agents/trending', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: posts query returns data, agents query returns data
+    mockPostsIs.mockResolvedValue({ data: POST_ROWS, error: null });
+    mockAgentsIn.mockResolvedValue({ data: AGENT_ROWS, error: null });
+  });
+
+  it('returns 200 with ranked trending agents', async () => {
+    const { GET } = await import('../../app/api/v1/agents/trending/route');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data).toHaveLength(3);
+    expect(body.data[0].rank).toBe(1);
+    expect(body.data[0].slug).toBe('aria-companion');
+    expect(body.data[0].commentCount).toBe(234);
+    expect(body.data[0].verified).toBe(true);
+  });
+
+  it('ranks agents by total comment count descending', async () => {
+    const { GET } = await import('../../app/api/v1/agents/trending/route');
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    const slugs = body.data.map((a: { slug: string }) => a.slug);
+    expect(slugs).toEqual(['aria-companion', 'muse-creative', 'sage-mentor']);
+  });
+
+  it('sets verified=true only for agents with verification_state=verified', async () => {
+    const { GET } = await import('../../app/api/v1/agents/trending/route');
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    const ariaEntry = body.data.find((a: { slug: string }) => a.slug === 'aria-companion');
+    const museEntry = body.data.find((a: { slug: string }) => a.slug === 'muse-creative');
+    expect(ariaEntry?.verified).toBe(true);
+    expect(museEntry?.verified).toBe(false);
+  });
+
+  it('returns empty array when no posts exist', async () => {
+    mockPostsIs.mockResolvedValue({ data: [], error: null });
+
+    const { GET } = await import('../../app/api/v1/agents/trending/route');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data).toEqual([]);
+  });
+
+  it('returns 500 when posts query fails', async () => {
+    mockPostsIs.mockResolvedValue({ data: null, error: { message: 'DB error' } });
+
+    const { GET } = await import('../../app/api/v1/agents/trending/route');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 500 when agents query fails', async () => {
+    mockAgentsIn.mockResolvedValue({ data: null, error: { message: 'DB error' } });
+
+    const { GET } = await import('../../app/api/v1/agents/trending/route');
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+  });
+
+  it('queries posts filtered by null original_post_id (top-level only)', async () => {
+    const { GET } = await import('../../app/api/v1/agents/trending/route');
+    await GET(makeRequest());
+
+    expect(mockPostsSelect).toHaveBeenCalledWith('author_id, comment_count');
+    expect(mockPostsIs).toHaveBeenCalledWith('original_post_id', null);
+  });
+});

--- a/apps/web/__tests__/explore/TrendingAgentsRail.test.tsx
+++ b/apps/web/__tests__/explore/TrendingAgentsRail.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TrendingAgentsRail } from '../../components/explore/TrendingAgentsRail';
 
 vi.mock('next/link', () => ({
@@ -18,52 +18,142 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+const MOCK_TRENDING = [
+  { slug: 'aria-companion', displayName: 'Aria', rank: 1, commentCount: 234, verified: true },
+  { slug: 'muse-creative', displayName: 'Muse', rank: 2, commentCount: 187, verified: false },
+  { slug: 'sage-mentor', displayName: 'Sage', rank: 3, commentCount: 156, verified: true },
+];
+
+function mockFetchSuccess(data: unknown[]) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data }),
+    })
+  );
+}
+
+function mockFetchError() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    })
+  );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('TrendingAgentsRail', () => {
-  it('renders exactly 6 trending agent cards', () => {
-    render(<TrendingAgentsRail />);
-    const cards = screen.getAllByTestId(/^trending-agent-card-/);
-    expect(cards).toHaveLength(6);
-  });
-
-  it('displays rank badges for each card', () => {
-    render(<TrendingAgentsRail />);
-    const rankBadges = screen.getAllByTestId(/^trending-rank-badge-/);
-    expect(rankBadges).toHaveLength(6);
-    expect(rankBadges[0]).toHaveTextContent('#1');
-    expect(rankBadges[1]).toHaveTextContent('#2');
-    expect(rankBadges[5]).toHaveTextContent('#6');
-  });
-
-  it('shows verified badges only for verified agents', () => {
-    render(<TrendingAgentsRail />);
-    // aria-companion (#1), sage-mentor (#3), echo-storyteller (#5) are verified
-    expect(screen.getByTestId('verified-badge-aria-companion')).toBeInTheDocument();
-    expect(screen.getByTestId('verified-badge-sage-mentor')).toBeInTheDocument();
-    expect(screen.getByTestId('verified-badge-echo-storyteller')).toBeInTheDocument();
-    // muse-creative (#2), nova-wellness (#4), pixel-study-buddy (#6) are not verified
-    expect(screen.queryByTestId('verified-badge-muse-creative')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('verified-badge-nova-wellness')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('verified-badge-pixel-study-buddy')).not.toBeInTheDocument();
-  });
-
-  it('shows comment count for each card', () => {
-    render(<TrendingAgentsRail />);
-    const commentEl = screen.getByTestId('comment-count-aria-companion');
-    expect(commentEl).toHaveTextContent('234 comments');
-    const commentEl2 = screen.getByTestId('comment-count-muse-creative');
-    expect(commentEl2).toHaveTextContent('187 comments');
-  });
-
   it('renders the "Trending Now" heading', () => {
+    mockFetchSuccess([]);
     render(<TrendingAgentsRail />);
     expect(screen.getByTestId('trending-agents-heading')).toHaveTextContent('Trending Now');
   });
 
-  it('links each card to the correct /agents/<slug> href', () => {
+  it('shows loading skeletons while fetching', () => {
+    mockFetchSuccess(MOCK_TRENDING);
     render(<TrendingAgentsRail />);
-    const ariaCard = screen.getByTestId('trending-agent-card-aria-companion');
-    expect(ariaCard).toHaveAttribute('href', '/agents/aria-companion');
-    const pixelCard = screen.getByTestId('trending-agent-card-pixel-study-buddy');
-    expect(pixelCard).toHaveAttribute('href', '/agents/pixel-study-buddy');
+    expect(screen.getByTestId('trending-agents-loading')).toBeInTheDocument();
+  });
+
+  it('renders agent cards after successful fetch', async () => {
+    mockFetchSuccess(MOCK_TRENDING);
+    render(<TrendingAgentsRail />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trending-agents-scroll')).toBeInTheDocument();
+    });
+
+    const cards = screen.getAllByTestId(/^trending-agent-card-/);
+    expect(cards).toHaveLength(3);
+  });
+
+  it('displays rank badges for fetched agents', async () => {
+    mockFetchSuccess(MOCK_TRENDING);
+    render(<TrendingAgentsRail />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trending-rank-badge-aria-companion')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('trending-rank-badge-aria-companion')).toHaveTextContent('#1');
+    expect(screen.getByTestId('trending-rank-badge-muse-creative')).toHaveTextContent('#2');
+    expect(screen.getByTestId('trending-rank-badge-sage-mentor')).toHaveTextContent('#3');
+  });
+
+  it('shows verified badges only for verified agents', async () => {
+    mockFetchSuccess(MOCK_TRENDING);
+    render(<TrendingAgentsRail />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trending-agents-scroll')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('verified-badge-aria-companion')).toBeInTheDocument();
+    expect(screen.getByTestId('verified-badge-sage-mentor')).toBeInTheDocument();
+    expect(screen.queryByTestId('verified-badge-muse-creative')).not.toBeInTheDocument();
+  });
+
+  it('shows comment count for each card', async () => {
+    mockFetchSuccess(MOCK_TRENDING);
+    render(<TrendingAgentsRail />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('comment-count-aria-companion')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('comment-count-aria-companion')).toHaveTextContent('234 comments');
+    expect(screen.getByTestId('comment-count-muse-creative')).toHaveTextContent('187 comments');
+  });
+
+  it('links each card to the correct /agents/<slug> href', async () => {
+    mockFetchSuccess(MOCK_TRENDING);
+    render(<TrendingAgentsRail />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trending-agent-card-aria-companion')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('trending-agent-card-aria-companion')).toHaveAttribute(
+      'href',
+      '/agents/aria-companion'
+    );
+  });
+
+  it('shows error state when fetch fails', async () => {
+    mockFetchError();
+    render(<TrendingAgentsRail />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trending-agents-error')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no agents are returned', async () => {
+    mockFetchSuccess([]);
+    render(<TrendingAgentsRail />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trending-agents-empty')).toBeInTheDocument();
+    });
+  });
+
+  it('fetches from /api/v1/agents/trending endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: MOCK_TRENDING }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<TrendingAgentsRail />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/agents/trending');
+    });
   });
 });

--- a/apps/web/app/api/v1/agents/trending/route.ts
+++ b/apps/web/app/api/v1/agents/trending/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseClient } from '@agentgram/db';
+import {
+  ErrorResponses,
+  createSuccessResponse,
+  jsonResponse,
+} from '@agentgram/shared';
+
+const TRENDING_LIMIT = 10;
+
+export const dynamic = 'force-dynamic';
+
+export type TrendingAgentEntry = {
+  slug: string;
+  displayName: string;
+  rank: number;
+  commentCount: number;
+  verified: boolean;
+};
+
+// GET /api/v1/agents/trending - Fetch trending agents ranked by total comment count
+export async function GET(_req: NextRequest) {
+  try {
+    const supabase = getSupabaseClient();
+
+    // Aggregate total comment_count per agent (author_id) from top-level posts
+    const { data: commentRows, error: commentError } = await supabase
+      .from('posts')
+      .select('author_id, comment_count')
+      .is('original_post_id', null);
+
+    if (commentError) {
+      console.error('Trending agents comment aggregation error:', commentError);
+      return jsonResponse(
+        ErrorResponses.databaseError('Failed to fetch trending agents'),
+        500
+      );
+    }
+
+    // Sum comment_count per author
+    const commentsByAgent = new Map<string, number>();
+    for (const row of commentRows ?? []) {
+      if (!row.author_id) continue;
+      commentsByAgent.set(
+        row.author_id,
+        (commentsByAgent.get(row.author_id) ?? 0) + (row.comment_count ?? 0)
+      );
+    }
+
+    if (commentsByAgent.size === 0) {
+      return jsonResponse(createSuccessResponse<TrendingAgentEntry[]>([]), 200);
+    }
+
+    // Sort descending, take top N
+    const topAgentIds = [...commentsByAgent.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, TRENDING_LIMIT)
+      .map(([id]) => id);
+
+    // Fetch agent details for the top agents
+    const { data: agents, error: agentsError } = await supabase
+      .from('agents')
+      .select('id, name, display_name, verification_state')
+      .in('id', topAgentIds);
+
+    if (agentsError) {
+      console.error('Trending agents fetch error:', agentsError);
+      return jsonResponse(
+        ErrorResponses.databaseError('Failed to fetch trending agents'),
+        500
+      );
+    }
+
+    // Build result ordered by rank (comment count descending)
+    const agentsById = new Map(
+      (agents ?? []).map((agent) => [agent.id, agent])
+    );
+
+    const result: TrendingAgentEntry[] = topAgentIds
+      .map((id, index) => {
+        const agent = agentsById.get(id);
+        if (!agent) return null;
+        return {
+          slug: agent.name as string,
+          displayName: (agent.display_name as string | null) ?? (agent.name as string),
+          rank: index + 1,
+          commentCount: commentsByAgent.get(id) ?? 0,
+          verified: agent.verification_state === 'verified',
+        };
+      })
+      .filter((entry): entry is TrendingAgentEntry => entry !== null);
+
+    return jsonResponse(createSuccessResponse(result), 200);
+  } catch (error) {
+    console.error('Trending agents error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}

--- a/apps/web/components/explore/TrendingAgentsRail.tsx
+++ b/apps/web/components/explore/TrendingAgentsRail.tsx
@@ -1,61 +1,12 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Bot, CheckCircle2, ChevronRight, Flame, MessageCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import type { TrendingAgentEntry } from '@/app/api/v1/agents/trending/route';
 
-type TrendingAgent = {
-  slug: string;
-  displayName: string;
-  rank: number;
-  commentCount: number;
-  verified: boolean;
-};
-
-const TRENDING_AGENTS: TrendingAgent[] = [
-  {
-    slug: 'aria-companion',
-    displayName: 'Aria',
-    rank: 1,
-    commentCount: 234,
-    verified: true,
-  },
-  {
-    slug: 'muse-creative',
-    displayName: 'Muse',
-    rank: 2,
-    commentCount: 187,
-    verified: false,
-  },
-  {
-    slug: 'sage-mentor',
-    displayName: 'Sage',
-    rank: 3,
-    commentCount: 156,
-    verified: true,
-  },
-  {
-    slug: 'nova-wellness',
-    displayName: 'Nova',
-    rank: 4,
-    commentCount: 112,
-    verified: false,
-  },
-  {
-    slug: 'echo-storyteller',
-    displayName: 'Echo',
-    rank: 5,
-    commentCount: 98,
-    verified: true,
-  },
-  {
-    slug: 'pixel-study-buddy',
-    displayName: 'Pixel',
-    rank: 6,
-    commentCount: 74,
-    verified: false,
-  },
-];
+type TrendingAgent = TrendingAgentEntry;
 
 function TrendingAgentCard({ agent }: { agent: TrendingAgent }) {
   return (
@@ -107,6 +58,38 @@ function TrendingAgentCard({ agent }: { agent: TrendingAgent }) {
 }
 
 export function TrendingAgentsRail() {
+  const [agents, setAgents] = useState<TrendingAgent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchTrending() {
+      try {
+        const res = await fetch('/api/v1/agents/trending');
+        if (!res.ok) throw new Error('Failed to fetch trending agents');
+        const json = await res.json();
+        if (!cancelled) {
+          setAgents(Array.isArray(json.data) ? json.data : []);
+        }
+      } catch {
+        if (!cancelled) {
+          setError(true);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void fetchTrending();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <section aria-label="Trending agents" data-testid="trending-agents-rail">
       <div className="mb-3 flex items-center justify-between">
@@ -129,14 +112,50 @@ export function TrendingAgentsRail() {
         </Link>
       </div>
 
-      <div
-        className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide"
-        data-testid="trending-agents-scroll"
-      >
-        {TRENDING_AGENTS.map((agent) => (
-          <TrendingAgentCard key={agent.slug} agent={agent} />
-        ))}
-      </div>
+      {loading && (
+        <div
+          className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide"
+          data-testid="trending-agents-loading"
+          aria-busy="true"
+        >
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex w-36 shrink-0 flex-col gap-2 rounded-xl border border-border/60 bg-card p-3 animate-pulse"
+              aria-hidden
+            />
+          ))}
+        </div>
+      )}
+
+      {!loading && error && (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="trending-agents-error"
+        >
+          Could not load trending agents.
+        </p>
+      )}
+
+      {!loading && !error && agents.length > 0 && (
+        <div
+          className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide"
+          data-testid="trending-agents-scroll"
+        >
+          {agents.map((agent) => (
+            <TrendingAgentCard key={agent.slug} agent={agent} />
+          ))}
+        </div>
+      )}
+
+      {!loading && !error && agents.length === 0 && (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="trending-agents-empty"
+        >
+          No trending agents yet.
+        </p>
+      )}
     </section>
   );
 }

--- a/apps/web/docs/pr-evidence/trending-agents-real-api.md
+++ b/apps/web/docs/pr-evidence/trending-agents-real-api.md
@@ -1,0 +1,22 @@
+# Trending Agents Real API — PR Evidence
+
+## Source
+backlog.md:331
+
+## Auth-only Proof
+N/A — trending endpoint is public
+
+## Before
+`TrendingAgentsRail` rendered from a hardcoded `TRENDING_AGENTS` constant with six fixed entries (aria-companion, muse-creative, sage-mentor, nova-wellness, echo-storyteller, pixel-study-buddy) and static rank/commentCount values baked in at build time.
+
+## After
+A new route `GET /api/v1/agents/trending` aggregates `comment_count` from top-level posts per agent, ranks agents descending by total comment count, and returns up to 10 entries with `slug`, `displayName`, `rank`, `commentCount`, and `verified` fields backed by live Supabase data.
+
+`TrendingAgentsRail` now fetches from this endpoint on mount via `useEffect`, showing skeleton placeholders while loading, an error message on failure, and live-ranked agent cards on success.
+
+## Implementation Details
+- **Route**: `apps/web/app/api/v1/agents/trending/route.ts` — aggregates `posts.comment_count` grouped by `author_id` (top-level posts only), sorts descending, fetches agent metadata for top 10, returns `TrendingAgentEntry[]`.
+- **Component**: `apps/web/components/explore/TrendingAgentsRail.tsx` — client component using `useEffect` + `fetch('/api/v1/agents/trending')`, with loading/error/empty states.
+- **Tests added**:
+  - `apps/web/__tests__/api/agents-trending.test.ts` — 7 unit tests covering ranking, verification, empty data, and DB error paths.
+  - `apps/web/__tests__/explore/TrendingAgentsRail.test.tsx` — 10 component tests covering loading state, fetched data rendering, error state, empty state, and endpoint URL.


### PR DESCRIPTION
## Source
backlog.md:331

## Auth-only Proof
N/A

## Summary
- Adds `GET /api/v1/agents/trending` route that aggregates `comment_count` from top-level posts per agent, ranks descending by total, and returns up to 10 `TrendingAgentEntry` records with `slug`, `displayName`, `rank`, `commentCount`, and `verified` from live Supabase data
- Updates `TrendingAgentsRail` to `useEffect`-fetch from `/api/v1/agents/trending` instead of the hardcoded `TRENDING_AGENTS` stub; renders loading skeletons, error state, and empty state
- Adds 7 route unit tests (`agents-trending.test.ts`) and rewrites 10 component tests (`TrendingAgentsRail.test.tsx`) to cover the async fetch path

## Test plan
- [x] `npx vitest run __tests__/api/agents-trending.test.ts` — 7 passed
- [x] `npx vitest run __tests__/explore/TrendingAgentsRail.test.tsx` — 10 passed
- [x] `npx vitest run __tests__/api/agents.test.ts` — 21 passed (no regression)
- [x] Full suite: 1770 passed, 1 pre-existing failure unrelated to this PR (`RootLayout font loading` / `PostUpdateContinuityBanner` localStorage SSR issue)

## Evidence
`apps/web/docs/pr-evidence/trending-agents-real-api.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)