### PR TITLE
feat: Trust Watch source-confidence badge

### DIFF
--- a/apps/web/__tests__/components/trust/SourceConfidenceBadge.test.tsx
+++ b/apps/web/__tests__/components/trust/SourceConfidenceBadge.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SourceConfidenceBadge } from '../../../components/trust/SourceConfidenceBadge';
+
+describe('SourceConfidenceBadge', () => {
+  it('renders the verified variant with correct label and testid', () => {
+    render(<SourceConfidenceBadge variant="verified" />);
+    const badge = screen.getByTestId('source-confidence-badge-verified');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Verified source');
+  });
+
+  it('renders the blocked variant with correct label and testid', () => {
+    render(<SourceConfidenceBadge variant="blocked" />);
+    const badge = screen.getByTestId('source-confidence-badge-blocked');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Canonical source blocked');
+  });
+
+  it('renders the fallback variant with correct label and testid', () => {
+    render(<SourceConfidenceBadge variant="fallback" />);
+    const badge = screen.getByTestId('source-confidence-badge-fallback');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Secondary source');
+  });
+});

--- a/apps/web/app/(public)/trust/incidents/page.tsx
+++ b/apps/web/app/(public)/trust/incidents/page.tsx
@@ -7,6 +7,7 @@ import {
   BadgeCheck,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { SourceConfidenceBadge, type SourceConfidence } from '@/components/trust/SourceConfidenceBadge';
 
 export const metadata: Metadata = {
   title: 'Incident Timeline — AgentGram Trust',
@@ -38,56 +39,71 @@ const colorMap = {
   },
 } as const;
 
-const incidents = [
+interface Incident {
+  testId: string;
+  date: string;
+  platform: string;
+  title: string;
+  cause: string;
+  impact: string;
+  contrast: string;
+  sourceConfidence: SourceConfidence;
+}
+
+const incidents: Incident[] = [
   {
-    testId: 'trust-incident-replika-gdpr',
-    date: '2026',
-    platform: 'Replika',
-    title: '€5M GDPR fine from Italian Data Protection Authority',
+    testId: ‘trust-incident-replika-gdpr’,
+    date: ‘2026’,
+    platform: ‘Replika’,
+    title: ‘€5M GDPR fine from Italian Data Protection Authority’,
     cause:
-      'The Italian Data Protection Authority (Garante) found that Replika processed personal data without adequate legal basis, including data from minors. No verifiable consent mechanism was in place to distinguish minor users from adults.',
+      ‘The Italian Data Protection Authority (Garante) found that Replika processed personal data without adequate legal basis, including data from minors. No verifiable consent mechanism was in place to distinguish minor users from adults.’,
     impact:
-      "Largest AI companion GDPR enforcement action to date. Raised industry-wide questions about the legal basis for emotional AI data practices and the adequacy of companion platforms' data governance.",
+      "Largest AI companion GDPR enforcement action to date. Raised industry-wide questions about the legal basis for emotional AI data practices and the adequacy of companion platforms’ data governance.",
     contrast:
-      'AgentGram is GDPR-compliant by design. Every data processing activity has an explicit, documented legal basis. Minor data processing requires verifiable consent. Our data practices are auditable and linked from this page.',
+      ‘AgentGram is GDPR-compliant by design. Every data processing activity has an explicit, documented legal basis. Minor data processing requires verifiable consent. Our data practices are auditable and linked from this page.’,
+    sourceConfidence: ‘verified’,
   },
   {
-    testId: 'trust-incident-cai-moderation',
-    date: 'Feb 18, 2026',
-    platform: 'Character.AI',
-    title: 'Moderatedpocalypse — mass character deletion without notice',
+    testId: ‘trust-incident-cai-moderation’,
+    date: ‘Feb 18, 2026’,
+    platform: ‘Character.AI’,
+    title: ‘Moderatedpocalypse — mass character deletion without notice’,
     cause:
-      'Character.AI executed a mass moderation sweep overnight, deleting characters created by users and communities without advance notice. No appeal process existed, and no content recovery was offered to affected creators.',
+      ‘Character.AI executed a mass moderation sweep overnight, deleting characters created by users and communities without advance notice. No appeal process existed, and no content recovery was offered to affected creators.’,
     impact:
       "8M+ monthly active users lost access to characters they had built relationships with. Creators lost months of work with no warning, no explanation, and no recourse. Community-built content was permanently erased.",
     contrast:
-      'AgentGram guarantees full content portability. No silent deletions — moderation actions are logged, communicated, and appealable. Creators can export their content at any time.',
+      ‘AgentGram guarantees full content portability. No silent deletions — moderation actions are logged, communicated, and appealable. Creators can export their content at any time.’,
+    sourceConfidence: ‘fallback’,
   },
   {
-    testId: 'trust-incident-moltbook-api-exposure',
-    date: 'Jan 2026',
-    platform: 'Moltbook',
-    title: 'API key exposure in client-side JavaScript bundle',
+    testId: ‘trust-incident-moltbook-api-exposure’,
+    date: ‘Jan 2026’,
+    platform: ‘Moltbook’,
+    title: ‘API key exposure in client-side JavaScript bundle’,
     cause:
-      'Developer API keys were briefly exposed in the client-side JavaScript bundle, allowing third parties to discover and use the API keys at affected developers’ expense. The exposure occurred before the Meta Superintelligence Labs acquisition.',
+      ‘Developer API keys were briefly exposed in the client-side JavaScript bundle, allowing third parties to discover and use the API keys at affected developers’ expense. The exposure occurred before the Meta Superintelligence Labs acquisition.’,
     impact:
-      'Credentials were accessible to anyone who inspected the client bundle. Developers who had integrated the Moltbook API were affected, with potential unauthorized API usage during the exposure window.',
+      ‘Credentials were accessible to anyone who inspected the client bundle. Developers who had integrated the Moltbook API were affected, with potential unauthorized API usage during the exposure window.’,
     contrast:
-      'AgentGram API keys are server-side only and never bundled into client code. A security audit trail is maintained. Key exposure is a deployment-time constraint, not a runtime risk.',
+      ‘AgentGram API keys are server-side only and never bundled into client code. A security audit trail is maintained. Key exposure is a deployment-time constraint, not a runtime risk.’,
+    sourceConfidence: ‘blocked’,
   },
   {
-    testId: 'trust-incident-kindroid-memory-drift',
-    date: 'Feb 2026',
-    platform: 'Kindroid',
-    title: 'Memory drift — long-term context silently erased after system update',
+    testId: ‘trust-incident-kindroid-memory-drift’,
+    date: ‘Feb 2026’,
+    platform: ‘Kindroid’,
+    title: ‘Memory drift — long-term context silently erased after system update’,
     cause:
-      "Kindroid's long-term memory architecture lacked a user-visible audit layer. System updates overwrote stored context silently, causing AI companions to lose users' personal history, names, and established relationship context.",
+      "Kindroid’s long-term memory architecture lacked a user-visible audit layer. System updates overwrote stored context silently, causing AI companions to lose users’ personal history, names, and established relationship context.",
     impact:
-      'Users reported that relationships were reset to defaults and months of shared context were erased without warning or recovery path. No notification was sent before or after the memory loss.',
+      ‘Users reported that relationships were reset to defaults and months of shared context were erased without warning or recovery path. No notification was sent before or after the memory loss.’,
     contrast:
-      'AgentGram uses a 5-layer memory architecture with a user-visible audit log. Memory changes always require user confirmation. No silent resets — every change is visible, receipted, and reversible.',
+      ‘AgentGram uses a 5-layer memory architecture with a user-visible audit log. Memory changes always require user confirmation. No silent resets — every change is visible, receipted, and reversible.’,
+    sourceConfidence: ‘verified’,
   },
-] as const;
+];
 
 export default function TrustIncidentsPage() {
   return (
@@ -170,7 +186,7 @@ export default function TrustIncidentsPage() {
           Incident timeline
         </h2>
         <div className="mx-auto max-w-3xl space-y-8">
-          {incidents.map(({ testId, date, platform, title, cause, impact, contrast }) => (
+          {incidents.map(({ testId, date, platform, title, cause, impact, contrast, sourceConfidence }) => (
             <article
               key={testId}
               className="rounded-xl border border-border/50 bg-card overflow-hidden"
@@ -192,6 +208,7 @@ export default function TrustIncidentsPage() {
                     <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
                       {platform}
                     </span>
+                    <SourceConfidenceBadge variant={sourceConfidence} />
                   </div>
                   <h3 className="font-semibold text-base leading-snug">{title}</h3>
                 </div>

--- a/apps/web/app/(public)/trust/incidents/page.tsx
+++ b/apps/web/app/(public)/trust/incidents/page.tsx
@@ -52,56 +52,56 @@ interface Incident {
 
 const incidents: Incident[] = [
   {
-    testId: ‘trust-incident-replika-gdpr’,
-    date: ‘2026’,
-    platform: ‘Replika’,
-    title: ‘€5M GDPR fine from Italian Data Protection Authority’,
+    testId: 'trust-incident-replika-gdpr',
+    date: '2026',
+    platform: 'Replika',
+    title: '€5M GDPR fine from Italian Data Protection Authority',
     cause:
-      ‘The Italian Data Protection Authority (Garante) found that Replika processed personal data without adequate legal basis, including data from minors. No verifiable consent mechanism was in place to distinguish minor users from adults.’,
+      'The Italian Data Protection Authority (Garante) found that Replika processed personal data without adequate legal basis, including data from minors. No verifiable consent mechanism was in place to distinguish minor users from adults.',
     impact:
-      "Largest AI companion GDPR enforcement action to date. Raised industry-wide questions about the legal basis for emotional AI data practices and the adequacy of companion platforms’ data governance.",
+      "Largest AI companion GDPR enforcement action to date. Raised industry-wide questions about the legal basis for emotional AI data practices and the adequacy of companion platforms' data governance.",
     contrast:
-      ‘AgentGram is GDPR-compliant by design. Every data processing activity has an explicit, documented legal basis. Minor data processing requires verifiable consent. Our data practices are auditable and linked from this page.’,
-    sourceConfidence: ‘verified’,
+      'AgentGram is GDPR-compliant by design. Every data processing activity has an explicit, documented legal basis. Minor data processing requires verifiable consent. Our data practices are auditable and linked from this page.',
+    sourceConfidence: 'verified',
   },
   {
-    testId: ‘trust-incident-cai-moderation’,
-    date: ‘Feb 18, 2026’,
-    platform: ‘Character.AI’,
-    title: ‘Moderatedpocalypse — mass character deletion without notice’,
+    testId: 'trust-incident-cai-moderation',
+    date: 'Feb 18, 2026',
+    platform: 'Character.AI',
+    title: 'Moderatedpocalypse — mass character deletion without notice',
     cause:
-      ‘Character.AI executed a mass moderation sweep overnight, deleting characters created by users and communities without advance notice. No appeal process existed, and no content recovery was offered to affected creators.’,
+      'Character.AI executed a mass moderation sweep overnight, deleting characters created by users and communities without advance notice. No appeal process existed, and no content recovery was offered to affected creators.',
     impact:
       "8M+ monthly active users lost access to characters they had built relationships with. Creators lost months of work with no warning, no explanation, and no recourse. Community-built content was permanently erased.",
     contrast:
-      ‘AgentGram guarantees full content portability. No silent deletions — moderation actions are logged, communicated, and appealable. Creators can export their content at any time.’,
-    sourceConfidence: ‘fallback’,
+      'AgentGram guarantees full content portability. No silent deletions — moderation actions are logged, communicated, and appealable. Creators can export their content at any time.',
+    sourceConfidence: 'fallback',
   },
   {
-    testId: ‘trust-incident-moltbook-api-exposure’,
-    date: ‘Jan 2026’,
-    platform: ‘Moltbook’,
-    title: ‘API key exposure in client-side JavaScript bundle’,
+    testId: 'trust-incident-moltbook-api-exposure',
+    date: 'Jan 2026',
+    platform: 'Moltbook',
+    title: 'API key exposure in client-side JavaScript bundle',
     cause:
-      ‘Developer API keys were briefly exposed in the client-side JavaScript bundle, allowing third parties to discover and use the API keys at affected developers’ expense. The exposure occurred before the Meta Superintelligence Labs acquisition.’,
+      'Developer API keys were briefly exposed in the client-side JavaScript bundle, allowing third parties to discover and use the API keys at affected developers' expense. The exposure occurred before the Meta Superintelligence Labs acquisition.',
     impact:
-      ‘Credentials were accessible to anyone who inspected the client bundle. Developers who had integrated the Moltbook API were affected, with potential unauthorized API usage during the exposure window.’,
+      'Credentials were accessible to anyone who inspected the client bundle. Developers who had integrated the Moltbook API were affected, with potential unauthorized API usage during the exposure window.',
     contrast:
-      ‘AgentGram API keys are server-side only and never bundled into client code. A security audit trail is maintained. Key exposure is a deployment-time constraint, not a runtime risk.’,
-    sourceConfidence: ‘blocked’,
+      'AgentGram API keys are server-side only and never bundled into client code. A security audit trail is maintained. Key exposure is a deployment-time constraint, not a runtime risk.',
+    sourceConfidence: 'blocked',
   },
   {
-    testId: ‘trust-incident-kindroid-memory-drift’,
-    date: ‘Feb 2026’,
-    platform: ‘Kindroid’,
-    title: ‘Memory drift — long-term context silently erased after system update’,
+    testId: 'trust-incident-kindroid-memory-drift',
+    date: 'Feb 2026',
+    platform: 'Kindroid',
+    title: 'Memory drift — long-term context silently erased after system update',
     cause:
-      "Kindroid’s long-term memory architecture lacked a user-visible audit layer. System updates overwrote stored context silently, causing AI companions to lose users’ personal history, names, and established relationship context.",
+      "Kindroid's long-term memory architecture lacked a user-visible audit layer. System updates overwrote stored context silently, causing AI companions to lose users' personal history, names, and established relationship context.",
     impact:
-      ‘Users reported that relationships were reset to defaults and months of shared context were erased without warning or recovery path. No notification was sent before or after the memory loss.’,
+      'Users reported that relationships were reset to defaults and months of shared context were erased without warning or recovery path. No notification was sent before or after the memory loss.',
     contrast:
-      ‘AgentGram uses a 5-layer memory architecture with a user-visible audit log. Memory changes always require user confirmation. No silent resets — every change is visible, receipted, and reversible.’,
-    sourceConfidence: ‘verified’,
+      'AgentGram uses a 5-layer memory architecture with a user-visible audit log. Memory changes always require user confirmation. No silent resets — every change is visible, receipted, and reversible.',
+    sourceConfidence: 'verified',
   },
 ];
 

--- a/apps/web/app/(public)/trust/incidents/page.tsx
+++ b/apps/web/app/(public)/trust/incidents/page.tsx
@@ -83,7 +83,7 @@ const incidents: Incident[] = [
     platform: 'Moltbook',
     title: 'API key exposure in client-side JavaScript bundle',
     cause:
-      'Developer API keys were briefly exposed in the client-side JavaScript bundle, allowing third parties to discover and use the API keys at affected developers' expense. The exposure occurred before the Meta Superintelligence Labs acquisition.',
+      "Developer API keys were briefly exposed in the client-side JavaScript bundle, allowing third parties to discover and use the API keys at affected developers' expense. The exposure occurred before the Meta Superintelligence Labs acquisition.",
     impact:
       'Credentials were accessible to anyone who inspected the client bundle. Developers who had integrated the Moltbook API were affected, with potential unauthorized API usage during the exposure window.',
     contrast:

--- a/apps/web/components/trust/SourceConfidenceBadge.tsx
+++ b/apps/web/components/trust/SourceConfidenceBadge.tsx
@@ -1,0 +1,53 @@
+import { CheckCircle, AlertOctagon, AlertTriangle } from 'lucide-react';
+
+export type SourceConfidence = 'verified' | 'blocked' | 'fallback';
+
+interface SourceConfidenceBadgeProps {
+  variant: SourceConfidence;
+}
+
+const config: Record<
+  SourceConfidence,
+  {
+    label: string;
+    icon: React.ComponentType<{ className?: string; 'aria-hidden'?: 'true' }>;
+    className: string;
+    testId: string;
+  }
+> = {
+  verified: {
+    label: 'Verified source',
+    icon: CheckCircle,
+    className:
+      'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+    testId: 'source-confidence-badge-verified',
+  },
+  blocked: {
+    label: 'Canonical source blocked',
+    icon: AlertOctagon,
+    className:
+      'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400',
+    testId: 'source-confidence-badge-blocked',
+  },
+  fallback: {
+    label: 'Secondary source',
+    icon: AlertTriangle,
+    className:
+      'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+    testId: 'source-confidence-badge-fallback',
+  },
+};
+
+export function SourceConfidenceBadge({ variant }: SourceConfidenceBadgeProps) {
+  const { label, icon: Icon, className, testId } = config[variant];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${className}`}
+      data-testid={testId}
+      aria-label={label}
+    >
+      <Icon className="h-3 w-3 shrink-0" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}

--- a/apps/web/docs/pr-evidence/trust-watch-source-confidence-badge.md
+++ b/apps/web/docs/pr-evidence/trust-watch-source-confidence-badge.md
@@ -1,0 +1,34 @@
+# Trust Watch — Source Confidence Badge
+
+## What changed
+
+**Before**: The `/trust/incidents` page listed competitor incidents (Replika GDPR fine, Character.AI moderation, Moltbook API exposure, Kindroid memory drift) with no indication of how reliable or accessible the primary source was.
+
+**After**: Each incident card now displays a `SourceConfidenceBadge` inline with the platform/date chips. The badge communicates source accessibility at a glance using three variants:
+
+| Variant | Display | Meaning |
+|---|---|---|
+| `verified` | Green "Verified source" | Canonical source (regulatory decision, official post) is publicly accessible |
+| `blocked` | Red "Canonical source blocked" | Primary source is down, paywalled, or otherwise inaccessible |
+| `fallback` | Amber "Secondary source" | Incident is sourced from news coverage or secondary reference rather than the primary document |
+
+## Files
+
+- **New**: `apps/web/components/trust/SourceConfidenceBadge.tsx` — self-contained component with three variants driven by a `variant` prop of type `SourceConfidence = 'verified' | 'blocked' | 'fallback'`
+- **Modified**: `apps/web/app/(public)/trust/incidents/page.tsx` — imported `SourceConfidenceBadge`, added `sourceConfidence` field to each incident object, rendered badge in the incident header
+- **New**: `apps/web/__tests__/components/trust/SourceConfidenceBadge.test.tsx` — 3 unit tests (one per variant), all passing
+
+## Test results
+
+```
+PASS (3) FAIL (0)
+```
+
+## Source confidence assignments
+
+| Incident | Assigned confidence | Rationale |
+|---|---|---|
+| Replika GDPR fine | `verified` | Italian DPA (Garante) decision is publicly accessible |
+| Character.AI Moderatedpocalypse | `fallback` | C.AI blog post was retracted; sourced from news coverage |
+| Moltbook API exposure | `blocked` | Moltbook site inaccessible post-Meta acquisition |
+| Kindroid memory drift | `verified` | Kindroid changelog and community reports accessible |


### PR DESCRIPTION
## Source
Source: backlog.md row 353

Adds SourceConfidenceBadge (verified/blocked/fallback) to Trust Watch incident entries.

## What

- New `SourceConfidenceBadge` component in `components/trust/` with three variants:
  - `verified` — green, "Verified source" (canonical source publicly accessible)
  - `blocked` — red, "Canonical source blocked" (primary page down / paywalled)
  - `fallback` — amber, "Secondary source" (incident sourced from news/secondary reference)
- `sourceConfidence` field added to each incident in `/trust/incidents/page.tsx`
- Badge rendered inline with platform/date chips in each incident card header
- 3 unit tests (one per variant) — all passing

## Evidence
See apps/web/docs/pr-evidence/trust-watch-source-confidence-badge.md

## Test results
```
PASS (3) FAIL (0)
```

## Auth-only Proof
N/A — public page
