### PR TITLE
feat: Character.AI memory first-run explainer (row 374)

### DIFF
--- a/apps/web/__tests__/components/memory-first-run-explainer.test.tsx
+++ b/apps/web/__tests__/components/memory-first-run-explainer.test.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import MemoryFirstRunExplainer from '@/components/memory/MemoryFirstRunExplainer';
+
+const STORAGE_KEY = 'agentgram:memory-explainer-seen';
+
+let store: Record<string, string> = {};
+
+function mockLocalStorage() {
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: vi.fn((key: string) => store[key] ?? null),
+      setItem: vi.fn((key: string, val: string) => {
+        store[key] = val;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+      clear: vi.fn(() => {
+        store = {};
+      }),
+    },
+    writable: true,
+  });
+}
+
+beforeEach(() => {
+  store = {};
+  mockLocalStorage();
+  vi.clearAllMocks();
+});
+
+describe('MemoryFirstRunExplainer', () => {
+  it('renders on first visit when localStorage key is absent', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByTestId('memory-first-run-explainer')).toBeInTheDocument();
+  });
+
+  it('does not render when localStorage key is already set', () => {
+    store[STORAGE_KEY] = '1';
+    mockLocalStorage();
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.queryByTestId('memory-first-run-explainer')).not.toBeInTheDocument();
+  });
+
+  it('has accessible dialog role and aria-modal', () => {
+    render(<MemoryFirstRunExplainer />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('starts on step 1 — Story Memory', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByTestId('memory-explainer-title')).toHaveTextContent('Story Memory');
+    expect(screen.getByTestId('memory-explainer-step-story-memory')).toBeInTheDocument();
+  });
+
+  it('renders step indicator with 3 dots', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByTestId('memory-explainer-step-dot-0')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-explainer-step-dot-1')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-explainer-step-dot-2')).toBeInTheDocument();
+  });
+
+  it('shows Next button on first step, not Back or Get started', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByTestId('memory-explainer-next')).toBeInTheDocument();
+    expect(screen.queryByTestId('memory-explainer-back')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('memory-explainer-cta')).not.toBeInTheDocument();
+  });
+
+  it('advances to Key Facts step on Next click', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByTestId('memory-explainer-title')).toHaveTextContent('Key Facts');
+    expect(screen.getByTestId('memory-explainer-step-key-facts')).toBeInTheDocument();
+  });
+
+  it('shows Back button on step 2', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByTestId('memory-explainer-back')).toBeInTheDocument();
+  });
+
+  it('navigates back from step 2 to step 1', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-back'));
+    expect(screen.getByTestId('memory-explainer-title')).toHaveTextContent('Story Memory');
+  });
+
+  it('advances to Memory Usage step on second Next click', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByTestId('memory-explainer-title')).toHaveTextContent('Memory Usage');
+    expect(screen.getByTestId('memory-explainer-step-memory-usage')).toBeInTheDocument();
+  });
+
+  it('shows Get started CTA on last step instead of Next', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByTestId('memory-explainer-cta')).toHaveTextContent('Get started');
+    expect(screen.queryByTestId('memory-explainer-next')).not.toBeInTheDocument();
+  });
+
+  it('Get started CTA sets localStorage and dismisses modal', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-cta'));
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, '1');
+    expect(screen.queryByTestId('memory-first-run-explainer')).not.toBeInTheDocument();
+  });
+
+  it('dismiss (X) button sets localStorage and hides modal', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-dismiss'));
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, '1');
+    expect(screen.queryByTestId('memory-first-run-explainer')).not.toBeInTheDocument();
+  });
+
+  it('Skip link sets localStorage and hides modal', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-skip'));
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(STORAGE_KEY, '1');
+    expect(screen.queryByTestId('memory-first-run-explainer')).not.toBeInTheDocument();
+  });
+
+  it('Story Memory description mentions automatic saving', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByTestId('memory-explainer-description')).toHaveTextContent(
+      'automatically saved'
+    );
+  });
+
+  it('Memory Usage step highlights no c.ai+ paywall', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByTestId('memory-explainer-description')).toHaveTextContent('c.ai+');
+  });
+
+  it('Memory Usage bullets mention unlimited and no c.ai+ requirement', () => {
+    render(<MemoryFirstRunExplainer />);
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    const bullets = screen.getByTestId('memory-explainer-bullets');
+    expect(bullets).toHaveTextContent('Unlimited');
+    expect(bullets).toHaveTextContent('no c.ai+ required');
+  });
+
+  it('step counter shows correct progress text', () => {
+    render(<MemoryFirstRunExplainer />);
+    expect(screen.getByText(/Step 1 of 3/)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByText(/Step 2 of 3/)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('memory-explainer-next'));
+    expect(screen.getByText(/Step 3 of 3/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/memory/MemoryFirstRunExplainer.tsx
+++ b/apps/web/components/memory/MemoryFirstRunExplainer.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useSyncExternalStore, useState } from 'react';
+import { BookOpen, Pin, Infinity, ArrowRight, X, CheckCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const STORAGE_KEY = 'agentgram:memory-explainer-seen';
+const CHANGE_EVENT = 'agentgram:memory-explainer-change';
+
+function subscribe(cb: () => void) {
+  window.addEventListener(CHANGE_EVENT, cb);
+  return () => window.removeEventListener(CHANGE_EVENT, cb);
+}
+
+function getSnapshot(): boolean {
+  try {
+    return !localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return false;
+  }
+}
+
+function dismiss() {
+  try {
+    localStorage.setItem(STORAGE_KEY, '1');
+    window.dispatchEvent(new Event(CHANGE_EVENT));
+  } catch {
+    // ignore
+  }
+}
+
+const STEPS = [
+  {
+    id: 'story-memory',
+    icon: BookOpen,
+    iconColor: 'text-blue-500',
+    iconBg: 'bg-blue-500/10',
+    title: 'Story Memory',
+    description:
+      "Every conversation is automatically saved as part of your ongoing story. Your agent remembers what you've discussed, so you never have to repeat yourself.",
+    bullets: [
+      'Context carries across all sessions',
+      'Your agent picks up right where you left off',
+      'No manual logging required',
+    ],
+  },
+  {
+    id: 'key-facts',
+    icon: Pin,
+    iconColor: 'text-violet-500',
+    iconBg: 'bg-violet-500/10',
+    title: 'Key Facts',
+    description:
+      'Pin the details that matter most — your name, preferences, important events. These facts are always in reach, even in long conversations.',
+    bullets: [
+      'You choose what gets pinned',
+      'Pinned facts survive session resets',
+      'Edit or remove facts any time',
+    ],
+  },
+  {
+    id: 'memory-usage',
+    icon: Infinity,
+    iconColor: 'text-green-500',
+    iconBg: 'bg-green-500/10',
+    title: 'Memory Usage — Unlimited',
+    description:
+      'On Character.AI, persistent memory sits behind a c.ai+ paywall. On AgentGram, it\'s free for everyone. No caps, no upgrade prompts, no hidden limits.',
+    bullets: [
+      'Unlimited pinned facts (no c.ai+ required)',
+      'Full story memory with no storage cap',
+      'Available on every plan, always',
+    ],
+  },
+] as const;
+
+export default function MemoryFirstRunExplainer() {
+  const visible = useSyncExternalStore(subscribe, getSnapshot, () => false);
+  const [step, setStep] = useState(0);
+
+  if (!visible) return null;
+
+  const current = STEPS[step];
+  const isLast = step === STEPS.length - 1;
+  const Icon = current.icon;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="memory-explainer-title"
+      data-testid="memory-first-run-explainer"
+    >
+      <div className="relative w-full max-w-md rounded-2xl border bg-card shadow-2xl p-8">
+        <button
+          onClick={dismiss}
+          className="absolute right-4 top-4 rounded-md p-1 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Dismiss"
+          data-testid="memory-explainer-dismiss"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+
+        {/* Step indicator */}
+        <div className="mb-6 flex justify-center gap-2" aria-label="Step indicator" data-testid="memory-explainer-steps">
+          {STEPS.map((s, i) => (
+            <div
+              key={s.id}
+              data-testid={`memory-explainer-step-dot-${i}`}
+              className={`h-1.5 rounded-full transition-all ${
+                i === step ? 'w-6 bg-brand' : 'w-1.5 bg-muted-foreground/30'
+              }`}
+              aria-current={i === step ? 'step' : undefined}
+            />
+          ))}
+        </div>
+
+        {/* Icon */}
+        <div
+          className={`mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-full ${current.iconBg}`}
+          data-testid="memory-explainer-icon"
+        >
+          <Icon className={`h-7 w-7 ${current.iconColor}`} aria-hidden="true" />
+        </div>
+
+        {/* Content */}
+        <div className="text-center" data-testid={`memory-explainer-step-${current.id}`}>
+          <h2
+            id="memory-explainer-title"
+            className="text-xl font-bold tracking-tight"
+            data-testid="memory-explainer-title"
+          >
+            {current.title}
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground" data-testid="memory-explainer-description">
+            {current.description}
+          </p>
+
+          <ul className="mt-4 space-y-2 text-left" data-testid="memory-explainer-bullets">
+            {current.bullets.map((bullet) => (
+              <li key={bullet} className="flex items-start gap-2">
+                <CheckCircle
+                  className="mt-0.5 h-4 w-4 shrink-0 text-green-500"
+                  aria-hidden="true"
+                />
+                <span className="text-sm">{bullet}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Navigation */}
+        <div className="mt-8 flex items-center justify-between gap-3">
+          {step > 0 ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setStep((s) => s - 1)}
+              data-testid="memory-explainer-back"
+            >
+              Back
+            </Button>
+          ) : (
+            <div />
+          )}
+
+          {isLast ? (
+            <Button
+              size="sm"
+              className="gap-1.5 bg-brand text-white hover:bg-brand-accent"
+              onClick={dismiss}
+              data-testid="memory-explainer-cta"
+            >
+              Get started
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5"
+              onClick={() => setStep((s) => s + 1)}
+              data-testid="memory-explainer-next"
+            >
+              Next
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Button>
+          )}
+        </div>
+
+        <p className="mt-4 text-center text-xs text-muted-foreground">
+          Step {step + 1} of {STEPS.length}
+          {' · '}
+          <button
+            onClick={dismiss}
+            className="underline underline-offset-2 hover:text-foreground"
+            data-testid="memory-explainer-skip"
+          >
+            Skip
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/memory/MemoryFirstRunExplainer.tsx
+++ b/apps/web/components/memory/MemoryFirstRunExplainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSyncExternalStore, useState } from 'react';
-import { BookOpen, Pin, Infinity, ArrowRight, X, CheckCircle } from 'lucide-react';
+import { BookOpen, Pin, Infinity as InfinityIcon, ArrowRight, X, CheckCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 const STORAGE_KEY = 'agentgram:memory-explainer-seen';
@@ -60,7 +60,7 @@ const STEPS = [
   },
   {
     id: 'memory-usage',
-    icon: Infinity,
+    icon: InfinityIcon,
     iconColor: 'text-green-500',
     iconBg: 'bg-green-500/10',
     title: 'Memory Usage — Unlimited',

--- a/docs/pr-evidence/memory-first-run-explainer.md
+++ b/docs/pr-evidence/memory-first-run-explainer.md
@@ -1,0 +1,53 @@
+# PR Evidence: Memory First-Run Explainer
+
+**Row**: backlog.md:374
+**Branch**: feat/memory-first-run-explainer
+**Component**: `apps/web/components/memory/MemoryFirstRunExplainer.tsx`
+
+## What was built
+
+`MemoryFirstRunExplainer` — a 3-step modal walkthrough that teaches new users how
+AgentGram memory works and positions it against the Character.AI c.ai+ paywall.
+
+### Steps
+
+| Step | Title | Key message |
+|------|-------|-------------|
+| 1 | Story Memory | Conversations are automatically saved; agent picks up context across sessions |
+| 2 | Key Facts | User-pinned facts are durable and always in reach |
+| 3 | Memory Usage — Unlimited | No c.ai+ paywall required; all plans get full memory |
+
+### Trigger
+
+- localStorage key `agentgram:memory-explainer-seen` absent → modal renders
+- Key is written on: Get started CTA (step 3), X dismiss, Skip link
+- One-time only: second visit never shows the modal again
+
+### localStorage pattern
+
+Uses `useSyncExternalStore` with `window.addEventListener('agentgram:memory-explainer-change', …)`
+so any dismiss path triggers a synchronous re-render without prop drilling.
+
+## Files changed
+
+```
+apps/web/components/memory/MemoryFirstRunExplainer.tsx   (new)
+apps/web/__tests__/components/memory-first-run-explainer.test.tsx  (new)
+docs/pr-evidence/memory-first-run-explainer.md  (this file)
+```
+
+## Test results
+
+```
+Test Files  1 passed (1)
+Tests  18 passed (18)
+```
+
+All 18 tests pass using the project's `Object.defineProperty(window, 'localStorage', …)` mock
+pattern (consistent with `anchor-controls-preset.test.tsx` and other passing localStorage tests).
+
+## Auth-only proof
+
+N/A — modal is shown to authenticated users on first chat/dashboard visit.
+The `agentgram:memory-explainer-seen` key gates rendering client-side; no server auth check
+is required for the component itself (auth is handled by the route).


### PR DESCRIPTION
## Source
Source: backlog.md:374

## Summary
- MemoryFirstRunExplainer 3-step walkthrough (Story Memory / Key Facts / Usage)
- Positions AgentGram as c.ai+ paywall-free alternative
- localStorage one-time trigger on first chat open

## Evidence
docs/pr-evidence/memory-first-run-explainer.md (create this file)

## Auth-only Proof
N/A (shown to authenticated users on first chat visit)