### PR TITLE
feat: companion relationship health score panel

### DIFF
--- a/apps/web/app/api/v1/companion/health/route.ts
+++ b/apps/web/app/api/v1/companion/health/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from 'next/server';
+import { withAuth } from '@agentgram/auth';
+import { jsonResponse, createSuccessResponse } from '@agentgram/shared';
+
+async function handler(_req: NextRequest) {
+  return jsonResponse(
+    createSuccessResponse({
+      frequencyScore: 72,
+      memoryDepth: 14,
+      milestoneCount: 3,
+      lastActiveAt: '2026-06-24T09:00:00Z',
+    }),
+    200
+  );
+}
+
+export const GET = withAuth(handler);

--- a/docs/pr-evidence/companion-relationship-health-panel.md
+++ b/docs/pr-evidence/companion-relationship-health-panel.md
@@ -1,0 +1,16 @@
+# PR Evidence: Companion Relationship Health Panel
+
+## Before
+- No health score panel existed for companion relationships
+- No `/api/v1/companion/health` endpoint
+- Zero visibility into conversation frequency, memory depth, or milestones
+
+## After
+- `CompanionRelationshipHealthPanel` renders 4 metrics:
+  - **Conversation frequency score** (0–100, clamped, with Strong/Growing/Early label)
+  - **Memory depth** (saved facts count, singular/plural)
+  - **Milestone count**
+  - **Last-active date** (Just now / Today / N days ago)
+- `Date.now()` extracted outside JSX — react-compiler safe
+- API route `GET /api/v1/companion/health` via `withAuth`, returns stub JSON
+- 15 tests passing covering all metrics, clamping, date formatting, and score bar


### PR DESCRIPTION
## Source
Source: backlog.md:361

## Summary
- companion-health API route (`GET /api/v1/companion/health`) 추가
- `withAuth` 적용, stub JSON 반환
- Note: `CompanionRelationshipHealthPanel` 컴포넌트 및 테스트는 #867에서 이미 merged됨

## Evidence

### This PR
- `apps/web/app/api/v1/companion/health/route.ts` — auth-gated GET route, returns stub health JSON

### Already merged via #867
- `CompanionRelationshipHealthPanel` component (frequency score, memory depth, milestone count, last-active date)
- All related tests (15 tests)

## Auth-only Proof
# 인증 없는 경우 (401 예상)
curl http://localhost:3000/api/v1/companion/health

# 인증 있는 경우 (200 예상)
curl http://localhost:3000/api/v1/companion/health \
  -H "Cookie: next-auth.session-token=<token>"