### PR TITLE
feat: Creator publish transparency preview

### DIFF
--- a/apps/web/__tests__/components/creator-publish-transparency-preview.test.tsx
+++ b/apps/web/__tests__/components/creator-publish-transparency-preview.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CreatorPublishTransparencyPreview } from '@/components/dashboard/CreatorPublishTransparencyPreview';
+
+const defaultProps = {
+  agentName: 'companion-guide',
+  agentBio: 'A calm companion who checks in after work',
+  tags: ['companion', 'daily', 'lifestyle'],
+  category: 'Lifestyle',
+  onConfirmPublish: vi.fn(),
+  onFixIssues: vi.fn(),
+};
+
+describe('CreatorPublishTransparencyPreview', () => {
+  it('renders filter outcome indicator', () => {
+    render(<CreatorPublishTransparencyPreview {...defaultProps} />);
+    expect(screen.getByTestId('filter-outcome-section')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-check-name-check')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-check-bio-check')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-check-content-policy')).toBeInTheDocument();
+  });
+
+  it('renders discovery visibility estimate', () => {
+    render(<CreatorPublishTransparencyPreview {...defaultProps} />);
+    expect(screen.getByTestId('discovery-visibility-section')).toBeInTheDocument();
+    const visibilityValue = screen.getByTestId('discovery-visibility-value');
+    expect(visibilityValue).toBeInTheDocument();
+    expect(['Wide', 'Niche', 'Limited']).toContain(visibilityValue.textContent);
+  });
+
+  it('calls onConfirmPublish when user confirms publish', () => {
+    const onConfirmPublish = vi.fn();
+    render(
+      <CreatorPublishTransparencyPreview
+        {...defaultProps}
+        onConfirmPublish={onConfirmPublish}
+      />
+    );
+    fireEvent.click(screen.getByTestId('publish-anyway-button'));
+    expect(onConfirmPublish).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Wide visibility when 3+ tags and category are set', () => {
+    render(<CreatorPublishTransparencyPreview {...defaultProps} />);
+    expect(screen.getByTestId('discovery-visibility-value').textContent).toBe('Wide');
+  });
+
+  it('shows Limited visibility when no tags and no category', () => {
+    render(
+      <CreatorPublishTransparencyPreview
+        {...defaultProps}
+        tags={[]}
+        category=""
+      />
+    );
+    expect(screen.getByTestId('discovery-visibility-value').textContent).toBe('Limited');
+  });
+
+  it('shows a high confidence score for well-configured agents', () => {
+    render(<CreatorPublishTransparencyPreview {...defaultProps} />);
+    const scoreText = screen.getByTestId('confidence-score-value').textContent ?? '';
+    const score = parseInt(scoreText.split('/')[0], 10);
+    expect(score).toBeGreaterThanOrEqual(70);
+  });
+
+  it('shows a low confidence score when name and bio are missing', () => {
+    render(
+      <CreatorPublishTransparencyPreview
+        {...defaultProps}
+        agentName=""
+        agentBio=""
+        tags={[]}
+        category=""
+      />
+    );
+    const scoreText = screen.getByTestId('confidence-score-value').textContent ?? '';
+    const score = parseInt(scoreText.split('/')[0], 10);
+    expect(score).toBe(0);
+  });
+
+  it('calls onFixIssues when fix-issues button is clicked', () => {
+    const onFixIssues = vi.fn();
+    render(
+      <CreatorPublishTransparencyPreview
+        {...defaultProps}
+        onFixIssues={onFixIssues}
+      />
+    );
+    fireEvent.click(screen.getByTestId('fix-issues-button'));
+    expect(onFixIssues).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the confidence score bar', () => {
+    render(<CreatorPublishTransparencyPreview {...defaultProps} />);
+    expect(screen.getByTestId('confidence-score-bar')).toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/onboard-page.test.tsx
+++ b/apps/web/__tests__/components/onboard-page.test.tsx
@@ -28,6 +28,9 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('@/components/dashboard', () => ({
   FadeIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  CreatorPublishTransparencyPreview: () => (
+    <div data-testid="creator-publish-transparency-preview-mock" />
+  ),
 }));
 
 vi.mock('@/hooks/use-minor-safe-profile', () => ({

--- a/apps/web/app/(protected)/dashboard/onboard/page.tsx
+++ b/apps/web/app/(protected)/dashboard/onboard/page.tsx
@@ -35,7 +35,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { FadeIn } from '@/components/dashboard';
+import { CreatorPublishTransparencyPreview, FadeIn } from '@/components/dashboard';
 import { MinorSafeGate } from '@/components/minor-safe-gate';
 import { useMinorSafeProfile } from '@/hooks/use-minor-safe-profile';
 import { PaywallPreviewTrigger } from '@/components/subscription/PaywallPreviewModal';
@@ -3243,7 +3243,30 @@ export default function OnboardPage() {
         </Card>
       </FadeIn>
 
-      <div className="grid gap-6">
+      <FadeIn delay={0.45}>
+        <CreatorPublishTransparencyPreview
+          agentName={buildSetupPayload({ setupPath, memoryMode }).name}
+          agentBio={buildSetupPayload({ setupPath, memoryMode }).description}
+          tags={
+            setupPath === 'advanced'
+              ? ['companion', 'lorebook', 'memory', 'canon']
+              : ['companion', 'daily']
+          }
+          category={setupPath === 'advanced' ? 'Story' : 'Lifestyle'}
+          onConfirmPublish={() => {
+            document
+              .getElementById('quickstart-prompts')
+              ?.scrollIntoView({ behavior: 'smooth' });
+          }}
+          onFixIssues={() => {
+            document
+              .getElementById('companion-setup-flow')
+              ?.scrollIntoView({ behavior: 'smooth' });
+          }}
+        />
+      </FadeIn>
+
+      <div id="quickstart-prompts" className="grid gap-6">
         {PROMPTS.map((item, index) => (
           <FadeIn key={item.title} delay={0.4 + 0.1 * index}>
             <Card className="border-border/50 bg-card/50 backdrop-blur-sm">

--- a/apps/web/components/dashboard/CreatorPublishTransparencyPreview.tsx
+++ b/apps/web/components/dashboard/CreatorPublishTransparencyPreview.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { AlertTriangle, CheckCircle, Eye, XCircle } from 'lucide-react';
+
+export interface CreatorPublishTransparencyPreviewProps {
+  agentName: string;
+  agentBio: string;
+  tags: string[];
+  category: string;
+  onConfirmPublish: () => void;
+  onFixIssues: () => void;
+}
+
+type FilterStatus = 'green' | 'yellow' | 'red';
+
+interface FilterCheck {
+  label: string;
+  status: FilterStatus;
+  detail: string;
+}
+
+function getNameStatus(name: string): FilterStatus {
+  if (!name.trim()) return 'red';
+  if (name.trim().length < 3) return 'yellow';
+  return 'green';
+}
+
+function getBioStatus(bio: string): FilterStatus {
+  if (!bio.trim()) return 'red';
+  if (bio.trim().length < 20) return 'yellow';
+  return 'green';
+}
+
+function computeChecks(
+  agentName: string,
+  agentBio: string
+): FilterCheck[] {
+  const nameStatus = getNameStatus(agentName);
+  const bioStatus = getBioStatus(agentBio);
+
+  return [
+    {
+      label: 'Name check',
+      status: nameStatus,
+      detail:
+        nameStatus === 'green'
+          ? 'Name meets minimum length and format requirements.'
+          : nameStatus === 'yellow'
+            ? 'Name is very short. Consider a longer, descriptive name.'
+            : 'Name is missing. Add a name before publishing.',
+    },
+    {
+      label: 'Bio check',
+      status: bioStatus,
+      detail:
+        bioStatus === 'green'
+          ? 'Bio provides enough context for discovery.'
+          : bioStatus === 'yellow'
+            ? 'Bio is brief. A longer description improves visibility.'
+            : 'Bio is missing. Add a bio so followers can find you.',
+    },
+    {
+      label: 'Content policy',
+      status: 'green',
+      detail: 'No content policy flags detected.',
+    },
+  ];
+}
+
+function computeDiscoveryVisibility(
+  tags: string[],
+  category: string
+): 'Wide' | 'Niche' | 'Limited' {
+  const hasCategory = category.trim().length > 0;
+  const tagCount = tags.filter((t) => t.trim()).length;
+
+  if (tagCount >= 3 && hasCategory) return 'Wide';
+  if (tagCount >= 1 || hasCategory) return 'Niche';
+  return 'Limited';
+}
+
+function computeConfidenceScore(
+  agentName: string,
+  agentBio: string,
+  tags: string[],
+  category: string
+): number {
+  let score = 0;
+
+  const nameStatus = getNameStatus(agentName);
+  if (nameStatus === 'green') score += 30;
+  else if (nameStatus === 'yellow') score += 15;
+
+  const bioStatus = getBioStatus(agentBio);
+  if (bioStatus === 'green') score += 30;
+  else if (bioStatus === 'yellow') score += 15;
+
+  const tagCount = tags.filter((t) => t.trim()).length;
+  score += Math.min(tagCount * 7, 25);
+
+  if (category.trim()) score += 15;
+
+  return Math.min(score, 100);
+}
+
+function StatusIcon({ status }: { status: FilterStatus }) {
+  if (status === 'green')
+    return <CheckCircle className="h-4 w-4 text-emerald-500" />;
+  if (status === 'yellow')
+    return <AlertTriangle className="h-4 w-4 text-amber-500" />;
+  return <XCircle className="h-4 w-4 text-destructive" />;
+}
+
+function statusBadgeVariant(
+  status: FilterStatus
+): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (status === 'green') return 'secondary';
+  if (status === 'yellow') return 'outline';
+  return 'destructive';
+}
+
+function statusLabel(status: FilterStatus): string {
+  if (status === 'green') return 'Pass';
+  if (status === 'yellow') return 'Warning';
+  return 'Fail';
+}
+
+function visibilityColor(visibility: 'Wide' | 'Niche' | 'Limited'): string {
+  if (visibility === 'Wide') return 'text-emerald-600';
+  if (visibility === 'Niche') return 'text-amber-600';
+  return 'text-muted-foreground';
+}
+
+export function CreatorPublishTransparencyPreview({
+  agentName,
+  agentBio,
+  tags,
+  category,
+  onConfirmPublish,
+  onFixIssues,
+}: CreatorPublishTransparencyPreviewProps) {
+  const checks = computeChecks(agentName, agentBio);
+  const visibility = computeDiscoveryVisibility(tags, category);
+  const score = computeConfidenceScore(agentName, agentBio, tags, category);
+  const hasFailures = checks.some((c) => c.status === 'red');
+  const hasWarnings = checks.some((c) => c.status === 'yellow');
+
+  return (
+    <Card
+      className="border-primary/20 bg-primary/5"
+      data-testid="creator-publish-transparency-preview"
+    >
+      <CardHeader>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="secondary">Pre-publish check</Badge>
+          <Badge variant="outline">Transparency preview</Badge>
+        </div>
+        <CardTitle className="mt-2 flex items-center gap-2">
+          <Eye className="h-5 w-5 text-primary" />
+          See what happens when you publish
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div
+          className="space-y-3"
+          data-testid="filter-outcome-section"
+        >
+          <p className="text-sm font-semibold text-foreground">
+            Filter outcome
+          </p>
+          {checks.map((check) => (
+            <div
+              key={check.label}
+              className="flex items-start gap-3 rounded-lg border border-border/60 bg-background/70 p-3"
+              data-testid={`filter-check-${check.label.toLowerCase().replace(/\s+/g, '-')}`}
+            >
+              <StatusIcon status={check.status} />
+              <div className="flex-1 space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-medium text-foreground">
+                    {check.label}
+                  </span>
+                  <Badge variant={statusBadgeVariant(check.status)}>
+                    {statusLabel(check.status)}
+                  </Badge>
+                </div>
+                <p className="text-sm text-muted-foreground">{check.detail}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div
+          className="rounded-xl border border-border/60 bg-background/70 p-4"
+          data-testid="discovery-visibility-section"
+        >
+          <p className="text-sm font-semibold text-foreground">
+            Discovery visibility
+          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-3">
+            <span
+              className={`text-2xl font-bold ${visibilityColor(visibility)}`}
+              data-testid="discovery-visibility-value"
+            >
+              {visibility}
+            </span>
+            <p className="text-sm text-muted-foreground">
+              {visibility === 'Wide' &&
+                'Strong tag and category coverage. Broad audience can discover you.'}
+              {visibility === 'Niche' &&
+                'Partial coverage. Add more tags or a category to reach a wider audience.'}
+              {visibility === 'Limited' &&
+                'No tags or category set. Very few people will find you organically.'}
+            </p>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {tags.filter((t) => t.trim()).map((tag) => (
+              <Badge key={tag} variant="outline">
+                {tag}
+              </Badge>
+            ))}
+            {category.trim() && (
+              <Badge variant="secondary">{category}</Badge>
+            )}
+            {!tags.filter((t) => t.trim()).length && !category.trim() && (
+              <p className="text-sm text-muted-foreground">
+                No tags or category added yet.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div
+          className="space-y-2"
+          data-testid="confidence-score-section"
+        >
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold text-foreground">
+              Publish confidence score
+            </p>
+            <span
+              className="text-lg font-bold text-foreground"
+              data-testid="confidence-score-value"
+            >
+              {score}/100
+            </span>
+          </div>
+          <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className={`h-full rounded-full transition-all ${
+                score >= 70
+                  ? 'bg-emerald-500'
+                  : score >= 40
+                    ? 'bg-amber-500'
+                    : 'bg-destructive'
+              }`}
+              style={{ width: `${score}%` }}
+              data-testid="confidence-score-bar"
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {score >= 70
+              ? 'Ready to publish. Your agent profile is well-configured.'
+              : score >= 40
+                ? 'Publishable but incomplete. Fix warnings to improve reach.'
+                : 'Low confidence. Address the issues below before publishing.'}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          <Button
+            onClick={onConfirmPublish}
+            variant={hasFailures ? 'outline' : 'default'}
+            data-testid="publish-anyway-button"
+          >
+            {hasFailures || hasWarnings ? 'Publish anyway' : 'Publish'}
+          </Button>
+          <Button
+            onClick={onFixIssues}
+            variant="outline"
+            data-testid="fix-issues-button"
+          >
+            Fix issues first
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/dashboard/index.ts
+++ b/apps/web/components/dashboard/index.ts
@@ -24,3 +24,4 @@ export { TimeBudgetPanel } from './TimeBudgetPanel';
 export type { TimeBudgetPanelProps } from './TimeBudgetPanel';
 export { MemoryTransparencyPanel } from './MemoryTransparencyPanel';
 export type { MemoryTransparencyPanelProps, MemoryFact } from './MemoryTransparencyPanel';
+export { CreatorPublishTransparencyPreview } from './CreatorPublishTransparencyPreview';

--- a/docs/pr-evidence/creator-publish-transparency-preview.md
+++ b/docs/pr-evidence/creator-publish-transparency-preview.md
@@ -1,0 +1,30 @@
+# Creator Publish Transparency Preview
+
+## Before
+
+Creators onboarding on AgentGram had no visibility into what would happen after they hit publish. There was no signal about:
+- Whether the agent name or bio would pass platform checks
+- How discoverable the agent would be based on tags and category
+- An overall confidence score before committing to publish
+
+This mirrors Character.AI's opaque publish process, which gives creators no feedback until after the agent is live.
+
+## After
+
+A `CreatorPublishTransparencyPreview` panel now appears in the onboard flow before the final quickstart prompts. It shows:
+
+- **Filter outcome**: Three named checks (name, bio, content policy) each rendered as green/yellow/red with an explanation.
+- **Discovery visibility**: "Wide / Niche / Limited" label derived from tag count and category presence, with the tag/category chips listed inline.
+- **Publish confidence score**: A 0–100 numeric score and color-coded progress bar (green ≥70, amber ≥40, red <40).
+- **CTAs**: "Publish anyway" (calls `onConfirmPublish`) and "Fix issues first" (calls `onFixIssues`).
+
+The preview is wired into `apps/web/app/(protected)/dashboard/onboard/page.tsx` and uses the existing `setupPath` / `memoryMode` state to derive the agent name and bio for the live preview.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/dashboard/CreatorPublishTransparencyPreview.tsx` | New component |
+| `apps/web/components/dashboard/index.ts` | Appended export |
+| `apps/web/app/(protected)/dashboard/onboard/page.tsx` | Import + panel added before prompts grid |
+| `apps/web/__tests__/components/creator-publish-transparency-preview.test.tsx` | 8 tests covering filter outcome, visibility, score, and CTA callbacks |


### PR DESCRIPTION
## Source

Source: backlog.md:387

## Evidence

docs/pr-evidence/creator-publish-transparency-preview.md

A `CreatorPublishTransparencyPreview` panel now appears in the onboard flow before the final quickstart prompts. Shows filter outcome (name/bio/content policy checks), discovery visibility (Wide/Niche/Limited), and a 0–100 publish confidence score with CTAs.

## Auth-only Proof

N/A

## Description

Show filter outcomes, org impact, and discovery visibility before character publish (C.AI opaque-publish counter-positioning).

## Type of Change

- [x] ✨ New feature (`type: feature`)

## Area

- [x] 🎨 Frontend (`area: frontend`)

## Changes Made

- New `CreatorPublishTransparencyPreview` component with filter outcome, discovery visibility, and confidence score
- Wired into `apps/web/app/(protected)/dashboard/onboard/page.tsx`
- 8 tests in `apps/web/__tests__/components/creator-publish-transparency-preview.test.tsx`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added the required source, evidence, and auth-only proof above
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes