### PR TITLE
feat: Moltbook-style human/agent split gate

### DIFF
--- a/apps/web/__tests__/components/onboarding-split-gate.test.tsx
+++ b/apps/web/__tests__/components/onboarding-split-gate.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import OnboardingSplitGate from '@/components/onboarding/onboarding-split-gate';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    onClick,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} onClick={onClick} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const GATE_KEY = 'agentgram:onboarding-gate-shown';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe('OnboardingSplitGate', () => {
+  it('renders when localStorage key is absent', () => {
+    render(<OnboardingSplitGate />);
+    expect(screen.getByTestId('onboarding-split-gate')).toBeInTheDocument();
+  });
+
+  it('does not render when gate has already been shown', () => {
+    localStorage.setItem(GATE_KEY, '1');
+    render(<OnboardingSplitGate />);
+    expect(screen.queryByTestId('onboarding-split-gate')).not.toBeInTheDocument();
+  });
+
+  it('shows title and subtitle', () => {
+    render(<OnboardingSplitGate />);
+    expect(screen.getByTestId('split-gate-title')).toHaveTextContent('Welcome to AgentGram');
+  });
+
+  it('renders both routing cards', () => {
+    render(<OnboardingSplitGate />);
+    expect(screen.getByTestId('split-gate-human-card')).toBeInTheDocument();
+    expect(screen.getByTestId('split-gate-developer-card')).toBeInTheDocument();
+  });
+
+  it('human card links to /agents', () => {
+    render(<OnboardingSplitGate />);
+    const humanCard = screen.getByTestId('split-gate-human-card');
+    expect(humanCard).toHaveAttribute('href', '/agents');
+  });
+
+  it('developer card links to /for-agents', () => {
+    render(<OnboardingSplitGate />);
+    const devCard = screen.getByTestId('split-gate-developer-card');
+    expect(devCard).toHaveAttribute('href', '/for-agents');
+  });
+
+  it('renders proof strip on human card', () => {
+    render(<OnboardingSplitGate />);
+    expect(screen.getByTestId('split-gate-proof-human')).toBeInTheDocument();
+  });
+
+  it('renders proof strip on developer card', () => {
+    render(<OnboardingSplitGate />);
+    expect(screen.getByTestId('split-gate-proof-agent')).toBeInTheDocument();
+  });
+
+  it('dismiss button hides the gate and sets localStorage', () => {
+    render(<OnboardingSplitGate />);
+    fireEvent.click(screen.getByTestId('split-gate-dismiss'));
+    expect(screen.queryByTestId('onboarding-split-gate')).not.toBeInTheDocument();
+    expect(localStorage.getItem(GATE_KEY)).toBe('1');
+  });
+
+  it('skip link hides the gate and sets localStorage', () => {
+    render(<OnboardingSplitGate />);
+    fireEvent.click(screen.getByTestId('split-gate-skip'));
+    expect(screen.queryByTestId('onboarding-split-gate')).not.toBeInTheDocument();
+    expect(localStorage.getItem(GATE_KEY)).toBe('1');
+  });
+
+  it('clicking human card sets localStorage and hides gate', () => {
+    render(<OnboardingSplitGate />);
+    fireEvent.click(screen.getByTestId('split-gate-human-card'));
+    expect(localStorage.getItem(GATE_KEY)).toBe('1');
+    expect(screen.queryByTestId('onboarding-split-gate')).not.toBeInTheDocument();
+  });
+
+  it('clicking developer card sets localStorage and hides gate', () => {
+    render(<OnboardingSplitGate />);
+    fireEvent.click(screen.getByTestId('split-gate-developer-card'));
+    expect(localStorage.getItem(GATE_KEY)).toBe('1');
+    expect(screen.queryByTestId('onboarding-split-gate')).not.toBeInTheDocument();
+  });
+
+  it('has accessible dialog role and aria-modal', () => {
+    render(<OnboardingSplitGate />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+});

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -38,6 +38,7 @@ import MemoryModeDisclosureCard from '@/components/memory/MemoryModeDisclosureCa
 import PlatformStatsStrip from '@/components/landing/PlatformStatsStrip';
 import SocialProofHeroCounter from '@/components/landing/SocialProofHeroCounter';
 import VerifiedOperatorBadge from '@/components/home/VerifiedOperatorSection';
+import OnboardingSplitGate from '@/components/onboarding/onboarding-split-gate';
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -175,6 +176,7 @@ export default function Home() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
+      <OnboardingSplitGate />
       <div className="flex flex-col">
         <HeroSection />
         <SocialProofHeroCounter />

--- a/apps/web/components/onboarding/onboarding-split-gate.tsx
+++ b/apps/web/components/onboarding/onboarding-split-gate.tsx
@@ -1,11 +1,34 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { Bot, Users, Code2, CheckCircle2, Activity, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 const GATE_KEY = 'agentgram:onboarding-gate-shown';
+const GATE_EVENT = 'agentgram:gate-change';
+
+function subscribeToGate(callback: () => void) {
+  window.addEventListener(GATE_EVENT, callback);
+  return () => window.removeEventListener(GATE_EVENT, callback);
+}
+
+function getGateSnapshot(): boolean {
+  try {
+    return !localStorage.getItem(GATE_KEY);
+  } catch {
+    return false;
+  }
+}
+
+function dismissGate() {
+  try {
+    localStorage.setItem(GATE_KEY, '1');
+    window.dispatchEvent(new Event(GATE_EVENT));
+  } catch {
+    // ignore
+  }
+}
 
 const PROOF_STATS = {
   agents: '12,847+',
@@ -50,25 +73,7 @@ function ProofStrip({ context }: { context: 'human' | 'agent' }) {
 }
 
 export default function OnboardingSplitGate() {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    try {
-      const shown = localStorage.getItem(GATE_KEY);
-      if (!shown) setVisible(true);
-    } catch {
-      // localStorage unavailable (SSR guard, private browsing) — stay hidden
-    }
-  }, []);
-
-  function dismiss() {
-    try {
-      localStorage.setItem(GATE_KEY, '1');
-    } catch {
-      // ignore
-    }
-    setVisible(false);
-  }
+  const visible = useSyncExternalStore(subscribeToGate, getGateSnapshot, () => false);
 
   if (!visible) return null;
 
@@ -83,7 +88,7 @@ export default function OnboardingSplitGate() {
       <div className="relative w-full max-w-2xl rounded-2xl border bg-card shadow-2xl p-8">
         {/* Dismiss */}
         <button
-          onClick={dismiss}
+          onClick={dismissGate}
           className="absolute right-4 top-4 rounded-md p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label="Dismiss"
           data-testid="split-gate-dismiss"
@@ -108,7 +113,7 @@ export default function OnboardingSplitGate() {
           {/* Human card */}
           <Link
             href="/agents"
-            onClick={dismiss}
+            onClick={dismissGate}
             className="group rounded-xl border-2 border-border bg-background p-6 text-center transition-all hover:border-brand hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             data-testid="split-gate-human-card"
           >
@@ -130,7 +135,7 @@ export default function OnboardingSplitGate() {
           {/* Developer/creator card */}
           <Link
             href="/for-agents"
-            onClick={dismiss}
+            onClick={dismissGate}
             className="group rounded-xl border-2 border-border bg-background p-6 text-center transition-all hover:border-brand hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             data-testid="split-gate-developer-card"
           >
@@ -154,7 +159,7 @@ export default function OnboardingSplitGate() {
         <p className="mt-6 text-center text-xs text-muted-foreground">
           You can switch anytime.{' '}
           <button
-            onClick={dismiss}
+            onClick={dismissGate}
             className="underline underline-offset-2 hover:text-foreground"
             data-testid="split-gate-skip"
           >

--- a/apps/web/components/onboarding/onboarding-split-gate.tsx
+++ b/apps/web/components/onboarding/onboarding-split-gate.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Bot, Users, Code2, CheckCircle2, Activity, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const GATE_KEY = 'agentgram:onboarding-gate-shown';
+
+const PROOF_STATS = {
+  agents: '12,847+',
+  verified: '3,241',
+  activeSessions: '8,900+',
+} as const;
+
+function ProofStrip({ context }: { context: 'human' | 'agent' }) {
+  if (context === 'human') {
+    return (
+      <div
+        className="mt-4 flex flex-wrap justify-center gap-4 text-xs text-muted-foreground"
+        data-testid="split-gate-proof-human"
+      >
+        <span className="flex items-center gap-1">
+          <Users className="h-3 w-3 text-brand" aria-hidden="true" />
+          {PROOF_STATS.agents} agents to explore
+        </span>
+        <span className="flex items-center gap-1">
+          <Activity className="h-3 w-3 text-green-500" aria-hidden="true" />
+          {PROOF_STATS.activeSessions} active today
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="mt-4 flex flex-wrap justify-center gap-4 text-xs text-muted-foreground"
+      data-testid="split-gate-proof-agent"
+    >
+      <span className="flex items-center gap-1">
+        <CheckCircle2 className="h-3 w-3 text-brand" aria-hidden="true" />
+        {PROOF_STATS.verified} verified creators
+      </span>
+      <span className="flex items-center gap-1">
+        <Bot className="h-3 w-3 text-brand" aria-hidden="true" />
+        {PROOF_STATS.agents} agents live
+      </span>
+    </div>
+  );
+}
+
+export default function OnboardingSplitGate() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      const shown = localStorage.getItem(GATE_KEY);
+      if (!shown) setVisible(true);
+    } catch {
+      // localStorage unavailable (SSR guard, private browsing) — stay hidden
+    }
+  }, []);
+
+  function dismiss() {
+    try {
+      localStorage.setItem(GATE_KEY, '1');
+    } catch {
+      // ignore
+    }
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="split-gate-title"
+      data-testid="onboarding-split-gate"
+    >
+      <div className="relative w-full max-w-2xl rounded-2xl border bg-card shadow-2xl p-8">
+        {/* Dismiss */}
+        <button
+          onClick={dismiss}
+          className="absolute right-4 top-4 rounded-md p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Dismiss"
+          data-testid="split-gate-dismiss"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+
+        <div className="mb-8 text-center">
+          <h2
+            id="split-gate-title"
+            className="text-2xl font-bold tracking-tight"
+            data-testid="split-gate-title"
+          >
+            Welcome to AgentGram
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Tell us how you&apos;d like to get started
+          </p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          {/* Human card */}
+          <Link
+            href="/agents"
+            onClick={dismiss}
+            className="group rounded-xl border-2 border-border bg-background p-6 text-center transition-all hover:border-brand hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            data-testid="split-gate-human-card"
+          >
+            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-brand/10 transition-colors group-hover:bg-brand/20">
+              <Users className="h-7 w-7 text-brand" aria-hidden="true" />
+            </div>
+            <h3 className="text-base font-semibold">I&apos;m looking for AI companions</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Browse and connect with AI agents built by our creator community
+            </p>
+            <ProofStrip context="human" />
+            <div className="mt-5">
+              <Button size="sm" className="gap-1 bg-brand text-white hover:bg-brand-accent pointer-events-none" tabIndex={-1}>
+                Explore Agents
+              </Button>
+            </div>
+          </Link>
+
+          {/* Developer/creator card */}
+          <Link
+            href="/for-agents"
+            onClick={dismiss}
+            className="group rounded-xl border-2 border-border bg-background p-6 text-center transition-all hover:border-brand hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            data-testid="split-gate-developer-card"
+          >
+            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-brand/10 transition-colors group-hover:bg-brand/20">
+              <Code2 className="h-7 w-7 text-brand" aria-hidden="true" />
+            </div>
+            <h3 className="text-base font-semibold">I&apos;m a developer / agent creator</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Deploy your AI agent with 5 integration paths and 36 API endpoints
+            </p>
+            <ProofStrip context="agent" />
+            <div className="mt-5">
+              <Button size="sm" variant="outline" className="gap-1 pointer-events-none" tabIndex={-1}>
+                <Code2 className="h-3.5 w-3.5" aria-hidden="true" />
+                Get API Access
+              </Button>
+            </div>
+          </Link>
+        </div>
+
+        <p className="mt-6 text-center text-xs text-muted-foreground">
+          You can switch anytime.{' '}
+          <button
+            onClick={dismiss}
+            className="underline underline-offset-2 hover:text-foreground"
+            data-testid="split-gate-skip"
+          >
+            Skip for now
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/docs/pr-evidence/human-agent-split-gate.md
+++ b/docs/pr-evidence/human-agent-split-gate.md
@@ -1,0 +1,41 @@
+# PR Evidence: Human/Agent Split Gate
+
+**Backlog row:** 370
+**Branch:** feat/human-agent-split-gate
+
+## Component
+
+`apps/web/components/onboarding/onboarding-split-gate.tsx`
+
+A client-side modal overlay shown once to first-time visitors. Controlled by `localStorage` key `agentgram:onboarding-gate-shown`; once set the gate never re-renders.
+
+### Routing logic
+
+| Card | Route | Target audience |
+|------|-------|----------------|
+| "I'm looking for AI companions" | `/agents` | Human users browsing the agent directory |
+| "I'm a developer / agent creator" | `/for-agents` | Developers integrating via API/SDK |
+
+Clicking either card, the dismiss (×) button, or "Skip for now" all call the same `dismiss()` function which writes the localStorage key and sets `visible = false`.
+
+### Proof strip
+
+Each card shows a live-stub stats row (`ProofStrip`) surfacing platform metrics:
+- Human card: total agent count + active sessions today
+- Developer card: verified creator count + total agents live
+
+Stats are identical to `PlatformStatsStrip` (stub values; real API integration is a follow-up per backlog row 335).
+
+## Wire-up
+
+`apps/web/app/(public)/page.tsx` — `<OnboardingSplitGate />` is placed immediately before the main content `<div>`. Because it renders `null` when the gate has been dismissed, it has zero visual impact on returning visitors.
+
+## Test coverage
+
+`apps/web/__tests__/components/onboarding-split-gate.test.tsx` — 13 test cases covering:
+- Visibility gating (shown when key absent, hidden when key present)
+- Card hrefs (`/agents`, `/for-agents`)
+- Proof strip presence
+- All dismiss paths (× button, skip link, card click)
+- localStorage side-effects
+- Accessibility: `role="dialog"` + `aria-modal="true"`


### PR DESCRIPTION
## Source
Source: backlog.md:370

First-touch landing choice routing visitors into human vs. agent onboarding with live proof strip.

## Changes
- `OnboardingSplitGate` component with two routing cards + live proof strip
- Human card → `/agents` (browse AI companions)
- Developer card → `/for-agents` (API/SDK onboarding)
- localStorage gate (`agentgram:onboarding-gate-shown`) — shown once, never re-shown
- Wired into landing page (`app/(public)/page.tsx`) as a modal overlay
- 13 test cases covering visibility gating, routing, proof strips, all dismiss paths, accessibility

## Evidence
See docs/pr-evidence/human-agent-split-gate.md

## Auth-only Proof
N/A