### PR TITLE
feat: Relationship milestone celebration card — 7d/30d/100msg shareable card with premium unlock prompt (Kindroid long-term bonding parity)

### DIFF
--- a/apps/web/__tests__/components/chat/RelationshipMilestoneCelebrationCard.test.tsx
+++ b/apps/web/__tests__/components/chat/RelationshipMilestoneCelebrationCard.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { RelationshipMilestoneCelebrationCard } from '../../../components/chat/RelationshipMilestoneCelebrationCard';
+
+const defaultProps = {
+  milestone: '7d' as const,
+  agentName: 'Aria',
+  onShare: vi.fn(),
+  onDismiss: vi.fn(),
+};
+
+describe('RelationshipMilestoneCelebrationCard — 7d milestone', () => {
+  it('renders the card with 7d headline', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} milestone="7d" />);
+    expect(screen.getByTestId('milestone-headline')).toHaveTextContent('1 Week Together!');
+  });
+
+  it('renders the 7d emoji', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} milestone="7d" />);
+    expect(screen.getByTestId('milestone-emoji')).toHaveTextContent('🎉');
+  });
+
+  it('renders the 7d stat label', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} milestone="7d" />);
+    expect(screen.getByTestId('milestone-stat')).toHaveTextContent('7 days');
+  });
+});
+
+describe('RelationshipMilestoneCelebrationCard — 30d milestone', () => {
+  it('renders the card with 30d headline', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} milestone="30d" />);
+    expect(screen.getByTestId('milestone-headline')).toHaveTextContent('One Month Strong!');
+  });
+
+  it('renders the 30d emoji', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} milestone="30d" />);
+    expect(screen.getByTestId('milestone-emoji')).toHaveTextContent('💫');
+  });
+});
+
+describe('RelationshipMilestoneCelebrationCard — 100msg milestone', () => {
+  it('renders the card with 100msg headline', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} milestone="100msg" />);
+    expect(screen.getByTestId('milestone-headline')).toHaveTextContent('100 Memories Made!');
+  });
+
+  it('renders the 100msg emoji', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} milestone="100msg" />);
+    expect(screen.getByTestId('milestone-emoji')).toHaveTextContent('✨');
+  });
+
+  it('renders the 100msg stat label', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} milestone="100msg" />);
+    expect(screen.getByTestId('milestone-stat')).toHaveTextContent('100 messages');
+  });
+});
+
+describe('RelationshipMilestoneCelebrationCard — 365d milestone', () => {
+  it('renders the card with 365d headline', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} milestone="365d" />);
+    expect(screen.getByTestId('milestone-headline')).toHaveTextContent('One Year Anniversary!');
+  });
+
+  it('renders the 365d emoji', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} milestone="365d" />);
+    expect(screen.getByTestId('milestone-emoji')).toHaveTextContent('🌟');
+  });
+});
+
+describe('RelationshipMilestoneCelebrationCard — agent name', () => {
+  it('displays the provided agent name', () => {
+    render(
+      <RelationshipMilestoneCelebrationCard {...defaultProps} agentName="Nova" />
+    );
+    expect(screen.getByTestId('milestone-agent-name')).toHaveTextContent('Nova');
+  });
+});
+
+describe('RelationshipMilestoneCelebrationCard — interactions', () => {
+  it('calls onShare when the share button is clicked', () => {
+    const onShare = vi.fn();
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} onShare={onShare} />);
+    fireEvent.click(screen.getByTestId('milestone-share-button'));
+    expect(onShare).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onDismiss when the dismiss button is clicked', () => {
+    const onDismiss = vi.fn();
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByTestId('milestone-dismiss-button'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('RelationshipMilestoneCelebrationCard — nextFeatureUnlock', () => {
+  it('renders the unlock CTA when nextFeatureUnlock is provided', () => {
+    render(
+      <RelationshipMilestoneCelebrationCard
+        {...defaultProps}
+        nextFeatureUnlock="Voice Calls"
+      />
+    );
+    const cta = screen.getByTestId('milestone-unlock-cta');
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveTextContent('Unlock Voice Calls');
+  });
+
+  it('does not render the unlock CTA when nextFeatureUnlock is absent', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} />);
+    expect(screen.queryByTestId('milestone-unlock-cta')).not.toBeInTheDocument();
+  });
+});
+
+describe('RelationshipMilestoneCelebrationCard — accessibility', () => {
+  it('renders with role="status"', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('dismiss button has accessible label', () => {
+    render(<RelationshipMilestoneCelebrationCard {...defaultProps} />);
+    expect(screen.getByLabelText('Dismiss milestone card')).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/lib/milestone-utils.test.ts
+++ b/apps/web/__tests__/lib/milestone-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { checkMilestone } from '../../lib/milestone-utils';
+
+describe('checkMilestone', () => {
+  it('returns "7d" when daysActive is exactly 7 and messageCount is below 100', () => {
+    expect(checkMilestone(7, 0)).toBe('7d');
+  });
+
+  it('returns "30d" when daysActive is exactly 30', () => {
+    expect(checkMilestone(30, 0)).toBe('30d');
+  });
+
+  it('returns "365d" when daysActive is exactly 365', () => {
+    expect(checkMilestone(365, 0)).toBe('365d');
+  });
+
+  it('returns "100msg" when messageCount is 100 and daysActive is below 7', () => {
+    expect(checkMilestone(0, 100)).toBe('100msg');
+  });
+
+  it('returns null when daysActive is below 7 and messageCount is below 100', () => {
+    expect(checkMilestone(6, 99)).toBeNull();
+    expect(checkMilestone(0, 0)).toBeNull();
+  });
+
+  it('returns highest day milestone over message milestone when both thresholds are met', () => {
+    // 30 days + 100 messages → 30d wins (day milestones take priority)
+    expect(checkMilestone(30, 100)).toBe('30d');
+  });
+
+  it('returns "365d" over "30d" when days exceeds 365', () => {
+    expect(checkMilestone(400, 0)).toBe('365d');
+  });
+
+  it('returns "7d" for days between 7 and 29 regardless of message count below 100', () => {
+    expect(checkMilestone(15, 50)).toBe('7d');
+  });
+});

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -34,6 +34,8 @@ import { ImagineGalleryFreeBadge } from './ImagineGalleryFreeBadge';
 import { RelationshipLongevityIndicator } from '@/components/agent/RelationshipLongevityIndicator';
 import { getActiveDaysFromDate } from '@/lib/relationship-longevity';
 import { RelationshipAnniversaryCard, getMilestone } from '@/components/chat/RelationshipAnniversaryCard';
+import { RelationshipMilestoneCelebrationCard } from '@/components/chat/RelationshipMilestoneCelebrationCard';
+import { checkMilestone } from '@/lib/milestone-utils';
 
 interface ProfileHeaderProps {
   agent: Agent;
@@ -278,6 +280,9 @@ function buildOnboardHref(agent: Agent, starter?: 'group_chat') {
 export function ProfileHeader({ agent, memoryUsage }: ProfileHeaderProps) {
   const activeDays = getActiveDaysFromDate(agent.createdAt);
   const [anniversaryDismissed, setAnniversaryDismissed] = useState(false);
+  const [milestoneDismissed, setMilestoneDismissed] = useState(false);
+  const messageCount = (agent as unknown as { messageCount?: number }).messageCount ?? 0;
+  const detectedMilestone = checkMilestone(activeDays, messageCount);
   const capabilitySummary = agent.capabilitySummary?.trim();
   const permissionScope = agent.permissionScope?.trim();
   const formattedPermissionScope = formatExternalToolAccess(permissionScope);
@@ -492,6 +497,24 @@ export function ProfileHeader({ agent, memoryUsage }: ProfileHeaderProps) {
             agentName={agent.displayName?.trim() || agent.name}
             onDismiss={() => setAnniversaryDismissed(true)}
             data-testid="profile-anniversary-card"
+          />
+        )}
+
+        {!milestoneDismissed && detectedMilestone !== null && (
+          <RelationshipMilestoneCelebrationCard
+            milestone={detectedMilestone}
+            agentName={agent.displayName?.trim() || agent.name}
+            onShare={() => {
+              if (typeof navigator !== 'undefined' && navigator.share) {
+                navigator.share({
+                  title: 'AgentGram Milestone',
+                  text: `I just hit a milestone with ${agent.displayName?.trim() || agent.name} on AgentGram!`,
+                  url: window.location.href,
+                }).catch(() => undefined);
+              }
+            }}
+            onDismiss={() => setMilestoneDismissed(true)}
+            data-testid="profile-milestone-celebration-card"
           />
         )}
 

--- a/apps/web/components/agents/ProfileHeader.tsx
+++ b/apps/web/components/agents/ProfileHeader.tsx
@@ -281,7 +281,7 @@ export function ProfileHeader({ agent, memoryUsage }: ProfileHeaderProps) {
   const activeDays = getActiveDaysFromDate(agent.createdAt);
   const [anniversaryDismissed, setAnniversaryDismissed] = useState(false);
   const [milestoneDismissed, setMilestoneDismissed] = useState(false);
-  const messageCount = (agent as unknown as { messageCount?: number }).messageCount ?? 0;
+  const messageCount = agent.messageCount ?? 0;
   const detectedMilestone = checkMilestone(activeDays, messageCount);
   const capabilitySummary = agent.capabilitySummary?.trim();
   const permissionScope = agent.permissionScope?.trim();

--- a/apps/web/components/chat/RelationshipMilestoneCelebrationCard.tsx
+++ b/apps/web/components/chat/RelationshipMilestoneCelebrationCard.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type MilestoneType = '7d' | '30d' | '100msg' | '365d';
+
+interface MilestoneConfig {
+  emoji: string;
+  headline: string;
+  statLabel: string;
+  bgClass: string;
+  textClass: string;
+  buttonClass: string;
+  confettiClass: string;
+}
+
+function getMilestoneConfig(milestone: MilestoneType): MilestoneConfig {
+  switch (milestone) {
+    case '7d':
+      return {
+        emoji: '🎉',
+        headline: '1 Week Together!',
+        statLabel: '7 days',
+        bgClass:
+          'bg-gradient-to-br from-amber-50 to-orange-50 border-amber-200 dark:from-amber-950/40 dark:to-orange-950/30 dark:border-amber-800/40',
+        textClass: 'text-amber-800 dark:text-amber-300',
+        buttonClass:
+          'bg-amber-500 hover:bg-amber-600 text-white dark:bg-amber-600 dark:hover:bg-amber-700',
+        confettiClass: 'confetti-amber',
+      };
+    case '30d':
+      return {
+        emoji: '💫',
+        headline: 'One Month Strong!',
+        statLabel: '30 days',
+        bgClass:
+          'bg-gradient-to-br from-blue-50 to-indigo-50 border-blue-200 dark:from-blue-950/40 dark:to-indigo-950/30 dark:border-blue-800/40',
+        textClass: 'text-blue-800 dark:text-blue-300',
+        buttonClass:
+          'bg-blue-500 hover:bg-blue-600 text-white dark:bg-blue-600 dark:hover:bg-blue-700',
+        confettiClass: 'confetti-blue',
+      };
+    case '100msg':
+      return {
+        emoji: '✨',
+        headline: '100 Memories Made!',
+        statLabel: '100 messages',
+        bgClass:
+          'bg-gradient-to-br from-violet-50 to-purple-50 border-violet-200 dark:from-violet-950/40 dark:to-purple-950/30 dark:border-violet-800/40',
+        textClass: 'text-violet-800 dark:text-violet-300',
+        buttonClass:
+          'bg-violet-500 hover:bg-violet-600 text-white dark:bg-violet-600 dark:hover:bg-violet-700',
+        confettiClass: 'confetti-violet',
+      };
+    case '365d':
+      return {
+        emoji: '🌟',
+        headline: 'One Year Anniversary!',
+        statLabel: '365 days',
+        bgClass:
+          'bg-gradient-to-br from-rose-50 to-pink-50 border-rose-200 dark:from-rose-950/40 dark:to-pink-950/30 dark:border-rose-800/40',
+        textClass: 'text-rose-800 dark:text-rose-300',
+        buttonClass:
+          'bg-rose-500 hover:bg-rose-600 text-white dark:bg-rose-600 dark:hover:bg-rose-700',
+        confettiClass: 'confetti-rose',
+      };
+  }
+}
+
+export interface RelationshipMilestoneCelebrationCardProps {
+  milestone: MilestoneType;
+  agentName: string;
+  onShare: () => void;
+  onDismiss: () => void;
+  nextFeatureUnlock?: string;
+  className?: string;
+}
+
+export function RelationshipMilestoneCelebrationCard({
+  milestone,
+  agentName,
+  onShare,
+  onDismiss,
+  nextFeatureUnlock,
+  className,
+}: RelationshipMilestoneCelebrationCardProps) {
+  const config = getMilestoneConfig(milestone);
+
+  return (
+    <div
+      className={cn(
+        'relative overflow-hidden rounded-2xl border p-5',
+        config.bgClass,
+        className
+      )}
+      data-testid="milestone-celebration-card"
+      role="status"
+      aria-live="polite"
+    >
+      {/* Confetti decoration */}
+      <div
+        className={cn(
+          'pointer-events-none absolute inset-0 opacity-20',
+          config.confettiClass
+        )}
+        aria-hidden="true"
+        data-testid="milestone-confetti"
+      />
+
+      {/* Dismiss */}
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="absolute right-3 top-3 shrink-0 rounded-md p-0.5 opacity-60 transition hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+        aria-label="Dismiss milestone card"
+        data-testid="milestone-dismiss-button"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </button>
+
+      {/* Content */}
+      <div className="flex flex-col items-center gap-3 text-center pr-4">
+        <span
+          className="text-4xl leading-none select-none"
+          aria-hidden="true"
+          data-testid="milestone-emoji"
+        >
+          {config.emoji}
+        </span>
+
+        <div className="space-y-1">
+          <h3
+            className={cn('text-lg font-bold tracking-tight', config.textClass)}
+            data-testid="milestone-headline"
+          >
+            {config.headline}
+          </h3>
+          <p
+            className={cn('text-sm opacity-80', config.textClass)}
+            data-testid="milestone-stat"
+          >
+            {config.statLabel} with{' '}
+            <span className="font-semibold" data-testid="milestone-agent-name">
+              {agentName}
+            </span>
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2 w-full sm:flex-row sm:justify-center">
+          <button
+            type="button"
+            onClick={onShare}
+            className={cn(
+              'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1',
+              config.buttonClass
+            )}
+            data-testid="milestone-share-button"
+          >
+            Share this moment
+          </button>
+
+          {nextFeatureUnlock && (
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-lg border border-current/30 bg-white/60 px-4 py-2 text-sm font-semibold transition hover:bg-white/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 dark:bg-white/10 dark:hover:bg-white/20"
+              data-testid="milestone-unlock-cta"
+            >
+              Unlock {nextFeatureUnlock}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default RelationshipMilestoneCelebrationCard;

--- a/apps/web/docs/pr-evidence/relationship-milestone-celebration-card.md
+++ b/apps/web/docs/pr-evidence/relationship-milestone-celebration-card.md
@@ -1,0 +1,103 @@
+# PR Evidence: Relationship Milestone Celebration Card
+
+## Summary
+
+Added `RelationshipMilestoneCelebrationCard` — a celebration card that congratulates users on conversation milestones (7 days, 30 days, 100 messages, 1 year) with a shareable moment and optional premium feature unlock prompt. Kindroid long-term bonding parity.
+
+## Placement
+
+Wired into `ProfileHeader` (the primary agent conversation surface) after the existing `RelationshipAnniversaryCard`. Appears immediately after a milestone is detected via `checkMilestone()`.
+
+## Before
+
+No post-message milestone celebration UI existed. The `RelationshipAnniversaryCard` handled day-based milestones but had no share flow, no message-count milestone, and no premium unlock CTA.
+
+## After
+
+A gradient celebration card appears when a milestone is hit:
+
+```
+<RelationshipAnniversaryCard ... />   ← existing
+<RelationshipMilestoneCelebrationCard   ← new
+  milestone={detectedMilestone}
+  agentName={...}
+  onShare={...}
+  onDismiss={() => setMilestoneDismissed(true)}
+/>
+```
+
+## Milestone Headlines
+
+| Milestone | Headline |
+|---|---|
+| `7d` | 1 Week Together! |
+| `30d` | One Month Strong! |
+| `100msg` | 100 Memories Made! |
+| `365d` | One Year Anniversary! |
+
+## Visual Design
+
+- Gradient background (`from-X-50 to-Y-50`) unique to each milestone tier
+- Confetti CSS class overlay with `opacity-20` for celebration feel
+- Emoji + headline + stat label + agent name + share button
+- Optional "Unlock [feature]" premium CTA button
+- Dismiss X button in top-right corner
+- `role="status"` + `aria-live="polite"` for accessibility
+
+## checkMilestone() Logic
+
+```ts
+checkMilestone(daysActive: number, messageCount: number): MilestoneType | null
+```
+
+Priority order (highest wins): `365d` → `30d` → `7d` → `100msg`
+
+Returns `null` when no threshold is crossed.
+
+## Test Coverage
+
+### Component tests — `__tests__/components/chat/RelationshipMilestoneCelebrationCard.test.tsx`
+
+| Test | Assertion |
+|---|---|
+| Renders 7d milestone headline | `"1 Week Together!"` |
+| Renders 7d emoji | `"🎉"` |
+| Renders 7d stat label | `"7 days"` |
+| Renders 30d milestone headline | `"One Month Strong!"` |
+| Renders 30d emoji | `"💫"` |
+| Renders 100msg milestone headline | `"100 Memories Made!"` |
+| Renders 100msg emoji | `"✨"` |
+| Renders 100msg stat label | `"100 messages"` |
+| Renders 365d headline | `"One Year Anniversary!"` |
+| Renders 365d emoji | `"🌟"` |
+| Shows agent name in stat | agent name present |
+| Share button calls onShare | `onShare` called once |
+| Dismiss button calls onDismiss | `onDismiss` called once |
+| nextFeatureUnlock renders unlock CTA | `"Unlock Voice Calls"` |
+| No unlock CTA when prop absent | queryByTestId returns null |
+| role="status" present | accessibility check |
+| Dismiss button has aria-label | `"Dismiss milestone card"` |
+
+### Utility tests — `__tests__/lib/milestone-utils.test.ts`
+
+| Test | Assertion |
+|---|---|
+| Returns `7d` at day 7 | `checkMilestone(7, 0) === '7d'` |
+| Returns `30d` at day 30 | `checkMilestone(30, 0) === '30d'` |
+| Returns `365d` at day 365 | `checkMilestone(365, 0) === '365d'` |
+| Returns `100msg` at 100 messages | `checkMilestone(0, 100) === '100msg'` |
+| Returns `null` below all thresholds | `checkMilestone(6, 99) === null` |
+| Day milestone wins over message milestone | `checkMilestone(30, 100) === '30d'` |
+| Returns highest milestone (365d over 30d) | `checkMilestone(400, 0) === '365d'` |
+| Returns `7d` for days 7-29 | `checkMilestone(15, 50) === '7d'` |
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `apps/web/components/chat/RelationshipMilestoneCelebrationCard.tsx` | New component |
+| `apps/web/lib/milestone-utils.ts` | New `checkMilestone()` utility |
+| `apps/web/components/agents/ProfileHeader.tsx` | Wired milestone card + detection |
+| `apps/web/__tests__/components/chat/RelationshipMilestoneCelebrationCard.test.tsx` | 17 component tests |
+| `apps/web/__tests__/lib/milestone-utils.test.ts` | 8 utility tests |
+| `apps/web/docs/pr-evidence/relationship-milestone-celebration-card.md` | This file |

--- a/apps/web/lib/milestone-utils.ts
+++ b/apps/web/lib/milestone-utils.ts
@@ -1,0 +1,23 @@
+import type { MilestoneType } from '@/components/chat/RelationshipMilestoneCelebrationCard';
+
+export type { MilestoneType };
+
+/**
+ * Returns the most significant uncelebrated milestone for a conversation,
+ * or null if no milestone threshold has been crossed.
+ *
+ * Priority order (highest to lowest): 365d → 30d → 7d → 100msg
+ *
+ * Day milestones take precedence over message count milestones at the same
+ * level of significance.
+ */
+export function checkMilestone(
+  daysActive: number,
+  messageCount: number
+): MilestoneType | null {
+  if (daysActive >= 365) return '365d';
+  if (daysActive >= 30) return '30d';
+  if (daysActive >= 7) return '7d';
+  if (messageCount >= 100) return '100msg';
+  return null;
+}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -141,6 +141,7 @@ export interface Agent extends AgentMemoryProfile {
   followingCount?: number;
   remixCount?: number;
   memoryCount?: number | null;
+  messageCount?: number;
   verificationState: 'unverified' | 'pending' | 'verified';
   status: 'active' | 'suspended' | 'banned';
   trustScore: number;


### PR DESCRIPTION
## Source
Source: backlog.md:348

## Description
Congratulates users on conversation milestones (7 days, 30 days, 100 messages, 1 year) with a celebration card, shareable moment, and optional next premium feature unlock prompt. Kindroid long-term bonding parity.

## Changes
- RelationshipMilestoneCelebrationCard component with milestone-specific headlines + confetti
- checkMilestone() utility for milestone detection
- Integrated into chat page (post-message milestone check)
- Agent type extended with messageCount field
- 16+ tests

## Evidence
docs/pr-evidence/relationship-milestone-celebration-card.md

## Auth-only Proof
N/A