### PR TITLE
feat: add VerifiedOperatorBadge component

### DIFF
--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -25,6 +25,7 @@ import { StoryRemixGallery } from '@/components/story/StoryRemixGallery';
 import { CommunityHandoffLinks } from './CommunityHandoffLinks';
 import { CommunityHubsStrip } from '@/components/explore/CommunityHubsStrip';
 import { MemoryIntegrityBadge } from '@/components/shared/MemoryIntegrityBadge';
+import { VerifiedOperatorBadge } from '@/components/common/VerifiedOperatorBadge';
 
 interface ProfileContentProps {
   agent: Agent;
@@ -65,6 +66,32 @@ export function ProfileContent({
       <AiDisclosureBanner />
       <ProfileHeader agent={agent} />
       <ProofStrip agent={agent} />
+      {/* Verified Operator claim surface */}
+      {/* TODO: connect to real operator verification API */}
+      <div
+        className="mt-3 px-4"
+        data-testid="verified-operator-claim-surface"
+      >
+        {agent.verificationState === 'verified' ? (
+          <div className="flex items-center gap-2">
+            <VerifiedOperatorBadge
+              operatorName={agent.publicOwnerLabel?.trim() || 'Verified Operator'}
+            />
+            {agent.publicOwnerLabel?.trim() && (
+              <span className="text-sm text-muted-foreground">
+                {agent.publicOwnerLabel.trim()}
+              </span>
+            )}
+          </div>
+        ) : (
+          <span
+            className="text-xs text-muted-foreground/70"
+            data-testid="unverified-operator-label"
+          >
+            Unverified
+          </span>
+        )}
+      </div>
       <div className="mt-2 px-4">
         <MemoryIntegrityBadge variant="compact" />
       </div>

--- a/apps/web/components/common/VerifiedOperatorBadge.tsx
+++ b/apps/web/components/common/VerifiedOperatorBadge.tsx
@@ -1,0 +1,44 @@
+import { ShieldCheck } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface VerifiedOperatorBadgeProps {
+  operatorName: string;
+  compact?: boolean;
+  className?: string;
+}
+
+export function VerifiedOperatorBadge({
+  operatorName,
+  compact = false,
+  className,
+}: VerifiedOperatorBadgeProps) {
+  if (compact) {
+    return (
+      <span
+        className={cn(
+          'inline-flex items-center justify-center rounded-full border border-blue-500/30 bg-blue-500/10 p-1 text-blue-600 dark:text-blue-400',
+          className
+        )}
+        title={`Verified Operator: ${operatorName}`}
+        data-testid="verified-operator-badge-compact"
+        aria-label={`Verified Operator: ${operatorName}`}
+      >
+        <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border border-blue-500/30 bg-blue-500/10 px-2.5 py-1 text-xs font-semibold text-blue-700 dark:text-blue-300',
+        className
+      )}
+      data-testid="verified-operator-badge"
+      aria-label={`Verified Operator: ${operatorName}`}
+    >
+      <ShieldCheck className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+      Verified Operator
+    </span>
+  );
+}

--- a/apps/web/components/common/index.ts
+++ b/apps/web/components/common/index.ts
@@ -11,3 +11,4 @@ export { default as ErrorAlert } from './ErrorAlert';
 export { default as PageContainer } from './PageContainer';
 export { WellbeingNudgeCard, WELLBEING_NUDGE_THRESHOLD_MS } from './WellbeingNudgeCard';
 export { GuidedFeedbackRail } from './GuidedFeedbackRail';
+export { VerifiedOperatorBadge } from './VerifiedOperatorBadge';


### PR DESCRIPTION
Adds VerifiedOperatorBadge UI component to ProfileContent for trusted operator display.

## Evidence
- `VerifiedOperatorBadge.tsx`: Badge component for verified operator status
- `ProfileContent.tsx`: Integrates badge into profile display
- `common/index.ts`: Export added

## Source
Source: backlog.md:341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Auth-only Proof
N/A