### PR TITLE
feat: Nomi memory headroom meter

### DIFF
--- a/apps/web/__tests__/components/memory-headroom-meter.test.tsx
+++ b/apps/web/__tests__/components/memory-headroom-meter.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  MemoryHeadroomMeter,
+  type MemoryHeadroomData,
+} from '@/components/memory/MemoryHeadroomMeter';
+
+function buildData(overrides: Partial<MemoryHeadroomData> = {}): MemoryHeadroomData {
+  return {
+    used: 40,
+    capacity: 200,
+    recentGains: [],
+    ...overrides,
+  };
+}
+
+describe('MemoryHeadroomMeter', () => {
+  it('renders the meter container', () => {
+    render(<MemoryHeadroomMeter data={buildData()} />);
+    expect(screen.getByTestId('memory-headroom-meter')).toBeInTheDocument();
+  });
+
+  it('renders the progress bar', () => {
+    render(<MemoryHeadroomMeter data={buildData({ used: 100, capacity: 200 })} />);
+    const bar = screen.getByTestId('memory-headroom-bar');
+    expect(bar).toBeInTheDocument();
+    expect(bar).toHaveAttribute('role', 'progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '50');
+  });
+
+  it('shows correct headroom percentage', () => {
+    render(<MemoryHeadroomMeter data={buildData({ used: 50, capacity: 200 })} />);
+    expect(screen.getByTestId('memory-headroom-pct')).toHaveTextContent('75% headroom');
+  });
+
+  it('shows remaining slots count', () => {
+    render(<MemoryHeadroomMeter data={buildData({ used: 40, capacity: 200 })} />);
+    expect(screen.getByTestId('memory-headroom-remaining')).toHaveTextContent('160 slots remaining');
+  });
+
+  it('shows used percentage label', () => {
+    render(<MemoryHeadroomMeter data={buildData({ used: 40, capacity: 200 })} />);
+    expect(screen.getByTestId('memory-headroom-used-pct')).toHaveTextContent('20% full');
+  });
+
+  it('does not show warning badge in normal state (< 80%)', () => {
+    render(<MemoryHeadroomMeter data={buildData({ used: 100, capacity: 200 })} />);
+    expect(screen.queryByTestId('memory-headroom-warning')).not.toBeInTheDocument();
+  });
+
+  it('shows warning badge when usage is high (>= 80%)', () => {
+    render(<MemoryHeadroomMeter data={buildData({ used: 170, capacity: 200 })} />);
+    expect(screen.getByTestId('memory-headroom-warning')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-headroom-warning')).toHaveTextContent(/high usage/i);
+  });
+
+  it('shows critical badge when usage is >= 95%', () => {
+    render(<MemoryHeadroomMeter data={buildData({ used: 195, capacity: 200 })} />);
+    const warning = screen.getByTestId('memory-headroom-warning');
+    expect(warning).toHaveTextContent(/critical/i);
+  });
+
+  it('renders retention gains when provided', () => {
+    const data = buildData({
+      recentGains: [{ label: 'facts retained', count: 5, period: 'this week' }],
+    });
+    render(<MemoryHeadroomMeter data={data} />);
+    expect(screen.getByTestId('memory-headroom-gains')).toBeInTheDocument();
+    expect(screen.getByTestId('memory-headroom-gain-0')).toHaveTextContent('+5 facts retained this week');
+  });
+
+  it('renders multiple retention gains', () => {
+    const data = buildData({
+      recentGains: [
+        { label: 'facts retained', count: 3, period: 'this week' },
+        { label: 'topics added', count: 2, period: 'today' },
+      ],
+    });
+    render(<MemoryHeadroomMeter data={data} />);
+    expect(screen.getByTestId('memory-headroom-gain-0')).toHaveTextContent('+3');
+    expect(screen.getByTestId('memory-headroom-gain-1')).toHaveTextContent('+2');
+  });
+
+  it('does not render gains section when recentGains is empty', () => {
+    render(<MemoryHeadroomMeter data={buildData({ recentGains: [] })} />);
+    expect(screen.queryByTestId('memory-headroom-gains')).not.toBeInTheDocument();
+  });
+
+  it('shows used/capacity in the bar section label', () => {
+    render(<MemoryHeadroomMeter data={buildData({ used: 40, capacity: 200 })} />);
+    expect(screen.getByTestId('memory-headroom-bar-section')).toHaveTextContent('40 / 200 facts used');
+  });
+
+  it('clamps bar fill to 100% when used exceeds capacity', () => {
+    render(<MemoryHeadroomMeter data={buildData({ used: 250, capacity: 200 })} />);
+    const fill = screen.getByTestId('memory-headroom-bar-fill');
+    expect(fill).toHaveStyle({ width: '100%' });
+  });
+});

--- a/apps/web/app/(protected)/dashboard/memory-map/page.tsx
+++ b/apps/web/app/(protected)/dashboard/memory-map/page.tsx
@@ -17,6 +17,10 @@ export const metadata = {
   title: 'Memory Map',
 };
 
+function getOneWeekAgo() {
+  return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+}
+
 export default async function MemoryMapPage() {
   const supabase = await createClient();
   const {
@@ -69,7 +73,7 @@ export default async function MemoryMapPage() {
 
   const MEMORY_CAPACITY = 200;
   const usedCount = rawFacts?.length ?? 0;
-  const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const oneWeekAgo = getOneWeekAgo();
   const recentCount = (rawFacts ?? []).filter(
     (m) => new Date(m.updated_at) >= oneWeekAgo
   ).length;

--- a/apps/web/app/(protected)/dashboard/memory-map/page.tsx
+++ b/apps/web/app/(protected)/dashboard/memory-map/page.tsx
@@ -3,6 +3,7 @@ import { Brain, MapIcon } from 'lucide-react';
 import { FadeIn } from '@/components/dashboard';
 import { MemoryMindMapPanel } from '@/components/dashboard/MemoryMindMapPanel';
 import { MemoryFreshnessTimeline, type MemoryFact } from '@/components/memory/MemoryFreshnessTimeline';
+import { MemoryHeadroomMeter } from '@/components/memory/MemoryHeadroomMeter';
 import {
   Card,
   CardContent,
@@ -66,6 +67,18 @@ export default async function MemoryMapPage() {
     lastUsedAt: new Date(m.updated_at),
   }));
 
+  const MEMORY_CAPACITY = 200;
+  const usedCount = rawFacts?.length ?? 0;
+  const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const recentCount = (rawFacts ?? []).filter(
+    (m) => new Date(m.updated_at) >= oneWeekAgo
+  ).length;
+  const headroomData = {
+    used: usedCount,
+    capacity: MEMORY_CAPACITY,
+    recentGains: recentCount > 0 ? [{ label: 'facts retained', count: recentCount, period: 'this week' }] : [],
+  };
+
   return (
     <div className="space-y-8">
       <FadeIn>
@@ -115,6 +128,9 @@ export default async function MemoryMapPage() {
             </FadeIn>
           ))}
           <FadeIn delay={0.05 + agentList.length * 0.05}>
+            <MemoryHeadroomMeter data={headroomData} />
+          </FadeIn>
+          <FadeIn delay={0.1 + agentList.length * 0.05}>
             <div className="rounded-xl border border-border/50 bg-card/50 p-6 space-y-4">
               <div>
                 <h2 className="text-lg font-semibold tracking-tight">Memory Freshness</h2>

--- a/apps/web/components/memory/MemoryHeadroomMeter.tsx
+++ b/apps/web/components/memory/MemoryHeadroomMeter.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { Brain, TrendingUp, AlertTriangle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+
+export interface RetentionGain {
+  label: string;
+  count: number;
+  period: string;
+}
+
+export interface MemoryHeadroomData {
+  used: number;
+  capacity: number;
+  recentGains?: RetentionGain[];
+}
+
+interface MemoryHeadroomMeterProps {
+  data: MemoryHeadroomData;
+  className?: string;
+}
+
+function headroomPct(used: number, capacity: number): number {
+  if (capacity <= 0) return 0;
+  return Math.max(0, Math.round(((capacity - used) / capacity) * 100));
+}
+
+function usedPct(used: number, capacity: number): number {
+  if (capacity <= 0) return 0;
+  return Math.min(100, Math.round((used / capacity) * 100));
+}
+
+function warningLevel(usedP: number): 'critical' | 'warning' | 'ok' {
+  if (usedP >= 95) return 'critical';
+  if (usedP >= 80) return 'warning';
+  return 'ok';
+}
+
+function barColor(level: 'critical' | 'warning' | 'ok'): string {
+  if (level === 'critical') return 'bg-destructive';
+  if (level === 'warning') return 'bg-amber-500';
+  return 'bg-violet-500';
+}
+
+function headroomBgColor(level: 'critical' | 'warning' | 'ok'): string {
+  if (level === 'critical') return 'border-destructive/30 bg-destructive/5';
+  if (level === 'warning') return 'border-amber-500/30 bg-amber-500/5';
+  return 'border-violet-500/20 bg-violet-500/5';
+}
+
+function headroomTextColor(level: 'critical' | 'warning' | 'ok'): string {
+  if (level === 'critical') return 'text-destructive font-semibold';
+  if (level === 'warning') return 'text-amber-600 dark:text-amber-400 font-medium';
+  return 'text-violet-600 dark:text-violet-400';
+}
+
+export function MemoryHeadroomMeter({ data, className }: MemoryHeadroomMeterProps) {
+  const { used, capacity, recentGains = [] } = data;
+  const usedP = usedPct(used, capacity);
+  const headroomP = headroomPct(used, capacity);
+  const remaining = Math.max(0, capacity - used);
+  const level = warningLevel(usedP);
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border p-4 space-y-4',
+        headroomBgColor(level),
+        className
+      )}
+      data-testid="memory-headroom-meter"
+      aria-label="Memory headroom meter"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <Brain className="h-4 w-4 text-violet-500" aria-hidden="true" />
+          <span>Memory Headroom</span>
+        </div>
+        {level !== 'ok' && (
+          <div
+            className="flex items-center gap-1 text-xs"
+            data-testid="memory-headroom-warning"
+            aria-label={level === 'critical' ? 'Memory critically full' : 'Memory usage high'}
+          >
+            <AlertTriangle
+              className={cn('h-3.5 w-3.5', level === 'critical' ? 'text-destructive' : 'text-amber-500')}
+              aria-hidden="true"
+            />
+            <span className={level === 'critical' ? 'text-destructive' : 'text-amber-600 dark:text-amber-400'}>
+              {level === 'critical' ? 'Critical' : 'High usage'}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Usage bar */}
+      <div className="space-y-1.5" data-testid="memory-headroom-bar-section">
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">
+            {used} / {capacity} facts used
+          </span>
+          <span className={headroomTextColor(level)} data-testid="memory-headroom-pct">
+            {headroomP}% headroom
+          </span>
+        </div>
+        <div
+          className="h-2.5 w-full rounded-full bg-muted overflow-hidden"
+          role="progressbar"
+          aria-valuenow={usedP}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Memory used: ${usedP}%`}
+          data-testid="memory-headroom-bar"
+        >
+          <div
+            className={cn('h-full rounded-full transition-all', barColor(level))}
+            style={{ width: `${usedP}%` }}
+            data-testid="memory-headroom-bar-fill"
+          />
+        </div>
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span data-testid="memory-headroom-remaining">
+            {remaining} slots remaining
+          </span>
+          <span data-testid="memory-headroom-used-pct">{usedP}% full</span>
+        </div>
+      </div>
+
+      {/* Retention gains */}
+      {recentGains.length > 0 && (
+        <div className="space-y-2" data-testid="memory-headroom-gains">
+          <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+            <TrendingUp className="h-3.5 w-3.5 text-green-500" aria-hidden="true" />
+            <span>Recent retention gains</span>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {recentGains.map((gain, i) => (
+              <Badge
+                key={i}
+                variant="secondary"
+                className="gap-1 text-xs bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20"
+                data-testid={`memory-headroom-gain-${i}`}
+              >
+                <TrendingUp className="h-2.5 w-2.5" aria-hidden="true" />
+                +{gain.count} {gain.label} {gain.period}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/memory/index.ts
+++ b/apps/web/components/memory/index.ts
@@ -1,0 +1,15 @@
+export { MemoryArchitectureDiagram } from './MemoryArchitectureDiagram';
+export { MemoryBulkDeleteImpactCard } from './MemoryBulkDeleteImpactCard';
+export { MemoryDeletionReceipt } from './MemoryDeletionReceipt';
+export { MemoryFirstRunExplainer } from './MemoryFirstRunExplainer';
+export { MemoryFreshnessTimeline } from './MemoryFreshnessTimeline';
+export { MemoryHeadroomMeter } from './MemoryHeadroomMeter';
+export type { MemoryHeadroomData, RetentionGain } from './MemoryHeadroomMeter';
+export { MemoryMindMapGraph } from './MemoryMindMapGraph';
+export { MemoryModeDisclosureCard } from './MemoryModeDisclosureCard';
+export { MemoryRetrievalBasisBadge } from './MemoryRetrievalBasisBadge';
+export { MemoryRetrievalModeSelector } from './MemoryRetrievalModeSelector';
+export { MemoryUsageMeter } from './MemoryUsageMeter';
+export type { MemoryUsageData } from './MemoryUsageMeter';
+export { RetrievalExplainabilityCard } from './RetrievalExplainabilityCard';
+export { SharedNoteScopePicker } from './SharedNoteScopePicker';

--- a/apps/web/components/memory/index.ts
+++ b/apps/web/components/memory/index.ts
@@ -1,12 +1,12 @@
 export { MemoryArchitectureDiagram } from './MemoryArchitectureDiagram';
 export { MemoryBulkDeleteImpactCard } from './MemoryBulkDeleteImpactCard';
 export { MemoryDeletionReceipt } from './MemoryDeletionReceipt';
-export { MemoryFirstRunExplainer } from './MemoryFirstRunExplainer';
+export { default as MemoryFirstRunExplainer } from './MemoryFirstRunExplainer';
 export { MemoryFreshnessTimeline } from './MemoryFreshnessTimeline';
 export { MemoryHeadroomMeter } from './MemoryHeadroomMeter';
 export type { MemoryHeadroomData, RetentionGain } from './MemoryHeadroomMeter';
 export { MemoryMindMapGraph } from './MemoryMindMapGraph';
-export { MemoryModeDisclosureCard } from './MemoryModeDisclosureCard';
+export { default as MemoryModeDisclosureCard } from './MemoryModeDisclosureCard';
 export { MemoryRetrievalBasisBadge } from './MemoryRetrievalBasisBadge';
 export { MemoryRetrievalModeSelector } from './MemoryRetrievalModeSelector';
 export { MemoryUsageMeter } from './MemoryUsageMeter';

--- a/apps/web/docs/pr-evidence/memory-headroom-meter.md
+++ b/apps/web/docs/pr-evidence/memory-headroom-meter.md
@@ -1,0 +1,50 @@
+# PR Evidence: Memory Headroom Meter
+
+**Backlog row:** 389
+**Branch:** feat/nomi-memory-headroom-meter
+**Date:** 2026-06-25
+
+## What was built
+
+`MemoryHeadroomMeter` — a visual meter component that surfaces retained-memory headroom and recent retention gains in the memory UI.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `apps/web/components/memory/MemoryHeadroomMeter.tsx` | New component |
+| `apps/web/components/memory/index.ts` | New barrel export |
+| `apps/web/app/(protected)/dashboard/memory-map/page.tsx` | Wired into memory map dashboard |
+| `apps/web/__tests__/components/memory-headroom-meter.test.tsx` | 13 tests |
+
+## Component features
+
+- **Headroom bar** — progress bar showing current used / capacity with `aria-*` attributes for accessibility
+- **Headroom %** — remaining capacity shown as a percentage label
+- **Remaining slots** — absolute count of unused slots
+- **Warning states** — amber badge at ≥80% usage, red "Critical" badge at ≥95%
+- **Retention gains** — green badges showing `+N facts retained this week` when recent gains are present
+- **Color coding** — violet (ok) → amber (warning) → destructive (critical) matching existing design system
+
+## Integration
+
+Wired into `memory-map/page.tsx`:
+- Computes `headroomData` from `agent_memories` query (capacity = 200 facts)
+- Counts facts updated in the last 7 days as weekly retention gain
+- Renders `<MemoryHeadroomMeter>` above the freshness timeline in the agents view
+
+## Tests (13 tests, ≥9 required)
+
+1. Renders meter container
+2. Renders progress bar with correct `role` and `aria-valuenow`
+3. Shows correct headroom percentage
+4. Shows remaining slots count
+5. Shows used percentage label
+6. No warning badge in normal state (<80%)
+7. Shows warning badge at ≥80% usage
+8. Shows critical badge at ≥95% usage
+9. Renders retention gains when provided
+10. Renders multiple retention gains
+11. Does not render gains section when empty
+12. Shows used/capacity label in bar section
+13. Clamps bar fill to 100% when used exceeds capacity


### PR DESCRIPTION
## Source
backlog.md:389

MemoryHeadroomMeter shows retained-memory headroom and recent retention gains.

## What changed
- `apps/web/components/memory/MemoryHeadroomMeter.tsx` — new component with headroom bar, warning states (≥80% amber, ≥95% critical), and retention gains badges
- `apps/web/components/memory/index.ts` — new barrel export for all memory components
- `apps/web/app/(protected)/dashboard/memory-map/page.tsx` — wired in headroom meter above freshness timeline
- `apps/web/__tests__/components/memory-headroom-meter.test.tsx` — 13 tests, all passing

## Evidence
docs/pr-evidence/memory-headroom-meter.md

## Auth-only Proof
N/A