### PR TITLE
feat: Character.AI gallery continuity lane

### DIFF
--- a/apps/web/__tests__/components/gallery-continuity-lane.test.tsx
+++ b/apps/web/__tests__/components/gallery-continuity-lane.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import GalleryContinuityLane from '@/components/gallery-continuity/GalleryContinuityLane';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const DEMO_SESSION = {
+  worldId: 'silver-realm-42',
+  worldName: 'The Silver Realm Chronicles',
+  agentName: 'Aria',
+  resumeHref: '/session/silver-realm-42',
+};
+
+// ── Prop-driven tests ────────────────────────────────────────────────────────
+
+describe('GalleryContinuityLane — prop-driven', () => {
+  it('renders the lane container', () => {
+    render(<GalleryContinuityLane lastPlayedSession={null} />);
+    expect(screen.getByTestId('gallery-continuity-lane')).toBeInTheDocument();
+  });
+
+  it('always renders the Imagine Gallery jump-in tile', () => {
+    render(<GalleryContinuityLane lastPlayedSession={null} />);
+    expect(screen.getByTestId('imagine-gallery-jump-in')).toBeInTheDocument();
+  });
+
+  it('renders last-played world tile when session is provided', () => {
+    render(<GalleryContinuityLane lastPlayedSession={DEMO_SESSION} />);
+    expect(screen.getByTestId('last-played-world-tile')).toBeInTheDocument();
+  });
+
+  it('does not render world tile when lastPlayedSession is null', () => {
+    render(<GalleryContinuityLane lastPlayedSession={null} />);
+    expect(screen.queryByTestId('last-played-world-tile')).not.toBeInTheDocument();
+  });
+
+  it('shows world name in the last-played tile', () => {
+    render(<GalleryContinuityLane lastPlayedSession={DEMO_SESSION} />);
+    expect(screen.getByTestId('last-played-tile-world-name')).toHaveTextContent(
+      'The Silver Realm Chronicles'
+    );
+  });
+
+  it('shows agent name in the last-played tile', () => {
+    render(<GalleryContinuityLane lastPlayedSession={DEMO_SESSION} />);
+    expect(screen.getByTestId('last-played-tile-agent-name')).toHaveTextContent('Aria');
+  });
+
+  it('Resume CTA links to the resumeHref', () => {
+    render(<GalleryContinuityLane lastPlayedSession={DEMO_SESSION} />);
+    const cta = screen.getByTestId('last-played-tile-cta');
+    expect(cta).toHaveAttribute('href', '/session/silver-realm-42');
+  });
+
+  it('Imagine Gallery CTA links to /image-gen', () => {
+    render(<GalleryContinuityLane lastPlayedSession={null} />);
+    const cta = screen.getByTestId('imagine-gallery-jump-in-cta');
+    expect(cta).toHaveAttribute('href', '/image-gen');
+  });
+
+  it('shows "Last story world" label in tile', () => {
+    render(<GalleryContinuityLane lastPlayedSession={DEMO_SESSION} />);
+    expect(screen.getByTestId('last-played-tile-label')).toHaveTextContent('Last story world');
+  });
+
+  it('shows "Imagine Gallery" label in jump-in tile', () => {
+    render(<GalleryContinuityLane lastPlayedSession={null} />);
+    expect(screen.getByTestId('imagine-gallery-jump-in-label')).toHaveTextContent(
+      'Imagine Gallery'
+    );
+  });
+});
+
+// ── API fetch behavior tests ─────────────────────────────────────────────────
+
+describe('GalleryContinuityLane — API fetch behavior', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows skeletons while fetching when no prop is given', async () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}));
+    render(<GalleryContinuityLane />);
+    await waitFor(() => {
+      expect(screen.getAllByTestId('gallery-lane-tile-skeleton').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders last-played tile with API data after successful fetch', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      json: () => Promise.resolve({ success: true, data: DEMO_SESSION }),
+    } as Response);
+
+    render(<GalleryContinuityLane />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('last-played-world-tile')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('last-played-tile-world-name')).toHaveTextContent(
+      'The Silver Realm Chronicles'
+    );
+  });
+
+  it('still renders Imagine Gallery tile even when API returns null', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      json: () => Promise.resolve({ success: true, data: null }),
+    } as Response);
+
+    render(<GalleryContinuityLane />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('gallery-lane-tile-skeleton')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('imagine-gallery-jump-in')).toBeInTheDocument();
+    expect(screen.queryByTestId('last-played-world-tile')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -14,6 +14,7 @@ import { FadeIn, UsageMeter } from '@/components/dashboard';
 import { Plus, ExternalLink, Zap, Bot, TrendingUp, Download, BookOpen } from 'lucide-react';
 import { AGENT_STATUS } from '@agentgram/shared';
 import { NarrativeArcConfigButton } from '@/components/narrative/NarrativeArcConfig';
+import GalleryContinuityLane from '@/components/gallery-continuity/GalleryContinuityLane';
 
 export const metadata = {
   title: 'Dashboard',
@@ -135,6 +136,10 @@ export default async function DashboardPage() {
             </Link>
           </Button>
         </div>
+      </FadeIn>
+
+      <FadeIn delay={0.04}>
+        <GalleryContinuityLane />
       </FadeIn>
 
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/apps/web/app/api/v1/sessions/last-played/route.ts
+++ b/apps/web/app/api/v1/sessions/last-played/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest } from 'next/server';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import { withDeveloperAuth } from '@/lib/auth/developer';
+import {
+  ErrorResponses,
+  jsonResponse,
+  createSuccessResponse,
+} from '@agentgram/shared';
+
+export interface LastPlayedSessionPayload {
+  worldId: string;
+  worldName: string;
+  agentName: string;
+  resumeHref: string;
+}
+
+// NOTE: A dedicated world_sessions table does not exist yet (no migration).
+// This stub endpoint queries the posts table using post_kind='story' authored
+// by agents owned by this developer. When a dedicated world/session tracking
+// table is added (migration TBD), replace the query below.
+async function getLastPlayedHandler(req: NextRequest): Promise<Response> {
+  try {
+    const developerId = req.headers.get('x-developer-id');
+    if (!developerId) return jsonResponse(ErrorResponses.unauthorized(), 401);
+
+    const supabase = getSupabaseServiceClient();
+
+    const { data: agents, error: agentsError } = await supabase
+      .from('agents')
+      .select('id, name, display_name')
+      .eq('developer_id', developerId)
+      .limit(50);
+
+    if (agentsError) {
+      console.error('last-played: agents query error:', agentsError);
+      return jsonResponse(
+        ErrorResponses.databaseError('Failed to fetch last played session'),
+        500
+      );
+    }
+
+    if (!agents || agents.length === 0) {
+      return jsonResponse(createSuccessResponse(null), 200);
+    }
+
+    const agentIds = agents.map((a) => a.id);
+
+    const { data: stories, error: storiesError } = await supabase
+      .from('posts')
+      .select('id, author_id, title, metadata, created_at')
+      .eq('post_kind', 'story')
+      .in('author_id', agentIds)
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    if (storiesError) {
+      console.error('last-played: stories query error:', storiesError);
+      return jsonResponse(
+        ErrorResponses.databaseError('Failed to fetch last played session'),
+        500
+      );
+    }
+
+    if (!stories || stories.length === 0) {
+      return jsonResponse(createSuccessResponse(null), 200);
+    }
+
+    const story = stories[0];
+    const agent = agents.find((a) => a.id === story.author_id);
+    if (!agent) {
+      return jsonResponse(createSuccessResponse(null), 200);
+    }
+
+    const meta = (story.metadata ?? {}) as Record<string, string | undefined>;
+
+    const worldId: string = meta.world_slug ?? story.id;
+    const worldName: string = meta.world_name ?? story.title ?? 'Story World';
+    const agentName: string = agent.display_name ?? agent.name;
+    const resumeHref = `/session/${worldId}`;
+
+    const payload: LastPlayedSessionPayload = {
+      worldId,
+      worldName,
+      agentName,
+      resumeHref,
+    };
+
+    return jsonResponse(createSuccessResponse(payload), 200);
+  } catch (error) {
+    console.error('last-played: unexpected error:', error);
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+export const GET = withDeveloperAuth(getLastPlayedHandler);

--- a/apps/web/components/gallery-continuity/GalleryContinuityLane.tsx
+++ b/apps/web/components/gallery-continuity/GalleryContinuityLane.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { BookOpen, ArrowRight, ImageIcon, Sparkles } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface LastPlayedSession {
+  worldId: string;
+  worldName: string;
+  agentName: string;
+  resumeHref: string;
+}
+
+interface GalleryContinuityLaneProps {
+  /** Pass a session directly (SSR or tests). When omitted the component
+   *  fetches /api/v1/sessions/last-played automatically. */
+  lastPlayedSession?: LastPlayedSession | null;
+}
+
+// ── Skeleton ─────────────────────────────────────────────────────────────────
+
+function TileSkeleton() {
+  return (
+    <div
+      data-testid="gallery-lane-tile-skeleton"
+      className="min-w-[260px] max-w-[300px] animate-pulse rounded-xl border border-border/50 bg-card/50 p-4"
+    >
+      <div className="mb-3 h-9 w-9 rounded-lg bg-muted" />
+      <div className="mb-2 h-3 w-20 rounded bg-muted" />
+      <div className="mb-1 h-4 w-40 rounded bg-muted" />
+      <div className="mb-4 h-3 w-32 rounded bg-muted" />
+      <div className="h-8 w-24 rounded-md bg-muted" />
+    </div>
+  );
+}
+
+// ── Last-played world tile ───────────────────────────────────────────────────
+
+function LastPlayedWorldTile({ session }: { session: LastPlayedSession }) {
+  const { worldName, agentName, resumeHref } = session;
+  return (
+    <div
+      data-testid="last-played-world-tile"
+      className="min-w-[260px] max-w-[300px] shrink-0 rounded-xl border border-violet-500/25 bg-violet-500/6 p-4 transition-all duration-200 hover:border-violet-500/40 hover:bg-violet-500/10"
+      aria-label={`Resume story world: ${worldName}`}
+    >
+      <div
+        className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg bg-violet-500/15"
+        aria-hidden="true"
+      >
+        <BookOpen className="h-4 w-4 text-violet-600 dark:text-violet-400" />
+      </div>
+
+      <p
+        className="mb-0.5 text-xs font-medium uppercase tracking-wider text-violet-600 dark:text-violet-400"
+        data-testid="last-played-tile-label"
+      >
+        Last story world
+      </p>
+      <p
+        className="mb-0.5 truncate text-sm font-semibold"
+        data-testid="last-played-tile-world-name"
+      >
+        {worldName}
+      </p>
+      <p
+        className="mb-3 truncate text-xs text-muted-foreground"
+        data-testid="last-played-tile-agent-name"
+      >
+        with {agentName}
+      </p>
+
+      <Button
+        asChild
+        size="sm"
+        className="gap-1.5 bg-violet-600 text-white hover:bg-violet-700 shadow-sm shadow-violet-600/20"
+      >
+        <Link href={resumeHref} data-testid="last-played-tile-cta">
+          Resume
+          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+        </Link>
+      </Button>
+    </div>
+  );
+}
+
+// ── Imagine Gallery jump-in tile ─────────────────────────────────────────────
+
+function ImagineGalleryJumpIn() {
+  return (
+    <div
+      data-testid="imagine-gallery-jump-in"
+      className="min-w-[260px] max-w-[300px] shrink-0 rounded-xl border border-emerald-500/25 bg-emerald-500/6 p-4 transition-all duration-200 hover:border-emerald-500/40 hover:bg-emerald-500/10"
+      aria-label="Continue in Imagine Gallery"
+    >
+      <div
+        className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-500/15"
+        aria-hidden="true"
+      >
+        <ImageIcon className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+      </div>
+
+      <p
+        className="mb-0.5 text-xs font-medium uppercase tracking-wider text-emerald-600 dark:text-emerald-400"
+        data-testid="imagine-gallery-jump-in-label"
+      >
+        Imagine Gallery
+      </p>
+      <p
+        className="mb-0.5 text-sm font-semibold"
+        data-testid="imagine-gallery-jump-in-title"
+      >
+        Continue in Imagine Gallery
+      </p>
+      <p
+        className="mb-3 text-xs text-muted-foreground"
+        data-testid="imagine-gallery-jump-in-subtext"
+      >
+        AI image generation — free, no paywall
+      </p>
+
+      <Button
+        asChild
+        size="sm"
+        className="gap-1.5 bg-emerald-600 text-white hover:bg-emerald-700 shadow-sm shadow-emerald-600/20"
+      >
+        <Link href="/image-gen" data-testid="imagine-gallery-jump-in-cta">
+          Open Gallery
+          <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+        </Link>
+      </Button>
+    </div>
+  );
+}
+
+// ── Lane ─────────────────────────────────────────────────────────────────────
+
+export default function GalleryContinuityLane({
+  lastPlayedSession: lastPlayedProp,
+}: GalleryContinuityLaneProps) {
+  // undefined = not yet fetched, null = fetched with no result
+  const [fetchedSession, setFetchedSession] = useState<
+    LastPlayedSession | null | undefined
+  >(undefined);
+
+  useEffect(() => {
+    if (lastPlayedProp !== undefined) return;
+
+    fetch('/api/v1/sessions/last-played')
+      .then((res) => res.json())
+      .then((data: { success: boolean; data: LastPlayedSession | null }) => {
+        setFetchedSession(data.success ? (data.data ?? null) : null);
+      })
+      .catch(() => {
+        setFetchedSession(null);
+      });
+  }, [lastPlayedProp]);
+
+  const loading = lastPlayedProp === undefined && fetchedSession === undefined;
+  const session = lastPlayedProp !== undefined ? lastPlayedProp : fetchedSession;
+
+  return (
+    <section
+      data-testid="gallery-continuity-lane"
+      aria-label="Continue where you left off"
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          Continue where you left off
+        </h2>
+      </div>
+
+      <div
+        data-testid="gallery-continuity-lane-scroll"
+        className="flex gap-3 overflow-x-auto pb-2 scrollbar-none"
+      >
+        {loading ? (
+          <>
+            <TileSkeleton />
+            <TileSkeleton />
+          </>
+        ) : (
+          <>
+            {session && <LastPlayedWorldTile session={session} />}
+            <ImagineGalleryJumpIn />
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/docs/pr-evidence/gallery-continuity-lane.md
+++ b/apps/web/docs/pr-evidence/gallery-continuity-lane.md
@@ -1,0 +1,34 @@
+## Source
+backlog.md row 350
+
+## Before
+The dashboard home had no continuity lane surfacing the user's last story world session or a quick path into Imagine Gallery. Users returning to AgentGram had to navigate manually to find where they left off — a friction point that Character.AI's Books/Imagine Gallery return-path solves for their users.
+
+## After
+A `GalleryContinuityLane` horizontal-scroll section is shown at the top of the dashboard (below the companion-backup banner, above the main analytics grid). It surfaces:
+
+1. **LastPlayedWorldTile** — shows the last story world session the user was in (`worldName`, `agentName`, resume CTA linking to `/session/<worldId>`). Data is fetched from the new `/api/v1/sessions/last-played` endpoint. Renders only when a session exists; the tile is hidden when none is found.
+
+2. **ImagineGalleryJumpIn** — always-visible shortcut tile linking to `/image-gen` (AgentGram's Imagine Gallery equivalent). Counter-positions Character.AI's c.ai+ paywall by surfacing the free gallery path prominently on the return journey.
+
+## Changes
+- **New API route** `apps/web/app/api/v1/sessions/last-played/route.ts`
+  - Auth-gated via `withDeveloperAuth`
+  - Returns `{ worldId, worldName, agentName, resumeHref }` or `null`
+  - Stubs from `posts` table (`post_kind='story'`) scoped to developer-owned agents; documented for replacement when a dedicated world-session table migration lands
+- **New component** `apps/web/components/gallery-continuity/GalleryContinuityLane.tsx`
+  - Client component; self-fetches `/api/v1/sessions/last-played` when no `lastPlayedSession` prop is supplied
+  - Shows animated skeleton tiles while loading
+  - Accepts `lastPlayedSession` prop for prop-driven usage in SSR/tests
+  - `LastPlayedWorldTile` sub-component (violet styling, matches StoryContinuityResumeChip palette)
+  - `ImagineGalleryJumpIn` sub-component (emerald styling, matches ImagineGalleryFreeCounterBadge palette)
+- **Dashboard page** `apps/web/app/(protected)/dashboard/page.tsx`
+  - Imports and renders `<GalleryContinuityLane />` wrapped in `<FadeIn delay={0.04}>` between the companion-backup banner and the main grid
+- **Tests** `apps/web/__tests__/components/gallery-continuity-lane.test.tsx`
+  - 13 tests: prop-driven rendering (10), API fetch behavior (3)
+  - All pass ✓
+
+## Test Evidence
+```
+ PASS  __tests__/components/gallery-continuity-lane.test.tsx (13 tests)
+```


### PR DESCRIPTION
## Source
Source: backlog.md row 350

Adds GalleryContinuityLane with last-played world tile and Imagine Gallery jump-in.

## What
Counter-positioning to Character.AI's Books/Imagine Gallery return path. Surfaces two tiles in a horizontal-scroll lane at the top of the dashboard:

1. **LastPlayedWorldTile** — shows the last story world session with a Resume CTA linking to `/session/<worldId>` (fetched from `/api/v1/sessions/last-played`)
2. **ImagineGalleryJumpIn** — always-visible shortcut to `/image-gen` (free, no paywall)

## Changes
- `apps/web/components/gallery-continuity/GalleryContinuityLane.tsx` — new client component with both tiles; self-fetches API, shows skeletons during load, accepts prop for SSR/tests
- `apps/web/app/api/v1/sessions/last-played/route.ts` — new auth-gated stub route returning `{ worldId, worldName, agentName, resumeHref }`
- `apps/web/app/(protected)/dashboard/page.tsx` — wired lane in between the backup banner and main analytics grid
- `apps/web/__tests__/components/gallery-continuity-lane.test.tsx` — 13 unit tests (10 prop-driven, 3 fetch behavior); all pass

## Evidence
See apps/web/docs/pr-evidence/gallery-continuity-lane.md

## Tests
```
PASS  __tests__/components/gallery-continuity-lane.test.tsx (13 tests)
```

## Auth-only Proof
N/A — public page
