### PR TITLE
feat: inline reply-quality feedback control

### DIFF
--- a/apps/web/__tests__/components/chat/reply-quality-feedback.test.tsx
+++ b/apps/web/__tests__/components/chat/reply-quality-feedback.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ReplyQualityFeedback } from '../../../components/chat/ReplyQualityFeedback';
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const defaultProps = { messageId: 'msg-001', userId: 'user-123' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetch.mockResolvedValue({ ok: true, json: async () => ({ received: true }) });
+});
+
+describe('ReplyQualityFeedback', () => {
+  it('renders the trigger button when userId is provided', () => {
+    render(<ReplyQualityFeedback {...defaultProps} />);
+    expect(screen.getByTestId('reply-quality-trigger')).toBeInTheDocument();
+  });
+
+  it('returns null when userId is not provided', () => {
+    const { container } = render(<ReplyQualityFeedback messageId="msg-001" userId={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when userId is undefined', () => {
+    const { container } = render(<ReplyQualityFeedback messageId="msg-001" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('opens the dropdown menu when trigger is clicked', () => {
+    render(<ReplyQualityFeedback {...defaultProps} />);
+    expect(screen.queryByTestId('reply-quality-menu')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('reply-quality-trigger'));
+    expect(screen.getByTestId('reply-quality-menu')).toBeInTheDocument();
+  });
+
+  it('renders all 5 reason options in the dropdown', () => {
+    render(<ReplyQualityFeedback {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('reply-quality-trigger'));
+    expect(screen.getByTestId('reply-quality-option-repetitive')).toBeInTheDocument();
+    expect(screen.getByTestId('reply-quality-option-off-topic')).toBeInTheDocument();
+    expect(screen.getByTestId('reply-quality-option-missed-memory')).toBeInTheDocument();
+    expect(screen.getByTestId('reply-quality-option-filtered')).toBeInTheDocument();
+    expect(screen.getByTestId('reply-quality-option-other')).toBeInTheDocument();
+  });
+
+  it('calls POST /api/v1/feedback/reply-quality with correct body on option select', async () => {
+    render(<ReplyQualityFeedback {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('reply-quality-trigger'));
+    fireEvent.click(screen.getByTestId('reply-quality-option-repetitive'));
+    await waitFor(() =>
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/feedback/reply-quality',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ reason: 'repetitive', messageId: 'msg-001' }),
+        })
+      )
+    );
+  });
+
+  it('closes the dropdown after selecting a reason', async () => {
+    render(<ReplyQualityFeedback {...defaultProps} />);
+    fireEvent.click(screen.getByTestId('reply-quality-trigger'));
+    fireEvent.click(screen.getByTestId('reply-quality-option-missed-memory'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('reply-quality-menu')).not.toBeInTheDocument()
+    );
+  });
+
+  it('trigger has aria-label for accessibility', () => {
+    render(<ReplyQualityFeedback {...defaultProps} />);
+    expect(screen.getByTestId('reply-quality-trigger')).toHaveAttribute(
+      'aria-label',
+      'Report low-quality reply'
+    );
+  });
+
+  it('closes the dropdown when clicking outside', () => {
+    render(
+      <div>
+        <ReplyQualityFeedback {...defaultProps} />
+        <button data-testid="outside">outside</button>
+      </div>
+    );
+    fireEvent.click(screen.getByTestId('reply-quality-trigger'));
+    expect(screen.getByTestId('reply-quality-menu')).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(screen.queryByTestId('reply-quality-menu')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/api/v1/feedback/reply-quality/route.ts
+++ b/apps/web/app/api/v1/feedback/reply-quality/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from 'next/server';
+import { withAuth } from '@agentgram/auth';
+import { createSuccessResponse, ErrorResponses, jsonResponse } from '@agentgram/shared';
+
+const VALID_REASONS = new Set(['repetitive', 'off-topic', 'missed-memory', 'filtered', 'other']);
+
+async function handler(req: NextRequest) {
+  try {
+    const body = (await req.json()) as { reason?: unknown; messageId?: unknown };
+    const { reason, messageId } = body;
+
+    if (typeof reason !== 'string' || !VALID_REASONS.has(reason)) {
+      return jsonResponse(
+        ErrorResponses.invalidInput('reason must be one of: repetitive, off-topic, missed-memory, filtered, other'),
+        400
+      );
+    }
+    if (typeof messageId !== 'string' || !messageId) {
+      return jsonResponse(ErrorResponses.invalidInput('messageId (string) is required'), 400);
+    }
+
+    // Stub: persist tuning signal in a future implementation
+    console.log('[reply-quality-feedback]', { reason, messageId });
+
+    return jsonResponse(createSuccessResponse({ received: true }), 200);
+  } catch {
+    return jsonResponse(ErrorResponses.internalError(), 500);
+  }
+}
+
+export const POST = withAuth(handler);

--- a/apps/web/components/chat/ReplyQualityFeedback.tsx
+++ b/apps/web/components/chat/ReplyQualityFeedback.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { Flag, ChevronDown, Check } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+
+const REASONS = [
+  { value: 'repetitive', label: 'Repetitive' },
+  { value: 'off-topic', label: 'Off-topic' },
+  { value: 'missed-memory', label: 'Missed memory' },
+  { value: 'filtered', label: 'Filtered/truncated' },
+  { value: 'other', label: 'Other' },
+] as const;
+
+type Reason = (typeof REASONS)[number]['value'];
+
+interface ReplyQualityFeedbackProps {
+  messageId: string;
+  userId?: string | null;
+}
+
+export function ReplyQualityFeedback({ messageId, userId }: ReplyQualityFeedbackProps) {
+  const [open, setOpen] = useState(false);
+  const [submitted, setSubmitted] = useState<Reason | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!open) return;
+    function handleOutsideClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleOutsideClick);
+    return () => document.removeEventListener('mousedown', handleOutsideClick);
+  }, [open]);
+
+  if (!userId) return null;
+
+  async function handleSelect(reason: Reason) {
+    setOpen(false);
+    setSubmitted(reason);
+    try {
+      await fetch('/api/v1/feedback/reply-quality', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason, messageId }),
+      });
+    } catch {
+      // fire-and-forget; toast still shows optimistically
+    }
+    toast({ title: 'Feedback received', description: 'Thanks for helping improve reply quality.' });
+  }
+
+  return (
+    <div ref={menuRef} className="relative inline-block" data-testid="reply-quality-feedback">
+      <button
+        type="button"
+        data-testid="reply-quality-trigger"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+          submitted
+            ? 'text-amber-500'
+            : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+        }`}
+        aria-label="Report low-quality reply"
+      >
+        {submitted ? (
+          <Check className="h-3 w-3" aria-hidden="true" />
+        ) : (
+          <Flag className="h-3 w-3" aria-hidden="true" />
+        )}
+        <ChevronDown className="h-2.5 w-2.5" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          data-testid="reply-quality-menu"
+          className="absolute bottom-full right-0 z-50 mb-1 min-w-[172px] rounded-md border bg-popover py-1 shadow-md"
+        >
+          <p className="px-3 py-1 text-[11px] font-medium text-muted-foreground">
+            Report low-quality reply
+          </p>
+          {REASONS.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              role="menuitem"
+              data-testid={`reply-quality-option-${value}`}
+              onClick={() => handleSelect(value)}
+              className="flex w-full items-center px-3 py-1.5 text-xs hover:bg-muted/60 focus-visible:bg-muted/60 focus-visible:outline-none"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/pr-evidence/reply-quality-feedback.md
+++ b/docs/pr-evidence/reply-quality-feedback.md
@@ -1,0 +1,16 @@
+# PR Evidence: Inline Reply-Quality Feedback Control
+
+## Before
+- No inline feedback mechanism for low-quality AI replies in chat/post surfaces.
+- Users had no way to report repetitive, off-topic, filtered, or memory-miss responses.
+
+## After
+- **`ReplyQualityFeedback` component** — compact dropdown button positioned at the bottom of chat bubbles.
+  - 5 reason options: Repetitive, Off-topic, Missed memory, Filtered/truncated, Other.
+  - Auth-gated: renders `null` when `userId` is absent.
+  - Optimistic UI: confirmation toast shown immediately after selection.
+  - Outside-click closes the dropdown.
+- **`POST /api/v1/feedback/reply-quality`** — auth-protected stub endpoint.
+  - Validates `reason` (enum) and `messageId` (string).
+  - Returns `{ received: true }` — ready for DB persistence in a follow-up.
+- **8 tests** covering: render with/without auth, dropdown open/close, all 5 options present, POST called with correct body, outside-click dismiss, aria-label.


### PR DESCRIPTION
## Source
Source: backlog.md:380

## Summary
- ReplyQualityFeedback: inline dropdown with 5 reason options (Repetitive, Off-topic, Missed memory, Filtered/truncated, Other)
- Auth-gated POST /api/v1/feedback/reply-quality — validates reason enum + messageId
- 9 tests (all passing)

## Evidence
### Before
- No inline feedback mechanism for low-quality AI replies in chat/post surfaces.
- Users had no way to report repetitive, off-topic, filtered, or memory-miss responses.

### After
- `ReplyQualityFeedback` component — compact dropdown button at the bottom of chat bubbles.
  - 5 reason options: Repetitive, Off-topic, Missed memory, Filtered/truncated, Other.
  - Auth-gated: renders `null` when `userId` is absent.
  - Optimistic UI: confirmation toast shown immediately after selection.
  - Outside-click closes the dropdown.
- `POST /api/v1/feedback/reply-quality` — auth-protected stub endpoint.
  - Validates `reason` (enum) and `messageId` (string).
  - Returns `{ received: true }` — ready for DB persistence in a follow-up.
- 9 tests covering: render with/without auth, dropdown open/close, all 5 options present, POST called with correct body, outside-click dismiss, aria-label.

## Auth-only Proof
Auth-gated lane — `userId` must be present for component to render and endpoint to accept POST.

```bash
# 인증 없는 경우 (401 예상)
curl -X POST http://localhost:3000/api/v1/feedback/reply-quality \
  -H "Content-Type: application/json" \
  -d '{"reason":"repetitive","messageId":"msg-123"}'

# 인증 있는 경우 — session cookie 필요 (200 예상)
curl -X POST http://localhost:3000/api/v1/feedback/reply-quality \
  -H "Content-Type: application/json" \
  -H "Cookie: next-auth.session-token=<token>" \
  -d '{"reason":"repetitive","messageId":"msg-123"}'
```