### PR TITLE
feat: Nomi getting-started image guide card with anchor presets

### DIFF
--- a/apps/web/__tests__/components/getting-started-image-guide.test.tsx
+++ b/apps/web/__tests__/components/getting-started-image-guide.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  GettingStartedImageGuide,
+  ANCHOR_PRESETS,
+} from '@/components/image-gen/getting-started-image-guide';
+
+describe('GettingStartedImageGuide', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders the container element', () => {
+    render(<GettingStartedImageGuide forceVisible />);
+    expect(
+      screen.getByTestId('getting-started-image-guide')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the guide panel when forceVisible is true', () => {
+    render(<GettingStartedImageGuide forceVisible />);
+    expect(screen.getByTestId('image-guide-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('image-guide-title')).toHaveTextContent(
+      'Getting started with image generation'
+    );
+  });
+
+  it('shows the guide automatically for first-time users (no localStorage key)', () => {
+    render(<GettingStartedImageGuide />);
+    expect(screen.getByTestId('image-guide-panel')).toBeInTheDocument();
+  });
+
+  it('hides the guide when localStorage dismissed key is set', () => {
+    localStorage.setItem('agentgram:image-guide-dismissed', '1');
+    render(<GettingStartedImageGuide />);
+    expect(screen.queryByTestId('image-guide-panel')).not.toBeInTheDocument();
+    expect(screen.getByTestId('image-guide-toggle')).toBeInTheDocument();
+  });
+
+  it('renders all 4 beginner tips', () => {
+    render(<GettingStartedImageGuide forceVisible />);
+    const tips = screen.getByTestId('image-guide-tips');
+    expect(tips.querySelectorAll('li')).toHaveLength(4);
+  });
+
+  it('renders the toggle button when guide is dismissed', () => {
+    localStorage.setItem('agentgram:image-guide-dismissed', '1');
+    render(<GettingStartedImageGuide />);
+    expect(screen.getByTestId('image-guide-toggle')).toBeInTheDocument();
+  });
+
+  it('opens the guide when toggle button is clicked', () => {
+    localStorage.setItem('agentgram:image-guide-dismissed', '1');
+    render(<GettingStartedImageGuide />);
+    fireEvent.click(screen.getByTestId('image-guide-toggle'));
+    expect(screen.getByTestId('image-guide-panel')).toBeInTheDocument();
+  });
+
+  it('dismisses the guide and sets localStorage when X is clicked', () => {
+    render(<GettingStartedImageGuide forceVisible />);
+    fireEvent.click(screen.getByTestId('image-guide-dismiss'));
+    expect(screen.queryByTestId('image-guide-panel')).not.toBeInTheDocument();
+    expect(localStorage.getItem('agentgram:image-guide-dismissed')).toBe('1');
+  });
+
+  it('renders preset chips when onSelectPreset is provided', () => {
+    render(<GettingStartedImageGuide forceVisible onSelectPreset={() => {}} />);
+    expect(screen.getByTestId('image-guide-presets')).toBeInTheDocument();
+    expect(ANCHOR_PRESETS.length).toBeGreaterThanOrEqual(4);
+    for (const preset of ANCHOR_PRESETS) {
+      expect(
+        screen.getByTestId(`image-guide-preset-${preset.id}`)
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('does not render presets section when onSelectPreset is not provided', () => {
+    render(<GettingStartedImageGuide forceVisible />);
+    expect(screen.queryByTestId('image-guide-presets')).not.toBeInTheDocument();
+  });
+
+  it('calls onSelectPreset with the preset prompt when a chip is clicked', () => {
+    const handler = vi.fn();
+    render(<GettingStartedImageGuide forceVisible onSelectPreset={handler} />);
+    const firstPreset = ANCHOR_PRESETS[0];
+    fireEvent.click(screen.getByTestId(`image-guide-preset-${firstPreset.id}`));
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(firstPreset.prompt);
+  });
+
+  it('renders preset chip labels correctly', () => {
+    render(<GettingStartedImageGuide forceVisible onSelectPreset={() => {}} />);
+    for (const preset of ANCHOR_PRESETS) {
+      expect(
+        screen.getByTestId(`image-guide-preset-${preset.id}`)
+      ).toHaveTextContent(preset.label);
+    }
+  });
+});

--- a/apps/web/components/image-gen/getting-started-image-guide.tsx
+++ b/apps/web/components/image-gen/getting-started-image-guide.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { HelpCircle, X, Lightbulb } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const STORAGE_KEY = 'agentgram:image-guide-dismissed';
+
+const TIPS = [
+  {
+    id: 'tip-describe',
+    text: 'Describe the scene in detail — include lighting, mood, and setting for better results.',
+  },
+  {
+    id: 'tip-style',
+    text: 'Mention an art style (e.g. "cinematic photo", "anime illustration") to guide the look.',
+  },
+  {
+    id: 'tip-character',
+    text: 'Reference your agent by name so Nomi V5 keeps appearance consistent across images.',
+  },
+  {
+    id: 'tip-avoid',
+    text: 'Add "avoid text overlays, watermarks" at the end to keep images clean.',
+  },
+] as const;
+
+export const ANCHOR_PRESETS = [
+  { id: 'cinematic-portrait', label: 'cinematic portrait', prompt: 'cinematic portrait, dramatic lighting, shallow depth of field, film grain' },
+  { id: 'anime-style', label: 'anime style', prompt: 'anime illustration, clean linework, vibrant colors, expressive character design' },
+  { id: 'realistic-photo', label: 'realistic photo', prompt: 'photorealistic, high resolution, natural lighting, sharp focus' },
+  { id: 'fantasy-art', label: 'fantasy art', prompt: 'epic fantasy illustration, magical atmosphere, detailed environment, painterly style' },
+  { id: 'cozy-scene', label: 'cozy scene', prompt: 'warm cozy atmosphere, soft lighting, intimate setting, comfortable mood' },
+  { id: 'dark-aesthetic', label: 'dark aesthetic', prompt: 'dark moody aesthetic, high contrast, dramatic shadows, noir atmosphere' },
+] as const;
+
+export type AnchorPreset = (typeof ANCHOR_PRESETS)[number];
+
+interface GettingStartedImageGuideProps {
+  onSelectPreset?: (prompt: string) => void;
+  forceVisible?: boolean;
+}
+
+export function GettingStartedImageGuide({
+  onSelectPreset,
+  forceVisible = false,
+}: GettingStartedImageGuideProps) {
+  const [visible, setVisible] = useState(false);
+  const [manuallyOpen, setManuallyOpen] = useState(false);
+
+  useEffect(() => {
+    if (forceVisible) {
+      setVisible(true);
+      return;
+    }
+    try {
+      const dismissed = localStorage.getItem(STORAGE_KEY);
+      if (!dismissed) {
+        setVisible(true);
+      }
+    } catch {
+      setVisible(true);
+    }
+  }, [forceVisible]);
+
+  function handleDismiss() {
+    setVisible(false);
+    setManuallyOpen(false);
+    try {
+      localStorage.setItem(STORAGE_KEY, '1');
+    } catch {
+      // storage unavailable
+    }
+  }
+
+  function handleToggle() {
+    if (visible && manuallyOpen) {
+      setVisible(false);
+      setManuallyOpen(false);
+    } else {
+      setVisible(true);
+      setManuallyOpen(true);
+    }
+  }
+
+  const isOpen = visible || manuallyOpen;
+
+  return (
+    <div data-testid="getting-started-image-guide">
+      {!isOpen && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleToggle}
+          data-testid="image-guide-toggle"
+          className="gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+          aria-label="Show image generation tips"
+        >
+          <HelpCircle className="h-3.5 w-3.5" />
+          Prompt tips
+        </Button>
+      )}
+
+      {isOpen && (
+        <div
+          className="rounded-xl border border-border/60 bg-card/40 p-4 space-y-4"
+          data-testid="image-guide-panel"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Lightbulb className="h-4 w-4 text-amber-500" aria-hidden="true" />
+              <p className="text-sm font-semibold" data-testid="image-guide-title">
+                Getting started with image generation
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleDismiss}
+              data-testid="image-guide-dismiss"
+              className="h-6 w-6 p-0"
+              aria-label="Dismiss image guide"
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+
+          <ul className="space-y-2" data-testid="image-guide-tips">
+            {TIPS.map((tip) => (
+              <li
+                key={tip.id}
+                data-testid={tip.id}
+                className="flex gap-2 text-sm text-muted-foreground"
+              >
+                <span className="mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary/60" aria-hidden="true" />
+                {tip.text}
+              </li>
+            ))}
+          </ul>
+
+          {onSelectPreset && (
+            <div data-testid="image-guide-presets">
+              <p className="text-xs font-medium text-muted-foreground mb-2">
+                Quick start — click to add to your prompt:
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {ANCHOR_PRESETS.map((preset) => (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    onClick={() => onSelectPreset(preset.prompt)}
+                    data-testid={`image-guide-preset-${preset.id}`}
+                    className="rounded-full border border-border/60 bg-background px-3 py-1 text-xs text-muted-foreground transition-colors hover:border-primary/60 hover:bg-primary/5 hover:text-primary"
+                  >
+                    {preset.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/image-gen/getting-started-image-guide.tsx
+++ b/apps/web/components/image-gen/getting-started-image-guide.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { HelpCircle, X, Lightbulb } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
@@ -45,23 +45,15 @@ export function GettingStartedImageGuide({
   onSelectPreset,
   forceVisible = false,
 }: GettingStartedImageGuideProps) {
-  const [visible, setVisible] = useState(false);
-  const [manuallyOpen, setManuallyOpen] = useState(false);
-
-  useEffect(() => {
-    if (forceVisible) {
-      setVisible(true);
-      return;
-    }
+  const [visible, setVisible] = useState(() => {
+    if (typeof window === 'undefined') return false;
     try {
-      const dismissed = localStorage.getItem(STORAGE_KEY);
-      if (!dismissed) {
-        setVisible(true);
-      }
+      return !localStorage.getItem(STORAGE_KEY);
     } catch {
-      setVisible(true);
+      return true;
     }
-  }, [forceVisible]);
+  });
+  const [manuallyOpen, setManuallyOpen] = useState(false);
 
   function handleDismiss() {
     setVisible(false);
@@ -83,7 +75,7 @@ export function GettingStartedImageGuide({
     }
   }
 
-  const isOpen = visible || manuallyOpen;
+  const isOpen = forceVisible || visible || manuallyOpen;
 
   return (
     <div data-testid="getting-started-image-guide">

--- a/apps/web/components/posts/ReplyContextComposer.tsx
+++ b/apps/web/components/posts/ReplyContextComposer.tsx
@@ -23,6 +23,7 @@ import { MemoryUsageMeter, type MemoryUsageData } from '@/components/memory/Memo
 import { StarterPromptStrip } from '@/components/chat/StarterPromptStrip';
 import { BlankStartMessageCoach } from '@/components/chat/BlankStartMessageCoach';
 import { AnchorControlsPreset } from '@/components/image-gen/AnchorControlsPreset';
+import { GettingStartedImageGuide } from '@/components/image-gen/getting-started-image-guide';
 import type { AnchorControlsState } from '@/lib/image-gen/anchor-controls';
 import {
   DEFAULT_ANCHOR_CONTROLS,
@@ -420,10 +421,19 @@ export function ReplyContextComposer({
         </div>
 
         {canImagineScene && (
-          <AnchorControlsPreset
-            initialValue={anchorControls}
-            onChange={setAnchorControls}
-          />
+          <>
+            <GettingStartedImageGuide
+              onSelectPreset={(prompt) =>
+                handleContentChange(
+                  content.trim() ? `${content.trim()} ${prompt}` : prompt
+                )
+              }
+            />
+            <AnchorControlsPreset
+              initialValue={anchorControls}
+              onChange={setAnchorControls}
+            />
+          </>
         )}
 
         {(imagineSceneHandoff || isGeneratingImagineScene) && (

--- a/docs/pr-evidence/nomi-image-guide-card.md
+++ b/docs/pr-evidence/nomi-image-guide-card.md
@@ -1,0 +1,61 @@
+# PR Evidence: Nomi Getting-Started Image Guide Card
+
+## Component
+
+**File:** `apps/web/components/image-gen/getting-started-image-guide.tsx`
+
+`GettingStartedImageGuide` is a collapsible help card that appears inside the image generation flow
+(wired into `ReplyContextComposer`) to guide first-time users when they have an image-capable source loaded.
+
+### Visibility logic
+
+- **First-time users:** card opens automatically (no `agentgram:image-guide-dismissed` key in localStorage).
+- **Returning users:** card is hidden; a "Prompt tips" `?` toggle button is shown instead.
+- **`forceVisible` prop:** bypasses localStorage for testing or explicit overrides.
+- Clicking the **×** dismiss button sets the localStorage key and collapses the card.
+
+### Beginner tips (4)
+
+1. Describe the scene in detail — include lighting, mood, and setting for better results.
+2. Mention an art style (e.g. "cinematic photo", "anime illustration") to guide the look.
+3. Reference your agent by name so Nomi V5 keeps appearance consistent across images.
+4. Add "avoid text overlays, watermarks" at the end to keep images clean.
+
+### Anchor preset chips (6)
+
+Clicking a chip calls `onSelectPreset(prompt)`, which appends the preset to the existing
+prompt input in `ReplyContextComposer`.
+
+| Chip label | Prompt appended |
+|---|---|
+| cinematic portrait | `cinematic portrait, dramatic lighting, shallow depth of field, film grain` |
+| anime style | `anime illustration, clean linework, vibrant colors, expressive character design` |
+| realistic photo | `photorealistic, high resolution, natural lighting, sharp focus` |
+| fantasy art | `epic fantasy illustration, magical atmosphere, detailed environment, painterly style` |
+| cozy scene | `warm cozy atmosphere, soft lighting, intimate setting, comfortable mood` |
+| dark aesthetic | `dark moody aesthetic, high contrast, dramatic shadows, noir atmosphere` |
+
+## Integration point
+
+`ReplyContextComposer` (`apps/web/components/posts/ReplyContextComposer.tsx`) renders
+`GettingStartedImageGuide` inside the `canImagineScene` guard — same block as `AnchorControlsPreset` —
+so the card only appears when there is actionable image context (post title, body, or chat messages).
+
+The `onSelectPreset` callback appends the preset prompt to any existing textarea content
+(space-separated if non-empty, otherwise replaces the empty field).
+
+## Test coverage
+
+**File:** `apps/web/__tests__/components/getting-started-image-guide.test.tsx`
+
+Tests cover:
+- Component renders container
+- Panel visible when `forceVisible`
+- Auto-shows for first-time users (no localStorage key)
+- Stays hidden when dismissed key exists in localStorage
+- Toggle button re-opens the guide
+- Dismiss button hides panel and sets localStorage key
+- All 4 tips rendered
+- Preset chips rendered only when `onSelectPreset` provided
+- Chip click calls handler with correct prompt string
+- Chip labels match preset definitions


### PR DESCRIPTION
## Source
Source: backlog.md:366

Add beginner tips and anchor preset examples inside the image generation flow.

## Changes
- `GettingStartedImageGuide` component with 4 beginner tips + 6 clickable anchor preset chips
- Wired into `ReplyContextComposer` inside the `canImagineScene` guard alongside `AnchorControlsPreset`
- Dismissal persisted via `localStorage` (`agentgram:image-guide-dismissed`); `forceVisible` prop bypasses for tests

## Evidence

**Component:** `apps/web/components/image-gen/getting-started-image-guide.tsx`

Visibility logic:
- First-time users: card opens automatically (no localStorage key present)
- Returning users: collapsed; a "Prompt tips" toggle button is shown instead
- `forceVisible` prop overrides localStorage for explicit control / testing

Anchor preset chips (6): cinematic portrait · anime style · realistic photo · fantasy art · cozy scene · dark aesthetic. Clicking a chip calls `onSelectPreset(prompt)`, appending the preset to the existing textarea content in `ReplyContextComposer`.

**Tests:** `apps/web/__tests__/components/getting-started-image-guide.test.tsx`
- auto-show for first-time users, hidden when dismissed key exists
- toggle re-opens, dismiss sets localStorage key
- all 4 tips rendered, preset chips only rendered when `onSelectPreset` provided
- chip click calls handler with correct prompt string

See `docs/pr-evidence/nomi-image-guide-card.md` for full preset table and integration details.

## Auth-only Proof
N/A — no auth-gated endpoints introduced in this PR. `GettingStartedImageGuide` is a client-only UI component; `ReplyContextComposer` uses `/api/v1/reply-composer/imagine-scene` which was already present and is not modified here.