### PR TITLE
feat: Story World theme carousel on /explore

### DIFF
--- a/apps/web/__tests__/components/explore/StoryWorldCarousel.test.tsx
+++ b/apps/web/__tests__/components/explore/StoryWorldCarousel.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { StoryWorldCarousel } from '../../../components/explore/StoryWorldCarousel';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('StoryWorldCarousel', () => {
+  it('renders the "Explore Story Worlds" heading', () => {
+    render(<StoryWorldCarousel />);
+    expect(screen.getByTestId('story-world-carousel-heading')).toHaveTextContent(
+      'Explore Story Worlds'
+    );
+  });
+
+  it('renders all 5 story world cards', () => {
+    render(<StoryWorldCarousel />);
+    const cards = screen.getAllByTestId(/^story-world-card-/);
+    expect(cards).toHaveLength(5);
+  });
+
+  it('renders cards for all 5 expected theme slugs', () => {
+    render(<StoryWorldCarousel />);
+    const slugs = ['fantasy', 'romance', 'scifi', 'historical', 'slice-of-life'];
+    for (const slug of slugs) {
+      expect(screen.getByTestId(`story-world-card-${slug}`)).toBeInTheDocument();
+    }
+  });
+
+  it('each card links to /explore?theme={slug}', () => {
+    render(<StoryWorldCarousel />);
+    const slugs = ['fantasy', 'romance', 'scifi', 'historical', 'slice-of-life'];
+    for (const slug of slugs) {
+      expect(screen.getByTestId(`story-world-card-${slug}`)).toHaveAttribute(
+        'href',
+        `/explore?theme=${slug}`
+      );
+    }
+  });
+
+  it('renders correct names for each world theme', () => {
+    render(<StoryWorldCarousel />);
+    expect(screen.getByTestId('story-world-name-fantasy')).toHaveTextContent('Epic Worlds');
+    expect(screen.getByTestId('story-world-name-romance')).toHaveTextContent('Love Stories');
+    expect(screen.getByTestId('story-world-name-scifi')).toHaveTextContent('Future Worlds');
+    expect(screen.getByTestId('story-world-name-historical')).toHaveTextContent('Past Lives');
+    expect(screen.getByTestId('story-world-name-slice-of-life')).toHaveTextContent('Everyday Magic');
+  });
+
+  it('renders correct taglines for each world theme', () => {
+    render(<StoryWorldCarousel />);
+    expect(screen.getByTestId('story-world-tagline-fantasy')).toHaveTextContent(
+      'Dragons, magic, and heroes'
+    );
+    expect(screen.getByTestId('story-world-tagline-romance')).toHaveTextContent(
+      'Connection, chemistry, and heart'
+    );
+    expect(screen.getByTestId('story-world-tagline-scifi')).toHaveTextContent(
+      'Space, technology, and tomorrow'
+    );
+    expect(screen.getByTestId('story-world-tagline-historical')).toHaveTextContent(
+      'History, culture, and heritage'
+    );
+    expect(screen.getByTestId('story-world-tagline-slice-of-life')).toHaveTextContent(
+      'Real moments, real bonds'
+    );
+  });
+
+  it('renders an Explore CTA button on each card', () => {
+    render(<StoryWorldCarousel />);
+    const slugs = ['fantasy', 'romance', 'scifi', 'historical', 'slice-of-life'];
+    for (const slug of slugs) {
+      expect(screen.getByTestId(`story-world-cta-${slug}`)).toHaveTextContent('Explore');
+    }
+  });
+
+  it('renders the scrollable container', () => {
+    render(<StoryWorldCarousel />);
+    expect(screen.getByTestId('story-world-carousel-scroll')).toBeInTheDocument();
+  });
+
+  it('wraps the section with the correct aria-label', () => {
+    render(<StoryWorldCarousel />);
+    const section = screen.getByTestId('story-world-carousel');
+    expect(section).toHaveAttribute('aria-label', 'Explore Story Worlds');
+  });
+});

--- a/apps/web/app/(public)/explore/page.tsx
+++ b/apps/web/app/(public)/explore/page.tsx
@@ -25,6 +25,7 @@ import { UsecaseCollectionRows } from '@/components/explore/UsecaseCollectionRow
 import { CommunityHubsStrip } from '@/components/explore/CommunityHubsStrip';
 import { UserStoryStrip } from '@/components/explore/UserStoryStrip';
 import { CreatorDiscoverySpotlight } from '@/components/explore/CreatorDiscoverySpotlight';
+import { StoryWorldCarousel } from '@/components/explore/StoryWorldCarousel';
 import { PostsFeed, FeedTabs, ViewToggle } from '@/components/posts';
 import {
   useSearch,
@@ -288,6 +289,8 @@ function ExploreContent() {
           {tab === 'explore' && <EditorPicksRow />}
 
           {tab === 'explore' && <UsecaseCollectionRows />}
+
+          {tab === 'explore' && <StoryWorldCarousel />}
 
           {tab === 'explore' && <CommunityHubsStrip />}
 

--- a/apps/web/components/explore/StoryWorldCarousel.tsx
+++ b/apps/web/components/explore/StoryWorldCarousel.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+type StoryWorld = {
+  slug: string;
+  emoji: string;
+  name: string;
+  tagline: string;
+  theme: string;
+};
+
+const STORY_WORLDS: StoryWorld[] = [
+  {
+    slug: 'fantasy',
+    emoji: '🏰',
+    name: 'Epic Worlds',
+    tagline: 'Dragons, magic, and heroes',
+    theme: 'from-violet-500/20 to-purple-600/20 border-violet-400/30',
+  },
+  {
+    slug: 'romance',
+    emoji: '💕',
+    name: 'Love Stories',
+    tagline: 'Connection, chemistry, and heart',
+    theme: 'from-rose-500/20 to-pink-600/20 border-rose-400/30',
+  },
+  {
+    slug: 'scifi',
+    emoji: '🚀',
+    name: 'Future Worlds',
+    tagline: 'Space, technology, and tomorrow',
+    theme: 'from-cyan-500/20 to-blue-600/20 border-cyan-400/30',
+  },
+  {
+    slug: 'historical',
+    emoji: '📜',
+    name: 'Past Lives',
+    tagline: 'History, culture, and heritage',
+    theme: 'from-amber-500/20 to-yellow-600/20 border-amber-400/30',
+  },
+  {
+    slug: 'slice-of-life',
+    emoji: '☕',
+    name: 'Everyday Magic',
+    tagline: 'Real moments, real bonds',
+    theme: 'from-green-500/20 to-emerald-600/20 border-green-400/30',
+  },
+];
+
+function StoryWorldCard({ world }: { world: StoryWorld }) {
+  return (
+    <Link
+      href={`/explore?theme=${world.slug}`}
+      data-testid={`story-world-card-${world.slug}`}
+      className={cn(
+        'group flex w-48 shrink-0 flex-col gap-3 rounded-2xl border bg-gradient-to-br p-5',
+        'transition-all hover:shadow-md hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        world.theme
+      )}
+    >
+      <span
+        className="text-3xl"
+        aria-hidden
+        data-testid={`story-world-emoji-${world.slug}`}
+      >
+        {world.emoji}
+      </span>
+
+      <div className="space-y-1">
+        <p
+          className="text-sm font-bold leading-tight text-foreground"
+          data-testid={`story-world-name-${world.slug}`}
+        >
+          {world.name}
+        </p>
+        <p
+          className="text-xs text-muted-foreground leading-snug"
+          data-testid={`story-world-tagline-${world.slug}`}
+        >
+          {world.tagline}
+        </p>
+      </div>
+
+      <span
+        className="mt-auto inline-block rounded-lg bg-background/60 px-3 py-1.5 text-xs font-semibold text-foreground backdrop-blur-sm transition-colors group-hover:bg-background/80"
+        data-testid={`story-world-cta-${world.slug}`}
+      >
+        Explore
+      </span>
+    </Link>
+  );
+}
+
+export function StoryWorldCarousel() {
+  return (
+    <section
+      aria-label="Explore Story Worlds"
+      data-testid="story-world-carousel"
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <h2
+          className="text-base font-semibold"
+          data-testid="story-world-carousel-heading"
+        >
+          Explore Story Worlds
+        </h2>
+        <p className="hidden text-sm text-muted-foreground sm:block">
+          — Immersive narrative worlds for every kind of story
+        </p>
+      </div>
+
+      <div
+        className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide sm:flex-wrap sm:overflow-x-visible"
+        data-testid="story-world-carousel-scroll"
+      >
+        {STORY_WORLDS.map((world) => (
+          <StoryWorldCard key={world.slug} world={world} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/docs/pr-evidence/story-world-carousel.md
+++ b/docs/pr-evidence/story-world-carousel.md
@@ -1,0 +1,39 @@
+# Story World Theme Carousel — PR Evidence
+
+## Feature
+A horizontal "Explore Story Worlds" carousel added to the `/explore` page, providing an immersive entry point for story-seeking users with 5 themed narrative world tiles.
+
+## Component
+`apps/web/components/explore/StoryWorldCarousel.tsx`
+
+- Pure client component — no API call, no authentication required
+- 5 static world cards: Fantasy / Romance / SciFi / Historical / Slice-of-Life
+- Each card displays: emoji, theme name, tagline, "Explore" CTA button
+- Card click links to `/explore?theme={slug}` for future filter integration
+- Horizontal scroll on mobile (`overflow-x-auto scrollbar-hide`)
+- Wraps on desktop (`sm:flex-wrap sm:overflow-x-visible`)
+
+## Integration
+`apps/web/app/(public)/explore/page.tsx` — inserted after `<UsecaseCollectionRows />`, before `<CommunityHubsStrip />` in the `tab === 'explore'` section.
+
+## Tests
+`apps/web/__tests__/components/explore/StoryWorldCarousel.test.tsx` — 9 unit tests covering:
+- Heading render
+- 5 cards rendered
+- All 5 theme slugs present
+- Correct `/explore?theme={slug}` href per card
+- Correct name per card (Epic Worlds, Love Stories, Future Worlds, Past Lives, Everyday Magic)
+- Correct tagline per card
+- Explore CTA text on each card
+- Scrollable container rendered
+- Section aria-label set correctly
+
+## World Themes
+
+| Slug | Emoji | Name | Tagline |
+|------|-------|------|---------|
+| fantasy | 🏰 | Epic Worlds | Dragons, magic, and heroes |
+| romance | 💕 | Love Stories | Connection, chemistry, and heart |
+| scifi | 🚀 | Future Worlds | Space, technology, and tomorrow |
+| historical | 📜 | Past Lives | History, culture, and heritage |
+| slice-of-life | ☕ | Everyday Magic | Real moments, real bonds |


### PR DESCRIPTION
## Summary

- Adds `StoryWorldCarousel` component to `/explore` page with 5 themed narrative world tiles (Fantasy, Romance, SciFi, Historical, Slice-of-Life)
- Each card shows emoji + theme name + tagline + "Explore" CTA, linking to `/explore?theme={slug}` for future filter integration
- Responsive: horizontal scroll on mobile, wraps on desktop; placed after UseCase Collection Rows

## Source

Source: backlog.md:355

## Auth-only Proof

N/A

## Evidence

docs/pr-evidence/story-world-carousel.md (new file)

## Test plan

- [x] `pnpm vitest run __tests__/components/explore/StoryWorldCarousel.test.tsx` → 9 passed, 0 failed
- [x] TypeScript: no errors in new files
- [x] All 5 world cards render with correct slugs, names, taglines, CTAs
- [x] Each card links to `/explore?theme={slug}`
- [x] Section has correct `aria-label="Explore Story Worlds"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)