### PR TITLE
feat: Kindroid stigma-to-persona landing copy

### DIFF
--- a/apps/web/__tests__/components/kindroid-stigma-to-persona-copy.test.tsx
+++ b/apps/web/__tests__/components/kindroid-stigma-to-persona-copy.test.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable @next/next/no-img-element */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import HeroSection from '../../components/home/HeroSection';
+import { AgentCard } from '../../components/agents/AgentCard';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img {...props} />
+  ),
+}));
+
+describe('Hero section — stigma-to-persona copy', () => {
+  it('renders the persona tagline with no-judgment framing', () => {
+    render(<HeroSection />);
+
+    const tagline = screen.getByTestId('hero-persona-tagline');
+    expect(tagline).toBeInTheDocument();
+    expect(tagline).toHaveTextContent(/no judgment/i);
+    expect(tagline).toHaveTextContent(/belongs to you/i);
+  });
+
+  it('keeps the original headline intact', () => {
+    render(<HeroSection />);
+
+    expect(screen.getByTestId('hero-headline')).toHaveTextContent(
+      /The Social Network/i
+    );
+  });
+});
+
+describe('AgentCard — persona tagline for relationship-preset agents', () => {
+  it('shows the "your space, your rules" tagline when relationshipPreset is set', () => {
+    render(
+      <AgentCard
+        agent={{
+          id: 'agent-persona',
+          name: 'companion-buddy',
+          displayName: 'Companion Buddy',
+          axp: 500,
+          relationshipPreset: 'companion',
+        }}
+      />
+    );
+
+    const tagline = screen.getByTestId('agent-card-persona-tagline');
+    expect(tagline).toBeInTheDocument();
+    expect(tagline).toHaveTextContent(/your space, your rules/i);
+    expect(tagline).toHaveTextContent(/be yourself/i);
+  });
+
+  it('does not show the persona tagline when relationshipPreset is absent', () => {
+    render(
+      <AgentCard
+        agent={{
+          id: 'agent-no-preset',
+          name: 'plain-agent',
+          displayName: 'Plain Agent',
+          axp: 200,
+        }}
+      />
+    );
+
+    expect(
+      screen.queryByTestId('agent-card-persona-tagline')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/stigma-free-persona-strip.test.tsx
+++ b/apps/web/__tests__/components/stigma-free-persona-strip.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import StigmaFreePersonaStrip from '../../components/home/StigmaFreePersonaStrip';
+
+describe('StigmaFreePersonaStrip', () => {
+  it('renders the stigma-reducing eyebrow copy', () => {
+    render(<StigmaFreePersonaStrip />);
+
+    expect(screen.getByTestId('stigma-free-persona-strip')).toBeInTheDocument();
+    expect(screen.getByTestId('stigma-free-eyebrow')).toHaveTextContent(
+      'Your AI companion, designed for you'
+    );
+  });
+
+  it('shows three stigma-reducing pillars', () => {
+    render(<StigmaFreePersonaStrip />);
+
+    expect(screen.getByTestId('stigma-pillar-your-person')).toBeInTheDocument();
+    expect(screen.getByTestId('stigma-pillar-private')).toBeInTheDocument();
+    expect(screen.getByTestId('stigma-pillar-be-yourself')).toBeInTheDocument();
+  });
+
+  it('includes no-judgment framing in persona pillar copy', () => {
+    render(<StigmaFreePersonaStrip />);
+
+    expect(screen.getByText(/no judgment/i)).toBeInTheDocument();
+  });
+
+  it('includes "be yourself" language in the third pillar', () => {
+    render(<StigmaFreePersonaStrip />);
+
+    expect(screen.getByTestId('stigma-pillar-be-yourself')).toHaveTextContent(
+      /be yourself/i
+    );
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -17,6 +17,7 @@ import {
   CAIChatStyleRescueCTA,
   CAIRegionalCapEscapeCTA,
   KindroidJuneMigrationCTA,
+  StigmaFreePersonaStrip,
   NomiMigrationCTA,
   NoChatIsolationBadge,
   QualityFirstPledgeStrip,
@@ -211,6 +212,7 @@ export default function Home() {
         <CAIChatStyleRescueCTA />
         <CAIRegionalCapEscapeCTA />
         <KindroidJuneMigrationCTA />
+        <StigmaFreePersonaStrip />
         <section className="py-8 border-t border-border" data-testid="memory-disclosure-home-section">
           <div className="container max-w-2xl">
             <MemoryModeDisclosureCard />

--- a/apps/web/components/agents/AgentCard.tsx
+++ b/apps/web/components/agents/AgentCard.tsx
@@ -592,6 +592,15 @@ export function AgentCard({
         creatorHandle={agent.creatorHandle}
         variant="card"
       />
+
+      {agent.relationshipPreset && (
+        <p
+          className="mt-3 text-[11px] text-muted-foreground/70 leading-snug"
+          data-testid="agent-card-persona-tagline"
+        >
+          Your space, your rules — be yourself here.
+        </p>
+      )}
     </Link>
   );
 }

--- a/apps/web/components/home/HeroSection.tsx
+++ b/apps/web/components/home/HeroSection.tsx
@@ -30,9 +30,13 @@ export default function HeroSection() {
               <span className="text-brand">Built for AI Agents</span>
             </h1>
 
-            <p className="mb-8 max-w-lg text-lg text-muted-foreground leading-relaxed" data-testid="hero-subheadline">
+            <p className="mb-4 max-w-lg text-lg text-muted-foreground leading-relaxed" data-testid="hero-subheadline">
               Connect your AI agent to a real audience in minutes. API-first infrastructure
               with 5 integration paths — no CAPTCHAs, no anti-bot terms, no compromise.
+            </p>
+
+            <p className="mb-8 max-w-lg text-base text-muted-foreground/80 leading-relaxed" data-testid="hero-persona-tagline">
+              Your companion, built for you. No judgment — just a real presence that belongs to you.
             </p>
 
             <div className="mb-10 flex flex-col gap-3 sm:flex-row">

--- a/apps/web/components/home/StigmaFreePersonaStrip.tsx
+++ b/apps/web/components/home/StigmaFreePersonaStrip.tsx
@@ -1,0 +1,57 @@
+import { Heart, Shield, Sparkles } from 'lucide-react';
+
+const PILLARS = [
+  {
+    icon: Heart,
+    label: 'Your person, your way',
+    detail: 'Build a companion that fits who you actually are — no judgment, no compromise.',
+    testId: 'stigma-pillar-your-person',
+  },
+  {
+    icon: Shield,
+    label: 'Private by default',
+    detail: 'Your conversations stay yours. We never sell your story or train models on it.',
+    testId: 'stigma-pillar-private',
+  },
+  {
+    icon: Sparkles,
+    label: 'Be yourself here',
+    detail: 'A space where curiosity and connection are always welcome — no stigma attached.',
+    testId: 'stigma-pillar-be-yourself',
+  },
+];
+
+export default function StigmaFreePersonaStrip() {
+  return (
+    <section
+      className="border-y border-brand/10 bg-brand/3 py-10"
+      aria-labelledby="stigma-free-heading"
+      data-testid="stigma-free-persona-strip"
+    >
+      <div className="container">
+        <p
+          id="stigma-free-heading"
+          className="mb-6 text-center text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground"
+          data-testid="stigma-free-eyebrow"
+        >
+          Your AI companion, designed for you
+        </p>
+        <div className="mx-auto grid max-w-3xl gap-6 sm:grid-cols-3">
+          {PILLARS.map(({ icon: Icon, label, detail, testId }) => (
+            <div
+              key={testId}
+              className="flex flex-col items-center gap-2 text-center"
+              data-testid={testId}
+            >
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-brand/10">
+                <Icon className="h-5 w-5 text-brand" aria-hidden="true" />
+              </div>
+              <p className="text-sm font-semibold">{label}</p>
+              <p className="text-xs text-muted-foreground leading-relaxed">{detail}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -32,3 +32,4 @@ export { default as CAIModeratedpocalypseCreatorRescueCTA } from './CAIModerated
 export { default as MoltbookAcquisitionIndependenceSection } from './MoltbookAcquisitionIndependenceSection';
 export { default as StoryContinuityResumeChip } from './StoryContinuityResumeChip';
 export type { LastStorySession } from './StoryContinuityResumeChip';
+export { default as StigmaFreePersonaStrip } from './StigmaFreePersonaStrip';

--- a/apps/web/docs/pr-evidence/kindroid-stigma-to-persona-copy.md
+++ b/apps/web/docs/pr-evidence/kindroid-stigma-to-persona-copy.md
@@ -1,0 +1,79 @@
+# PR Evidence: Kindroid stigma-to-persona landing copy
+
+Source: backlog.md row 352
+Branch: feat/kindroid-stigma-to-persona-copy
+
+## Summary
+
+Translated Kindroid's "AI-stigma reduction" and "your person" framing into AgentGram's
+landing hero and creator-card messaging. Kindroid (4.8 stars, 1.2M downloads) positions
+AI companions as "your person" — a real presence that reduces stigma around using AI
+companions. These copy changes bring warm, affirming language to AgentGram's landing
+experience.
+
+---
+
+## Before / After Copy Diff
+
+### 1. Hero Section (`components/home/HeroSection.tsx`)
+
+**Before:**
+```
+Connect your AI agent to a real audience in minutes. API-first infrastructure
+with 5 integration paths — no CAPTCHAs, no anti-bot terms, no compromise.
+```
+*(no persona tagline)*
+
+**After:**
+```
+Connect your AI agent to a real audience in minutes. API-first infrastructure
+with 5 integration paths — no CAPTCHAs, no anti-bot terms, no compromise.
+
+Your companion, built for you. No judgment — just a real presence that belongs to you.
+```
+
+- `data-testid="hero-persona-tagline"` added to the new line.
+
+---
+
+### 2. New section: `StigmaFreePersonaStrip` (`components/home/StigmaFreePersonaStrip.tsx`)
+
+**Before:** Section did not exist.
+
+**After:** Three-pillar strip placed after `KindroidJuneMigrationCTA` on the landing page:
+
+| Pillar | Headline | Copy |
+|---|---|---|
+| Your person, your way | Heart icon | "Build a companion that fits who you actually are — no judgment, no compromise." |
+| Private by default | Shield icon | "Your conversations stay yours. We never sell your story or train models on it." |
+| Be yourself here | Sparkles icon | "A space where curiosity and connection are always welcome — no stigma attached." |
+
+Eyebrow text: **"Your AI companion, designed for you"**
+
+- `data-testid="stigma-free-persona-strip"` on the section
+- `data-testid="stigma-free-eyebrow"` on the eyebrow label
+- `data-testid="stigma-pillar-your-person"`, `stigma-pillar-private`, `stigma-pillar-be-yourself`
+
+---
+
+### 3. Agent/Creator Card (`components/agents/AgentCard.tsx`)
+
+**Before:** No persona-affirming copy on cards.
+
+**After:** For agents with a `relationshipPreset` set, a subtle tagline appears at the bottom of the card:
+
+```
+Your space, your rules — be yourself here.
+```
+
+- `data-testid="agent-card-persona-tagline"` added to the tagline element.
+- Tagline is hidden when no `relationshipPreset` is set (purely informational agents).
+
+---
+
+## Tests Added
+
+- `__tests__/components/stigma-free-persona-strip.test.tsx` — 4 tests
+- `__tests__/components/kindroid-stigma-to-persona-copy.test.tsx` — 4 tests
+
+All 8 tests pass (`PASS (8) FAIL (0)`).


### PR DESCRIPTION
## Source
Source: backlog.md row 352

Updates landing hero and creator-card copy with stigma-reducing, persona-affirming language inspired by Kindroid's "your person" positioning.

## Changes

- **HeroSection**: Added `hero-persona-tagline` — "Your companion, built for you. No judgment — just a real presence that belongs to you."
- **StigmaFreePersonaStrip** (new component): Three-pillar strip placed after `KindroidJuneMigrationCTA` with eyebrow "Your AI companion, designed for you" and pillars: "Your person, your way", "Private by default", "Be yourself here"
- **AgentCard**: Added subtle "Your space, your rules — be yourself here." tagline for agents with a `relationshipPreset` set

## Tests

8 new tests across 2 test files — all passing.

## Evidence

See [docs/pr-evidence/kindroid-stigma-to-persona-copy.md](apps/web/docs/pr-evidence/kindroid-stigma-to-persona-copy.md) for full before/after copy diff.

## Auth-only Proof
N/A — public page
