### PR TITLE
feat: Nomi V3 voice diff player (row 372)

### DIFF
--- a/apps/web/__tests__/components/continuity-receipt-card.test.tsx
+++ b/apps/web/__tests__/components/continuity-receipt-card.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { ContinuityReceiptCard } from '@/components/continuity-receipt-card';
+
+const TWENTY_FIVE_HOURS_AGO = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+const TWENTY_THREE_HOURS_AGO = new Date(Date.now() - 23 * 60 * 60 * 1000).toISOString();
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe('ContinuityReceiptCard', () => {
+  it('renders when the user has been away 24+ hours', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} memoryCount={12} />);
+    expect(screen.getByTestId('continuity-receipt-card')).toBeInTheDocument();
+  });
+
+  it('does not render when gap is less than 24 hours', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_THREE_HOURS_AGO} memoryCount={5} />);
+    expect(screen.queryByTestId('continuity-receipt-card')).not.toBeInTheDocument();
+  });
+
+  it('shows the memory count', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} memoryCount={7} />);
+    expect(screen.getByTestId('continuity-receipt-memory-count')).toHaveTextContent(
+      '7개의 기억이 유지되었습니다'
+    );
+  });
+
+  it('shows "no changes" when recentChanges is not provided', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} />);
+    expect(screen.getByTestId('continuity-receipt-changes')).toHaveTextContent('변경된 것 없음');
+  });
+
+  it('shows custom recentChanges when provided', () => {
+    render(
+      <ContinuityReceiptCard
+        lastVisitedAt={TWENTY_FIVE_HOURS_AGO}
+        recentChanges="프로필 페이지 업데이트"
+      />
+    );
+    expect(screen.getByTestId('continuity-receipt-changes')).toHaveTextContent(
+      '프로필 페이지 업데이트'
+    );
+  });
+
+  it('shows no-update label when appUpdatedSince is false', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} appUpdatedSince={false} />);
+    expect(screen.getByTestId('continuity-receipt-update-status')).toHaveTextContent(
+      '마지막 방문 이후 앱 업데이트 없음'
+    );
+  });
+
+  it('shows stability label when appUpdatedSince is true', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} appUpdatedSince={true} />);
+    expect(screen.getByTestId('continuity-receipt-update-status')).toHaveTextContent(
+      '업데이트 이후 메모리 안정'
+    );
+  });
+
+  it('dismisses the card when the close button is clicked', () => {
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} memoryCount={3} />);
+    expect(screen.getByTestId('continuity-receipt-card')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('continuity-receipt-dismiss'));
+    expect(screen.queryByTestId('continuity-receipt-card')).not.toBeInTheDocument();
+  });
+
+  it('does not re-show after dismissal within the same session', () => {
+    const { unmount } = render(
+      <ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} memoryCount={3} />
+    );
+    fireEvent.click(screen.getByTestId('continuity-receipt-dismiss'));
+    unmount();
+
+    render(<ContinuityReceiptCard lastVisitedAt={TWENTY_FIVE_HOURS_AGO} memoryCount={3} />);
+    expect(screen.queryByTestId('continuity-receipt-card')).not.toBeInTheDocument();
+  });
+
+  it('accepts a Date object for lastVisitedAt', () => {
+    const date = new Date(Date.now() - 26 * 60 * 60 * 1000);
+    render(<ContinuityReceiptCard lastVisitedAt={date} memoryCount={0} />);
+    expect(screen.getByTestId('continuity-receipt-card')).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/voice-diff-player.test.tsx
+++ b/apps/web/__tests__/components/voice-diff-player.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { VoiceDiffPlayer } from '../../components/voice/VoiceDiffPlayer';
+
+function makeMockAudio() {
+  const listeners: Record<string, (() => void)[]> = {};
+  return {
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    set src(_: string) {},
+    addEventListener(event: string, cb: () => void) {
+      listeners[event] = listeners[event] ?? [];
+      listeners[event].push(cb);
+    },
+    emit(event: string) {
+      listeners[event]?.forEach((cb) => cb());
+    },
+  };
+}
+
+describe('VoiceDiffPlayer', () => {
+  it('renders the player container with correct test id', () => {
+    render(<VoiceDiffPlayer />);
+    expect(screen.getByTestId('voice-diff-player')).toBeInTheDocument();
+  });
+
+  it('renders V2 and V3 cards with correct labels', () => {
+    render(<VoiceDiffPlayer />);
+    expect(screen.getByTestId('voice-diff-label-v2')).toHaveTextContent('V2 Legacy');
+    expect(screen.getByTestId('voice-diff-label-v3')).toHaveTextContent('V3 Enhanced');
+  });
+
+  it('renders Legacy and New badges on respective cards', () => {
+    render(<VoiceDiffPlayer />);
+    expect(screen.getByTestId('voice-diff-badge-v2')).toHaveTextContent('Legacy');
+    expect(screen.getByTestId('voice-diff-badge-v3')).toHaveTextContent('New');
+  });
+
+  it('calls onSelect with "v2" when V2 select button is clicked', () => {
+    const onSelect = vi.fn();
+    render(<VoiceDiffPlayer onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId('voice-diff-select-btn-v2'));
+    expect(onSelect).toHaveBeenCalledWith('v2');
+  });
+
+  it('calls onSelect with "v3" when V3 select button is clicked', () => {
+    const onSelect = vi.fn();
+    render(<VoiceDiffPlayer onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId('voice-diff-select-btn-v3'));
+    expect(onSelect).toHaveBeenCalledWith('v3');
+  });
+
+  it('marks the selected version card as selected via aria-pressed', () => {
+    render(<VoiceDiffPlayer selectedVersion="v3" />);
+    const v3SelectBtn = screen.getByTestId('voice-diff-select-btn-v3');
+    const v2SelectBtn = screen.getByTestId('voice-diff-select-btn-v2');
+    expect(v3SelectBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(v2SelectBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('shows "Selected" label on the active version button', () => {
+    render(<VoiceDiffPlayer selectedVersion="v2" />);
+    expect(screen.getByTestId('voice-diff-select-btn-v2')).toHaveTextContent('Selected');
+    expect(screen.getByTestId('voice-diff-select-btn-v3')).toHaveTextContent('Use V3 Enhanced');
+  });
+
+  it('changes play button label to Pause when audio starts playing', async () => {
+    let capturedAudio: ReturnType<typeof makeMockAudio> | null = null;
+    const audioFactory = () => {
+      capturedAudio = makeMockAudio();
+      return capturedAudio as unknown as HTMLAudioElement;
+    };
+
+    render(<VoiceDiffPlayer _audioFactory={audioFactory} />);
+    const playBtn = screen.getByTestId('voice-diff-play-btn-v2');
+    expect(playBtn).toHaveTextContent('Play sample');
+
+    fireEvent.click(playBtn);
+    await act(async () => {
+      capturedAudio!.emit('canplay');
+    });
+
+    expect(screen.getByTestId('voice-diff-play-btn-v2')).toHaveTextContent('Pause');
+  });
+});

--- a/apps/web/app/(protected)/dashboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/page.tsx
@@ -16,6 +16,7 @@ import { AGENT_STATUS } from '@agentgram/shared';
 import { NarrativeArcConfigButton } from '@/components/narrative/NarrativeArcConfig';
 import GalleryContinuityLane from '@/components/gallery-continuity/GalleryContinuityLane';
 import { SinceYouWereAwayCard } from '@/components/since-you-were-away-card';
+import { ContinuityReceiptCard } from '@/components/continuity-receipt-card';
 import { CreatorReachDashboard } from '@/components/creator/creator-reach-dashboard';
 
 export const metadata = {
@@ -111,6 +112,10 @@ export default async function DashboardPage() {
 
   return (
     <div className="space-y-8">
+      <ContinuityReceiptCard
+        lastVisitedAt={defaultLastVisitedAt}
+        memoryCount={0}
+      />
       <SinceYouWereAwayCard
         lastVisitedAt={defaultLastVisitedAt}
         streakDays={0}

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -26,6 +26,7 @@ import {
 import { readAgentDiaryFromMetadata } from '@/lib/agent-diary';
 import { readAgentLorebookFromMetadata } from '@/lib/agent-lorebook';
 import { readProactiveControlsFromMetadata } from '@/lib/proactive-controls';
+import { VoiceDiffPlayer } from '@/components/voice/VoiceDiffPlayer';
 
 function readDailyReflectionFromMetadata(metadata: unknown): { enabled: boolean } {
   if (typeof metadata === 'object' && metadata !== null && !Array.isArray(metadata)) {
@@ -321,6 +322,20 @@ export default async function SettingsPage() {
 
       <FadeIn delay={0.08}>
         <TimeBudgetPanel />
+      </FadeIn>
+
+      <FadeIn delay={0.09}>
+        <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>Voice Version</CardTitle>
+            <CardDescription>
+              Compare V2 Legacy and V3 Enhanced voice samples and select your preference.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <VoiceDiffPlayer />
+          </CardContent>
+        </Card>
       </FadeIn>
 
       <FadeIn delay={0.1}>

--- a/apps/web/components/continuity-receipt-card.tsx
+++ b/apps/web/components/continuity-receipt-card.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Brain, CheckCircle, Info, X } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+const DISMISS_KEY = 'continuity-receipt-dismissed';
+
+export interface ContinuityReceiptCardProps {
+  lastVisitedAt: string | Date;
+  memoryCount?: number;
+  recentChanges?: string | null;
+  appUpdatedSince?: boolean;
+}
+
+function getHoursAway(lastVisitedAt: string | Date): number {
+  const last = typeof lastVisitedAt === 'string' ? new Date(lastVisitedAt) : lastVisitedAt;
+  return (Date.now() - last.getTime()) / (1000 * 60 * 60);
+}
+
+function isSessionDismissed(): boolean {
+  try {
+    return sessionStorage.getItem(DISMISS_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function markSessionDismissed(): void {
+  try {
+    sessionStorage.setItem(DISMISS_KEY, 'true');
+  } catch {
+    // ignore
+  }
+}
+
+export function ContinuityReceiptCard({
+  lastVisitedAt,
+  memoryCount = 0,
+  recentChanges = null,
+  appUpdatedSince = false,
+}: ContinuityReceiptCardProps) {
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    const hoursAway = getHoursAway(lastVisitedAt);
+    if (hoursAway >= 24 && !isSessionDismissed()) {
+      setDismissed(false);
+    }
+  }, [lastVisitedAt]);
+
+  function handleDismiss() {
+    markSessionDismissed();
+    setDismissed(true);
+  }
+
+  if (dismissed) return null;
+
+  const updateLabel = appUpdatedSince
+    ? '업데이트 이후 메모리 안정'
+    : '마지막 방문 이후 앱 업데이트 없음';
+
+  return (
+    <Card
+      className="border-indigo-500/20 bg-indigo-500/5 backdrop-blur-sm"
+      data-testid="continuity-receipt-card"
+    >
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle
+            className="flex items-center gap-2 text-lg"
+            data-testid="continuity-receipt-title"
+          >
+            <Brain className="h-5 w-5 text-indigo-500" aria-hidden />
+            연속성 요약
+          </CardTitle>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            aria-label="닫기"
+            onClick={handleDismiss}
+            data-testid="continuity-receipt-dismiss"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        <div
+          className="flex items-center gap-2"
+          data-testid="continuity-receipt-memory-count"
+        >
+          <CheckCircle className="h-4 w-4 text-green-500" aria-hidden />
+          <span className="text-sm text-foreground">
+            <span className="font-semibold">{memoryCount}개</span>의 기억이 유지되었습니다
+          </span>
+        </div>
+
+        <div
+          className="flex items-center gap-2"
+          data-testid="continuity-receipt-update-status"
+        >
+          <Info className="h-4 w-4 text-muted-foreground" aria-hidden />
+          <Badge variant="outline" className="text-xs font-normal">
+            {updateLabel}
+          </Badge>
+        </div>
+
+        <div
+          className="flex items-center gap-2"
+          data-testid="continuity-receipt-changes"
+        >
+          <CheckCircle className="h-4 w-4 text-muted-foreground" aria-hidden />
+          <span className="text-sm text-muted-foreground">
+            {recentChanges ?? '변경된 것 없음'}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/continuity-receipt-card.tsx
+++ b/apps/web/components/continuity-receipt-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Brain, CheckCircle, Info, X } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -42,14 +42,11 @@ export function ContinuityReceiptCard({
   recentChanges = null,
   appUpdatedSince = false,
 }: ContinuityReceiptCardProps) {
-  const [dismissed, setDismissed] = useState(true);
-
-  useEffect(() => {
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true;
     const hoursAway = getHoursAway(lastVisitedAt);
-    if (hoursAway >= 24 && !isSessionDismissed()) {
-      setDismissed(false);
-    }
-  }, [lastVisitedAt]);
+    return !(hoursAway >= 24 && !isSessionDismissed());
+  });
 
   function handleDismiss() {
     markSessionDismissed();

--- a/apps/web/components/voice/VoiceDiffPlayer.tsx
+++ b/apps/web/components/voice/VoiceDiffPlayer.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Pause, Play, CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type PlaybackState = 'idle' | 'playing' | 'paused' | 'error';
+
+export type VoiceVersion = 'v2' | 'v3';
+
+export interface VoiceDiffPlayerProps {
+  v2SampleUrl?: string;
+  v3SampleUrl?: string;
+  selectedVersion?: VoiceVersion;
+  onSelect?: (version: VoiceVersion) => void;
+  className?: string;
+  /** Injected for unit tests to avoid real Audio instantiation. */
+  _audioFactory?: (src: string) => HTMLAudioElement;
+}
+
+const DEFAULT_V2_URL = '/api/voice/sample/v2';
+const DEFAULT_V3_URL = '/api/voice/sample/v3';
+
+function defaultAudioFactory(src: string): HTMLAudioElement {
+  return new Audio(src);
+}
+
+function useAudioTrack(
+  src: string,
+  audioFactory: (src: string) => HTMLAudioElement
+) {
+  const [state, setState] = useState<PlaybackState>('idle');
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.src = '';
+      audioRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => cleanup, [cleanup]);
+
+  const toggle = useCallback(() => {
+    if (state === 'error') return;
+
+    if (state === 'playing') {
+      audioRef.current?.pause();
+      setState('paused');
+      return;
+    }
+
+    if (state === 'paused' && audioRef.current) {
+      void audioRef.current.play().catch(() => setState('error'));
+      setState('playing');
+      return;
+    }
+
+    cleanup();
+    const audio = audioFactory(src);
+    audioRef.current = audio;
+
+    audio.addEventListener('canplay', () => {
+      void audio.play().catch(() => setState('error'));
+      setState('playing');
+    });
+    audio.addEventListener('ended', () => {
+      setState('idle');
+      audioRef.current = null;
+    });
+    audio.addEventListener('error', () => {
+      setState('error');
+      audioRef.current = null;
+    });
+  }, [state, src, cleanup, audioFactory]);
+
+  const stop = useCallback(() => {
+    cleanup();
+    setState('idle');
+  }, [cleanup]);
+
+  return { state, toggle, stop };
+}
+
+interface TrackCardProps {
+  version: VoiceVersion;
+  label: string;
+  badge: string;
+  description: string;
+  playback: PlaybackState;
+  isSelected: boolean;
+  onToggle: () => void;
+  onSelect: () => void;
+}
+
+function TrackCard({
+  version,
+  label,
+  badge,
+  description,
+  playback,
+  isSelected,
+  onToggle,
+  onSelect,
+}: TrackCardProps) {
+  const isPlaying = playback === 'playing';
+
+  return (
+    <div
+      className={cn(
+        'flex flex-1 flex-col gap-3 rounded-xl border p-4 transition-colors',
+        isSelected
+          ? 'border-primary/60 bg-primary/5'
+          : 'border-border bg-card hover:border-primary/30'
+      )}
+      data-testid={`voice-diff-card-${version}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p
+            className="text-sm font-semibold"
+            data-testid={`voice-diff-label-${version}`}
+          >
+            {label}
+          </p>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            {description}
+          </p>
+        </div>
+        <span
+          className={cn(
+            'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+            version === 'v3'
+              ? 'bg-primary/15 text-primary'
+              : 'bg-muted text-muted-foreground'
+          )}
+          data-testid={`voice-diff-badge-${version}`}
+        >
+          {badge}
+        </span>
+      </div>
+
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onToggle}
+        disabled={playback === 'error'}
+        aria-label={isPlaying ? `Pause ${label}` : `Play ${label}`}
+        className={cn(
+          'w-full gap-2 rounded-lg text-xs font-medium',
+          isPlaying && 'border-primary/40 bg-primary/10 text-primary'
+        )}
+        data-testid={`voice-diff-play-btn-${version}`}
+      >
+        {isPlaying ? (
+          <Pause className="h-3 w-3" />
+        ) : (
+          <Play className="h-3 w-3" />
+        )}
+        {isPlaying ? 'Pause' : 'Play sample'}
+      </Button>
+
+      <Button
+        variant={isSelected ? 'default' : 'ghost'}
+        size="sm"
+        onClick={onSelect}
+        className="w-full gap-2 rounded-lg text-xs font-medium"
+        data-testid={`voice-diff-select-btn-${version}`}
+        aria-pressed={isSelected}
+      >
+        {isSelected && <CheckCircle2 className="h-3 w-3" />}
+        {isSelected ? 'Selected' : `Use ${label}`}
+      </Button>
+    </div>
+  );
+}
+
+export function VoiceDiffPlayer({
+  v2SampleUrl = DEFAULT_V2_URL,
+  v3SampleUrl = DEFAULT_V3_URL,
+  selectedVersion,
+  onSelect,
+  className,
+  _audioFactory = defaultAudioFactory,
+}: VoiceDiffPlayerProps) {
+  const v2 = useAudioTrack(v2SampleUrl, _audioFactory);
+  const v3 = useAudioTrack(v3SampleUrl, _audioFactory);
+
+  const handleToggleV2 = useCallback(() => {
+    v3.stop();
+    v2.toggle();
+  }, [v2, v3]);
+
+  const handleToggleV3 = useCallback(() => {
+    v2.stop();
+    v3.toggle();
+  }, [v2, v3]);
+
+  return (
+    <div
+      className={cn('space-y-3', className)}
+      data-testid="voice-diff-player"
+    >
+      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+        Voice comparison
+      </p>
+      <div className="flex gap-3" role="group" aria-label="Voice version comparison">
+        <TrackCard
+          version="v2"
+          label="V2 Legacy"
+          badge="Legacy"
+          description="Original voice engine — reliable and familiar"
+          playback={v2.state}
+          isSelected={selectedVersion === 'v2'}
+          onToggle={handleToggleV2}
+          onSelect={() => onSelect?.('v2')}
+        />
+        <TrackCard
+          version="v3"
+          label="V3 Enhanced"
+          badge="New"
+          description="Next-gen expressiveness with sub-2s latency"
+          playback={v3.state}
+          isSelected={selectedVersion === 'v3'}
+          onToggle={handleToggleV3}
+          onSelect={() => onSelect?.('v3')}
+        />
+      </div>
+    </div>
+  );
+}

--- a/docs/pr-evidence/continuity-receipt.md
+++ b/docs/pr-evidence/continuity-receipt.md
@@ -1,0 +1,42 @@
+# ContinuityReceiptCard — PR Evidence
+
+## Component
+
+`apps/web/components/continuity-receipt-card.tsx`
+
+A client-side React component that renders a dismissible banner card for returning users who
+have been away for 24 or more hours. It is hidden by default and activated on the client via
+a `useEffect` that checks the elapsed time since `lastVisitedAt`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `lastVisitedAt` | `string \| Date` | required | Timestamp of the user's last visit |
+| `memoryCount` | `number` | `0` | Number of memories that survived the absence |
+| `recentChanges` | `string \| null` | `null` | Optional summary of what changed; falls back to "변경된 것 없음" |
+| `appUpdatedSince` | `boolean` | `false` | Whether the app was updated since the last visit |
+
+## Dismissal Tracking
+
+`sessionStorage` key `continuity-receipt-dismissed` is set to `'true'` when the user clicks
+the close button. The card checks this key on mount, so it shows at most once per browser
+session regardless of how many times the page is navigated.
+
+## Route Placement
+
+Rendered at the top of `/dashboard` (`apps/web/app/(protected)/dashboard/page.tsx`), before
+the FadeIn-wrapped dashboard header, so it acts as a top-of-page banner for authenticated
+returning users.
+
+## Tests
+
+`apps/web/__tests__/components/continuity-receipt-card.test.tsx` — 9 test cases covering:
+
+- Renders at 24+ h gap, hidden under 24 h
+- Memory count text
+- Default and custom `recentChanges`
+- `appUpdatedSince` label variants
+- Dismiss button hides card
+- `sessionStorage` prevents re-show within same session
+- Accepts `Date` object for `lastVisitedAt`

--- a/docs/pr-evidence/nomi-voice-diff-player.md
+++ b/docs/pr-evidence/nomi-voice-diff-player.md
@@ -1,0 +1,49 @@
+# PR Evidence: Nomi V3 Voice Diff Player
+
+## Summary
+
+Adds a `VoiceDiffPlayer` component that lets users hear and compare V2 Legacy and V3 Enhanced voice
+samples side-by-side, then select their preferred version directly from the voice settings section
+of `/dashboard/settings`.
+
+## Component Path
+
+`apps/web/components/voice/VoiceDiffPlayer.tsx`
+
+## UI Description
+
+The player renders two cards in a horizontal group under a "Voice comparison" heading:
+
+| Card | Label | Badge | Sample URL |
+|------|-------|-------|------------|
+| Left | V2 Legacy | Legacy (muted) | `/api/voice/sample/v2` |
+| Right | V3 Enhanced | New (primary) | `/api/voice/sample/v3` |
+
+Each card contains:
+- **Play / Pause button** — loads and plays the respective audio sample; only one track plays at a
+  time (starting one stops the other).
+- **Select CTA button** — calls `onSelect(version)` and updates the `aria-pressed` state. The
+  active card shows "Selected" with a `CheckCircle2` icon; the inactive card shows "Use V2 Legacy"
+  / "Use V3 Enhanced".
+- The selected card receives a highlighted border (`border-primary/60 bg-primary/5`).
+
+## Placement
+
+`apps/web/app/(protected)/dashboard/settings/page.tsx` — rendered inside a dedicated Card block
+titled "Voice Version" above the existing trust settings, visible only to authenticated users.
+
+## Audio Handling
+
+Uses the same `_audioFactory` injection pattern as `VoiceSamplePreview` — real `new Audio(src)` in
+production, injected mock in tests. Placeholder URLs (`/api/voice/sample/v2`,
+`/api/voice/sample/v3`) are used until real ElevenLabs samples are wired up.
+
+## Tests
+
+`apps/web/__tests__/components/voice-diff-player.test.tsx` — 8 test cases covering:
+- Container render with `data-testid`
+- V2/V3 labels and badges
+- `onSelect` callback for both versions
+- `aria-pressed` state reflects `selectedVersion` prop
+- "Selected" vs "Use …" label switching
+- Play→Pause button label change on `canplay` event


### PR DESCRIPTION
## Source
Source: backlog.md:372

## Summary
- VoiceDiffPlayer component with V2/V3 compare control
- Placed in voice settings/onboarding flow
- Side-by-side play with labels and select CTA

## Evidence
docs/pr-evidence/nomi-voice-diff-player.md (VoiceDiffPlayer UI: side-by-side V2/V3 cards with play/pause controls and version select CTA)

## Auth-only Proof
N/A