### PR TITLE
fix: hide upgrade CTA for premium subscribers in MemoryModeDisclosureCard

### DIFF
--- a/apps/web/__tests__/components/memory-mode-disclosure-card.test.tsx
+++ b/apps/web/__tests__/components/memory-mode-disclosure-card.test.tsx
@@ -112,4 +112,42 @@ describe('MemoryModeDisclosureCard', () => {
     const region = screen.getByRole('region', { name: 'Retrievable vs Persistent Memory' });
     expect(region).toBeInTheDocument();
   });
+
+  describe('isPremium gate', () => {
+    it('hides upgrade CTA when isPremium=true', () => {
+      render(<MemoryModeDisclosureCard isPremium />);
+      expect(screen.queryByTestId('memory-disclosure-upgrade-cta')).not.toBeInTheDocument();
+    });
+
+    it('shows active badge when isPremium=true', () => {
+      render(<MemoryModeDisclosureCard isPremium />);
+      expect(screen.getByTestId('memory-disclosure-premium-active')).toBeInTheDocument();
+      expect(screen.getByTestId('memory-disclosure-premium-active')).toHaveTextContent(
+        'Persistent Memory Active'
+      );
+    });
+
+    it('shows upgrade CTA when isPremium=false (default)', () => {
+      render(<MemoryModeDisclosureCard />);
+      expect(screen.getByTestId('memory-disclosure-upgrade-cta')).toBeInTheDocument();
+    });
+
+    it('does not show active badge when isPremium=false (default)', () => {
+      render(<MemoryModeDisclosureCard />);
+      expect(screen.queryByTestId('memory-disclosure-premium-active')).not.toBeInTheDocument();
+    });
+
+    it('still renders comparison columns and features when isPremium=true', () => {
+      render(<MemoryModeDisclosureCard isPremium />);
+      expect(screen.getByTestId('memory-disclosure-free-column')).toBeInTheDocument();
+      expect(screen.getByTestId('memory-disclosure-premium-column')).toBeInTheDocument();
+    });
+
+    it('still renders onContinue button alongside active badge when isPremium=true', () => {
+      const onContinue = vi.fn();
+      render(<MemoryModeDisclosureCard isPremium onContinue={onContinue} />);
+      expect(screen.getByTestId('memory-disclosure-premium-active')).toBeInTheDocument();
+      expect(screen.getByTestId('memory-disclosure-continue-btn')).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/components/memory/MemoryModeDisclosureCard.tsx
+++ b/apps/web/components/memory/MemoryModeDisclosureCard.tsx
@@ -19,11 +19,13 @@ const PREMIUM_FEATURES = [
 interface MemoryModeDisclosureCardProps {
   onContinue?: () => void;
   className?: string;
+  isPremium?: boolean;
 }
 
 export default function MemoryModeDisclosureCard({
   onContinue,
   className = '',
+  isPremium = false,
 }: MemoryModeDisclosureCardProps) {
   return (
     <div
@@ -133,17 +135,27 @@ export default function MemoryModeDisclosureCard({
       </p>
 
       <div className="mt-5 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
-        <Button
-          asChild
-          size="sm"
-          className="gap-1.5 bg-violet-600 text-white hover:bg-violet-700 shadow-sm shadow-violet-600/20"
-        >
-          <Link href="/pricing" data-testid="memory-disclosure-upgrade-cta">
-            <Crown className="h-3.5 w-3.5" aria-hidden="true" />
-            Unlock 이어하기+기억 제어
-            <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
-          </Link>
-        </Button>
+        {isPremium ? (
+          <div
+            className="flex items-center gap-1.5 rounded-full border border-violet-500/40 bg-violet-500/10 px-3 py-1.5 text-sm font-medium text-violet-700 dark:text-violet-400"
+            data-testid="memory-disclosure-premium-active"
+          >
+            <CheckCircle className="h-4 w-4" aria-hidden="true" />
+            Persistent Memory Active
+          </div>
+        ) : (
+          <Button
+            asChild
+            size="sm"
+            className="gap-1.5 bg-violet-600 text-white hover:bg-violet-700 shadow-sm shadow-violet-600/20"
+          >
+            <Link href="/pricing" data-testid="memory-disclosure-upgrade-cta">
+              <Crown className="h-3.5 w-3.5" aria-hidden="true" />
+              Unlock 이어하기+기억 제어
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
+          </Button>
+        )}
 
         {onContinue && (
           <Button

--- a/apps/web/docs/pr-evidence/memory-disclosure-premium-gate.md
+++ b/apps/web/docs/pr-evidence/memory-disclosure-premium-gate.md
@@ -1,0 +1,36 @@
+# PR Evidence: isPremium gate in MemoryModeDisclosureCard
+
+## Component Change Summary
+
+**File**: `apps/web/components/memory/MemoryModeDisclosureCard.tsx`
+
+Added `isPremium?: boolean` prop (default `false`) to `MemoryModeDisclosureCardProps`.
+
+The CTA section at the bottom of the card is now conditionally rendered:
+
+- **isPremium=false (default)**: Shows the existing "Unlock 이어하기+기억 제어" violet button linking to `/pricing` (`data-testid="memory-disclosure-upgrade-cta"`).
+- **isPremium=true**: Hides the upgrade button entirely and renders a "Persistent Memory Active" badge (`data-testid="memory-disclosure-premium-active"`) styled with violet tones to match the premium column.
+
+The comparison columns, features list, ultra-tier note, and optional `onContinue` button are unaffected by `isPremium`.
+
+## Before / After
+
+| Scenario | Before | After |
+|---|---|---|
+| Free user | Unlock CTA shown | Unlock CTA shown ✓ |
+| Premium subscriber | Unlock CTA shown ❌ | "Persistent Memory Active" badge shown ✓ |
+
+## Test Coverage
+
+**File**: `apps/web/__tests__/components/memory-mode-disclosure-card.test.tsx`
+
+6 new tests added under `describe('isPremium gate')`:
+
+1. `hides upgrade CTA when isPremium=true` — `memory-disclosure-upgrade-cta` absent
+2. `shows active badge when isPremium=true` — `memory-disclosure-premium-active` present with correct text
+3. `shows upgrade CTA when isPremium=false (default)` — baseline regression
+4. `does not show active badge when isPremium=false (default)` — baseline regression
+5. `still renders comparison columns and features when isPremium=true` — no structural regression
+6. `still renders onContinue button alongside active badge when isPremium=true` — both CTA elements coexist correctly
+
+**Result**: 20/20 tests pass (14 existing + 6 new).


### PR DESCRIPTION
## Source
Source: backlog.md:row isPremium gate (PR #822 navi-nit)

## Summary
Premium subscribers saw "Unlock Premium" CTA in MemoryModeDisclosureCard because isPremium prop was missing. Adds isPremium gate so subscribed users see their active tier copy instead of the upgrade prompt.

## Auth-only Proof
N/A

## Evidence
See docs/pr-evidence/memory-disclosure-premium-gate.md