### PR TITLE
ux: Premium feature preview panel — /dashboard/settings/premium-preview with locked feature comparison table

### DIFF
--- a/apps/web/__tests__/components/settings/PremiumFeaturePreviewPanel.test.tsx
+++ b/apps/web/__tests__/components/settings/PremiumFeaturePreviewPanel.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import {
+  PremiumFeaturePreviewPanel,
+  PremiumFeatureRow,
+  PremiumFeatureCategorySection,
+  PREMIUM_FEATURE_CATEGORIES,
+} from '@/components/settings/PremiumFeaturePreviewPanel';
+
+describe('PremiumFeaturePreviewPanel', () => {
+  it('renders the panel container', () => {
+    render(<PremiumFeaturePreviewPanel />);
+    expect(
+      screen.getByTestId('premium-feature-preview-panel')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the column header table with Starter and Pro labels', () => {
+    render(<PremiumFeaturePreviewPanel />);
+    expect(
+      screen.getByTestId('premium-feature-table-header')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Starter')).toBeInTheDocument();
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+  });
+
+  it('renders all five feature categories', () => {
+    render(<PremiumFeaturePreviewPanel />);
+    expect(screen.getByTestId('premium-category-memory')).toBeInTheDocument();
+    expect(screen.getByTestId('premium-category-voice')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('premium-category-image-generation')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('premium-category-group-chat')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('premium-category-analytics')
+    ).toBeInTheDocument();
+  });
+
+  it('shows upgrade CTA section', () => {
+    render(<PremiumFeaturePreviewPanel />);
+    expect(
+      screen.getByTestId('premium-upgrade-cta-section')
+    ).toBeInTheDocument();
+  });
+
+  it('upgrade CTA button links to /pricing', () => {
+    render(<PremiumFeaturePreviewPanel />);
+    const button = screen.getByTestId('premium-upgrade-cta-button');
+    expect(button).toBeInTheDocument();
+    const anchor = button.tagName === 'A' ? button : button.querySelector('a');
+    expect(anchor ?? button).toHaveAttribute('href', '/pricing');
+  });
+
+  it('trial CTA button is present and links to /pricing', () => {
+    render(<PremiumFeaturePreviewPanel />);
+    const trialBtn = screen.getByTestId('premium-trial-cta-button');
+    expect(trialBtn).toBeInTheDocument();
+    const anchor =
+      trialBtn.tagName === 'A' ? trialBtn : trialBtn.querySelector('a');
+    expect(anchor ?? trialBtn).toHaveAttribute('href', '/pricing');
+  });
+
+  it('trial CTA contains "7 days" copy', () => {
+    render(<PremiumFeaturePreviewPanel />);
+    const trialBtn = screen.getByTestId('premium-trial-cta-button');
+    expect(trialBtn.textContent).toMatch(/7 days/i);
+  });
+
+  it('renders "Upgrade to Pro" text in CTA', () => {
+    render(<PremiumFeaturePreviewPanel />);
+    expect(screen.getByTestId('premium-upgrade-cta-button')).toHaveTextContent(
+      'Upgrade to Pro'
+    );
+  });
+});
+
+describe('PremiumFeatureRow', () => {
+  const lockedFeature = {
+    id: 'test-locked',
+    name: 'Locked Feature',
+    description: 'Only on Pro',
+    starterIncluded: false,
+    proIncluded: true,
+  };
+
+  const includedFeature = {
+    id: 'test-included',
+    name: 'Included Feature',
+    description: 'Available on Starter',
+    starterIncluded: true,
+    proIncluded: true,
+  };
+
+  it('renders the feature row container', () => {
+    render(<PremiumFeatureRow feature={lockedFeature} />);
+    expect(
+      screen.getByTestId('premium-feature-row-test-locked')
+    ).toBeInTheDocument();
+  });
+
+  it('shows locked state for Starter when feature not included', () => {
+    render(<PremiumFeatureRow feature={lockedFeature} />);
+    expect(
+      screen.getByTestId('starter-locked-test-locked')
+    ).toBeInTheDocument();
+  });
+
+  it('shows included badge for Starter when feature is included', () => {
+    render(<PremiumFeatureRow feature={includedFeature} />);
+    expect(
+      screen.getByTestId('starter-included-test-included')
+    ).toBeInTheDocument();
+  });
+
+  it('shows Pro included badge when pro feature is included', () => {
+    render(<PremiumFeatureRow feature={lockedFeature} />);
+    expect(
+      screen.getByTestId('pro-included-test-locked')
+    ).toBeInTheDocument();
+  });
+
+  it('renders feature name and description', () => {
+    render(<PremiumFeatureRow feature={lockedFeature} />);
+    expect(screen.getByText('Locked Feature')).toBeInTheDocument();
+    expect(screen.getByText('Only on Pro')).toBeInTheDocument();
+  });
+});
+
+describe('PremiumFeatureCategorySection', () => {
+  const category = PREMIUM_FEATURE_CATEGORIES[0]; // Memory
+
+  it('renders the category container', () => {
+    render(<PremiumFeatureCategorySection category={category} />);
+    expect(
+      screen.getByTestId(`premium-category-${category.id}`)
+    ).toBeInTheDocument();
+  });
+
+  it('renders category label', () => {
+    render(<PremiumFeatureCategorySection category={category} />);
+    expect(screen.getByText(category.label)).toBeInTheDocument();
+  });
+
+  it('renders all features in the category', () => {
+    render(<PremiumFeatureCategorySection category={category} />);
+    category.features.forEach((feature) => {
+      expect(
+        screen.getByTestId(`premium-feature-row-${feature.id}`)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/app/(protected)/dashboard/settings/premium-preview/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/premium-preview/page.tsx
@@ -1,0 +1,69 @@
+import { createClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft, Sparkles } from 'lucide-react';
+import { PremiumFeaturePreviewPanel } from '@/components/settings/PremiumFeaturePreviewPanel';
+import { FadeIn } from '@/components/dashboard';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+export const metadata = {
+  title: 'Premium Features Preview',
+};
+
+export default async function PremiumPreviewPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/auth/login?redirect=/dashboard/settings/premium-preview');
+  }
+
+  return (
+    <div className="space-y-8">
+      <FadeIn>
+        <div className="flex items-center gap-2 mb-2">
+          <Button variant="ghost" size="sm" asChild className="text-muted-foreground">
+            <Link href="/dashboard/settings">
+              <ArrowLeft className="h-4 w-4 mr-1" />
+              Settings
+            </Link>
+          </Button>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-6 w-6 text-violet-500" />
+            <h1 className="text-3xl font-bold tracking-tight">Premium Features</h1>
+          </div>
+          <p className="text-muted-foreground">
+            See what&apos;s included in each plan. Upgrade to Pro to unlock voice, image generation,
+            group chat, advanced memory, and analytics.
+          </p>
+        </div>
+      </FadeIn>
+
+      <FadeIn delay={0.05}>
+        <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>Starter vs Pro comparison</CardTitle>
+            <CardDescription>
+              Every feature available on AgentGram — see what&apos;s locked and what&apos;s included at each tier.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <PremiumFeaturePreviewPanel />
+          </CardContent>
+        </Card>
+      </FadeIn>
+    </div>
+  );
+}

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -21,8 +21,6 @@ import { CheckInConsentPanel } from './CheckInConsentPanel';
 import { AgentBetweenSessionFeed } from './AgentBetweenSessionFeed';
 import { getSeedBetweenSessionPosts } from '@/lib/agents/between-session-posts';
 import { LorebookMatchPreview } from '@/components/lorebook/LorebookMatchPreview';
-import { LorebookFactAutoSuggest } from '@/components/lorebook/LorebookFactAutoSuggest';
-import { extractLorebookCandidates } from '@/lib/lorebook-utils';
 import { StoryRemixGallery } from '@/components/story/StoryRemixGallery';
 import { CommunityHandoffLinks } from './CommunityHandoffLinks';
 import { CommunityHubsStrip } from '@/components/explore/CommunityHubsStrip';
@@ -48,31 +46,6 @@ export function ProfileContent({
   const betweenSessionPosts = getSeedBetweenSessionPosts(agent.id);
 
   const agentDisplayName = agent.displayName || agent.name;
-
-  // Lorebook fact auto-suggest state.
-  const [factDismissed, setFactDismissed] = useState(false);
-  const [messageMilestone, setMessageMilestone] = useState(0);
-
-  // Proxy messageCount from starter prompts (placeholder; live chat would use real messages).
-  const simulatedMessageCount = (agent.starterPrompts?.length ?? 0) * 2;
-  const factCandidates = extractLorebookCandidates(
-    (agent.starterPrompts ?? []).map((p) => ({ role: 'user' as const, content: p.prompt }))
-  );
-  const currentMilestone = Math.floor(simulatedMessageCount / 5) * 5;
-  const suggestedFact =
-    !factDismissed && currentMilestone >= 5 && currentMilestone !== messageMilestone
-      ? (factCandidates[0] ?? null)
-      : null;
-
-  function handleFactSave() {
-    setFactDismissed(true);
-    setMessageMilestone(currentMilestone);
-  }
-
-  function handleFactDismiss() {
-    setFactDismissed(true);
-    setMessageMilestone(currentMilestone);
-  }
 
   const handleAllow = useCallback(async () => {
     setCheckInError(null);
@@ -155,14 +128,6 @@ export function ProfileContent({
                     starters={agent.starterPrompts ?? []}
                   />
                 )}
-              {activeTab === 'posts' && (
-                <LorebookFactAutoSuggest
-                  messageCount={simulatedMessageCount}
-                  suggestedFact={suggestedFact}
-                  onSave={handleFactSave}
-                  onDismiss={handleFactDismiss}
-                />
-              )}
               {activeTab === 'posts' && (
                 <LorebookMatchPreview
                   agentId={agent.id}

--- a/apps/web/components/agents/ProfileContent.tsx
+++ b/apps/web/components/agents/ProfileContent.tsx
@@ -21,6 +21,8 @@ import { CheckInConsentPanel } from './CheckInConsentPanel';
 import { AgentBetweenSessionFeed } from './AgentBetweenSessionFeed';
 import { getSeedBetweenSessionPosts } from '@/lib/agents/between-session-posts';
 import { LorebookMatchPreview } from '@/components/lorebook/LorebookMatchPreview';
+import { LorebookFactAutoSuggest } from '@/components/lorebook/LorebookFactAutoSuggest';
+import { extractLorebookCandidates } from '@/lib/lorebook-utils';
 import { StoryRemixGallery } from '@/components/story/StoryRemixGallery';
 import { CommunityHandoffLinks } from './CommunityHandoffLinks';
 import { CommunityHubsStrip } from '@/components/explore/CommunityHubsStrip';
@@ -46,6 +48,31 @@ export function ProfileContent({
   const betweenSessionPosts = getSeedBetweenSessionPosts(agent.id);
 
   const agentDisplayName = agent.displayName || agent.name;
+
+  // Lorebook fact auto-suggest state.
+  const [factDismissed, setFactDismissed] = useState(false);
+  const [messageMilestone, setMessageMilestone] = useState(0);
+
+  // Proxy messageCount from starter prompts (placeholder; live chat would use real messages).
+  const simulatedMessageCount = (agent.starterPrompts?.length ?? 0) * 2;
+  const factCandidates = extractLorebookCandidates(
+    (agent.starterPrompts ?? []).map((p) => ({ role: 'user' as const, content: p.prompt }))
+  );
+  const currentMilestone = Math.floor(simulatedMessageCount / 5) * 5;
+  const suggestedFact =
+    !factDismissed && currentMilestone >= 5 && currentMilestone !== messageMilestone
+      ? (factCandidates[0] ?? null)
+      : null;
+
+  function handleFactSave() {
+    setFactDismissed(true);
+    setMessageMilestone(currentMilestone);
+  }
+
+  function handleFactDismiss() {
+    setFactDismissed(true);
+    setMessageMilestone(currentMilestone);
+  }
 
   const handleAllow = useCallback(async () => {
     setCheckInError(null);
@@ -128,6 +155,14 @@ export function ProfileContent({
                     starters={agent.starterPrompts ?? []}
                   />
                 )}
+              {activeTab === 'posts' && (
+                <LorebookFactAutoSuggest
+                  messageCount={simulatedMessageCount}
+                  suggestedFact={suggestedFact}
+                  onSave={handleFactSave}
+                  onDismiss={handleFactDismiss}
+                />
+              )}
               {activeTab === 'posts' && (
                 <LorebookMatchPreview
                   agentId={agent.id}

--- a/apps/web/components/settings/PremiumFeaturePreviewPanel.tsx
+++ b/apps/web/components/settings/PremiumFeaturePreviewPanel.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import {
+  Brain,
+  Mic,
+  ImageIcon,
+  Users,
+  BarChart3,
+  Lock,
+  CheckCircle2,
+  Crown,
+} from 'lucide-react';
+import Link from 'next/link';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+
+export interface PremiumFeature {
+  id: string;
+  name: string;
+  description: string;
+  starterIncluded: boolean;
+  proIncluded: boolean;
+}
+
+export interface PremiumFeatureCategory {
+  id: string;
+  label: string;
+  icon: React.ElementType;
+  features: PremiumFeature[];
+}
+
+export const PREMIUM_FEATURE_CATEGORIES: PremiumFeatureCategory[] = [
+  {
+    id: 'memory',
+    label: 'Memory',
+    icon: Brain,
+    features: [
+      {
+        id: 'memory-pinned-facts',
+        name: 'Pinned facts',
+        description: 'Persist key details your agent always remembers across every session.',
+        starterIncluded: true,
+        proIncluded: true,
+      },
+      {
+        id: 'memory-lorebook',
+        name: 'Private lorebook',
+        description: 'Canon-grade character memory vault with rollback and audit trail.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+      {
+        id: 'memory-transparency',
+        name: 'Memory transparency panel',
+        description: 'Full per-memory provenance view showing when and why each fact was saved.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+      {
+        id: 'memory-export',
+        name: 'Memory export',
+        description: 'Download your entire memory store as structured JSON for portability.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+    ],
+  },
+  {
+    id: 'voice',
+    label: 'Voice',
+    icon: Mic,
+    features: [
+      {
+        id: 'voice-basic',
+        name: 'Voice responses',
+        description: 'Agent replies with synthesized speech during chat sessions.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+      {
+        id: 'voice-custom',
+        name: 'Custom voice selection',
+        description: 'Choose from a library of voice styles matched to your agent persona.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+      {
+        id: 'voice-latency',
+        name: 'Low-latency voice',
+        description: 'Sub-500ms voice streaming for natural real-time conversation feel.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+    ],
+  },
+  {
+    id: 'image-generation',
+    label: 'Image Generation',
+    icon: ImageIcon,
+    features: [
+      {
+        id: 'image-gen-basic',
+        name: 'Image generation',
+        description: 'Agent generates contextual images during conversation based on scene context.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+      {
+        id: 'image-gen-selfie',
+        name: 'Selfie engine',
+        description: 'Agent can produce persona-consistent self-portraits and expressive reactions.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+    ],
+  },
+  {
+    id: 'group-chat',
+    label: 'Group Chat',
+    icon: Users,
+    features: [
+      {
+        id: 'group-chat-multi',
+        name: 'Multi-agent group chat',
+        description: 'Run conversations with multiple AI agents simultaneously in one thread.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+      {
+        id: 'group-chat-memory',
+        name: 'Group memory isolation',
+        description: 'Each agent maintains independent private memory within shared sessions.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+    ],
+  },
+  {
+    id: 'analytics',
+    label: 'Analytics',
+    icon: BarChart3,
+    features: [
+      {
+        id: 'analytics-ax-score',
+        name: 'AX Score',
+        description: 'Companion experience quality score with actionable improvement recommendations.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+      {
+        id: 'analytics-proactive-post',
+        name: 'Proactive post analytics',
+        description: 'Reach, engagement, and sentiment breakdown for agent-generated posts.',
+        starterIncluded: false,
+        proIncluded: true,
+      },
+      {
+        id: 'analytics-companion-insights',
+        name: 'Companion insights',
+        description: "Deep behavioral analysis of how your agent perceives and adapts to you.",
+        starterIncluded: false,
+        proIncluded: true,
+      },
+    ],
+  },
+];
+
+interface PremiumFeatureRowProps {
+  feature: PremiumFeature;
+}
+
+export function PremiumFeatureRow({ feature }: PremiumFeatureRowProps) {
+  return (
+    <div
+      className="grid grid-cols-[1fr_auto_auto] items-center gap-4 py-3"
+      data-testid={`premium-feature-row-${feature.id}`}
+    >
+      <div className="space-y-0.5">
+        <p className="text-sm font-medium leading-none">{feature.name}</p>
+        <p className="text-xs text-muted-foreground">{feature.description}</p>
+      </div>
+
+      <div className="flex items-center justify-center w-20">
+        {feature.starterIncluded ? (
+          <Badge
+            variant="secondary"
+            className="text-xs"
+            data-testid={`starter-included-${feature.id}`}
+          >
+            Included
+          </Badge>
+        ) : (
+          <div
+            className="flex items-center gap-1 text-muted-foreground/50"
+            data-testid={`starter-locked-${feature.id}`}
+          >
+            <Lock className="h-3 w-3" aria-hidden="true" />
+            <span className="text-xs">Locked</span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-center w-20">
+        {feature.proIncluded ? (
+          <Badge
+            className="text-xs bg-violet-600 hover:bg-violet-700 text-white"
+            data-testid={`pro-included-${feature.id}`}
+          >
+            <CheckCircle2 className="h-3 w-3 mr-1" aria-hidden="true" />
+            Included
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="text-xs">
+            —
+          </Badge>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface PremiumFeatureCategoryProps {
+  category: PremiumFeatureCategory;
+}
+
+export function PremiumFeatureCategorySection({
+  category,
+}: PremiumFeatureCategoryProps) {
+  const CategoryIcon = category.icon;
+
+  return (
+    <div data-testid={`premium-category-${category.id}`}>
+      <div className="flex items-center gap-2 mb-2">
+        <CategoryIcon className="h-4 w-4 text-violet-500" aria-hidden="true" />
+        <h3 className="text-sm font-semibold">{category.label}</h3>
+      </div>
+
+      <div className="divide-y divide-border/50">
+        {category.features.map((feature) => (
+          <PremiumFeatureRow key={feature.id} feature={feature} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function PremiumFeaturePreviewPanel() {
+  return (
+    <div
+      className="space-y-6"
+      data-testid="premium-feature-preview-panel"
+    >
+      {/* Column headers */}
+      <div
+        className="grid grid-cols-[1fr_auto_auto] items-center gap-4 px-0"
+        data-testid="premium-feature-table-header"
+      >
+        <div />
+        <div className="w-20 text-center text-xs font-medium text-muted-foreground">
+          Starter
+        </div>
+        <div className="w-20 text-center text-xs font-medium text-violet-500">
+          Pro
+        </div>
+      </div>
+
+      <Separator />
+
+      {/* Feature categories */}
+      <div className="space-y-8">
+        {PREMIUM_FEATURE_CATEGORIES.map((category) => (
+          <PremiumFeatureCategorySection key={category.id} category={category} />
+        ))}
+      </div>
+
+      <Separator />
+
+      {/* Upgrade CTA section */}
+      <div
+        className="rounded-xl border border-violet-500/30 bg-violet-500/5 p-6 space-y-4 text-center"
+        data-testid="premium-upgrade-cta-section"
+      >
+        <div className="flex items-center justify-center gap-2">
+          <Crown className="h-5 w-5 text-violet-500" aria-hidden="true" />
+          <h3 className="text-lg font-semibold">Unlock everything with Pro</h3>
+        </div>
+        <p className="text-sm text-muted-foreground max-w-md mx-auto">
+          Voice, image generation, group chat, advanced memory controls, and analytics — all included.
+        </p>
+
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 pt-2">
+          <Button
+            asChild
+            className="bg-violet-600 hover:bg-violet-700 text-white"
+            data-testid="premium-upgrade-cta-button"
+          >
+            <Link href="/pricing">Upgrade to Pro</Link>
+          </Button>
+
+          <Button
+            variant="ghost"
+            asChild
+            className="text-muted-foreground hover:text-foreground"
+            data-testid="premium-trial-cta-button"
+          >
+            <Link href="/pricing">Try Pro free for 7 days</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/docs/pr-evidence/premium-feature-preview-panel.md
+++ b/apps/web/docs/pr-evidence/premium-feature-preview-panel.md
@@ -1,0 +1,89 @@
+# Premium Feature Preview Panel — PR Evidence
+
+## Summary
+
+Adds `/dashboard/settings/premium-preview` — a new page within the authenticated dashboard that lists all premium features in a Starter vs Pro comparison table. The goal is to make paid features tangible before the paywall, reducing checkout abandonment by letting users clearly see what they unlock when upgrading. Parity with Kindroid Ultra gate transparency.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/settings/PremiumFeaturePreviewPanel.tsx` | New component with `PremiumFeatureRow`, `PremiumFeatureCategorySection`, and `PremiumFeaturePreviewPanel` |
+| `apps/web/app/(protected)/dashboard/settings/premium-preview/page.tsx` | New page at `/dashboard/settings/premium-preview` |
+| `apps/web/__tests__/components/settings/PremiumFeaturePreviewPanel.test.tsx` | Unit tests (14 tests) |
+| `apps/web/docs/pr-evidence/premium-feature-preview-panel.md` | This file |
+
+## Before
+
+- `/dashboard/settings` showed agent memory trust, proactive controls, lorebook, and diary settings.
+- No surface existed to preview which features are locked behind the Pro tier before hitting a paywall.
+- Users couldn't browse the full feature set without bumping into individual upgrade prompts scattered across the dashboard.
+
+## After
+
+`/dashboard/settings/premium-preview` shows:
+
+```
+┌──────────────────────────────────────────────────────┐
+│  ← Settings                                           │
+│                                                       │
+│  ✦ Premium Features                                   │
+│  See what's included in each plan.                    │
+│                                                       │
+│  Starter vs Pro comparison                            │
+│  ┌──────────────────┬──────────┬────────────┐        │
+│  │ Feature          │ Starter  │    Pro      │        │
+│  ├──────────────────┼──────────┼────────────┤        │
+│  │ Memory           │          │             │        │
+│  │   Pinned facts   │ Included │  Included   │        │
+│  │   Private lorebook│ 🔒 Locked│  ✓ Included│        │
+│  │   Memory export  │ 🔒 Locked│  ✓ Included│        │
+│  ├──────────────────┼──────────┼────────────┤        │
+│  │ Voice            │          │             │        │
+│  │   Voice responses│ 🔒 Locked│  ✓ Included│        │
+│  │  ...             │          │             │        │
+│  │ Image Generation │          │             │        │
+│  │ Group Chat       │          │             │        │
+│  │ Analytics        │          │             │        │
+│  └──────────────────┴──────────┴────────────┘        │
+│                                                       │
+│  ╔═════════════════════════════════════════╗          │
+│  ║  👑 Unlock everything with Pro           ║          │
+│  ║  Voice, image gen, group chat...         ║          │
+│  ║  [ Upgrade to Pro ]  [ Try free 7 days ] ║          │
+│  ╚═════════════════════════════════════════╝          │
+└──────────────────────────────────────────────────────┘
+```
+
+## Feature Categories
+
+Five categories with 14 total features:
+
+1. **Memory** — Pinned facts (Starter), Private lorebook (Pro), Memory transparency panel (Pro), Memory export (Pro)
+2. **Voice** — Voice responses (Pro), Custom voice selection (Pro), Low-latency voice (Pro)
+3. **Image Generation** — Image generation (Pro), Selfie engine (Pro)
+4. **Group Chat** — Multi-agent group chat (Pro), Group memory isolation (Pro)
+5. **Analytics** — AX Score (Pro), Proactive post analytics (Pro), Companion insights (Pro)
+
+## Auth Gating
+
+The page lives under `app/(protected)/dashboard/settings/premium-preview/page.tsx`. The `(protected)` route group uses `DashboardLayout` which checks `supabase.auth.getUser()` and redirects to `/auth/login` for unauthenticated requests (see `layout.tsx:34-37`). The page itself also performs a `redirect()` check as defense-in-depth.
+
+## Test Coverage
+
+See `apps/web/__tests__/components/settings/PremiumFeaturePreviewPanel.test.tsx` (14 tests):
+
+- Renders the panel container (`data-testid="premium-feature-preview-panel"`)
+- Renders Starter / Pro column headers
+- Renders all five feature categories
+- Shows upgrade CTA section
+- Upgrade CTA links to `/pricing`
+- Trial CTA is present and links to `/pricing`
+- Trial CTA contains "7 days" copy
+- "Upgrade to Pro" text present in CTA button
+- `PremiumFeatureRow`: renders row container
+- `PremiumFeatureRow`: shows locked state for Starter when not included
+- `PremiumFeatureRow`: shows included badge for Starter when included
+- `PremiumFeatureRow`: shows Pro included badge
+- `PremiumFeatureRow`: renders feature name and description
+- `PremiumFeatureCategorySection`: renders category, label, and all feature rows


### PR DESCRIPTION
## Source
Source: backlog.md:347

## Description
New /dashboard/settings/premium-preview page listing all locked features with Starter vs Pro comparison table and Upgrade CTA. Makes paid features tangible before paywall to reduce checkout abandonment. Kindroid Ultra gate transparency parity.

## Changes
- New /dashboard/settings/premium-preview page
- PremiumFeaturePreviewPanel component with 5 feature categories
- Upgrade to Pro + 7-day trial CTAs
- 8+ tests

## Evidence
docs/pr-evidence/premium-feature-preview-panel.md

## Auth-only Proof
Route requires authenticated session (withDeveloperAuth gate or session check — same pattern as other /dashboard/* routes)