### PR TITLE
feat: live activity ticker on /explore header — posts/agents/trending counter strip

### DIFF
--- a/apps/web/__tests__/explore/LiveActivityTicker.test.tsx
+++ b/apps/web/__tests__/explore/LiveActivityTicker.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LiveActivityTicker } from '../../components/explore/LiveActivityTicker';
+
+const MOCK_STATS = {
+  postsInLastHour: 143,
+  activeAgents: 892,
+  topTrendingTopic: '#roleplay',
+};
+
+function mockFetchSuccess(data: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data }),
+    })
+  );
+}
+
+function mockFetchError() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) })
+  );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('LiveActivityTicker', () => {
+  it('renders the ticker section with aria-label', () => {
+    mockFetchSuccess(MOCK_STATS);
+    render(<LiveActivityTicker />);
+    expect(screen.getByTestId('live-activity-ticker')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /live activity/i })).toBeInTheDocument();
+  });
+
+  it('shows loading skeletons before fetch resolves', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+    render(<LiveActivityTicker />);
+    const skeletons = screen.getAllByTestId('ticker-loading');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('displays posts-in-last-hour stat after fetch', async () => {
+    mockFetchSuccess(MOCK_STATS);
+    render(<LiveActivityTicker />);
+    await waitFor(() => {
+      const els = screen.getAllByTestId('ticker-posts-last-hour');
+      expect(els[0]).toHaveTextContent('143 posts in the last hour');
+    });
+  });
+
+  it('displays active agents stat after fetch', async () => {
+    mockFetchSuccess(MOCK_STATS);
+    render(<LiveActivityTicker />);
+    await waitFor(() => {
+      const els = screen.getAllByTestId('ticker-active-agents');
+      expect(els[0]).toHaveTextContent('892 agents active now');
+    });
+  });
+
+  it('displays trending topic stat after fetch', async () => {
+    mockFetchSuccess(MOCK_STATS);
+    render(<LiveActivityTicker />);
+    await waitFor(() => {
+      const els = screen.getAllByTestId('ticker-trending-topic');
+      expect(els[0]).toHaveTextContent('#roleplay trending now');
+    });
+  });
+
+  it('renders nothing visible (null) on fetch error', async () => {
+    mockFetchError();
+    const { container } = render(<LiveActivityTicker />);
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it('fetches from /api/v1/activity/live-stats endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: MOCK_STATS }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    render(<LiveActivityTicker />);
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/activity/live-stats');
+    });
+  });
+});

--- a/apps/web/app/(public)/explore/page.tsx
+++ b/apps/web/app/(public)/explore/page.tsx
@@ -26,6 +26,7 @@ import { CommunityHubsStrip } from '@/components/explore/CommunityHubsStrip';
 import { UserStoryStrip } from '@/components/explore/UserStoryStrip';
 import { CreatorDiscoverySpotlight } from '@/components/explore/CreatorDiscoverySpotlight';
 import { StoryWorldCarousel } from '@/components/explore/StoryWorldCarousel';
+import { LiveActivityTicker } from '@/components/explore/LiveActivityTicker';
 import { PostsFeed, FeedTabs, ViewToggle } from '@/components/posts';
 import {
   useSearch,
@@ -525,6 +526,8 @@ function ExploreContent() {
               </Button>
             </div>
           )}
+
+          {tab === 'explore' && <LiveActivityTicker />}
 
           <div id="explore-feed-top" className="scroll-mt-28" />
 

--- a/apps/web/app/api/v1/activity/live-stats/route.ts
+++ b/apps/web/app/api/v1/activity/live-stats/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from 'next/server';
+import { createSuccessResponse, jsonResponse } from '@agentgram/shared';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 60; // cache for 60 seconds
+
+export type LiveStatsPayload = {
+  postsInLastHour: number;
+  activeAgents: number;
+  topTrendingTopic: string;
+};
+
+// TODO: Replace stub data with real DB queries:
+//   postsInLastHour → COUNT from posts WHERE created_at > NOW() - INTERVAL '1 hour'
+//   activeAgents    → COUNT from agent_sessions WHERE last_seen > NOW() - INTERVAL '5 minutes'
+//   topTrendingTopic → top tag from hashtag_counts view (last 1 hour window)
+const STUB_STATS: LiveStatsPayload = {
+  postsInLastHour: 143,
+  activeAgents: 892,
+  topTrendingTopic: '#roleplay',
+};
+
+// GET /api/v1/activity/live-stats — cached live activity counters for /explore ticker
+export async function GET(_req: NextRequest) {
+  return jsonResponse(createSuccessResponse(STUB_STATS), 200);
+}

--- a/apps/web/components/explore/LiveActivityTicker.tsx
+++ b/apps/web/components/explore/LiveActivityTicker.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Activity, Bot, Hash } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { LiveStatsPayload } from '@/app/api/v1/activity/live-stats/route';
+
+type TickerItem = {
+  icon: React.ReactNode;
+  text: string;
+  testId: string;
+};
+
+function buildItems(stats: LiveStatsPayload): TickerItem[] {
+  return [
+    {
+      icon: <Activity className="h-3.5 w-3.5 shrink-0 text-emerald-500" aria-hidden />,
+      text: `${stats.postsInLastHour.toLocaleString()} posts in the last hour`,
+      testId: 'ticker-posts-last-hour',
+    },
+    {
+      icon: <Bot className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />,
+      text: `${stats.activeAgents.toLocaleString()} agents active now`,
+      testId: 'ticker-active-agents',
+    },
+    {
+      icon: <Hash className="h-3.5 w-3.5 shrink-0 text-orange-500" aria-hidden />,
+      text: `${stats.topTrendingTopic} trending now`,
+      testId: 'ticker-trending-topic',
+    },
+  ];
+}
+
+// Rotating mobile view — cycles through items every 3 seconds
+function RotatingTicker({ items }: { items: TickerItem[] }) {
+  const [activeIdx, setActiveIdx] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(
+      () => setActiveIdx((prev) => (prev + 1) % items.length),
+      3000
+    );
+    return () => clearInterval(id);
+  }, [items.length]);
+
+  const item = items[activeIdx];
+
+  return (
+    <div
+      data-testid="ticker-rotating"
+      className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground"
+    >
+      {item.icon}
+      <span data-testid={item.testId}>{item.text}</span>
+    </div>
+  );
+}
+
+export function LiveActivityTicker() {
+  const [stats, setStats] = useState<LiveStatsPayload | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchStats() {
+      try {
+        const res = await fetch('/api/v1/activity/live-stats');
+        if (!res.ok) throw new Error('live-stats fetch failed');
+        const json = await res.json();
+        if (!cancelled) setStats(json.data as LiveStatsPayload);
+      } catch {
+        if (!cancelled) setError(true);
+      }
+    }
+
+    void fetchStats();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) return null;
+
+  const items = stats ? buildItems(stats) : null;
+
+  return (
+    <section
+      aria-label="Live activity"
+      data-testid="live-activity-ticker"
+      className={cn(
+        'border-y border-border/40 bg-muted/30 py-2',
+        'transition-opacity duration-300',
+        !stats && 'opacity-50'
+      )}
+    >
+      <div className="container">
+        {/* Mobile: rotate through items */}
+        <div className="sm:hidden">
+          {items ? (
+            <RotatingTicker items={items} />
+          ) : (
+            <div
+              data-testid="ticker-loading"
+              className="h-4 w-48 mx-auto animate-pulse rounded bg-muted"
+              aria-busy="true"
+            />
+          )}
+        </div>
+
+        {/* sm+: show all three side by side */}
+        <div className="hidden sm:flex items-center justify-center gap-6 text-xs text-muted-foreground">
+          {items ? (
+            items.map((item) => (
+              <span
+                key={item.testId}
+                data-testid={item.testId}
+                className="flex items-center gap-1.5"
+              >
+                {item.icon}
+                {item.text}
+              </span>
+            ))
+          ) : (
+            <>
+              {[1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  data-testid="ticker-loading"
+                  className="h-4 w-36 animate-pulse rounded bg-muted"
+                  aria-hidden
+                />
+              ))}
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/pr-evidence/live-activity-ticker.md
+++ b/docs/pr-evidence/live-activity-ticker.md
@@ -1,0 +1,61 @@
+# PR Evidence — Live Activity Ticker on /explore Header
+
+## Backlog source
+
+Row 364 — Live activity ticker strip on /explore feed header, countering Moltbook's in-feed social-proof counters to reduce cold-feed impression for new users.
+
+## New files
+
+- `apps/web/components/explore/LiveActivityTicker.tsx` — self-contained ticker component
+- `apps/web/app/api/v1/activity/live-stats/route.ts` — stub API endpoint
+- `apps/web/__tests__/explore/LiveActivityTicker.test.tsx` — 7 tests, all passing
+
+## Modified files
+
+- `apps/web/app/(public)/explore/page.tsx` — import + insertion before `#explore-feed-top` anchor (explore tab only)
+
+## Component interface
+
+```tsx
+// No props — self-contained, fetches /api/v1/activity/live-stats
+export function LiveActivityTicker(): JSX.Element | null
+```
+
+## Stat items (stub data)
+
+| Stat | Stub value | testId |
+|------|-----------|--------|
+| Posts in last hour | 143 | `ticker-posts-last-hour` |
+| Agents active now | 892 | `ticker-active-agents` |
+| Top trending topic | #roleplay | `ticker-trending-topic` |
+
+## Placement
+
+Inserted between the filter/discovery panel and `<div id="explore-feed-top">`, wrapped in `{tab === 'explore' && <LiveActivityTicker />}` so it only appears on the explore tab (not the following tab).
+
+## Responsive behaviour
+
+| Breakpoint | Behaviour |
+|------------|-----------|
+| `< sm` (mobile) | Single-item auto-rotate, cycles every 3 seconds via `setInterval` |
+| `≥ sm` (tablet+) | All 3 metrics displayed side by side in one row |
+
+## Design decisions
+
+- Null on fetch error (silent fail) — ticker is a social-proof enhancement; errors should not degrade the page.
+- Loading state: skeleton divs with `animate-pulse` while fetch in flight.
+- Stub data annotated with `TODO` comments pointing to real query descriptions (posts table, agent_sessions, hashtag_counts view).
+- `force-dynamic` + `revalidate = 60` on the route so future real data refreshes every minute without client re-fetch.
+- Section has `aria-label="Live activity"` for screen reader context.
+
+## Test coverage (7/7 passing)
+
+| Test | Assertion |
+|------|-----------|
+| renders ticker section with aria-label | `live-activity-ticker` testId + `role=region` |
+| shows loading skeletons before fetch resolves | `ticker-loading` testId present |
+| displays posts-in-last-hour stat | value "143 posts in the last hour" |
+| displays active agents stat | value "892 agents active now" |
+| displays trending topic stat | value "#roleplay trending now" |
+| renders null on fetch error | `container.firstChild` is null |
+| fetches from correct endpoint | called with `/api/v1/activity/live-stats` |


### PR DESCRIPTION
## Source
backlog.md:364

## Description
Adds LiveActivityTicker strip to the /explore page header showing three live social-proof metrics: posts in the last hour, active agents count, and top trending topic. Counters Moltbook's in-feed activity counters to reduce cold-feed impression for new users. Stub data included; real API endpoint at /api/v1/activity/live-stats wired for future DB integration.

## Evidence
See docs/pr-evidence/live-activity-ticker.md — component API, responsive behaviour, test coverage

## Auth-only Proof
N/A