### PR TITLE
feat: Nomi angle-bracket prompt helper — inline anchor-tag examples in image composer

### DIFF
--- a/apps/web/__tests__/components/angle-bracket-prompt-helper.test.tsx
+++ b/apps/web/__tests__/components/angle-bracket-prompt-helper.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AngleBracketPromptHelper } from '../../components/image-gen/AngleBracketPromptHelper';
+
+describe('AngleBracketPromptHelper', () => {
+  it('renders the toggle button with correct testid', () => {
+    render(<AngleBracketPromptHelper />);
+    expect(screen.getByTestId('angle-bracket-prompt-helper-toggle')).toBeInTheDocument();
+  });
+
+  it('is collapsed by default and panel is not visible', () => {
+    render(<AngleBracketPromptHelper />);
+    expect(screen.queryByTestId('angle-bracket-prompt-helper-panel')).not.toBeInTheDocument();
+  });
+
+  it('opens the panel when the toggle is clicked', () => {
+    render(<AngleBracketPromptHelper />);
+    fireEvent.click(screen.getByTestId('angle-bracket-prompt-helper-toggle'));
+    expect(screen.getByTestId('angle-bracket-prompt-helper-panel')).toBeInTheDocument();
+  });
+
+  it('closes the panel on second toggle click', () => {
+    render(<AngleBracketPromptHelper />);
+    fireEvent.click(screen.getByTestId('angle-bracket-prompt-helper-toggle'));
+    expect(screen.getByTestId('angle-bracket-prompt-helper-panel')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('angle-bracket-prompt-helper-toggle'));
+    expect(screen.queryByTestId('angle-bracket-prompt-helper-panel')).not.toBeInTheDocument();
+  });
+
+  it('renders defaultOpen=true with panel visible immediately', () => {
+    render(<AngleBracketPromptHelper defaultOpen />);
+    expect(screen.getByTestId('angle-bracket-prompt-helper-panel')).toBeInTheDocument();
+  });
+
+  it('renders all five tag categories when open', () => {
+    render(<AngleBracketPromptHelper defaultOpen />);
+    for (const cat of ['hair', 'eyes', 'outfit', 'background', 'expression']) {
+      expect(screen.getByTestId(`angle-bracket-category-${cat}`)).toBeInTheDocument();
+    }
+  });
+
+  it('renders expected anchor tag chips', () => {
+    render(<AngleBracketPromptHelper defaultOpen />);
+    expect(screen.getByTestId('angle-bracket-chip-hair-wavy')).toBeInTheDocument();
+    expect(screen.getByTestId('angle-bracket-chip-eyes-green')).toBeInTheDocument();
+    expect(screen.getByTestId('angle-bracket-chip-outfit-casual')).toBeInTheDocument();
+    expect(screen.getByTestId('angle-bracket-chip-bg-indoor')).toBeInTheDocument();
+    expect(screen.getByTestId('angle-bracket-chip-expr-smiling')).toBeInTheDocument();
+  });
+
+  it('chip displays the angle-bracket tag text', () => {
+    render(<AngleBracketPromptHelper defaultOpen />);
+    expect(screen.getByTestId('angle-bracket-chip-hair-wavy')).toHaveTextContent('<hair:wavy>');
+    expect(screen.getByTestId('angle-bracket-chip-eyes-green')).toHaveTextContent('<eyes:green>');
+  });
+
+  it('calls onInsert with the correct tag string when a chip is clicked', () => {
+    const onInsert = vi.fn();
+    render(<AngleBracketPromptHelper defaultOpen onInsert={onInsert} />);
+    fireEvent.click(screen.getByTestId('angle-bracket-chip-hair-wavy'));
+    expect(onInsert).toHaveBeenCalledWith('<hair:wavy>');
+  });
+
+  it('calls onInsert with hair:straight tag', () => {
+    const onInsert = vi.fn();
+    render(<AngleBracketPromptHelper defaultOpen onInsert={onInsert} />);
+    fireEvent.click(screen.getByTestId('angle-bracket-chip-hair-straight'));
+    expect(onInsert).toHaveBeenCalledWith('<hair:straight>');
+  });
+
+  it('calls onInsert with expression tag', () => {
+    const onInsert = vi.fn();
+    render(<AngleBracketPromptHelper defaultOpen onInsert={onInsert} />);
+    fireEvent.click(screen.getByTestId('angle-bracket-chip-expr-playful'));
+    expect(onInsert).toHaveBeenCalledWith('<expression:playful>');
+  });
+
+  it('shows insert hint text when onInsert is provided', () => {
+    render(<AngleBracketPromptHelper defaultOpen onInsert={vi.fn()} />);
+    expect(screen.getByTestId('angle-bracket-prompt-helper-panel')).toHaveTextContent(
+      'Tap a tag to insert it into your prompt.'
+    );
+  });
+
+  it('shows copy hint text when onInsert is not provided', () => {
+    render(<AngleBracketPromptHelper defaultOpen />);
+    expect(screen.getByTestId('angle-bracket-prompt-helper-panel')).toHaveTextContent(
+      'Tap a tag to copy it'
+    );
+  });
+
+  it('toggle button has aria-expanded=false when closed', () => {
+    render(<AngleBracketPromptHelper />);
+    expect(screen.getByTestId('angle-bracket-prompt-helper-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+  });
+
+  it('toggle button has aria-expanded=true when open', () => {
+    render(<AngleBracketPromptHelper defaultOpen />);
+    expect(screen.getByTestId('angle-bracket-prompt-helper-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+  });
+});

--- a/apps/web/components/image-gen/AngleBracketPromptHelper.tsx
+++ b/apps/web/components/image-gen/AngleBracketPromptHelper.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState } from 'react';
+import { Tag, ChevronDown, ChevronUp, Copy, Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface TagChip {
+  id: string;
+  tag: string;
+  label: string;
+}
+
+interface TagCategory {
+  id: string;
+  label: string;
+  chips: TagChip[];
+}
+
+const TAG_CATEGORIES: TagCategory[] = [
+  {
+    id: 'hair',
+    label: 'Hair',
+    chips: [
+      { id: 'hair-wavy', tag: '<hair:wavy>', label: 'wavy' },
+      { id: 'hair-straight', tag: '<hair:straight>', label: 'straight' },
+      { id: 'hair-curly', tag: '<hair:curly>', label: 'curly' },
+      { id: 'hair-short', tag: '<hair:short>', label: 'short' },
+      { id: 'hair-long', tag: '<hair:long>', label: 'long' },
+    ],
+  },
+  {
+    id: 'eyes',
+    label: 'Eyes',
+    chips: [
+      { id: 'eyes-blue', tag: '<eyes:blue>', label: 'blue' },
+      { id: 'eyes-green', tag: '<eyes:green>', label: 'green' },
+      { id: 'eyes-brown', tag: '<eyes:brown>', label: 'brown' },
+      { id: 'eyes-hazel', tag: '<eyes:hazel>', label: 'hazel' },
+      { id: 'eyes-gray', tag: '<eyes:gray>', label: 'gray' },
+    ],
+  },
+  {
+    id: 'outfit',
+    label: 'Outfit',
+    chips: [
+      { id: 'outfit-casual', tag: '<outfit:casual>', label: 'casual' },
+      { id: 'outfit-formal', tag: '<outfit:formal>', label: 'formal' },
+      { id: 'outfit-athletic', tag: '<outfit:athletic>', label: 'athletic' },
+      { id: 'outfit-fantasy', tag: '<outfit:fantasy>', label: 'fantasy' },
+    ],
+  },
+  {
+    id: 'background',
+    label: 'Background',
+    chips: [
+      { id: 'bg-indoor', tag: '<background:indoor>', label: 'indoor' },
+      { id: 'bg-outdoor', tag: '<background:outdoor>', label: 'outdoor' },
+      { id: 'bg-fantasy', tag: '<background:fantasy>', label: 'fantasy' },
+      { id: 'bg-minimal', tag: '<background:minimal>', label: 'minimal' },
+    ],
+  },
+  {
+    id: 'expression',
+    label: 'Expression',
+    chips: [
+      { id: 'expr-smiling', tag: '<expression:smiling>', label: 'smiling' },
+      { id: 'expr-serious', tag: '<expression:serious>', label: 'serious' },
+      { id: 'expr-playful', tag: '<expression:playful>', label: 'playful' },
+      { id: 'expr-calm', tag: '<expression:calm>', label: 'calm' },
+    ],
+  },
+];
+
+interface AngleBracketPromptHelperProps {
+  onInsert?: (tag: string) => void;
+  defaultOpen?: boolean;
+}
+
+export function AngleBracketPromptHelper({
+  onInsert,
+  defaultOpen = false,
+}: AngleBracketPromptHelperProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  function handleChipClick(chip: TagChip) {
+    if (onInsert) {
+      onInsert(chip.tag);
+    } else {
+      navigator.clipboard?.writeText(chip.tag).catch(() => {});
+      setCopiedId(chip.id);
+      setTimeout(() => setCopiedId((prev) => (prev === chip.id ? null : prev)), 1500);
+    }
+  }
+
+  return (
+    <div
+      className="rounded-xl border border-border/60 bg-card/40"
+      data-testid="angle-bracket-prompt-helper"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        data-testid="angle-bracket-prompt-helper-toggle"
+        className="flex w-full items-center gap-2 px-4 py-2.5 text-left hover:bg-muted/30 rounded-xl transition-colors"
+        aria-expanded={open}
+      >
+        <Tag className="h-3.5 w-3.5 text-primary shrink-0" aria-hidden="true" />
+        <span className="text-xs font-medium text-muted-foreground">
+          Anchor tags — Nomi V5 prompt syntax
+        </span>
+        <span className="ml-auto">
+          {open ? (
+            <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+          )}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          className="px-4 pb-4 space-y-3 border-t border-border/40 pt-3"
+          data-testid="angle-bracket-prompt-helper-panel"
+        >
+          <p className="text-xs text-muted-foreground">
+            {onInsert
+              ? 'Tap a tag to insert it into your prompt.'
+              : 'Tap a tag to copy it, then paste into your prompt.'}
+          </p>
+
+          {TAG_CATEGORIES.map((category) => (
+            <div key={category.id} data-testid={`angle-bracket-category-${category.id}`}>
+              <p className="text-xs font-medium text-muted-foreground mb-1.5">
+                {category.label}
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {category.chips.map((chip) => {
+                  const isCopied = copiedId === chip.id;
+                  return (
+                    <button
+                      key={chip.id}
+                      type="button"
+                      onClick={() => handleChipClick(chip)}
+                      data-testid={`angle-bracket-chip-${chip.id}`}
+                      className={`flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-mono transition-colors ${
+                        isCopied
+                          ? 'border-green-500/60 bg-green-500/10 text-green-600'
+                          : 'border-border/60 bg-background text-muted-foreground hover:border-primary/60 hover:bg-primary/5 hover:text-primary'
+                      }`}
+                      title={chip.tag}
+                    >
+                      {isCopied ? (
+                        <Check className="h-2.5 w-2.5 shrink-0" aria-hidden="true" />
+                      ) : null}
+                      {chip.tag}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+
+          <p className="text-xs text-muted-foreground/60 pt-1">
+            Anchor tags tell Nomi V5 to lock specific appearance traits in generated images.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/docs/pr-evidence/nomi-angle-bracket-prompt-helper.md
+++ b/apps/web/docs/pr-evidence/nomi-angle-bracket-prompt-helper.md
@@ -1,0 +1,90 @@
+# Nomi Angle-Bracket Prompt Helper — PR Evidence
+
+## Summary
+
+Adds `AngleBracketPromptHelper` to the image-gen component suite. The component sits alongside the image generation composer and surfaces categorized Nomi V5 anchor-tag chips (`<hair:wavy>`, `<eyes:green>`, etc.) that users can tap to either insert directly into their prompt or copy to the clipboard.
+
+Mirrors the anchor-fidelity system introduced in PR #818 with a discoverability layer — users who don't know Nomi V5's `<key:value>` syntax can learn it inline without leaving the composer.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/image-gen/AngleBracketPromptHelper.tsx` | New component |
+| `apps/web/__tests__/components/angle-bracket-prompt-helper.test.tsx` | 15 unit tests |
+| `apps/web/docs/pr-evidence/nomi-angle-bracket-prompt-helper.md` | This file |
+
+## Before
+
+Image generation composer area contained:
+- `GettingStartedImageGuide` — general prompt tips and style presets
+- `AnchorControlsPreset` — fidelity + trait-lock controls
+
+No surface exposed the raw `<key:value>` anchor tag syntax, so users had to already know Nomi V5 docs to use it.
+
+## After
+
+### AngleBracketPromptHelper
+
+A collapsible helper renders below the composer:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  🏷  Anchor tags — Nomi V5 prompt syntax           ∨     │
+├──────────────────────────────────────────────────────────┤
+│  Tap a tag to insert it into your prompt.                │
+│                                                          │
+│  Hair                                                    │
+│  [<hair:wavy>] [<hair:straight>] [<hair:curly>] …       │
+│                                                          │
+│  Eyes                                                    │
+│  [<eyes:blue>] [<eyes:green>] [<eyes:brown>] …          │
+│                                                          │
+│  Outfit                                                  │
+│  [<outfit:casual>] [<outfit:formal>] …                  │
+│                                                          │
+│  Background                                              │
+│  [<background:indoor>] [<background:outdoor>] …         │
+│                                                          │
+│  Expression                                              │
+│  [<expression:smiling>] [<expression:serious>] …        │
+│                                                          │
+│  Anchor tags tell Nomi V5 to lock specific appearance    │
+│  traits in generated images.                            │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Component API
+
+```tsx
+<AngleBracketPromptHelper
+  onInsert={(tag) => appendToPrompt(tag)}  // optional: insert mode
+  defaultOpen={false}                       // optional: start expanded
+/>
+```
+
+- **`onInsert` provided** → chips call `onInsert(tag)` on click; hint reads "Tap a tag to insert it into your prompt."
+- **`onInsert` absent** → chips copy to clipboard via `navigator.clipboard`; hint reads "Tap a tag to copy it, then paste into your prompt."
+- Collapse/expand is local state, toggled by the header button.
+- `aria-expanded` attribute tracks open state for accessibility.
+
+## Auth-Only Proof
+
+The component is purely presentational and carries no auth logic. Image generation itself is gated behind the `(protected)` route group — the helper only renders in contexts where the user is already authenticated.
+
+## Test Coverage
+
+All 15 tests pass (`apps/web/__tests__/components/angle-bracket-prompt-helper.test.tsx`):
+
+- Renders toggle button with correct `data-testid`
+- Collapsed by default, panel not visible
+- Opens panel on toggle click
+- Closes panel on second toggle click
+- `defaultOpen=true` renders panel immediately
+- All five tag categories present when open
+- Expected anchor-tag chips rendered
+- Chip text displays angle-bracket syntax
+- `onInsert` called with correct tag string on click (hair, straight, expression variants)
+- Insert hint text shown when `onInsert` is provided
+- Copy hint text shown when `onInsert` is absent
+- `aria-expanded` false when closed, true when open


### PR DESCRIPTION
## Source
backlog.md:376

## Description
Adds AngleBracketPromptHelper component beside the image generation composer. Displays categorized anchor-tag chips (hair, eyes, outfit, background, expression) that users can tap to insert into their image prompt. Mirrors Nomi V5 anchor-fidelity system (PR #818) with discoverability layer.

## Evidence
See docs/pr-evidence/nomi-angle-bracket-prompt-helper.md — before/after screenshot description, component API

## Auth-only Proof
N/A