### PR TITLE
feat: Kindroid mobile-vs-web pricing clarity banner — web price advantage CTA

### DIFF
--- a/apps/web/__tests__/components/pricing/MobileWebPricingBanner.test.tsx
+++ b/apps/web/__tests__/components/pricing/MobileWebPricingBanner.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { MobileWebPricingBanner } from '@/components/pricing/MobileWebPricingBanner';
+
+const DISMISS_KEY = 'mobile-web-pricing-banner-dismissed';
+
+function makeLocalStorageMock() {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    _reset: () => { store = {}; },
+  };
+}
+
+const localStorageMock = makeLocalStorageMock();
+
+vi.stubGlobal('localStorage', localStorageMock);
+
+describe('MobileWebPricingBanner', () => {
+  beforeEach(() => {
+    localStorageMock._reset();
+    vi.clearAllMocks();
+  });
+
+  it('renders the banner when not dismissed', () => {
+    render(<MobileWebPricingBanner />);
+    expect(screen.getByTestId('mobile-web-pricing-banner')).toBeInTheDocument();
+  });
+
+  it('displays the web price advantage headline', () => {
+    render(<MobileWebPricingBanner />);
+    const headline = screen.getByTestId('mobile-web-pricing-headline');
+    expect(headline.textContent).toMatch(/Subscribe on web/i);
+    expect(headline.textContent).toMatch(/no app store markup/i);
+  });
+
+  it('shows web price vs app store price comparison', () => {
+    render(<MobileWebPricingBanner />);
+    const comparison = screen.getByTestId('mobile-web-pricing-comparison');
+    expect(comparison).toBeInTheDocument();
+    expect(screen.getByTestId('web-price-label').textContent).toMatch(/Web:/i);
+    expect(screen.getByTestId('app-store-price-label').textContent).toMatch(/iOS\/Android/i);
+    expect(screen.getByTestId('app-store-price-label').textContent).toMatch(/30%/i);
+  });
+
+  it('renders the Subscribe on web CTA link pointing to /pricing#plans', () => {
+    render(<MobileWebPricingBanner />);
+    const cta = screen.getByTestId('mobile-web-pricing-cta');
+    expect(cta).toBeInTheDocument();
+    expect(cta.textContent).toMatch(/Subscribe on web/i);
+    expect(cta.getAttribute('href')).toBe('/pricing#plans');
+  });
+
+  it('shows Kindroid counter-positioning copy', () => {
+    render(<MobileWebPricingBanner />);
+    const counter = screen.getByTestId('mobile-web-pricing-counter');
+    expect(counter.textContent).toMatch(/Kindroid/i);
+    expect(counter.textContent).toMatch(/web price is always our best price/i);
+  });
+
+  it('renders the dismiss button with accessible label', () => {
+    render(<MobileWebPricingBanner />);
+    const dismissBtn = screen.getByTestId('mobile-web-pricing-dismiss');
+    expect(dismissBtn).toBeInTheDocument();
+    expect(dismissBtn).toHaveAttribute('aria-label', 'Dismiss pricing banner');
+  });
+
+  it('hides the banner after clicking dismiss', () => {
+    render(<MobileWebPricingBanner />);
+    const dismissBtn = screen.getByTestId('mobile-web-pricing-dismiss');
+    fireEvent.click(dismissBtn);
+    expect(screen.queryByTestId('mobile-web-pricing-banner')).not.toBeInTheDocument();
+  });
+
+  it('persists dismissed state to localStorage', () => {
+    render(<MobileWebPricingBanner />);
+    const dismissBtn = screen.getByTestId('mobile-web-pricing-dismiss');
+    fireEvent.click(dismissBtn);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(DISMISS_KEY, 'true');
+  });
+
+  it('does not render when localStorage flag is already set', () => {
+    localStorageMock.getItem.mockImplementation((key: string) =>
+      key === DISMISS_KEY ? 'true' : null
+    );
+    render(<MobileWebPricingBanner />);
+    expect(screen.queryByTestId('mobile-web-pricing-banner')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, PricingCompetitorAnchorRow, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, PricingCompetitorAnchorRow, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -179,6 +179,8 @@ export default function PricingPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-background to-background/80">
+      <MobileWebPricingBanner />
+
       <section className="container py-24">
         <motion.div
           initial={{ opacity: 0, y: 20 }}

--- a/apps/web/components/pricing/MobileWebPricingBanner.tsx
+++ b/apps/web/components/pricing/MobileWebPricingBanner.tsx
@@ -20,7 +20,7 @@ export function MobileWebPricingBanner() {
   const handleDismiss = () => {
     localStorage.setItem(DISMISS_KEY, 'true');
     window.dispatchEvent(
-      new StorageEvent('storage', { key: DISMISS_KEY, newValue: 'true', storageArea: localStorage })
+      new StorageEvent('storage', { key: DISMISS_KEY, newValue: 'true' })
     );
   };
 

--- a/apps/web/components/pricing/MobileWebPricingBanner.tsx
+++ b/apps/web/components/pricing/MobileWebPricingBanner.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Smartphone, Globe, X, ArrowRight, BadgeDollarSign } from 'lucide-react';
+
+const DISMISS_KEY = 'mobile-web-pricing-banner-dismissed';
+
+export function MobileWebPricingBanner() {
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    const stored = typeof localStorage !== 'undefined' ? localStorage.getItem(DISMISS_KEY) : null;
+    if (stored !== 'true') {
+      setDismissed(false);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(DISMISS_KEY, 'true');
+    }
+    setDismissed(true);
+  };
+
+  if (dismissed) return null;
+
+  return (
+    <div
+      className="sticky top-0 z-40 w-full border-b border-emerald-500/30 bg-emerald-950/95 backdrop-blur-sm"
+      data-testid="mobile-web-pricing-banner"
+      role="banner"
+      aria-label="Web pricing advantage"
+    >
+      <div className="container flex items-center justify-between gap-4 py-3">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-4 gap-y-1.5">
+          <BadgeDollarSign
+            className="h-5 w-5 shrink-0 text-emerald-400"
+            aria-hidden="true"
+          />
+
+          <p
+            className="text-sm font-semibold text-emerald-300"
+            data-testid="mobile-web-pricing-headline"
+          >
+            Subscribe on web for the best price — no app store markup
+          </p>
+
+          <div
+            className="flex flex-wrap items-center gap-2"
+            data-testid="mobile-web-pricing-comparison"
+          >
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2.5 py-0.5 text-xs font-medium text-emerald-300">
+              <Globe className="h-3 w-3" aria-hidden="true" />
+              <span data-testid="web-price-label">Web: $9/mo</span>
+            </span>
+            <span className="text-xs text-emerald-500/70">vs</span>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-orange-500/40 bg-orange-500/10 px-2.5 py-0.5 text-xs font-medium text-orange-300">
+              <Smartphone className="h-3 w-3" aria-hidden="true" />
+              <span data-testid="app-store-price-label">iOS/Android: up to 30% more</span>
+            </span>
+          </div>
+
+          <p
+            className="text-xs text-emerald-400/70"
+            data-testid="mobile-web-pricing-counter"
+          >
+            Unlike Kindroid, our web price is always our best price.
+          </p>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <a
+            href="/pricing#plans"
+            data-testid="mobile-web-pricing-cta"
+            className="inline-flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+          >
+            Subscribe on web
+            <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </a>
+
+          <button
+            onClick={handleDismiss}
+            className="rounded-md p-1 text-emerald-400/60 transition-colors hover:bg-emerald-500/10 hover:text-emerald-300"
+            aria-label="Dismiss pricing banner"
+            data-testid="mobile-web-pricing-dismiss"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/MobileWebPricingBanner.tsx
+++ b/apps/web/components/pricing/MobileWebPricingBanner.tsx
@@ -1,25 +1,27 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useSyncExternalStore } from 'react';
 import { Smartphone, Globe, X, ArrowRight, BadgeDollarSign } from 'lucide-react';
 
 const DISMISS_KEY = 'mobile-web-pricing-banner-dismissed';
 
-export function MobileWebPricingBanner() {
-  const [dismissed, setDismissed] = useState(true);
+function subscribe(callback: () => void) {
+  window.addEventListener('storage', callback);
+  return () => window.removeEventListener('storage', callback);
+}
 
-  useEffect(() => {
-    const stored = typeof localStorage !== 'undefined' ? localStorage.getItem(DISMISS_KEY) : null;
-    if (stored !== 'true') {
-      setDismissed(false);
-    }
-  }, []);
+function getSnapshot(): boolean {
+  return localStorage.getItem(DISMISS_KEY) === 'true';
+}
+
+export function MobileWebPricingBanner() {
+  const dismissed = useSyncExternalStore(subscribe, getSnapshot, () => true);
 
   const handleDismiss = () => {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem(DISMISS_KEY, 'true');
-    }
-    setDismissed(true);
+    localStorage.setItem(DISMISS_KEY, 'true');
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: DISMISS_KEY, newValue: 'true', storageArea: localStorage })
+    );
   };
 
   if (dismissed) return null;

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -8,3 +8,4 @@ export { PaidConversionSocialProofBlock } from './PaidConversionSocialProofBlock
 export { ReplikaUltraFatigueFunnel } from './ReplikaUltraFatigueFunnel';
 export { ReplicaUltraFeatureDeltaCard } from './ReplicaUltraFeatureDeltaCard';
 export { ControlSurfacePaidFunnelSection } from './ControlSurfacePaidFunnelSection';
+export { MobileWebPricingBanner } from './MobileWebPricingBanner';

--- a/apps/web/docs/pr-evidence/kindroid-mobile-web-pricing-banner.md
+++ b/apps/web/docs/pr-evidence/kindroid-mobile-web-pricing-banner.md
@@ -1,0 +1,51 @@
+# PR Evidence: Kindroid Mobile-vs-Web Pricing Clarity Banner (Row 378)
+
+## Problem
+
+Kindroid's June 2, 2026 mobile pricing change confused users about web vs app-store pricing. App stores (iOS App Store, Google Play) charge developers a 15–30% commission on in-app purchases, which is typically passed on to subscribers as a price markup. Users who subscribe via the app store pay more for the same tier than users who subscribe on the web — but without explicit messaging this is invisible.
+
+**Before:** No messaging on /pricing about the web vs app-store price difference. Users could navigate to app-store subscriptions and pay a premium without understanding there was a cheaper web alternative.
+
+## After
+
+A sticky `MobileWebPricingBanner` appears at the top of /pricing. It:
+- Explains that subscribing on web avoids app-store markup
+- Shows the web price ($9/mo Starter) alongside a callout that iOS/Android can be up to 30% more
+- Counter-positions explicitly against Kindroid: "Unlike Kindroid, our web price is always our best price"
+- Includes a "Subscribe on web" CTA linking to `/pricing#plans`
+- Is dismissable; dismissed state persists in `localStorage` under key `mobile-web-pricing-banner-dismissed`
+
+## Component API
+
+```tsx
+import { MobileWebPricingBanner } from '@/components/pricing';
+
+// No props required — fully self-contained
+<MobileWebPricingBanner />
+```
+
+### data-testid attributes
+
+| testid | Description |
+|---|---|
+| `mobile-web-pricing-banner` | Root wrapper element |
+| `mobile-web-pricing-headline` | "Subscribe on web…" headline text |
+| `mobile-web-pricing-comparison` | Price comparison chip row |
+| `web-price-label` | Web price chip label |
+| `app-store-price-label` | App-store price chip label |
+| `mobile-web-pricing-counter` | Kindroid counter-positioning copy |
+| `mobile-web-pricing-cta` | "Subscribe on web" CTA button/link |
+| `mobile-web-pricing-dismiss` | Dismiss (×) button |
+
+### Dismiss behavior
+
+- On mount: reads `localStorage.getItem('mobile-web-pricing-banner-dismissed')`; banner hidden if `'true'`
+- On dismiss click: sets `localStorage.setItem('mobile-web-pricing-banner-dismissed', 'true')` and removes banner from DOM
+
+## Placement
+
+Added as the first child of the root `<div>` in `apps/web/app/(public)/pricing/page.tsx`, before the hero `<section>`. Sticky at `top-0 z-40` so it stays visible as users scroll.
+
+## Auth-only Proof
+
+N/A


### PR DESCRIPTION
## Source
backlog.md:378

## Description
Adds MobileWebPricingBanner to /pricing page explaining that web subscriptions avoid app-store markup (up to 30% on iOS/Android). Counter-positions against Kindroid's June 2026 pricing change confusion by making AgentGram's web-best-price guarantee explicit. Dismissable with localStorage persistence.

## Evidence
See apps/web/docs/pr-evidence/kindroid-mobile-web-pricing-banner.md — before/after description, component API

## Auth-only Proof
N/A