### PR TITLE
feat: post-update trust continuity bundle — update safety guarantee CTA

### DIFF
--- a/apps/web/__tests__/components/update-safety-guarantee-cta.test.tsx
+++ b/apps/web/__tests__/components/update-safety-guarantee-cta.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { UpdateSafetyGuaranteeCTA } from '@/components/update-safety-guarantee-cta';
+
+describe('UpdateSafetyGuaranteeCTA', () => {
+  it('renders the section heading', () => {
+    render(<UpdateSafetyGuaranteeCTA />);
+    expect(screen.getByTestId('update-safety-guarantee-cta')).toBeInTheDocument();
+    expect(screen.getByTestId('update-safety-heading')).toHaveTextContent(
+      "Update Safety — We've Got You Covered"
+    );
+  });
+
+  it('renders all three guarantee bullets with correct links', () => {
+    render(<UpdateSafetyGuaranteeCTA />);
+
+    const memoryBullet = screen.getByTestId('update-safety-memory-bullet');
+    expect(memoryBullet).toBeInTheDocument();
+    expect(memoryBullet).toHaveTextContent(
+      'Memory stability guaranteed — zero silent resets on updates'
+    );
+    expect(memoryBullet).toHaveAttribute('href', '/trust');
+
+    const incidentsBullet = screen.getByTestId('update-safety-incidents-bullet');
+    expect(incidentsBullet).toBeInTheDocument();
+    expect(incidentsBullet).toHaveTextContent(
+      'Live incident history — every update tracked at /trust/incidents'
+    );
+    expect(incidentsBullet).toHaveAttribute('href', '/trust/incidents');
+
+    const alertsBullet = screen.getByTestId('update-safety-alerts-bullet');
+    expect(alertsBullet).toBeInTheDocument();
+    expect(alertsBullet).toHaveTextContent(
+      'Real-time update health alerts — proactive notice before any change affects your experience'
+    );
+    expect(alertsBullet).toHaveAttribute('href', '/trust');
+  });
+
+  it('renders the premium CTA linking to /pricing#plans', () => {
+    render(<UpdateSafetyGuaranteeCTA />);
+
+    const cta = screen.getByTestId('update-safety-cta-button');
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveTextContent('Get the Update Safety Guarantee');
+    expect(cta).toHaveAttribute('href', '/pricing#plans');
+  });
+
+  it('renders the competitor comparison line mentioning Replika and C.AI', () => {
+    render(<UpdateSafetyGuaranteeCTA />);
+
+    const comparison = screen.getByTestId('update-safety-comparison');
+    expect(comparison).toBeInTheDocument();
+    expect(comparison).toHaveTextContent('Replika');
+    expect(comparison).toHaveTextContent('memory resets on Pro→Ultra migration');
+    expect(comparison).toHaveTextContent('C.AI');
+    expect(comparison).toHaveTextContent('no incident transparency');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -26,6 +26,7 @@ import { RepetitionFreeMemoryBadge } from '@/components/repetition-free-memory-b
 import { MemoryIntegrityBadge } from '@/components/shared/MemoryIntegrityBadge';
 import { ViralSafetyMemoryPaidFunnel } from '@/components/ViralSafetyMemoryPaidFunnel';
 import { SocialProofPaidCTABundle } from '@/components/social-proof-paid-cta-bundle';
+import { UpdateSafetyGuaranteeCTA } from '@/components/update-safety-guarantee-cta';
 
 function getPlans(billingEnabled: boolean) {
   return [
@@ -661,6 +662,7 @@ export default function PricingPage() {
 
       <ReplikaCredentialTrustBadge />
 
+      <UpdateSafetyGuaranteeCTA />
 
       <MemoryGuaranteeLandingSection />
 

--- a/apps/web/components/update-safety-guarantee-cta.tsx
+++ b/apps/web/components/update-safety-guarantee-cta.tsx
@@ -1,0 +1,109 @@
+import Link from 'next/link';
+import { ShieldCheck, History, Bell, ArrowRight } from 'lucide-react';
+
+const guarantees = [
+  {
+    icon: ShieldCheck,
+    text: 'Memory stability guaranteed — zero silent resets on updates',
+    href: '/trust',
+    testId: 'update-safety-memory-bullet',
+    colorClass: 'text-emerald-600 dark:text-emerald-400',
+    borderClass: 'border-emerald-500/20 bg-emerald-500/5',
+    linkClass: 'text-emerald-700 hover:text-emerald-800 dark:text-emerald-400 dark:hover:text-emerald-300',
+  },
+  {
+    icon: History,
+    text: 'Live incident history — every update tracked at /trust/incidents',
+    href: '/trust/incidents',
+    testId: 'update-safety-incidents-bullet',
+    colorClass: 'text-blue-600 dark:text-blue-400',
+    borderClass: 'border-blue-500/20 bg-blue-500/5',
+    linkClass: 'text-blue-700 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300',
+  },
+  {
+    icon: Bell,
+    text: 'Real-time update health alerts — proactive notice before any change affects your experience',
+    href: '/trust',
+    testId: 'update-safety-alerts-bullet',
+    colorClass: 'text-amber-600 dark:text-amber-400',
+    borderClass: 'border-amber-500/20 bg-amber-500/5',
+    linkClass: 'text-amber-700 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-300',
+  },
+] as const;
+
+export function UpdateSafetyGuaranteeCTA() {
+  return (
+    <section
+      className="container pb-10"
+      data-testid="update-safety-guarantee-cta"
+      aria-labelledby="update-safety-heading"
+    >
+      <div className="mx-auto max-w-6xl rounded-2xl border border-emerald-500/20 bg-emerald-500/5 px-6 py-8 shadow-sm">
+        <div className="mb-6 space-y-2">
+          <div className="flex items-center gap-2">
+            <span
+              className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-700 dark:text-emerald-400"
+              data-testid="update-safety-badge"
+            >
+              <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+              Update Safety Guarantee
+            </span>
+          </div>
+          <h2
+            id="update-safety-heading"
+            className="text-2xl font-bold text-foreground"
+            data-testid="update-safety-heading"
+          >
+            Update Safety — We&apos;ve Got You Covered
+          </h2>
+          <p className="text-sm text-muted-foreground max-w-2xl">
+            Every AgentGram update is transparent, trackable, and safe. We proactively disclose update
+            risks, maintain a public incident history, and guarantee memory continuity — so you never
+            experience a silent reset or unexplained change.
+          </p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          {guarantees.map(({ icon: Icon, text, href, testId, colorClass, borderClass, linkClass }) => (
+            <Link
+              key={testId}
+              href={href}
+              className={`flex flex-col gap-3 rounded-xl border p-5 transition-colors hover:bg-background/80 ${borderClass}`}
+              data-testid={testId}
+              aria-label={text}
+            >
+              <Icon className={`h-5 w-5 shrink-0 ${colorClass}`} aria-hidden="true" />
+              <p className={`text-sm font-semibold leading-snug ${linkClass}`}>
+                {text}
+              </p>
+            </Link>
+          ))}
+        </div>
+
+        <div
+          className="mt-6 rounded-lg border border-border/40 bg-background/60 px-4 py-3 text-xs text-muted-foreground"
+          data-testid="update-safety-comparison"
+        >
+          <span className="font-medium text-foreground">vs. competitors: </span>
+          Replika: memory resets on Pro→Ultra migration. C.AI: no incident transparency (Moderatedpocalypse — zero advance notice, no appeal).
+        </div>
+
+        <div className="mt-6 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Link
+            href="/pricing#plans"
+            className="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-6 py-3 text-sm font-semibold text-white shadow-md shadow-emerald-500/20 transition-colors hover:bg-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+            data-testid="update-safety-cta-button"
+          >
+            Get the Update Safety Guarantee
+            <ArrowRight className="h-4 w-4" aria-hidden="true" />
+          </Link>
+          <p className="text-xs text-muted-foreground">
+            Included in all paid tiers — Pro and above.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default UpdateSafetyGuaranteeCTA;

--- a/apps/web/docs/pr-evidence/post-update-trust-continuity-bundle.md
+++ b/apps/web/docs/pr-evidence/post-update-trust-continuity-bundle.md
@@ -1,0 +1,42 @@
+# Post-Update Trust Continuity Bundle — PR Evidence
+
+## Backlog row
+343
+
+## Source PRs
+
+### PR #831 — PostUpdateContinuityHealthBanner
+- **Component**: `apps/web/components/ui/PostUpdateContinuityBanner.tsx`
+- **What it does**: Displays an amber dismissable banner when the app version changes, warning users that agent memory or replies may temporarily feel different after an update. Tracks the last-seen version in localStorage and shows once per new version.
+- **Why it matters**: Provides the "proactive notice" pillar of the update safety guarantee — users are informed before changes can surprise them.
+
+### PR #797 — Trust Watch on /trust
+- **Component**: `apps/web/components/trust/TrustWatchSection.tsx`
+- **What it does**: An incident feed embedded on the /trust page documenting real competitor trust failures (C.AI Moderatedpocalypse, Replika GDPR fine, Moltbook acquisition) with AgentGram's architectural contrast for each.
+- **Why it matters**: Provides the "transparent update history" pillar — AgentGram publicly documents industry failures and commits to doing differently.
+
+### PR #814 — /trust/incidents living incident database
+- **Page**: `apps/web/app/(public)/trust/incidents/page.tsx`
+- **What it does**: Expands the Trust Watch section into a full living incident database at `/trust/incidents`. Each incident has a full root cause analysis, documented user impact, and AgentGram's specific architectural contrast. Updated as new incidents occur.
+- **Why it matters**: Provides the "live incident history" pillar — an independently linkable, SEO-indexed record that reassures Replika/C.AI migrants that they'll never be left in the dark after an update.
+
+## What this CTA bundles
+
+`UpdateSafetyGuaranteeCTA` (`apps/web/components/update-safety-guarantee-cta.tsx`) surfaces these three features as a unified premium conversion signal on `/pricing`:
+
+1. **Memory stability guaranteed** — links to /trust (Trust Watch live feed)
+2. **Live incident history** — links to /trust/incidents (living incident database)
+3. **Real-time update health alerts** — references the PostUpdateContinuityBanner system
+
+Together these form the "update safety guarantee" narrative: AgentGram transparently discloses update risks, maintains a public incident history, and guarantees memory continuity — unlike Replika (Pro→Ultra memory resets) or C.AI (Moderatedpocalypse: zero advance notice, no appeal, no transparency).
+
+## Competitive signal
+
+- **Replika**: Memory resets reported on Pro→Ultra migration. No incident history published.
+- **C.AI**: "Moderatedpocalypse" (Feb 18, 2026) — 8M+ MAU lost access to characters with zero advance notice, no appeal process, and no content recovery.
+
+AgentGram commits to visible update history, real-time alerts, and stability guarantees as a paid-tier differentiator capturing update-fatigue migrants from both platforms.
+
+## Placement
+
+The CTA is placed in `apps/web/app/(public)/pricing/page.tsx` after `ReplikaCredentialTrustBadge` and before `MemoryGuaranteeLandingSection` — in the trust/safety cluster of the pricing page.


### PR DESCRIPTION
## Source
backlog.md:343

## Description
Bundles PostUpdateContinuityHealthBanner (PR #831) + Trust Watch (PR #797) + /trust/incidents (PR #814) into a single UpdateSafetyGuaranteeCTA section on /pricing. Converts the update-transparency stack into a premium paid tier upgrade signal, capturing Replika/C.AI update-fatigue migrators.

## Evidence
See apps/web/docs/pr-evidence/post-update-trust-continuity-bundle.md

## Auth-only Proof
N/A

## Competitive signal
Replika memory reset on Pro→Ultra migration; C.AI Moderatedpocalypse with zero incident transparency — AgentGram commits to visible update history and stability guarantee.