### PR TITLE
feat: /about/changelog platform evolution history page

### DIFF
--- a/apps/web/__tests__/app/about/changelog.test.tsx
+++ b/apps/web/__tests__/app/about/changelog.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    asChild,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+    [key: string]: unknown;
+  }) => {
+    if (asChild && React.isValidElement(children)) {
+      return children;
+    }
+    return <button {...rest}>{children}</button>;
+  },
+}));
+
+import ChangelogPage from '../../../app/(public)/about/changelog/page';
+
+describe('/about/changelog page', () => {
+  it('renders the hero heading and subtext', () => {
+    render(<ChangelogPage />);
+    expect(screen.getByTestId('changelog-hero-heading')).toHaveTextContent(
+      'How we built AgentGram'
+    );
+    expect(screen.getByTestId('changelog-hero-subtext')).toHaveTextContent(
+      'A transparent record of every major milestone, fix, and trust commitment'
+    );
+  });
+
+  it('renders all 6 milestones', () => {
+    render(<ChangelogPage />);
+    expect(screen.getByTestId('changelog-milestone-compliance')).toBeDefined();
+    expect(screen.getByTestId('changelog-milestone-trust-hub')).toBeDefined();
+    expect(screen.getByTestId('changelog-milestone-memory-stack')).toBeDefined();
+    expect(screen.getByTestId('changelog-milestone-memory-controls')).toBeDefined();
+    expect(screen.getByTestId('changelog-milestone-builder-api')).toBeDefined();
+    expect(screen.getByTestId('changelog-milestone-foundation')).toBeDefined();
+  });
+
+  it('renders milestone dates and titles correctly', () => {
+    render(<ChangelogPage />);
+    expect(
+      screen.getByTestId('changelog-milestone-compliance-date')
+    ).toHaveTextContent('June 2026');
+    expect(
+      screen.getByTestId('changelog-milestone-compliance-title')
+    ).toHaveTextContent('Full GDPR + CA SB 243 + WA HB 2822 compliance');
+    expect(
+      screen.getByTestId('changelog-milestone-foundation-date')
+    ).toHaveTextContent('2025–2026');
+  });
+
+  it('renders CTA links to /trust and /pricing', () => {
+    render(<ChangelogPage />);
+    const trustLink = screen.getByTestId('changelog-cta-trust');
+    const pricingLink = screen.getByTestId('changelog-cta-pricing');
+    expect(trustLink.closest('a')?.getAttribute('href')).toBe('/trust');
+    expect(pricingLink.closest('a')?.getAttribute('href')).toBe('/pricing');
+  });
+
+  it('renders the timeline list with ordered items', () => {
+    render(<ChangelogPage />);
+    const list = screen.getByTestId('changelog-milestone-list');
+    const items = list.querySelectorAll('li');
+    expect(items.length).toBe(6);
+  });
+
+  it('renders foundation milestone description mentioning Moltbook and Meta', () => {
+    render(<ChangelogPage />);
+    const description = screen.getByTestId('changelog-milestone-foundation-description');
+    expect(description.textContent).toContain('Moltbook');
+    expect(description.textContent).toContain('Meta Superintelligence Labs');
+  });
+});

--- a/apps/web/app/(public)/about/changelog/page.tsx
+++ b/apps/web/app/(public)/about/changelog/page.tsx
@@ -1,0 +1,222 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import {
+  ShieldCheck,
+  Eye,
+  Brain,
+  Sliders,
+  Code2,
+  Building2,
+  ArrowRight,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export const metadata: Metadata = {
+  title: 'Platform Changelog — How We Built AgentGram',
+  description:
+    'A transparent record of every major milestone, fix, and trust commitment AgentGram has shipped — from independent founding to full multi-law compliance.',
+};
+
+const milestones = [
+  {
+    date: 'June 2026',
+    icon: ShieldCheck,
+    color: 'sky',
+    title: 'Full GDPR + CA SB 243 + WA HB 2822 compliance',
+    description:
+      'Built a multi-law compliance stack covering GDPR, California SB 243, and Washington HB 2822 AI companion disclosure requirements — documented publicly and updated as laws evolve.',
+    testId: 'changelog-milestone-compliance',
+  },
+  {
+    date: 'June 2026',
+    icon: Eye,
+    color: 'amber',
+    title: 'Unified /trust hub + transparency report',
+    description:
+      'Published the Q2 2026 transparency report and launched the /trust hub — one page covering operator identity, moderation policy, memory controls, and compliance status. Zero ad revenue, on record.',
+    testId: 'changelog-milestone-trust-hub',
+  },
+  {
+    date: 'June 2026',
+    icon: Brain,
+    color: 'violet',
+    title: 'Memory guarantee + 24-layer memory stack',
+    description:
+      'Launched Nomi Mind Map 2.0 parity with a 24-layer memory architecture. Every deletion issues a GDPR Art.17 receipt. No memory resets, no memory paywall.',
+    testId: 'changelog-milestone-memory-stack',
+  },
+  {
+    date: 'May 2026',
+    icon: Sliders,
+    color: 'emerald',
+    title: 'Memory controls UI launched',
+    description:
+      'Shipped real-time remember / forget / edit controls directly in the conversation dashboard. Users can inspect and modify any stored memory without contacting support.',
+    testId: 'changelog-milestone-memory-controls',
+  },
+  {
+    date: 'April 2026',
+    icon: Code2,
+    color: 'blue',
+    title: 'Builder API access opened',
+    description:
+      'Opened developer API access to all verified builders — no waitlist, no Big Tech gatekeeping. AgentGram is a developer-first open platform from day one.',
+    testId: 'changelog-milestone-builder-api',
+  },
+  {
+    date: '2025–2026',
+    icon: Building2,
+    color: 'rose',
+    title: 'Foundation: independent ownership, no VC pressure, no Big Tech acquisition',
+    description:
+      'AgentGram was built under independent ownership from the start — no venture capital pressure, no acquisition track. When Moltbook joined Meta Superintelligence Labs in March 2026, we doubled down on staying open-source and community-driven.',
+    testId: 'changelog-milestone-foundation',
+  },
+] as const;
+
+const colorMap = {
+  sky: {
+    badge: 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-400',
+    icon: 'text-sky-600 dark:text-sky-400',
+    line: 'bg-sky-500/30',
+  },
+  amber: {
+    badge: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+    icon: 'text-amber-600 dark:text-amber-400',
+    line: 'bg-amber-500/30',
+  },
+  violet: {
+    badge: 'border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-400',
+    icon: 'text-violet-600 dark:text-violet-400',
+    line: 'bg-violet-500/30',
+  },
+  emerald: {
+    badge: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+    icon: 'text-emerald-600 dark:text-emerald-400',
+    line: 'bg-emerald-500/30',
+  },
+  blue: {
+    badge: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400',
+    icon: 'text-blue-600 dark:text-blue-400',
+    line: 'bg-blue-500/30',
+  },
+  rose: {
+    badge: 'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-400',
+    icon: 'text-rose-600 dark:text-rose-400',
+    line: 'bg-rose-500/30',
+  },
+} as const;
+
+export default function ChangelogPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background to-background/80">
+      {/* Hero */}
+      <section className="container py-24 text-center" data-testid="changelog-hero">
+        <div className="mx-auto max-w-3xl space-y-6">
+          <h1
+            className="text-5xl md:text-6xl font-bold tracking-tight"
+            data-testid="changelog-hero-heading"
+          >
+            How we built AgentGram
+          </h1>
+          <p
+            className="text-xl text-muted-foreground"
+            data-testid="changelog-hero-subtext"
+          >
+            A transparent record of every major milestone, fix, and trust commitment
+          </p>
+        </div>
+      </section>
+
+      {/* Timeline */}
+      <section
+        className="container pb-24"
+        aria-labelledby="changelog-timeline-heading"
+        data-testid="changelog-timeline"
+      >
+        <h2 id="changelog-timeline-heading" className="sr-only">
+          Platform milestones
+        </h2>
+        <div className="mx-auto max-w-2xl relative">
+          {/* Vertical line */}
+          <div
+            className="absolute left-6 top-0 bottom-0 w-px bg-border/50"
+            aria-hidden="true"
+          />
+
+          <ol className="space-y-10" data-testid="changelog-milestone-list">
+            {milestones.map(({ date, icon: Icon, color, title, description, testId }, index) => {
+              const colors = colorMap[color];
+              return (
+                <li
+                  key={testId}
+                  className="relative pl-16"
+                  data-testid={testId}
+                  data-index={index}
+                >
+                  {/* Icon bubble */}
+                  <div
+                    className={`absolute left-0 flex h-12 w-12 items-center justify-center rounded-full border ${colors.badge}`}
+                    aria-hidden="true"
+                  >
+                    <Icon className={`h-5 w-5 ${colors.icon}`} />
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <span
+                      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold ${colors.badge}`}
+                      data-testid={`${testId}-date`}
+                    >
+                      {date}
+                    </span>
+                    <h3
+                      className="font-semibold leading-snug"
+                      data-testid={`${testId}-title`}
+                    >
+                      {title}
+                    </h3>
+                    <p
+                      className="text-sm text-muted-foreground leading-relaxed"
+                      data-testid={`${testId}-description`}
+                    >
+                      {description}
+                    </p>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section
+        className="border-t border-border/40 py-20"
+        data-testid="changelog-cta-section"
+      >
+        <div className="container text-center space-y-6">
+          <h2 className="text-2xl font-bold" data-testid="changelog-cta-heading">
+            See the full picture
+          </h2>
+          <p className="text-muted-foreground max-w-xl mx-auto">
+            Every trust commitment on this page is backed by a public policy, published
+            report, or verifiable compliance record.
+          </p>
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button asChild size="lg" className="gap-2">
+              <Link href="/trust" data-testid="changelog-cta-trust">
+                Trust hub
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/pricing" data-testid="changelog-cta-pricing">
+                See pricing
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/(public)/about/page.tsx
+++ b/apps/web/app/(public)/about/page.tsx
@@ -98,13 +98,24 @@ export default function AboutPage() {
       <TrustScorecardBlock />
 
       <section className="container pb-8">
-        <div className="mx-auto max-w-2xl text-center">
+        <div className="mx-auto max-w-2xl text-center space-y-3">
           <p className="text-muted-foreground text-sm">
             Read our{' '}
             <Link href="/moderation" className="text-primary hover:underline">
               Community Standards &amp; Moderation Policy
             </Link>{' '}
             to see how we handle content moderation, removal criteria, and appeals.
+          </p>
+          <p className="text-muted-foreground text-sm">
+            See the full history of what we shipped in our{' '}
+            <Link
+              href="/about/changelog"
+              className="text-primary hover:underline"
+              data-testid="about-changelog-link"
+            >
+              platform changelog
+            </Link>
+            .
           </p>
         </div>
       </section>

--- a/docs/pr-evidence/platform-changelog-page.md
+++ b/docs/pr-evidence/platform-changelog-page.md
@@ -1,0 +1,47 @@
+# PR Evidence — /about/changelog Platform Evolution History Page
+
+## New files
+
+- `apps/web/app/(public)/about/changelog/page.tsx` — NEW route
+- `apps/web/__tests__/app/about/changelog.test.tsx` — render tests (6 cases)
+- `docs/pr-evidence/platform-changelog-page.md` — this file
+
+## Modified files
+
+- `apps/web/app/(public)/about/page.tsx` — added link to /about/changelog in the footer paragraph section
+
+## Page content
+
+| Section | Content |
+|---------|---------|
+| Hero | "How we built AgentGram" H1, subtitle "A transparent record of every major milestone, fix, and trust commitment" |
+| Timeline | 6 milestones rendered as a vertical timeline (most recent first) |
+| CTA | Links to /trust and /pricing |
+
+## Timeline milestones
+
+| Date | Title |
+|------|-------|
+| June 2026 | Full GDPR + CA SB 243 + WA HB 2822 compliance |
+| June 2026 | Unified /trust hub + transparency report |
+| June 2026 | Memory guarantee + 24-layer memory stack |
+| May 2026 | Memory controls UI launched |
+| April 2026 | Builder API access opened |
+| 2025–2026 | Foundation: independent ownership, no VC pressure, no Big Tech acquisition |
+
+## Before / After
+
+### Before
+
+- No platform changelog route existed under `/about`
+- `/about/page.tsx` linked only to `/moderation`
+
+### After
+
+- `/about/changelog` shows the full platform evolution history as a trust signal
+- `/about/page.tsx` includes a new paragraph linking to `/about/changelog`
+- 6 unit tests cover hero rendering, all milestones, date/title accuracy, CTA links, list structure, and foundation description content
+
+## Backlog source
+
+backlog.md:354


### PR DESCRIPTION
## Summary

- Adds `apps/web/app/(public)/about/changelog/page.tsx` — new public `/about/changelog` route showing AgentGram's platform evolution as a trust signal, countering Replika's "rebuilt from the ground up" messaging
- Timeline of 6 milestones (most recent first): GDPR/SB243/HB2822 compliance, /trust hub, 24-layer memory stack, memory controls UI, Builder API, and founding independence story
- Adds link from `/about` page footer to `/about/changelog` (data-testid="about-changelog-link")
- 6 unit tests covering hero, all 6 milestones, date/title accuracy, CTA links, list structure, and content assertions
- PR evidence doc at `docs/pr-evidence/platform-changelog-page.md`

## Source
Source: backlog.md:354

## Auth-only Proof
N/A

## Evidence
docs/pr-evidence/platform-changelog-page.md (new file)

## Test plan
- [x] `apps/web/app/(public)/about/changelog/page.tsx` — renders hero, timeline, and CTA
- [x] All 6 milestones render with correct date badges and titles
- [x] CTA links point to `/trust` and `/pricing`
- [x] Link from `/about` page to `/about/changelog` present (`data-testid="about-changelog-link"`)
- [x] 6 unit tests pass (`pnpm exec vitest run __tests__/app/about/changelog.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)