### PR TITLE
feat: memory relationship timeline + pricing upgrade CTA on memory dashboard

### DIFF
--- a/apps/web/__tests__/components/memory-export-dashboard.test.tsx
+++ b/apps/web/__tests__/components/memory-export-dashboard.test.tsx
@@ -151,4 +151,37 @@ describe('MemoryExportDashboard', () => {
     render(<MemoryExportDashboard memories={[buildMemory()]} />);
     expect(screen.getByTestId('memory-export-actions-card')).toBeInTheDocument();
   });
+
+  it('renders the relationship timeline section', () => {
+    render(<MemoryExportDashboard memories={[buildMemory()]} />);
+    expect(screen.getByTestId('memory-relationship-timeline')).toBeInTheDocument();
+  });
+
+  it('timeline shows first memory date when memories are present', () => {
+    render(<MemoryExportDashboard memories={[buildMemory({ createdAt: '2026-05-01T12:00:00.000Z' })]} />);
+    expect(screen.getByTestId('memory-first-fact-date')).toHaveTextContent('May 1, 2026');
+  });
+
+  it('timeline shows milestone count equal to memory count', () => {
+    const memories = [
+      buildMemory({ id: 'm1' }),
+      buildMemory({ id: 'm2', key: 'hobby', value: 'Loves hiking.' }),
+    ];
+    render(<MemoryExportDashboard memories={memories} />);
+    expect(screen.getByTestId('memory-milestone-count')).toHaveTextContent('2 key moments');
+  });
+
+  it('timeline shows dash dates when no memories', () => {
+    render(<MemoryExportDashboard memories={[]} />);
+    const dateCells = screen.getAllByTestId(/memory-(first-fact|relationship-start)-date/);
+    dateCells.forEach((cell) => expect(cell).toHaveTextContent('—'));
+  });
+
+  it('renders the upgrade CTA with a link to /pricing', () => {
+    render(<MemoryExportDashboard memories={[]} />);
+    const cta = screen.getByTestId('memory-upgrade-cta');
+    expect(cta).toBeInTheDocument();
+    const link = screen.getByTestId('memory-upgrade-cta-link');
+    expect(link).toHaveAttribute('href', '/pricing');
+  });
 });

--- a/apps/web/components/dashboard/MemoryExportDashboard.tsx
+++ b/apps/web/components/dashboard/MemoryExportDashboard.tsx
@@ -267,7 +267,6 @@ export function MemoryExportDashboard({ memories: initialMemories }: Props) {
       {/* Relationship timeline — reframes memory as a trust asset */}
       <MemoryRelationshipTimeline
         firstFactDate={firstFactDate}
-        relationshipStartDate={firstFactDate}
         milestoneCount={milestoneCount}
       />
 

--- a/apps/web/components/dashboard/MemoryExportDashboard.tsx
+++ b/apps/web/components/dashboard/MemoryExportDashboard.tsx
@@ -4,11 +4,13 @@ import { useState } from 'react';
 import Link from 'next/link';
 import {
   ArrowLeft,
+  ArrowUpRight,
   Brain,
   Download,
   FileJson,
   FileText,
   Network,
+  Sparkles,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -20,6 +22,7 @@ import {
 } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { MemoryTierTabs } from './MemoryTierTabs';
+import { MemoryRelationshipTimeline } from '@/components/memory/MemoryRelationshipTimeline';
 import { MultilingualMemoryBadge } from '@/components/agents/MultilingualMemoryBadge';
 import {
   MemoryDeletionReceipt,
@@ -161,6 +164,14 @@ function buildMindMapData(memories: MemoryExportRecord[]): {
 
 export function MemoryExportDashboard({ memories: initialMemories }: Props) {
   const [memories, setMemories] = useState<MemoryExportRecord[]>(initialMemories);
+
+  const firstFactDate = memories.length > 0
+    ? memories.reduce((earliest, m) =>
+        m.createdAt < earliest ? m.createdAt : earliest,
+        memories[0].createdAt
+      )
+    : undefined;
+  const milestoneCount = memories.length;
   const [deleting, setDeleting] = useState<Set<string>>(new Set());
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deletionReceipt, setDeletionReceipt] = useState<MemoryDeletionReceiptData | null>(null);
@@ -251,6 +262,38 @@ export function MemoryExportDashboard({ memories: initialMemories }: Props) {
         <div data-testid="memory-export-multilingual-badge">
           <MultilingualMemoryBadge />
         </div>
+      </div>
+
+      {/* Relationship timeline — reframes memory as a trust asset */}
+      <MemoryRelationshipTimeline
+        firstFactDate={firstFactDate}
+        relationshipStartDate={firstFactDate}
+        milestoneCount={milestoneCount}
+      />
+
+      {/* Pricing upgrade CTA */}
+      <div
+        className="rounded-xl border border-violet-200 bg-violet-50/60 dark:border-violet-800/40 dark:bg-violet-950/20 px-6 py-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+        data-testid="memory-upgrade-cta"
+      >
+        <div className="flex items-start gap-3">
+          <Sparkles className="mt-0.5 h-5 w-5 shrink-0 text-violet-500" aria-hidden="true" />
+          <div className="space-y-0.5">
+            <p className="text-sm font-semibold text-foreground">Unlock the full memory layer</p>
+            <p className="text-xs text-muted-foreground">
+              Premium plans include unlimited memory slots, priority recall, and relationship insights — so nothing gets forgotten.
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/pricing"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+          data-testid="memory-upgrade-cta-link"
+          aria-label="View pricing plans to unlock full memory layer"
+        >
+          View plans
+          <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
+        </Link>
       </div>
 
       {/* Export Actions */}

--- a/docs/pr-evidence/memory-timeline-pricing-cta.md
+++ b/docs/pr-evidence/memory-timeline-pricing-cta.md
@@ -1,0 +1,23 @@
+# PR Evidence: Memory Relationship Timeline + Pricing Upgrade CTA
+
+## Source
+backlog.md row 398 — [STRATEGY] Memory relationship timeline reframe + /pricing paid CTA
+
+## Changes
+- `apps/web/components/dashboard/MemoryExportDashboard.tsx`: Added `MemoryRelationshipTimeline` component above Export Actions card; added upgrade CTA section linking to `/pricing`
+- `apps/web/__tests__/components/memory-export-dashboard.test.tsx`: Added 5 new tests covering timeline render, date display, milestone count, empty state, and upgrade CTA link
+
+## Before
+Memory Export dashboard showed only export actions + memory list. No relationship framing, no upgrade path from memory management to paid tier.
+
+## After
+Memory Export dashboard now opens with:
+1. **"Your shared history" timeline** — shows relationship start date, first memory date, and milestone count (reframes memory as a relationship trust asset, direct counter to Nomi's memory layer visibility feature)
+2. **"Unlock the full memory layer" upgrade CTA** — violet-accented card with "View plans" button linking to `/pricing`, surfaces premium memory features (unlimited slots, priority recall, relationship insights) at the moment users are most engaged with their memory data
+
+## Test results
+- 2344 tests passed (248 test files)
+- 5 new tests added for timeline + CTA coverage
+
+## Competitive signal
+Nomi "기억 레이어 가시화" counter (2026-06-25 research §핵심 발견 2): Nomi surfaces memory architecture visibility as a trust differentiator. This PR counters with relationship-framed memory timeline on the dashboard + paid tier CTA at point of engagement.


### PR DESCRIPTION
## Source
backlog.md:398

## Summary
- Adds `MemoryRelationshipTimeline` ('Your shared history') above Export Actions on the memory dashboard — shows relationship start date, first memory date, and milestone count
- Adds violet upgrade CTA below the timeline linking to `/pricing` with 'Unlock the full memory layer' messaging
- Counters Nomi 2026 memory layer visibility feature with relationship-framed memory narrative + paid tier funnel at point of engagement

## Changes
- `apps/web/components/dashboard/MemoryExportDashboard.tsx` — import + render MemoryRelationshipTimeline, compute firstFactDate/milestoneCount from memories, add upgrade CTA section
- `apps/web/__tests__/components/memory-export-dashboard.test.tsx` — 5 new tests
- `docs/pr-evidence/memory-timeline-pricing-cta.md` — evidence doc

## Evidence
Before: Memory Export dashboard opened directly to export actions + memory list. No relationship framing, no upgrade path.

After: Dashboard opens with relationship timeline header + pricing CTA — reframes memory management as relationship trust asset, surfaces paid tier at moment of highest memory engagement.

See: docs/pr-evidence/memory-timeline-pricing-cta.md

## Auth-only Proof
N/A

## Test results
2344 tests passed (248 files), 5 new tests added.