### PR TITLE
docs: creator reach dashboard evidence follow-up (PR #877 artifact-pack fix)

### DIFF
--- a/apps/web/docs/pr-evidence/creator-reach-dashboard.md
+++ b/apps/web/docs/pr-evidence/creator-reach-dashboard.md
@@ -1,0 +1,46 @@
+# PR Evidence: Character.AI Creator Reach Dashboard
+
+## Backlog Row
+Row 371 — Character.AI creator reach dashboard
+
+## Signal
+Character.AI offers limited visibility to creators on how their characters perform post-publish. Creators have no native dashboard showing follower growth, discovery lift, or reach after publishing. AgentGram fills this gap with a dedicated creator reach dashboard that surfaces growth stats and discovery metrics so creators can see whether they are growing.
+
+## Changes
+
+### New Components
+
+**`apps/web/components/creator/CreatorReachDashboard.tsx`**
+- Dashboard panel showing creator reach, follows, and discovery lift after publish
+- Metrics: total followers, weekly follower delta, discovery impressions, publish-to-follow conversion rate
+- `data-testid="creator-reach-dashboard"`
+- `aria-labelledby` wired to heading id
+
+**`apps/web/components/creator/CreatorDiscoveryPanel.tsx`**
+- Discovery stats panel with real DB queries replacing hardcoded values (fixed in c801ce30)
+- `useEffect` lazy init fix applied (commit 27d65ef2)
+- `data-testid="creator-discovery-panel"`
+
+### Edited Files
+
+**`apps/web/app/(public)/creator/dashboard/page.tsx`**
+- Imports `CreatorReachDashboard`
+- Renders reach dashboard after publish summary section
+
+### Tests
+
+Tests shipped with PR #877 on commit c801ce30 in origin/develop. CI GREEN at develop HEAD (Unit Tests + Lint PASS as of 2026-06-26).
+
+## Auth-only Proof
+
+N/A — component is public-facing creator dashboard, no auth-only surface.
+
+## Before / After
+
+**Before:** Creators had no way to see follower growth, discovery lift, or reach attribution after publishing a character. Stats were either missing or hardcoded placeholders.
+
+**After:** Creator reach dashboard with live DB-backed metrics: follower delta, discovery impressions, and publish-to-follow conversion rate. Creators can now directly measure whether publishing is growing their audience.
+
+## Note
+
+PR #877 was originally merged with an Artifact Pack Guard failure due to a row reference error in the PR body (row 365 instead of row 371). Code and tests are correctly reflected in origin/develop at commit c801ce30. This docs PR provides the corrected evidence document.


### PR DESCRIPTION
## Source

backlog.md:371

## Description
Evidence doc for PR #877 creator reach dashboard. Artifact Pack Guard failed at merge due to row reference error in original PR body (365→371). Code and tests correctly shipped in origin/develop at commit c801ce30.

## Evidence

docs/pr-evidence/creator-reach-dashboard.md (docs diff)

## Auth-only Proof

N/A