### PR TITLE
feat: Memory Mind Map visual node graph — interactive memory nodes with temporal/thematic connections (Nomi Mind Map 2.0 parity)

### DIFF
--- a/apps/web/__tests__/components/memory/MemoryMindMapGraph.test.tsx
+++ b/apps/web/__tests__/components/memory/MemoryMindMapGraph.test.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryMindMapGraph } from '@/components/memory/MemoryMindMapGraph';
+import type { MemoryNode, MemoryEdge } from '@/types/memory';
+
+const NOW = '2026-06-01T12:00:00.000Z';
+
+function makeNode(id: string, overrides: Partial<MemoryNode> = {}): MemoryNode {
+  return {
+    id,
+    fact: `Fact for ${id}`,
+    category: 'profile_fact',
+    lastUsedAt: NOW,
+    x: 110,
+    y: 80,
+    ...overrides,
+  };
+}
+
+function makeEdge(
+  sourceId: string,
+  targetId: string,
+  type: MemoryEdge['type'] = 'temporal'
+): MemoryEdge {
+  return { sourceId, targetId, type };
+}
+
+const DEFAULT_NODES: MemoryNode[] = [
+  makeNode('node-1', { x: 110, y: 80 }),
+  makeNode('node-2', { x: 330, y: 80, category: 'relationship_context' }),
+  makeNode('node-3', { x: 110, y: 220 }),
+];
+
+const DEFAULT_EDGES: MemoryEdge[] = [
+  makeEdge('node-1', 'node-2', 'temporal'),
+  makeEdge('node-2', 'node-3', 'thematic'),
+];
+
+describe('MemoryMindMapGraph', () => {
+  it('renders the graph container', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    expect(screen.getByTestId('memory-mindmap-graph')).toBeInTheDocument();
+  });
+
+  it('renders all memory nodes', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    for (const node of DEFAULT_NODES) {
+      expect(screen.getByTestId(`mindmap-node-${node.id}`)).toBeInTheDocument();
+    }
+  });
+
+  it('renders SVG edges container', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    expect(screen.getByTestId('mindmap-svg-edges')).toBeInTheDocument();
+  });
+
+  it('renders edge lines for connected nodes', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    expect(screen.getByTestId('mindmap-edge-node-1-node-2')).toBeInTheDocument();
+    expect(screen.getByTestId('mindmap-edge-node-2-node-3')).toBeInTheDocument();
+  });
+
+  it('shows category badge on each node', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    expect(screen.getByTestId('mindmap-node-category-node-1')).toHaveTextContent('profile fact');
+    expect(screen.getByTestId('mindmap-node-category-node-2')).toHaveTextContent('relationship context');
+  });
+
+  it('shows last-used timestamp on each node', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    const ts = screen.getByTestId('mindmap-node-timestamp-node-1');
+    expect(ts).toBeInTheDocument();
+    // The timestamp text should be non-empty (relative date)
+    expect(ts.textContent?.trim().length).toBeGreaterThan(0);
+  });
+
+  it('renders zoom in and zoom out controls', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    expect(screen.getByTestId('zoom-in-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('zoom-out-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('zoom-reset-btn')).toBeInTheDocument();
+  });
+
+  it('increments zoom when zoom-in is clicked', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    const zoomReset = screen.getByTestId('zoom-reset-btn');
+    expect(zoomReset.textContent).toContain('100%');
+    fireEvent.click(screen.getByTestId('zoom-in-btn'));
+    expect(zoomReset.textContent).toContain('120%');
+  });
+
+  it('decrements zoom when zoom-out is clicked', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    const zoomReset = screen.getByTestId('zoom-reset-btn');
+    fireEvent.click(screen.getByTestId('zoom-out-btn'));
+    expect(zoomReset.textContent).toContain('80%');
+  });
+
+  it('resets zoom to 100% when zoom-reset is clicked', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    fireEvent.click(screen.getByTestId('zoom-in-btn'));
+    fireEvent.click(screen.getByTestId('zoom-in-btn'));
+    fireEvent.click(screen.getByTestId('zoom-reset-btn'));
+    expect(screen.getByTestId('zoom-reset-btn').textContent).toContain('100%');
+  });
+
+  it('renders connection type toggle with temporal, thematic, and both options', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    expect(screen.getByTestId('connection-type-temporal')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-type-thematic')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-type-both')).toBeInTheDocument();
+  });
+
+  it('connection type toggle defaults to "both"', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    expect(screen.getByTestId('connection-type-both')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('connection-type-temporal')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('connection-type-thematic')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('switches connection type to temporal when temporal button is clicked', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    fireEvent.click(screen.getByTestId('connection-type-temporal'));
+    expect(screen.getByTestId('connection-type-temporal')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('connection-type-both')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('filters out thematic edges when temporal mode is active', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    fireEvent.click(screen.getByTestId('connection-type-temporal'));
+    // The thematic edge should not render (thematic edge is node-2 -> node-3)
+    expect(screen.queryByTestId('mindmap-edge-node-2-node-3')).not.toBeInTheDocument();
+    // The temporal edge should still render
+    expect(screen.getByTestId('mindmap-edge-node-1-node-2')).toBeInTheDocument();
+  });
+
+  it('filters out temporal edges when thematic mode is active', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    fireEvent.click(screen.getByTestId('connection-type-thematic'));
+    // The temporal edge should not render
+    expect(screen.queryByTestId('mindmap-edge-node-1-node-2')).not.toBeInTheDocument();
+    // The thematic edge should render
+    expect(screen.getByTestId('mindmap-edge-node-2-node-3')).toBeInTheDocument();
+  });
+
+  it('shows detail panel when a node is clicked', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    fireEvent.click(screen.getByTestId('mindmap-node-node-1'));
+    expect(screen.getByTestId('mindmap-node-detail')).toBeInTheDocument();
+  });
+
+  it('closes detail panel when close button is clicked', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    fireEvent.click(screen.getByTestId('mindmap-node-node-1'));
+    expect(screen.getByTestId('mindmap-node-detail')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('mindmap-node-detail-close'));
+    expect(screen.queryByTestId('mindmap-node-detail')).not.toBeInTheDocument();
+  });
+
+  it('deselects a node when clicked again', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    fireEvent.click(screen.getByTestId('mindmap-node-node-1'));
+    expect(screen.getByTestId('mindmap-node-detail')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('mindmap-node-node-1'));
+    expect(screen.queryByTestId('mindmap-node-detail')).not.toBeInTheDocument();
+  });
+
+  it('renders empty state when no nodes are provided', () => {
+    render(<MemoryMindMapGraph nodes={[]} edges={[]} />);
+    expect(screen.getByTestId('mindmap-empty-state')).toBeInTheDocument();
+    expect(screen.getByText('No memories to map')).toBeInTheDocument();
+  });
+
+  it('does not render SVG edges in empty state', () => {
+    render(<MemoryMindMapGraph nodes={[]} edges={[]} />);
+    expect(screen.queryByTestId('mindmap-svg-edges')).not.toBeInTheDocument();
+  });
+
+  it('marks node as selected with aria-pressed', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    const nodeBtn = screen.getByTestId('mindmap-node-node-2');
+    expect(nodeBtn).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(nodeBtn);
+    expect(nodeBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('each node has an aria-label containing the fact text', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    expect(screen.getByTestId('mindmap-node-node-1')).toHaveAttribute(
+      'aria-label',
+      `Memory node: ${DEFAULT_NODES[0].fact}`
+    );
+  });
+
+  it('zoom out does not go below minimum zoom', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    // Click zoom out many times — zoom should floor at 40% (ZOOM_MIN = 0.4)
+    for (let i = 0; i < 10; i++) {
+      fireEvent.click(screen.getByTestId('zoom-out-btn'));
+    }
+    expect(screen.getByTestId('zoom-reset-btn').textContent).toContain('40%');
+  });
+
+  it('renders the zoom controls group with accessible label', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    expect(screen.getByRole('group', { name: 'Zoom controls' })).toBeInTheDocument();
+  });
+
+  it('renders the connection type group with accessible label', () => {
+    render(<MemoryMindMapGraph nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />);
+    expect(screen.getByRole('group', { name: 'Connection type' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/dashboard/MemoryExportDashboard.tsx
+++ b/apps/web/components/dashboard/MemoryExportDashboard.tsx
@@ -8,6 +8,7 @@ import {
   Download,
   FileJson,
   FileText,
+  Network,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -17,6 +18,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { MemoryTierTabs } from './MemoryTierTabs';
 import { MultilingualMemoryBadge } from '@/components/agents/MultilingualMemoryBadge';
 import {
@@ -24,6 +26,8 @@ import {
   downloadReceiptJson,
   type MemoryDeletionReceiptData,
 } from '@/components/memory/MemoryDeletionReceipt';
+import { MemoryMindMapGraph } from '@/components/memory/MemoryMindMapGraph';
+import type { MemoryNode, MemoryEdge } from '@/types/memory';
 
 export interface MemoryExportRecord {
   id: string;
@@ -105,6 +109,56 @@ function exportCsv(memories: MemoryExportRecord[]) {
   );
 }
 
+function buildMindMapData(memories: MemoryExportRecord[]): {
+  nodes: MemoryNode[];
+  edges: MemoryEdge[];
+} {
+  const cols = 4;
+  const colGap = 220;
+  const rowGap = 140;
+  const offsetX = 110;
+  const offsetY = 80;
+
+  const nodes: MemoryNode[] = memories.map((m, i) => ({
+    id: m.id,
+    fact: m.value,
+    category: m.category,
+    lastUsedAt: m.updatedAt,
+    x: offsetX + (i % cols) * colGap,
+    y: offsetY + Math.floor(i / cols) * rowGap,
+  }));
+
+  const edges: MemoryEdge[] = [];
+
+  // Temporal edges: connect consecutive nodes sorted by createdAt
+  const sorted = [...memories].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  );
+  for (let i = 0; i < sorted.length - 1; i++) {
+    edges.push({
+      sourceId: sorted[i].id,
+      targetId: sorted[i + 1].id,
+      type: 'temporal',
+    });
+  }
+
+  // Thematic edges: connect nodes sharing the same category (first occurrence to each subsequent)
+  const seenCategories = new Map<string, string>();
+  for (const m of memories) {
+    if (seenCategories.has(m.category)) {
+      edges.push({
+        sourceId: seenCategories.get(m.category)!,
+        targetId: m.id,
+        type: 'thematic',
+      });
+    } else {
+      seenCategories.set(m.category, m.id);
+    }
+  }
+
+  return { nodes, edges };
+}
+
 export function MemoryExportDashboard({ memories: initialMemories }: Props) {
   const [memories, setMemories] = useState<MemoryExportRecord[]>(initialMemories);
   const [deleting, setDeleting] = useState<Set<string>>(new Set());
@@ -172,6 +226,8 @@ export function MemoryExportDashboard({ memories: initialMemories }: Props) {
       });
     }
   }
+
+  const { nodes: mindMapNodes, edges: mindMapEdges } = buildMindMapData(memories);
 
   return (
     <div className="space-y-8 max-w-3xl" data-testid="memory-export-dashboard">
@@ -255,16 +311,34 @@ export function MemoryExportDashboard({ memories: initialMemories }: Props) {
         </div>
       )}
 
-      {/* Memory List — dual-layer tier view */}
-      <div data-testid="memory-list">
-        <MemoryTierTabs
-          memories={memories}
-          deleting={deleting}
-          onDelete={handleDelete}
-          deprioritizing={deprioritizing}
-          onDeprioritize={handleDeprioritize}
-        />
-      </div>
+      {/* Memory views — List and Mind Map tabs */}
+      <Tabs defaultValue="list" data-testid="memory-dashboard-tabs">
+        <TabsList data-testid="memory-dashboard-tabs-list">
+          <TabsTrigger value="list" data-testid="tab-memory-list">
+            Memory List
+          </TabsTrigger>
+          <TabsTrigger value="mind-map" data-testid="tab-mind-map">
+            <Network className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+            Mind Map
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="list" data-testid="tabpanel-memory-list">
+          <div data-testid="memory-list">
+            <MemoryTierTabs
+              memories={memories}
+              deleting={deleting}
+              onDelete={handleDelete}
+              deprioritizing={deprioritizing}
+              onDeprioritize={handleDeprioritize}
+            />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="mind-map" data-testid="tabpanel-mind-map">
+          <MemoryMindMapGraph nodes={mindMapNodes} edges={mindMapEdges} />
+        </TabsContent>
+      </Tabs>
 
       {/* GDPR note */}
       <Card className="border-border/50 bg-card/50 backdrop-blur-sm">

--- a/apps/web/components/memory/MemoryMindMapGraph.tsx
+++ b/apps/web/components/memory/MemoryMindMapGraph.tsx
@@ -1,0 +1,326 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { Brain, GitBranch, Clock, Minus, Plus, RotateCcw } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import type { MemoryNode, MemoryEdge, MindMapConnectionType } from '@/types/memory';
+
+const CATEGORY_COLORS: Record<string, { bg: string; border: string; text: string; badge: string }> = {
+  profile_fact: {
+    bg: 'bg-blue-500/10',
+    border: 'border-blue-500/30',
+    text: 'text-blue-700 dark:text-blue-300',
+    badge: 'bg-blue-500/20 text-blue-700 dark:text-blue-300',
+  },
+  relationship_context: {
+    bg: 'bg-violet-500/10',
+    border: 'border-violet-500/30',
+    text: 'text-violet-700 dark:text-violet-300',
+    badge: 'bg-violet-500/20 text-violet-700 dark:text-violet-300',
+  },
+  default: {
+    bg: 'bg-muted/40',
+    border: 'border-border',
+    text: 'text-foreground',
+    badge: 'bg-muted text-muted-foreground',
+  },
+};
+
+function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days === 0) return 'today';
+  if (days === 1) return '1 day ago';
+  if (days < 30) return `${days} days ago`;
+  const months = Math.floor(days / 30);
+  if (months === 1) return '1 month ago';
+  return `${months} months ago`;
+}
+
+function truncate(text: string, maxLen: number): string {
+  return text.length > maxLen ? `${text.slice(0, maxLen)}…` : text;
+}
+
+interface MemoryNodeCardProps {
+  node: MemoryNode;
+  onClick: (node: MemoryNode) => void;
+  isSelected: boolean;
+}
+
+function MemoryNodeCard({ node, onClick, isSelected }: MemoryNodeCardProps) {
+  const colors = CATEGORY_COLORS[node.category] ?? CATEGORY_COLORS.default;
+
+  return (
+    <button
+      data-testid={`mindmap-node-${node.id}`}
+      aria-label={`Memory node: ${node.fact}`}
+      aria-pressed={isSelected}
+      onClick={() => onClick(node)}
+      style={{
+        position: 'absolute',
+        left: node.x,
+        top: node.y,
+        width: 200,
+        transform: 'translate(-50%, -50%)',
+      }}
+      className={`rounded-lg border px-3 py-2 text-left text-xs shadow-sm transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary hover:shadow-md ${colors.bg} ${colors.border} ${isSelected ? 'ring-2 ring-primary' : ''}`}
+    >
+      <p className={`font-medium leading-snug ${colors.text}`} aria-hidden="true">
+        {truncate(node.fact, 60)}
+      </p>
+      <div className="mt-1.5 flex items-center gap-1.5 flex-wrap">
+        <span
+          className={`inline-block rounded-full px-1.5 py-0.5 text-[10px] font-medium ${colors.badge}`}
+          data-testid={`mindmap-node-category-${node.id}`}
+        >
+          {node.category.replace('_', ' ')}
+        </span>
+        <span
+          className="flex items-center gap-0.5 text-[10px] text-muted-foreground"
+          data-testid={`mindmap-node-timestamp-${node.id}`}
+        >
+          <Clock className="h-2.5 w-2.5" aria-hidden="true" />
+          {formatRelativeTime(node.lastUsedAt)}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+interface SvgEdgesProps {
+  edges: MemoryEdge[];
+  nodes: MemoryNode[];
+  connectionType: MindMapConnectionType;
+}
+
+function SvgEdges({ edges, nodes, connectionType }: SvgEdgesProps) {
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
+
+  const visibleEdges = edges.filter((e) => {
+    if (connectionType === 'temporal') return e.type === 'temporal';
+    if (connectionType === 'thematic') return e.type === 'thematic';
+    return true;
+  });
+
+  return (
+    <svg
+      data-testid="mindmap-svg-edges"
+      aria-hidden="true"
+      style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none' }}
+    >
+      {visibleEdges.map((edge) => {
+        const src = nodeById.get(edge.sourceId);
+        const tgt = nodeById.get(edge.targetId);
+        if (!src || !tgt) return null;
+
+        const isThematic = edge.type === 'thematic';
+        const strokeColor = isThematic ? '#8b5cf6' : '#3b82f6';
+        const strokeDash = isThematic ? '4 3' : undefined;
+
+        return (
+          <line
+            key={`${edge.sourceId}-${edge.targetId}-${edge.type}`}
+            data-testid={`mindmap-edge-${edge.sourceId}-${edge.targetId}`}
+            x1={src.x}
+            y1={src.y}
+            x2={tgt.x}
+            y2={tgt.y}
+            stroke={strokeColor}
+            strokeWidth={1.5}
+            strokeDasharray={strokeDash}
+            strokeOpacity={0.5}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+export interface MemoryMindMapGraphProps {
+  nodes: MemoryNode[];
+  edges: MemoryEdge[];
+}
+
+const ZOOM_STEP = 0.2;
+const ZOOM_MIN = 0.4;
+const ZOOM_MAX = 2.0;
+const CANVAS_WIDTH = 900;
+const CANVAS_HEIGHT = 600;
+
+export function MemoryMindMapGraph({ nodes, edges }: MemoryMindMapGraphProps) {
+  const [zoom, setZoom] = useState(1);
+  const [connectionType, setConnectionType] = useState<MindMapConnectionType>('both');
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleZoomIn = useCallback(() => {
+    setZoom((z) => Math.min(z + ZOOM_STEP, ZOOM_MAX));
+  }, []);
+
+  const handleZoomOut = useCallback(() => {
+    setZoom((z) => Math.max(z - ZOOM_STEP, ZOOM_MIN));
+  }, []);
+
+  const handleZoomReset = useCallback(() => {
+    setZoom(1);
+  }, []);
+
+  const handleNodeClick = useCallback((node: MemoryNode) => {
+    setSelectedNodeId((prev) => (prev === node.id ? null : node.id));
+  }, []);
+
+  const selectedNode = nodes.find((n) => n.id === selectedNodeId) ?? null;
+
+  const CONNECTION_TYPES: MindMapConnectionType[] = ['temporal', 'thematic', 'both'];
+
+  return (
+    <div data-testid="memory-mindmap-graph" className="space-y-3">
+      {/* Controls */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        {/* Connection type toggle */}
+        <div
+          role="group"
+          aria-label="Connection type"
+          className="flex items-center gap-1.5"
+          data-testid="connection-type-toggle"
+        >
+          {CONNECTION_TYPES.map((type) => (
+            <button
+              key={type}
+              data-testid={`connection-type-${type}`}
+              aria-pressed={connectionType === type}
+              onClick={() => setConnectionType(type)}
+              className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+                connectionType === type
+                  ? 'border-primary bg-primary text-primary-foreground'
+                  : 'border-border bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground'
+              }`}
+            >
+              {type === 'temporal' && <Clock className="h-3 w-3" aria-hidden="true" />}
+              {type === 'thematic' && <GitBranch className="h-3 w-3" aria-hidden="true" />}
+              {type === 'both' && <Brain className="h-3 w-3" aria-hidden="true" />}
+              {type.charAt(0).toUpperCase() + type.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        {/* Zoom controls */}
+        <div
+          role="group"
+          aria-label="Zoom controls"
+          className="flex items-center gap-1"
+          data-testid="zoom-controls"
+        >
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-7 w-7"
+            onClick={handleZoomOut}
+            disabled={zoom <= ZOOM_MIN}
+            aria-label="Zoom out"
+            data-testid="zoom-out-btn"
+          >
+            <Minus className="h-3 w-3" />
+          </Button>
+          <button
+            className="min-w-[3.5rem] rounded border border-border bg-background px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            onClick={handleZoomReset}
+            aria-label="Reset zoom to 100%"
+            data-testid="zoom-reset-btn"
+          >
+            <RotateCcw className="mr-1 inline h-2.5 w-2.5" aria-hidden="true" />
+            {Math.round(zoom * 100)}%
+          </button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-7 w-7"
+            onClick={handleZoomIn}
+            disabled={zoom >= ZOOM_MAX}
+            aria-label="Zoom in"
+            data-testid="zoom-in-btn"
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Canvas */}
+      <div
+        ref={containerRef}
+        data-testid="mindmap-canvas"
+        role="region"
+        aria-label="Memory mind map canvas"
+        className="relative overflow-auto rounded-xl border border-border bg-muted/20"
+        style={{ height: 500 }}
+      >
+        {nodes.length === 0 ? (
+          <div
+            data-testid="mindmap-empty-state"
+            className="flex h-full flex-col items-center justify-center gap-3 text-center"
+          >
+            <Brain className="h-10 w-10 text-muted-foreground/30" aria-hidden="true" />
+            <p className="text-sm font-medium text-muted-foreground">No memories to map</p>
+            <p className="text-xs text-muted-foreground/70">
+              Memories will appear here as nodes once the agent starts learning.
+            </p>
+          </div>
+        ) : (
+          <div
+            data-testid="mindmap-scaled-inner"
+            style={{
+              transform: `scale(${zoom})`,
+              transformOrigin: 'top left',
+              width: CANVAS_WIDTH,
+              height: CANVAS_HEIGHT,
+              position: 'relative',
+            }}
+          >
+            <SvgEdges edges={edges} nodes={nodes} connectionType={connectionType} />
+            {nodes.map((node) => (
+              <MemoryNodeCard
+                key={node.id}
+                node={node}
+                onClick={handleNodeClick}
+                isSelected={selectedNodeId === node.id}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Selected node detail panel */}
+      {selectedNode && (
+        <div
+          data-testid="mindmap-node-detail"
+          className="rounded-lg border border-border bg-card px-4 py-3 text-sm"
+          role="region"
+          aria-label={`Details for memory: ${selectedNode.fact}`}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1 space-y-1">
+              <p className="font-medium leading-snug text-foreground">{selectedNode.fact}</p>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline" className="text-[10px] h-5">
+                  {selectedNode.category.replace('_', ' ')}
+                </Badge>
+                <span className="text-xs text-muted-foreground">
+                  Last used {formatRelativeTime(selectedNode.lastUsedAt)}
+                </span>
+              </div>
+            </div>
+            <button
+              onClick={() => setSelectedNodeId(null)}
+              aria-label="Close node detail"
+              className="shrink-0 rounded p-1 text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              data-testid="mindmap-node-detail-close"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/docs/pr-evidence/memory-mindmap-visual-nodes.md
+++ b/apps/web/docs/pr-evidence/memory-mindmap-visual-nodes.md
@@ -1,0 +1,48 @@
+# Memory Mind Map Visual Node Graph
+
+## Feature Description
+
+Renders stored memories as interactive nodes with SVG connection lines showing temporal and thematic relationships in the Memory Export dashboard. Implements Nomi Mind Map 2.0 parity.
+
+## Component Path
+
+`apps/web/components/memory/MemoryMindMapGraph.tsx`
+
+## Integration
+
+Added as a "Mind Map" tab in the Memory Export Dashboard alongside the existing Memory List tab:
+
+- Dashboard component: `apps/web/components/dashboard/MemoryExportDashboard.tsx`
+- Tab trigger: `data-testid="tab-mind-map"`
+- Tab panel: `data-testid="tabpanel-mind-map"`
+
+## Types Added
+
+`apps/web/types/memory.ts` — exports:
+
+- `MemoryNode` — id, fact, category, lastUsedAt, x, y
+- `MemoryEdge` — sourceId, targetId, type (temporal | thematic)
+- `MindMapConnectionType` — 'temporal' | 'thematic' | 'both'
+
+## Key Features
+
+- Memory nodes rendered as styled, keyboard-navigable buttons positioned on an SVG canvas
+- SVG lines connect related nodes (blue solid = temporal, violet dashed = thematic)
+- Each node shows: fact text (truncated at 60 chars), category badge, last-used relative timestamp
+- Zoom in/out via CSS transform scale (range 0.4x–2.0x, step 0.2)
+- Connection type toggle: temporal / thematic / both
+- Node click reveals a detail panel with full fact and metadata
+- Empty state shown when no memories exist
+- Fully accessible: aria-labels on nodes, aria-pressed on toggles, role="group" on control sets
+
+## Test Count
+
+20 tests
+
+## Test Path
+
+`apps/web/__tests__/components/memory/MemoryMindMapGraph.test.tsx`
+
+## Auth Gate
+
+Rendered only inside the authenticated `/dashboard/memory-export` route (existing auth gate in `app/(protected)/dashboard/memory-export/page.tsx`).

--- a/apps/web/types/memory.ts
+++ b/apps/web/types/memory.ts
@@ -1,0 +1,29 @@
+/**
+ * Types for the Memory Mind Map visual node graph (Nomi Mind Map 2.0 parity).
+ */
+
+export type MindMapConnectionType = 'temporal' | 'thematic' | 'both';
+
+export interface MemoryNode {
+  id: string;
+  /** The memory fact text displayed in the node. */
+  fact: string;
+  /** Memory category, e.g. "profile_fact" or "relationship_context". */
+  category: string;
+  /** ISO timestamp of when the memory was last accessed or updated. */
+  lastUsedAt: string;
+  /** X position (px) on the mind map canvas. */
+  x: number;
+  /** Y position (px) on the mind map canvas. */
+  y: number;
+}
+
+export interface MemoryEdge {
+  sourceId: string;
+  targetId: string;
+  /**
+   * temporal — edge connects nodes close in time.
+   * thematic — edge connects nodes sharing a topic or category.
+   */
+  type: 'temporal' | 'thematic';
+}


### PR DESCRIPTION
## Source
Source: backlog.md:344

## Description
Renders stored memories as interactive nodes with SVG connection lines showing temporal and thematic relationships in the memory dashboard. Nomi Mind Map 2.0 parity.

## Changes
- New MemoryMindMapGraph component with SVG edge rendering
- Zoom controls and connection type toggle (temporal/thematic/both)
- Mind Map tab in Memory Dashboard
- MemoryNode/MemoryEdge types added
- 8+ tests

## Evidence
docs/pr-evidence/memory-mindmap-visual-nodes.md

## Auth-only Proof
N/A