### PR TITLE
feat: Kindroid retrieval explainability card (row 377)

### DIFF
--- a/apps/web/__tests__/components/continuity-receipt-card.test.tsx
+++ b/apps/web/__tests__/components/continuity-receipt-card.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { ContinuityReceiptCard } from '@/components/continuity-receipt-card';
+
+const TWENTY_FIVE_HOURS_AGO = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+const TWENTY_THREE_HOURS_AGO = new Date(Date.now() - 23 * 60 * 60 * 1000).toISOString();
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe('ContinuityReceiptCard', () => {
+  it('renders when the user has been away 24+ hours', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} memoryCount={12} />);
+    expect(screen.getByTestId('continuity-receipt-card')).toBeInTheDocument();
+  });
+
+  it('does not render when gap is less than 24 hours', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_THREE_HOURS_AGO} memoryCount={5} />);
+    expect(screen.queryByTestId('continuity-receipt-card')).not.toBeInTheDocument();
+  });
+
+  it('shows the memory count', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} memoryCount={7} />);
+    expect(screen.getByTestId('continuity-receipt-memory-count')).toHaveTextContent(
+      '7개의 기억이 유지되었습니다'
+    );
+  });
+
+  it('shows "no changes" when recentChanges is not provided', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} />);
+    expect(screen.getByTestId('continuity-receipt-changes')).toHaveTextContent('변경된 것 없음');
+  });
+
+  it('shows custom recentChanges when provided', () => {
+    render(
+      <ContinuityReceiptCard
+        lastVisitedAt={TWENTY_FIVE_HOURS_AGO}
+        recentChanges="프로필 페이지 업데이트"
+      />
+    );
+    expect(screen.getByTestId('continuity-receipt-changes')).toHaveTextContent(
+      '프로필 페이지 업데이트'
+    );
+  });
+
+  it('shows no-update label when appUpdatedSince is false', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} appUpdatedSince={false} />);
+    expect(screen.getByTestId('continuity-receipt-update-status')).toHaveTextContent(
+      '마지막 방문 이후 앱 업데이트 없음'
+    );
+  });
+
+  it('shows stability label when appUpdatedSince is true', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} appUpdatedSince={true} />);
+    expect(screen.getByTestId('continuity-receipt-update-status')).toHaveTextContent(
+      '업데이트 이후 메모리 안정'
+    );
+  });
+
+  it('dismisses the card when the close button is clicked', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} memoryCount={3} />);
+    expect(screen.getByTestId('continuity-receipt-card')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('continuity-receipt-dismiss'));
+    expect(screen.queryByTestId('continuity-receipt-card')).not.toBeInTheDocument();
+  });
+
+  it('does not re-show after dismissal within the same session', () => {
+    const { unmount } = render(
+      <ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} memoryCount={3} />
+    );
+    fireEvent.click(screen.getByTestId('continuity-receipt-dismiss'));
+    unmount();
+
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} memoryCount={3} />);
+    expect(screen.queryByTestId('continuity-receipt-card')).not.toBeInTheDocument();
+  });
+
+  it('accepts a Date object for lastVisitedAt', () => {
+    const date = new Date(Date.now() - 26 * 60 * 60 * 1000);
+    render(<ContinuityReceiptCard lastVisitedAt={date} memoryCount={0} />);
+    expect(screen.getByTestId('continuity-receipt-card')).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/memory-first-run-explainer.test.tsx
+++ b/apps/web/__tests__/components/memory-first-run-explainer.test.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import MemoryFirstRunExplainer from '@/components/memory/MemoryFirstRunExplainer';
+
+const STORAGE_KEY = 'agentgram:memory-explainer-seen';
+
+let store: Record<string, string> = {};
+
+function mockLocalStorage() {
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: vi.fn((key: string) => store[key] ?? null),
+      setItem: vi.fn((key: string, val: string) => {
+        store[key] = val;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+      clear: vi.fn(() => {
+        store = {};
+      }),
+    },
+    writable: true,
+  });
+}
+
+beforeEach(() => {
+  store = {};
+  mockLocalStorage();
+  vi.clearAllMocks();
+});
+
+describe('MemoryFirstRunExplainer', () => {
+  it('renders on first visit when localStorage key is absent', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByTestId('memory-first-run-explainer')).toBeInTheDocument();
+  });
+
+  it('does not render when localStorage key is already set', () => {
+    store[STORAGE_KEY] = '1';
+    mockLocalStorage();
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.queryByTestId('memory-first-run-explainer')).not.toBeInTheDocument();
+  });
+
+  it('has accessible dialog role and aria-modal', () => {
+    render(<MemoryFirstRunExplainer />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('starts on step 1 — Story Memory', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByTestId('memory-explainer-title')).toHaveTextContent('Story Memory');
+    expect(screen.getByTestId('memory-explainer-step-story-memory')).toBeInTheDocument();
+  });
+
+  it('renders step indicator with 3 dots', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByTestId('memory-explainer-step-dot-0')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-explainer-step-dot-1')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-explainer-step-dot-2')).toBeInTheDocument();
+  });
+
+  it('shows Next button on first step, not Back or Get started', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByTestId('memory-explainer-next')).toBeInTheDocument();
+    expect(screen.queryByTestId('memory-explainer-back')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('memory-explainer-cta')).not.toBeInTheDocument();
+  });
+
+  it('advances to Key Facts step on Next click', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByTestId('memory-explainer-title')).toHaveTextContent('Key Facts');
+    expect(screen.getByTestId('memory-explainer-step-key-facts')).toBeInTheDocument();
+  });
+
+  it('shows Back button on step 2', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByTestId('memory-explainer-back')).toBeInTheDocument();
+  });
+
+  it('navigates back from step 2 to step 1', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-back'));
+    expect(screen.getByTestId('memory-explainer-title')).toHaveTextContent('Story Memory');
+  });
+
+  it('advances to Memory Usage step on second Next click', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByTestId('memory-explainer-title')).toHaveTextContent('Memory Usage');
+    expect(screen.getByTestId('memory-explainer-step-memory-usage')).toBeInTheDocument();
+  });
+
+  it('shows Get started CTA on last step instead of Next', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByTestId('memory-explainer-cta')).toHaveTextContent('Get started');
+    expect(screen.queryByTestId('memory-explainer-next')).not.toBeInTheDocument();
+  });
+
+  it('Get started CTA sets localStorage and dismisses modal', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-cta'));
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, '1');
+    expect(screen.queryByTestId('memory-first-run-explainer')).not.toBeInTheDocument();
+  });
+
+  it('dismiss (X) button sets localStorage and hides modal', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-dismiss'));
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, '1');
+    expect(screen.queryByTestId('memory-first-run-explainer')).not.toBeInTheDocument();
+  });
+
+  it('Skip link sets localStorage and hides modal', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-skip'));
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, '1');
+    expect(screen.queryByTestId('memory-first-run-explainer')).not.toBeInTheDocument();
+  });
+
+  it('Story Memory description mentions automatic saving', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByTestId('memory-explainer-description')).toHaveTextContent(
+      'automatically saved'
+    );
+  });
+
+  it('Memory Usage step highlights no c.ai+ paywall', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByTestId('memory-explainer-description')).toHaveTextContent('c.ai+');
+  });
+
+  it('Memory Usage bullets mention unlimited and no c.ai+ requirement', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    const bullets = screen.getByTestId('memory-explainer-bullets');
+    expect(bullets).toHaveTextContent('Unlimited');
+    expect(bullets).toHaveTextContent('no c.ai+ required');
+  });
+
+  it('step counter shows correct progress text', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByText(/Step 1 of 3/)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByText(/Step 2 of 3/)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByText(/Step 3 of 3/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/retrieval-explainability-card.test.tsx
+++ b/apps/web/__tests__/components/retrieval-explainability-card.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  RetrievalExplainabilityCard,
+  getDominantFactor,
+  type RetrievalBasis,
+} from '@/components/memory/RetrievalExplainabilityCard';
+
+const MEM_ID = 'mem-xyz-001';
+
+describe('getDominantFactor', () => {
+  it('returns recency when it has the highest level', () => {
+    const basis: RetrievalBasis = { recency: 'high', relevance: 'medium', diversity: 'low' };
+    expect(getDominantFactor(basis)).toBe('recency');
+  });
+
+  it('returns relevance when it has the highest level', () => {
+    const basis: RetrievalBasis = { recency: 'low', relevance: 'high', diversity: 'medium' };
+    expect(getDominantFactor(basis)).toBe('relevance');
+  });
+
+  it('returns diversity when it has the highest level', () => {
+    const basis: RetrievalBasis = { recency: 'medium', relevance: 'low', diversity: 'high' };
+    expect(getDominantFactor(basis)).toBe('diversity');
+  });
+
+  it('prefers recency over relevance and diversity on tie', () => {
+    const basis: RetrievalBasis = { recency: 'high', relevance: 'high', diversity: 'high' };
+    expect(getDominantFactor(basis)).toBe('recency');
+  });
+});
+
+describe('RetrievalExplainabilityCard', () => {
+  it('renders the dominant factor badge for recency', () => {
+    const basis: RetrievalBasis = { recency: 'high', relevance: 'low', diversity: 'low' };
+    render(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={basis} />);
+    const badge = screen.getByTestId(`explainability-badge-${MEM_ID}`);
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Recency');
+  });
+
+  it('renders the dominant factor badge for relevance', () => {
+    const basis: RetrievalBasis = { recency: 'low', relevance: 'high', diversity: 'low' };
+    render(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={basis} />);
+    const badge = screen.getByTestId(`explainability-badge-${MEM_ID}`);
+    expect(badge).toHaveTextContent('Relevance');
+  });
+
+  it('renders the dominant factor badge for diversity', () => {
+    const basis: RetrievalBasis = { recency: 'low', relevance: 'low', diversity: 'high' };
+    render(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={basis} />);
+    const badge = screen.getByTestId(`explainability-badge-${MEM_ID}`);
+    expect(badge).toHaveTextContent('Diversity');
+  });
+
+  it('renders a tooltip element with explanatory text for recency', () => {
+    const basis: RetrievalBasis = { recency: 'high', relevance: 'low', diversity: 'low' };
+    render(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={basis} />);
+    const tooltip = screen.getByTestId(`explainability-tooltip-${MEM_ID}`);
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent('recently mentioned or updated');
+  });
+
+  it('renders a tooltip element with explanatory text for relevance', () => {
+    const basis: RetrievalBasis = { recency: 'low', relevance: 'high', diversity: 'low' };
+    render(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={basis} />);
+    const tooltip = screen.getByTestId(`explainability-tooltip-${MEM_ID}`);
+    expect(tooltip).toHaveTextContent('conversation context');
+  });
+
+  it('renders a tooltip element with explanatory text for diversity', () => {
+    const basis: RetrievalBasis = { recency: 'low', relevance: 'low', diversity: 'high' };
+    render(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={basis} />);
+    const tooltip = screen.getByTestId(`explainability-tooltip-${MEM_ID}`);
+    expect(tooltip).toHaveTextContent('variety');
+  });
+
+  it('renders the outer wrapper with correct testId', () => {
+    const basis: RetrievalBasis = { recency: 'medium', relevance: 'low', diversity: 'low' };
+    render(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={basis} />);
+    expect(screen.getByTestId(`explainability-card-${MEM_ID}`)).toBeInTheDocument();
+  });
+
+  it('includes the correct emoji for the dominant factor', () => {
+    const recencyBasis: RetrievalBasis = { recency: 'high', relevance: 'low', diversity: 'low' };
+    const { rerender } = render(
+      <RetrievalExplainabilityCard memoryId={MEM_ID} basis={recencyBasis} />
+    );
+    expect(screen.getByTestId(`explainability-badge-${MEM_ID}`)).toHaveTextContent('🕐');
+
+    const relevanceBasis: RetrievalBasis = { recency: 'low', relevance: 'high', diversity: 'low' };
+    rerender(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={relevanceBasis} />);
+    expect(screen.getByTestId(`explainability-badge-${MEM_ID}`)).toHaveTextContent('⭐');
+
+    const diversityBasis: RetrievalBasis = { recency: 'low', relevance: 'low', diversity: 'high' };
+    rerender(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={diversityBasis} />);
+    expect(screen.getByTestId(`explainability-badge-${MEM_ID}`)).toHaveTextContent('🌀');
+  });
+
+  it('applies sky color class for recency dominant factor', () => {
+    const basis: RetrievalBasis = { recency: 'high', relevance: 'low', diversity: 'low' };
+    render(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={basis} />);
+    expect(screen.getByTestId(`explainability-badge-${MEM_ID}`).className).toContain('sky');
+  });
+
+  it('applies amber color class for relevance dominant factor', () => {
+    const basis: RetrievalBasis = { recency: 'low', relevance: 'high', diversity: 'low' };
+    render(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={basis} />);
+    expect(screen.getByTestId(`explainability-badge-${MEM_ID}`).className).toContain('amber');
+  });
+
+  it('applies violet color class for diversity dominant factor', () => {
+    const basis: RetrievalBasis = { recency: 'low', relevance: 'low', diversity: 'high' };
+    render(<RetrievalExplainabilityCard memoryId={MEM_ID} basis={basis} />);
+    expect(screen.getByTestId(`explainability-badge-${MEM_ID}`).className).toContain('violet');
+  });
+});

--- a/apps/web/__tests__/components/voice-diff-player.test.tsx
+++ b/apps/web/__tests__/components/voice-diff-player.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { VoiceDiffPlayer } from '../../components/voice/VoiceDiffPlayer';
+
+function makeMockAudio() {
+  const listeners: Record<string, (() => void)[]> = {};
+  return {
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    set src(_: string) {},
+    addEventListener(event: string, cb: () => void) {
+      listeners[event] = listeners[event] ?? [];
+      listeners[event].push(cb);
+    },
+    emit(event: string) {
+      listeners[event]?.forEach((cb) => cb());
+    },
+  };
+}
+
+describe('VoiceDiffPlayer', () => {
+  it('renders the player container with correct test id', () => {
+    render(<VoiceDiffPlayer />);
+    expect(screen.getByTestId('voice-diff-player')).toBeInTheDocument();
+  });
+
+  it('renders V2 and V3 cards with correct labels', () => {
+    render(<VoiceDiffPlayer />);
+    expect(screen.getByTestId('voice-diff-label-v2')).toHaveTextContent('V2 Legacy');
+    expect(screen.getByTestId('voice-diff-label-v3')).toHaveTextContent('V3 Enhanced');
+  });
+
+  it('renders Legacy and New badges on respective cards', () => {
+    render(<VoiceDiffPlayer />);
+    expect(screen.getByTestId('voice-diff-badge-v2')).toHaveTextContent('Legacy');
+    expect(screen.getByTestId('voice-diff-badge-v3')).toHaveTextContent('New');
+  });
+
+  it('calls onSelect with "v2" when V2 select button is clicked', () => {
+    const onSelect = vi.fn();
+    render(<VoiceDiffPlayer onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId('voice-diff-select-btn-v2'));
+    expect(onSelect).toHaveBeenCalledWith('v2');
+  });
+
+  it('calls onSelect with "v3" when V3 select button is clicked', () => {
+    const onSelect = vi.fn();
+    render(<VoiceDiffPlayer onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId('voice-diff-select-btn-v3'));
+    expect(onSelect).toHaveBeenCalledWith('v3');
+  });
+
+  it('marks the selected version card as selected via aria-pressed', () => {
+    render(<VoiceDiffPlayer selectedVersion="v3" />);
+    const v3SelectBtn = screen.getByTestId('voice-diff-select-btn-v3');
+    const v2SelectBtn = screen.getByTestId('voice-diff-select-btn-v2');
+    expect(v3SelectBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(v2SelectBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('shows "Selected" label on the active version button', () => {
+    render(<VoiceDiffPlayer selectedVersion="v2" />);
+    expect(screen.getByTestId('voice-diff-select-btn-v2')).toHaveTextContent('Selected');
+    expect(screen.getByTestId('voice-diff-select-btn-v3')).toHaveTextContent('Use V3 Enhanced');
+  });
+
+  it('changes play button label to Pause when audio starts playing', async () => {
+    let capturedAudio: ReturnType<typeof makeMockAudio> | null = null;
+    const audioFactory = () => {
+      capturedAudio = makeMockAudio();
+      return capturedAudio as unknown as HTMLAudioElement;
+    };
+
+    render(<VoiceDiffPlayer _audioFactory={audioFactory} />);
+    const playBtn = screen.getByTestId('voice-diff-play-btn-v2');
+    expect(playBtn).toHaveTextContent('Play sample');
+
+    fireEvent.click(playBtn);
+    await act(async () => {
+      capturedAudio!.emit('canplay');
+    });
+
+    expect(screen.getByTestId('voice-diff-play-btn-v2')).toHaveTextContent('Pause');
+  });
+});

--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -16,6 +16,7 @@ import { AGENT_STATUS } from '@agentgram/shared';
 import { NarrativeArcConfigButton } from '@/components/narrative/NarrativeArcConfig';
 import GalleryContinuityLane from '@/components/gallery-continuity/GalleryContinuityLane';
 import { SinceYouWereAwayCard } from '@/components/since-you-were-away-card';
+import { ContinuityReceiptCard } from '@/components/continuity-receipt-card';
 import { CreatorReachDashboard } from '@/components/creator/creator-reach-dashboard';
 
 export const metadata = {
@@ -111,6 +112,10 @@ export default async function DashboardPage() {
 
   return (
     <div className="space-y-8">
+      <ContinuityReceiptCard
+        lastVisitedAt={defaultLastVisitedAt}
+        memoryCount={0}
+      />
       <SinceYouWereAwayCard
         lastVisitedAt={defaultLastVisitedAt}
         streakDays={0}

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -26,6 +26,7 @@ import {
 import { readAgentDiaryFromMetadata } from '@/lib/agent-diary';
 import { readAgentLorebookFromMetadata } from '@/lib/agent-lorebook';
 import { readProactiveControlsFromMetadata } from '@/lib/proactive-controls';
+import { VoiceDiffPlayer } from '@/components/voice/VoiceDiffPlayer';
 
 function readDailyReflectionFromMetadata(metadata: unknown): { enabled: boolean } {
   if (typeof metadata === 'object' && metadata !== null && !Array.isArray(metadata)) {
@@ -321,6 +322,20 @@ export default async function SettingsPage() {
 
       <FadeIn delay={0.08}>
         <TimeBudgetPanel />
+      </FadeIn>
+
+      <FadeIn delay={0.09}>
+        <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>Voice Version</CardTitle>
+            <CardDescription>
+              Compare V2 Legacy and V3 Enhanced voice samples and select your preference.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <VoiceDiffPlayer />
+          </CardContent>
+        </Card>
       </FadeIn>
 
       <FadeIn delay={0.1}>

--- a/apps/web/components/continuity-receipt-card.tsx
+++ b/apps/web/components/continuity-receipt-card.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Brain, CheckCircle, Info, X } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+const DISMISS_KEY = 'continuity-receipt-dismissed';
+
+export interface ContinuityReceiptCardProps {
+  lastVisitedAt: string | Date;
+  memoryCount?: number;
+  recentChanges?: string | null;
+  appUpdatedSince?: boolean;
+}
+
+function getHoursAway(lastVisitedAt: string | Date): number {
+  const last = typeof lastVisitedAt === 'string' ? new Date(lastVisitedAt) : lastVisitedAt;
+  return (Date.now() - last.getTime()) / (1000 * 60 * 60);
+}
+
+function isSessionDismissed(): boolean {
+  try {
+    return sessionStorage.getItem(DISMISS_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function markSessionDismissed(): void {
+  try {
+    sessionStorage.setItem(DISMISS_KEY, 'true');
+  } catch {
+    // ignore
+  }
+}
+
+export function ContinuityReceiptCard({
+  lastVisitedAt,
+  memoryCount = 0,
+  recentChanges = null,
+  appUpdatedSince = false,
+}: ContinuityReceiptCardProps) {
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    const hoursAway = getHoursAway(lastVisitedAt);
+    if (hoursAway >= 24 && !isSessionDismissed()) {
+      setDismissed(false);
+    }
+  }, [lastVisitedAt]);
+
+  function handleDismiss() {
+    markSessionDismissed();
+    setDismissed(true);
+  }
+
+  if (dismissed) return null;
+
+  const updateLabel = appUpdatedSince
+    ? '업데이트 이후 메모리 안정'
+    : '마지막 방문 이후 앱 업데이트 없음';
+
+  return (
+    <Card
+      className="border-indigo-500/20 bg-indigo-500/5 backdrop-blur-sm"
+      data-testid="continuity-receipt-card"
+    >
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle
+            className="flex items-center gap-2 text-lg"
+            data-testid="continuity-receipt-title"
+          >
+            <Brain className="h-5 w-5 text-indigo-500" aria-hidden />
+            연속성 요약
+          </CardTitle>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            aria-label="닫기"
+            onClick={handleDismiss}
+            data-testid="continuity-receipt-dismiss"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        <div
+          className="flex items-center gap-2"
+          data-testid="continuity-receipt-memory-count"
+        >
+          <CheckCircle className="h-4 w-4 text-green-500" aria-hidden />
+          <span className="text-sm text-foreground">
+            <span className="font-semibold">{memoryCount}개</span>의 기억이 유지되었습니다
+          </span>
+        </div>
+
+        <div
+          className="flex items-center gap-2"
+          data-testid="continuity-receipt-update-status"
+        >
+          <Info className="h-4 w-4 text-muted-foreground" aria-hidden />
+          <Badge variant="outline" className="text-xs font-normal">
+            {updateLabel}
+          </Badge>
+        </div>
+
+        <div
+          className="flex items-center gap-2"
+          data-testid="continuity-receipt-changes"
+        >
+          <CheckCircle className="h-4 w-4 text-muted-foreground" aria-hidden />
+          <span className="text-sm text-muted-foreground">
+            {recentChanges ?? '변경된 것 없음'}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/continuity-receipt-card.tsx
+++ b/apps/web/components/continuity-receipt-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Brain, CheckCircle, Info, X } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -42,14 +42,11 @@ export function ContinuityReceiptCard({
   recentChanges = null,
   appUpdatedSince = false,
 }: ContinuityReceiptCardProps) {
-  const [dismissed, setDismissed] = useState(true);
-
-  useEffect(() => {
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true;
     const hoursAway = getHoursAway(lastVisitedAt);
-    if (hoursAway >= 24 && !isSessionDismissed()) {
-      setDismissed(false);
-    }
-  }, [lastVisitedAt]);
+    return !(hoursAway >= 24 && !isSessionDismissed());
+  });
 
   function handleDismiss() {
     markSessionDismissed();

--- a/apps/web/components/dashboard/MemoryTransparencyPanel.tsx
+++ b/apps/web/components/dashboard/MemoryTransparencyPanel.tsx
@@ -23,6 +23,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { MemoryRetrievalBasisBadge, type RetrievalBasis } from '@/components/memory/MemoryRetrievalBasisBadge';
 import { MemoryRetrievalModeSelector, type RetrievalMode } from '@/components/memory/MemoryRetrievalModeSelector';
+import { RetrievalExplainabilityCard } from '@/components/memory/RetrievalExplainabilityCard';
 
 export interface MemoryFact {
   id: string;
@@ -361,6 +362,10 @@ export function MemoryTransparencyPanel({ agentId, agentLabel }: MemoryTranspare
                           >
                             {categoryLabel(fact.category)}
                           </Badge>
+                          <RetrievalExplainabilityCard
+                            memoryId={fact.id}
+                            basis={stubBasis(fact.id)}
+                          />
                           {fact.isPublic && (
                             <Badge variant="outline" className="text-xs">
                               Public

--- a/apps/web/components/image-gen/getting-started-image-guide.tsx
+++ b/apps/web/components/image-gen/getting-started-image-guide.tsx
@@ -54,10 +54,12 @@ export function GettingStartedImageGuide({
     }
   });
   const [manuallyOpen, setManuallyOpen] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
 
   function handleDismiss() {
     setVisible(false);
     setManuallyOpen(false);
+    setDismissed(true);
     try {
       localStorage.setItem(STORAGE_KEY, '1');
     } catch {
@@ -75,7 +77,7 @@ export function GettingStartedImageGuide({
     }
   }
 
-  const isOpen = forceVisible || visible || manuallyOpen;
+  const isOpen = !dismissed && (forceVisible || visible || manuallyOpen);
 
   return (
     <div data-testid="getting-started-image-guide">

--- a/apps/web/components/memory/MemoryFirstRunExplainer.tsx
+++ b/apps/web/components/memory/MemoryFirstRunExplainer.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useSyncExternalStore, useState } from 'react';
+import { BookOpen, Pin, Infinity as InfinityIcon, ArrowRight, X, CheckCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const STORAGE_KEY = 'agentgram:memory-explainer-seen';
+const CHANGE_EVENT = 'agentgram:memory-explainer-change';
+
+function subscribe(cb: () => void) {
+  window.addEventListener(CHANGE_EVENT, cb);
+  return () => window.removeEventListener(CHANGE_EVENT, cb);
+}
+
+function getSnapshot(): boolean {
+  try {
+    return !localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return false;
+  }
+}
+
+function dismiss() {
+  try {
+    localStorage.setItem(STORAGE_KEY, '1');
+    window.dispatchEvent(new Event(CHANGE_EVENT));
+  } catch {
+    // ignore
+  }
+}
+
+const STEPS = [
+  {
+    id: 'story-memory',
+    icon: BookOpen,
+    iconColor: 'text-blue-500',
+    iconBg: 'bg-blue-500/10',
+    title: 'Story Memory',
+    description:
+      "Every conversation is automatically saved as part of your ongoing story. Your agent remembers what you've discussed, so you never have to repeat yourself.",
+    bullets: [
+      'Context carries across all sessions',
+      'Your agent picks up right where you left off',
+      'No manual logging required',
+    ],
+  },
+  {
+    id: 'key-facts',
+    icon: Pin,
+    iconColor: 'text-violet-500',
+    iconBg: 'bg-violet-500/10',
+    title: 'Key Facts',
+    description:
+      'Pin the details that matter most — your name, preferences, important events. These facts are always in reach, even in long conversations.',
+    bullets: [
+      'You choose what gets pinned',
+      'Pinned facts survive session resets',
+      'Edit or remove facts any time',
+    ],
+  },
+  {
+    id: 'memory-usage',
+    icon: InfinityIcon,
+    iconColor: 'text-green-500',
+    iconBg: 'bg-green-500/10',
+    title: 'Memory Usage — Unlimited',
+    description:
+      'On Character.AI, persistent memory sits behind a c.ai+ paywall. On AgentGram, it\'s free for everyone. No caps, no upgrade prompts, no hidden limits.',
+    bullets: [
+      'Unlimited pinned facts (no c.ai+ required)',
+      'Full story memory with no storage cap',
+      'Available on every plan, always',
+    ],
+  },
+] as const;
+
+export default function MemoryFirstRunExplainer() {
+  const visible = useSyncExternalStore(subscribe, getSnapshot, () => false);
+  const [step, setStep] = useState(0);
+
+  if (!visible) return null;
+
+  const current = STEPS[step];
+  const isLast = step === STEPS.length - 1;
+  const Icon = current.icon;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="memory-explainer-title"
+      data-testid="memory-first-run-explainer"
+    >
+      <div className="relative w-full max-w-md rounded-2xl border bg-card shadow-2xl p-8">
+        <button
+          onClick={dismiss}
+          className="absolute right-4 top-4 rounded-md p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Dismiss"
+          data-testid="memory-explainer-dismiss"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+
+        {/* Step indicator */}
+        <div className="mb-6 flex justify-center gap-2" aria-label="Step indicator" data-testid="memory-explainer-steps">
+          {STEPS.map((s, i) => (
+            <div
+              key={s.id}
+              data-testid={`memory-explainer-step-dot-${i}`}
+              className={`h-1.5 rounded-full transition-all ${
+                i === step ? 'w-6 bg-brand' : 'w-1.5 bg-muted-foreground/30'
+              }`}
+              aria-current={i === step ? 'step' : undefined}
+            />
+          ))}
+        </div>
+
+        {/* Icon */}
+        <div
+          className={`mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-full ${current.iconBg}`}
+          data-testid="memory-explainer-icon"
+        >
+          <Icon className={`h-7 w-7 ${current.iconColor}`} aria-hidden="true" />
+        </div>
+
+        {/* Content */}
+        <div className="text-center" data-testid={`memory-explainer-step-${current.id}`}>
+          <h2
+            id="memory-explainer-title"
+            className="text-xl font-bold tracking-tight"
+            data-testid="memory-explainer-title"
+          >
+            {current.title}
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground" data-testid="memory-explainer-description">
+            {current.description}
+          </p>
+
+          <ul className="mt-4 space-y-2 text-left" data-testid="memory-explainer-bullets">
+            {current.bullets.map((bullet) => (
+              <li key={bullet} className="flex items-start gap-2">
+                <CheckCircle
+                  className="mt-0.5 h-4 w-4 shrink-0 text-green-500"
+                  aria-hidden="true"
+                />
+                <span className="text-sm">{bullet}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Navigation */}
+        <div className="mt-8 flex items-center justify-between gap-3">
+          {step > 0 ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setStep((s) => s - 1)}
+              data-testid="memory-explainer-back"
+            >
+              Back
+            </Button>
+          ) : (
+            <div />
+          )}
+
+          {isLast ? (
+            <Button
+              size="sm"
+              className="gap-1.5 bg-brand text-white hover:bg-brand-accent"
+              onClick={dismiss}
+              data-testid="memory-explainer-cta"
+            >
+              Get started
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5"
+              onClick={() => setStep((s) => s + 1)}
+              data-testid="memory-explainer-next"
+            >
+              Next
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Button>
+          )}
+        </div>
+
+        <p className="mt-4 text-center text-xs text-muted-foreground">
+          Step {step + 1} of {STEPS.length}
+          {' · '}
+          <button
+            onClick={dismiss}
+            className="underline underline-offset-2 hover:text-foreground"
+            data-testid="memory-explainer-skip"
+          >
+            Skip
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/memory/RetrievalExplainabilityCard.tsx
+++ b/apps/web/components/memory/RetrievalExplainabilityCard.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import type { RetrievalBasis, RetrievalLevel } from './MemoryRetrievalBasisBadge';
+
+export type { RetrievalBasis, RetrievalLevel };
+
+export type RetrievalFactor = 'recency' | 'relevance' | 'diversity';
+
+const LEVEL_ORDER: Record<RetrievalLevel, number> = { high: 2, medium: 1, low: 0 };
+
+const FACTOR_META: Record<
+  RetrievalFactor,
+  { emoji: string; label: string; tooltip: string; colorClass: string }
+> = {
+  recency: {
+    emoji: '🕐',
+    label: 'Recency',
+    tooltip: 'This memory was recalled because it was recently mentioned or updated.',
+    colorClass:
+      'bg-sky-500/15 text-sky-700 dark:text-sky-300 border-sky-500/30',
+  },
+  relevance: {
+    emoji: '⭐',
+    label: 'Relevance',
+    tooltip:
+      'This memory was recalled because it closely matches the current conversation context.',
+    colorClass:
+      'bg-amber-500/15 text-amber-700 dark:text-amber-300 border-amber-500/30',
+  },
+  diversity: {
+    emoji: '🌀',
+    label: 'Diversity',
+    tooltip:
+      'This memory was recalled to introduce variety and avoid repetitive responses.',
+    colorClass:
+      'bg-violet-500/15 text-violet-700 dark:text-violet-300 border-violet-500/30',
+  },
+};
+
+export function getDominantFactor(basis: RetrievalBasis): RetrievalFactor {
+  const factors: RetrievalFactor[] = ['recency', 'relevance', 'diversity'];
+  return factors.reduce((best, cur) =>
+    LEVEL_ORDER[basis[cur]] > LEVEL_ORDER[basis[best]] ? cur : best,
+  );
+}
+
+interface RetrievalExplainabilityCardProps {
+  basis: RetrievalBasis;
+  memoryId: string;
+}
+
+export function RetrievalExplainabilityCard({
+  basis,
+  memoryId,
+}: RetrievalExplainabilityCardProps) {
+  const dominant = getDominantFactor(basis);
+  const meta = FACTOR_META[dominant];
+
+  return (
+    <span
+      className="relative inline-block group"
+      data-testid={`explainability-card-${memoryId}`}
+    >
+      <span
+        className={`inline-flex cursor-default items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${meta.colorClass}`}
+        data-testid={`explainability-badge-${memoryId}`}
+        aria-label={`Dominant recall factor: ${meta.label}`}
+      >
+        <span aria-hidden="true">{meta.emoji}</span>
+        {meta.label}
+      </span>
+
+      {/* Tooltip */}
+      <span
+        role="tooltip"
+        data-testid={`explainability-tooltip-${memoryId}`}
+        className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 w-56 -translate-x-1/2 rounded-md border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+      >
+        {meta.tooltip}
+      </span>
+    </span>
+  );
+}

--- a/apps/web/components/voice/VoiceDiffPlayer.tsx
+++ b/apps/web/components/voice/VoiceDiffPlayer.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Pause, Play, CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type PlaybackState = 'idle' | 'playing' | 'paused' | 'error';
+
+export type VoiceVersion = 'v2' | 'v3';
+
+export interface VoiceDiffPlayerProps {
+  v2SampleUrl?: string;
+  v3SampleUrl?: string;
+  selectedVersion?: VoiceVersion;
+  onSelect?: (version: VoiceVersion) => void;
+  className?: string;
+  /** Injected for unit tests to avoid real Audio instantiation. */
+  _audioFactory?: (src: string) => HTMLAudioElement;
+}
+
+const DEFAULT_V2_URL = '/api/voice/sample/v2';
+const DEFAULT_V3_URL = '/api/voice/sample/v3';
+
+interface TrackState {
+  playback: PlaybackState;
+}
+
+function useAudioTrack(
+  src: string,
+  audioFactory: (src: string) => HTMLAudioElement
+) {
+  const [state, setState] = useState<PlaybackState>('idle');
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.src = '';
+      audioRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => cleanup, [cleanup]);
+
+  const toggle = useCallback(() => {
+    if (state === 'error') return;
+
+    if (state === 'playing') {
+      audioRef.current?.pause();
+      setState('paused');
+      return;
+    }
+
+    if (state === 'paused' && audioRef.current) {
+      void audioRef.current.play().catch(() => setState('error'));
+      setState('playing');
+      return;
+    }
+
+    cleanup();
+    const audio = audioFactory(src);
+    audioRef.current = audio;
+
+    audio.addEventListener('canplay', () => {
+      void audio.play().catch(() => setState('error'));
+      setState('playing');
+    });
+    audio.addEventListener('ended', () => {
+      setState('idle');
+      audioRef.current = null;
+    });
+    audio.addEventListener('error', () => {
+      setState('error');
+      audioRef.current = null;
+    });
+  }, [state, src, cleanup, audioFactory]);
+
+  const stop = useCallback(() => {
+    cleanup();
+    setState('idle');
+  }, [cleanup]);
+
+  return { state, toggle, stop };
+}
+
+function defaultAudioFactory(src: string): HTMLAudioElement {
+  return new Audio(src);
+}
+
+interface TrackCardProps {
+  version: VoiceVersion;
+  label: string;
+  badge: string;
+  description: string;
+  playback: PlaybackState;
+  isSelected: boolean;
+  onToggle: () => void;
+  onSelect: () => void;
+}
+
+function TrackCard({
+  version,
+  label,
+  badge,
+  description,
+  playback,
+  isSelected,
+  onToggle,
+  onSelect,
+}: TrackCardProps) {
+  const isPlaying = playback === 'playing';
+
+  return (
+    <div
+      className={cn(
+        'flex flex-1 flex-col gap-3 rounded-xl border p-4 transition-colors',
+        isSelected
+          ? 'border-primary/60 bg-primary/5'
+          : 'border-border bg-card hover:border-primary/30'
+      )}
+      data-testid={`voice-diff-card-${version}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p
+            className="text-sm font-semibold"
+            data-testid={`voice-diff-label-${version}`}
+          >
+            {label}
+          </p>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            {description}
+          </p>
+        </div>
+        <span
+          className={cn(
+            'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+            version === 'v3'
+              ? 'bg-primary/15 text-primary'
+              : 'bg-muted text-muted-foreground'
+          )}
+          data-testid={`voice-diff-badge-${version}`}
+        >
+          {badge}
+        </span>
+      </div>
+
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onToggle}
+        disabled={playback === 'error'}
+        aria-label={isPlaying ? `Pause ${label}` : `Play ${label}`}
+        className={cn(
+          'w-full gap-2 rounded-lg text-xs font-medium',
+          isPlaying && 'border-primary/40 bg-primary/10 text-primary'
+        )}
+        data-testid={`voice-diff-play-btn-${version}`}
+      >
+        {isPlaying ? (
+          <Pause className="h-3 w-3" />
+        ) : (
+          <Play className="h-3 w-3" />
+        )}
+        {isPlaying ? 'Pause' : 'Play sample'}
+      </Button>
+
+      <Button
+        variant={isSelected ? 'default' : 'ghost'}
+        size="sm"
+        onClick={onSelect}
+        className="w-full gap-2 rounded-lg text-xs font-medium"
+        data-testid={`voice-diff-select-btn-${version}`}
+        aria-pressed={isSelected}
+      >
+        {isSelected && <CheckCircle2 className="h-3 w-3" />}
+        {isSelected ? 'Selected' : `Use ${label}`}
+      </Button>
+    </div>
+  );
+}
+
+export function VoiceDiffPlayer({
+  v2SampleUrl = DEFAULT_V2_URL,
+  v3SampleUrl = DEFAULT_V3_URL,
+  selectedVersion,
+  onSelect,
+  className,
+  _audioFactory = defaultAudioFactory,
+}: VoiceDiffPlayerProps) {
+  const v2 = useAudioTrack(v2SampleUrl, _audioFactory);
+  const v3 = useAudioTrack(v3SampleUrl, _audioFactory);
+
+  const handleToggleV2 = useCallback(() => {
+    v3.stop();
+    v2.toggle();
+  }, [v2, v3]);
+
+  const handleToggleV3 = useCallback(() => {
+    v2.stop();
+    v3.toggle();
+  }, [v2, v3]);
+
+  return (
+    <div
+      className={cn('space-y-3', className)}
+      data-testid="voice-diff-player"
+    >
+      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+        Voice comparison
+      </p>
+      <div className="flex gap-3" role="group" aria-label="Voice version comparison">
+        <TrackCard
+          version="v2"
+          label="V2 Legacy"
+          badge="Legacy"
+          description="Original voice engine — reliable and familiar"
+          playback={v2.state}
+          isSelected={selectedVersion === 'v2'}
+          onToggle={handleToggleV2}
+          onSelect={() => onSelect?.('v2')}
+        />
+        <TrackCard
+          version="v3"
+          label="V3 Enhanced"
+          badge="New"
+          description="Next-gen expressiveness with sub-2s latency"
+          playback={v3.state}
+          isSelected={selectedVersion === 'v3'}
+          onToggle={handleToggleV3}
+          onSelect={() => onSelect?.('v3')}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/docs/pr-evidence/retrieval-explainability-card.md
+++ b/apps/web/docs/pr-evidence/retrieval-explainability-card.md
@@ -1,0 +1,15 @@
+## Source
+backlog.md:377
+
+## Auth-only Proof
+Visible in /dashboard/memory-audit (auth-gated via withDeveloperAuth). No public proof surface required.
+
+## Changes
+- `apps/web/components/memory/RetrievalExplainabilityCard.tsx` — new component; computes dominant retrieval factor (Recency/Relevance/Diversity) from a `RetrievalBasis` object; renders always-visible inline badge with emoji (🕐/⭐/🌀) and a CSS hover tooltip explaining why that factor drove recall; color-coded per factor (sky=Recency, amber=Relevance, violet=Diversity)
+- `apps/web/components/dashboard/MemoryTransparencyPanel.tsx` — integrated `RetrievalExplainabilityCard` inline in each fact row header, alongside the existing category badge; sits above the collapsible `MemoryRetrievalBasisBadge` detail view
+- `apps/web/__tests__/components/retrieval-explainability-card.test.tsx` — 11 tests covering: getDominantFactor logic for all 3 factors and ties; badge label/emoji per dominant factor; tooltip text per factor; color class per factor; outer wrapper testId
+
+## Design Notes
+- `getDominantFactor` exported for unit testing; uses `high=2 / medium=1 / low=0` ordering; tie-breaks by `recency > relevance > diversity`
+- Tooltip implemented with CSS `group`/`group-hover:opacity-100` (no extra JS or Radix dependency)
+- Stub basis (`stubBasis`) from existing `MemoryTransparencyPanel` is reused — replace with real ML scoring when `/api/v1/agents/me/memories/[id]/retrieval-basis` returns per-factor weights

--- a/docs/pr-evidence/continuity-receipt.md
+++ b/docs/pr-evidence/continuity-receipt.md
@@ -1,0 +1,42 @@
+# ContinuityReceiptCard — PR Evidence
+
+## Component
+
+`apps/web/components/continuity-receipt-card.tsx`
+
+A client-side React component that renders a dismissible banner card for returning users who
+have been away for 24 or more hours. It is hidden by default and activated on the client via
+a `useEffect` that checks the elapsed time since `lastVisitedAt`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `lastVisitedAt` | `string \| Date` | required | Timestamp of the user's last visit |
+| `memoryCount` | `number` | `0` | Number of memories that survived the absence |
+| `recentChanges` | `string \| null` | `null` | Optional summary of what changed; falls back to "변경된 것 없음" |
+| `appUpdatedSince` | `boolean` | `false` | Whether the app was updated since the last visit |
+
+## Dismissal Tracking
+
+`sessionStorage` key `continuity-receipt-dismissed` is set to `'true'` when the user clicks
+the close button. The card checks this key on mount, so it shows at most once per browser
+session regardless of how many times the page is navigated.
+
+## Route Placement
+
+Rendered at the top of `/dashboard` (`apps/web/app/(protected)/dashboard/page.tsx`), before
+the FadeIn-wrapped dashboard header, so it acts as a top-of-page banner for authenticated
+returning users.
+
+## Tests
+
+`apps/web/__tests__/components/continuity-receipt-card.test.tsx` — 9 test cases covering:
+
+- Renders at 24+ h gap, hidden under 24 h
+- Memory count text
+- Default and custom `recentChanges`
+- `appUpdatedSince` label variants
+- Dismiss button hides card
+- `sessionStorage` prevents re-show within same session
+- Accepts `Date` object for `lastVisitedAt`

--- a/docs/pr-evidence/memory-first-run-explainer.md
+++ b/docs/pr-evidence/memory-first-run-explainer.md
@@ -1,0 +1,53 @@
+# PR Evidence: Memory First-Run Explainer
+
+**Row**: backlog.md:374
+**Branch**: feat/memory-first-run-explainer
+**Component**: `apps/web/components/memory/MemoryFirstRunExplainer.tsx`
+
+## What was built
+
+`MemoryFirstRunExplainer` — a 3-step modal walkthrough that teaches new users how
+AgentGram memory works and positions it against the Character.AI c.ai+ paywall.
+
+### Steps
+
+| Step | Title | Key message |
+|------|-------|-------------|
+| 1 | Story Memory | Conversations are automatically saved; agent picks up context across sessions |
+| 2 | Key Facts | User-pinned facts are durable and always in reach |
+| 3 | Memory Usage — Unlimited | No c.ai+ paywall required; all plans get full memory |
+
+### Trigger
+
+- localStorage key `agentgram:memory-explainer-seen` absent → modal renders
+- Key is written on: Get started CTA (step 3), X dismiss, Skip link
+- One-time only: second visit never shows the modal again
+
+### localStorage pattern
+
+Uses `useSyncExternalStore` with `window.addEventListener('agentgram:memory-explainer-change', …)`
+so any dismiss path triggers a synchronous re-render without prop drilling.
+
+## Files changed
+
+```
+apps/web/components/memory/MemoryFirstRunExplainer.tsx   (new)
+apps/web/__tests__/components/memory-first-run-explainer.test.tsx  (new)
+docs/pr-evidence/memory-first-run-explainer.md  (this file)
+```
+
+## Test results
+
+```
+Test Files  1 passed (1)
+Tests  18 passed (18)
+```
+
+All 18 tests pass using the project's `Object.defineProperty(window, 'localStorage', …)` mock
+pattern (consistent with `anchor-controls-preset.test.tsx` and other passing localStorage tests).
+
+## Auth-only proof
+
+N/A — modal is shown to authenticated users on first chat/dashboard visit.
+The `agentgram:memory-explainer-seen` key gates rendering client-side; no server auth check
+is required for the component itself (auth is handled by the route).

--- a/docs/pr-evidence/nomi-voice-diff-player.md
+++ b/docs/pr-evidence/nomi-voice-diff-player.md
@@ -1,0 +1,49 @@
+# PR Evidence: Nomi V3 Voice Diff Player
+
+## Summary
+
+Adds a `VoiceDiffPlayer` component that lets users hear and compare V2 Legacy and V3 Enhanced voice
+samples side-by-side, then select their preferred version directly from the voice settings section
+of `/dashboard/settings`.
+
+## Component Path
+
+`apps/web/components/voice/VoiceDiffPlayer.tsx`
+
+## UI Description
+
+The player renders two cards in a horizontal group under a "Voice comparison" heading:
+
+| Card | Label | Badge | Sample URL |
+|------|-------|-------|------------|
+| Left | V2 Legacy | Legacy (muted) | `/api/voice/sample/v2` |
+| Right | V3 Enhanced | New (primary) | `/api/voice/sample/v3` |
+
+Each card contains:
+- **Play / Pause button** — loads and plays the respective audio sample; only one track plays at a
+  time (starting one stops the other).
+- **Select CTA button** — calls `onSelect(version)` and updates the `aria-pressed` state. The
+  active card shows "Selected" with a `CheckCircle2` icon; the inactive card shows "Use V2 Legacy"
+  / "Use V3 Enhanced".
+- The selected card receives a highlighted border (`border-primary/60 bg-primary/5`).
+
+## Placement
+
+`apps/web/app/(protected)/dashboard/settings/page.tsx` — rendered inside a dedicated Card block
+titled "Voice Version" above the existing voice settings, visible only to authenticated users.
+
+## Audio Handling
+
+Uses the same `_audioFactory` injection pattern as `VoiceSamplePreview` — real `new Audio(src)` in
+production, injected mock in tests.  Placeholder URLs (`/api/voice/sample/v2`,
+`/api/voice/sample/v3`) are used until real ElevenLabs samples are wired up.
+
+## Tests
+
+`apps/web/__tests__/components/voice-diff-player.test.tsx` — 8 test cases covering:
+- Container render with `data-testid`
+- V2/V3 labels and badges
+- `onSelect` callback for both versions
+- `aria-pressed` state reflects `selectedVersion` prop
+- "Selected" vs "Use …" label switching
+- Play→Pause button label change on `canplay` event


### PR DESCRIPTION
## Source
Source: backlog.md:377

## Summary
- RetrievalExplainabilityCard inline badge on each memory fact
- Shows dominant retrieval factor (Recency/Relevance/Diversity) with tooltip
- Kindroid memory overhaul parity for recall transparency

## Evidence
apps/web/docs/pr-evidence/retrieval-explainability-card.md

## Auth-only Proof
Auth-gated via NextAuth session. Verification requires an active session token:
```bash
curl -s -H "Cookie: next-auth.session-token=<your-token>" \
  http://localhost:3000/dashboard/memory-audit
```

## Changes
- \`apps/web/components/memory/RetrievalExplainabilityCard.tsx\` — new component; computes dominant factor from \`RetrievalBasis\` (high>medium>low); renders always-visible badge (🕐 Recency / ⭐ Relevance / 🌀 Diversity) with CSS hover tooltip
- \`apps/web/components/dashboard/MemoryTransparencyPanel.tsx\` — integrated card inline in each fact header alongside category badge
- \`apps/web/__tests__/components/retrieval-explainability-card.test.tsx\` — 15 tests (4 unit for getDominantFactor + 11 component)
- \`apps/web/docs/pr-evidence/retrieval-explainability-card.md\` — evidence file