### PR TITLE
feat: add RealtimePolicyIndicator to character creator description input

### DIFF
--- a/apps/web/__tests__/components/realtime-policy-indicator.test.tsx
+++ b/apps/web/__tests__/components/realtime-policy-indicator.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RealtimePolicyIndicator } from '@/components/creator/RealtimePolicyIndicator';
+
+describe('RealtimePolicyIndicator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when value is empty', () => {
+    render(<RealtimePolicyIndicator value="" />);
+    expect(screen.queryByTestId('realtime-policy-indicator')).toBeNull();
+  });
+
+  it('shows green status for a clean description longer than 10 chars', async () => {
+    render(<RealtimePolicyIndicator value="Answers user questions helpfully" />);
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    const indicator = screen.getByTestId('realtime-policy-indicator');
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveAttribute('data-status', 'green');
+    expect(screen.getByText('Looks good')).toBeInTheDocument();
+  });
+
+  it('shows amber status for a very short description', async () => {
+    render(<RealtimePolicyIndicator value="Hi" />);
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    const indicator = screen.getByTestId('realtime-policy-indicator');
+    expect(indicator).toHaveAttribute('data-status', 'amber');
+    expect(screen.getByText('Review suggested')).toBeInTheDocument();
+  });
+
+  it('shows red status when description contains a policy-flagged term', async () => {
+    render(<RealtimePolicyIndicator value="This contains explicit content" />);
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    const indicator = screen.getByTestId('realtime-policy-indicator');
+    expect(indicator).toHaveAttribute('data-status', 'red');
+    expect(screen.getByText('Policy concern')).toBeInTheDocument();
+  });
+
+  it('shows amber status for non-alphabetic input', async () => {
+    render(<RealtimePolicyIndicator value="12345678901" />);
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    const indicator = screen.getByTestId('realtime-policy-indicator');
+    expect(indicator).toHaveAttribute('data-status', 'amber');
+  });
+
+  it('applies custom className', () => {
+    render(
+      <RealtimePolicyIndicator
+        value="A valid description text here"
+        className="mt-2"
+      />
+    );
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    const indicator = screen.getByTestId('realtime-policy-indicator');
+    expect(indicator.className).toContain('mt-2');
+  });
+});

--- a/apps/web/components/creator/RealtimePolicyIndicator.tsx
+++ b/apps/web/components/creator/RealtimePolicyIndicator.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AlertTriangle, CheckCircle, XCircle } from 'lucide-react';
+
+interface RealtimePolicyIndicatorProps {
+  value: string;
+  className?: string;
+}
+
+type PolicyStatus = 'green' | 'amber' | 'red';
+
+interface PolicyState {
+  status: PolicyStatus;
+  label: string;
+}
+
+const HARMFUL_PATTERN = /\b(hate|violence|explicit|abuse|terror|kill|rape|gore)\b/i;
+
+function computeStatus(value: string): PolicyState {
+  if (value.length === 0) {
+    return { status: 'green', label: 'Looks good' };
+  }
+  if (HARMFUL_PATTERN.test(value)) {
+    return { status: 'red', label: 'Policy concern' };
+  }
+  if (value.length < 10) {
+    return { status: 'amber', label: 'Review suggested' };
+  }
+  const hasValidChars = /[a-zA-Z]/.test(value);
+  if (!hasValidChars) {
+    return { status: 'amber', label: 'Review suggested' };
+  }
+  return { status: 'green', label: 'Looks good' };
+}
+
+export function RealtimePolicyIndicator({
+  value,
+  className = '',
+}: RealtimePolicyIndicatorProps) {
+  const [policyState, setPolicyState] = useState<PolicyState>(() =>
+    computeStatus(value)
+  );
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setPolicyState(computeStatus(value));
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [value]);
+
+  if (value.length === 0) return null;
+
+  const { status, label } = policyState;
+
+  return (
+    <div
+      className={`flex items-center gap-1.5 text-xs ${className}`}
+      data-testid="realtime-policy-indicator"
+      data-status={status}
+    >
+      {status === 'green' && (
+        <CheckCircle className="h-3.5 w-3.5 text-emerald-500" />
+      )}
+      {status === 'amber' && (
+        <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+      )}
+      {status === 'red' && (
+        <XCircle className="h-3.5 w-3.5 text-destructive" />
+      )}
+      <span
+        className={
+          status === 'green'
+            ? 'text-emerald-600'
+            : status === 'amber'
+              ? 'text-amber-600'
+              : 'text-destructive'
+        }
+      >
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/components/creator/index.ts
+++ b/apps/web/components/creator/index.ts
@@ -1,0 +1,3 @@
+export { RealtimePolicyIndicator } from './RealtimePolicyIndicator';
+export { CreatorDiscoveryPanel } from './CreatorDiscoveryPanel';
+export { CreatorDiscoveryPrompts } from './CreatorDiscoveryPrompts';

--- a/apps/web/components/dashboard/AgentMemoryTrustForm.tsx
+++ b/apps/web/components/dashboard/AgentMemoryTrustForm.tsx
@@ -13,6 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { RealtimePolicyIndicator } from '@/components/creator';
 
 type EditableSnapshot = {
   displayName: string;
@@ -322,6 +323,7 @@ export function AgentMemoryTrustForm({ settings }: AgentMemoryTrustFormProps) {
               placeholder="Short public profile summary"
               value={form.description}
             />
+            <RealtimePolicyIndicator value={form.description} />
           </label>
 
           <label className="space-y-2">

--- a/apps/web/docs/pr-evidence/realtime-publish-policy-signal.md
+++ b/apps/web/docs/pr-evidence/realtime-publish-policy-signal.md
@@ -1,0 +1,51 @@
+# PR Evidence: Real-time Publish Policy Signal
+
+**Backlog ref:** backlog.md:394
+**Branch:** feat/realtime-publish-policy-signal
+**Base:** develop
+**Extends:** PR #895 (CreatorPublishTransparencyPreview — end-of-flow static preview)
+
+## What was built
+
+### New component: `RealtimePolicyIndicator`
+- **Path:** `apps/web/components/creator/RealtimePolicyIndicator.tsx`
+- **Props:** `{ value: string; className?: string }`
+- **States:**
+  - `green` — "Looks good" (clean text, length ≥ 10, has alphabetic chars)
+  - `amber` — "Review suggested" (too short < 10 chars, or no alphabetic content)
+  - `red` — "Policy concern" (contains flagged terms: hate, violence, explicit, abuse, terror, kill, rape, gore)
+- **Debounce:** 300ms via `useEffect` + `setTimeout`
+- **Hides itself** when `value` is empty (no visual noise on empty state)
+
+### Integration point
+- **File:** `apps/web/components/dashboard/AgentMemoryTrustForm.tsx`
+- **Location:** Below the "Profile summary" description `<textarea>`, inside the `<label>` block
+- Receives `form.description` as live `value` prop — updates on every keystroke, debounced 300ms
+
+### Barrel export
+- **New file:** `apps/web/components/creator/index.ts`
+- Exports `RealtimePolicyIndicator`, `CreatorDiscoveryPanel`, `CreatorDiscoveryPrompts`
+
+## Tests
+- **Path:** `apps/web/__tests__/components/realtime-policy-indicator.test.tsx`
+- **Assertions (6):**
+  1. Empty value → renders nothing
+  2. Clean long text → green / "Looks good"
+  3. Short text (< 10 chars) → amber / "Review suggested"
+  4. Policy-flagged term ("explicit") → red / "Policy concern"
+  5. Non-alphabetic digits-only → amber
+  6. Custom `className` applied to wrapper
+
+## Competitive positioning
+Character.AI launched a 60-day "creation transparency" counter on 2026-06-01.
+This feature counters with inline per-keystroke policy signal — creators see compliance
+status as they type, not only at end-of-flow publish time. Lower friction, higher trust signal.
+
+## Files changed
+| File | Change |
+|------|--------|
+| `apps/web/components/creator/RealtimePolicyIndicator.tsx` | Created |
+| `apps/web/components/creator/index.ts` | Created (barrel) |
+| `apps/web/components/dashboard/AgentMemoryTrustForm.tsx` | Import + indicator below description textarea |
+| `apps/web/__tests__/components/realtime-policy-indicator.test.tsx` | Created (6 assertions) |
+| `apps/web/docs/pr-evidence/realtime-publish-policy-signal.md` | Created (this file) |


### PR DESCRIPTION
## Source
backlog.md:394

Extends PR #895 static publish preview with inline real-time content policy signal during character description input.

## Changes
- New component: RealtimePolicyIndicator (green/amber/red states, 300ms debounce)
- Integrated into character creator description field (AgentMemoryTrustForm Profile summary textarea)
- Barrel export: components/creator/index.ts
- Tests: 6 assertions covering all policy states and edge cases

## Evidence
[docs/pr-evidence/realtime-publish-policy-signal.md]

## Auth-only Proof
N/A

## Notes
Character.AI 60-day creation transparency counter-positioning.