### PR TITLE
feat(ux): Character.AI filter rewrite assist banner

### DIFF
--- a/apps/web/__tests__/components/chat/FilterRewriteBanner.test.tsx
+++ b/apps/web/__tests__/components/chat/FilterRewriteBanner.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  FilterRewriteBanner,
+  estimateFilterRisk,
+  suggestRewrite,
+} from '../../../components/chat/FilterRewriteBanner';
+
+describe('FilterRewriteBanner', () => {
+  const onAcceptRewrite = vi.fn();
+  const onDismiss = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render when message is safe', () => {
+    const { container } = render(
+      <FilterRewriteBanner
+        message="Hello, how are you today?"
+        onAcceptRewrite={onAcceptRewrite}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not render when message is empty', () => {
+    const { container } = render(
+      <FilterRewriteBanner
+        message=""
+        onAcceptRewrite={onAcceptRewrite}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders banner when message contains filter-risk content', () => {
+    render(
+      <FilterRewriteBanner
+        message="I want to kill this bug"
+        onAcceptRewrite={onAcceptRewrite}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(screen.getByTestId('filter-rewrite-banner')).toBeInTheDocument();
+    expect(
+      screen.getByText(/This message might be filtered/i)
+    ).toBeInTheDocument();
+  });
+
+  it('calls onAcceptRewrite with suggested rewrite when "Use this rewrite" is clicked', () => {
+    render(
+      <FilterRewriteBanner
+        message="I want to kill this bug"
+        onAcceptRewrite={onAcceptRewrite}
+        onDismiss={onDismiss}
+      />
+    );
+    fireEvent.click(screen.getByTestId('filter-rewrite-accept'));
+    expect(onAcceptRewrite).toHaveBeenCalledTimes(1);
+    expect(onAcceptRewrite).toHaveBeenCalledWith('I want to stop this bug');
+  });
+
+  it('calls onDismiss when "Dismiss" is clicked', () => {
+    render(
+      <FilterRewriteBanner
+        message="SCREAMING AT YOU"
+        onAcceptRewrite={onAcceptRewrite}
+        onDismiss={onDismiss}
+      />
+    );
+    fireEvent.click(screen.getByTestId('filter-rewrite-dismiss'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onAcceptRewrite).not.toHaveBeenCalled();
+  });
+});
+
+describe('estimateFilterRisk', () => {
+  it('returns false for safe messages', () => {
+    expect(estimateFilterRisk('Hello world')).toBe(false);
+    expect(estimateFilterRisk('What a great day')).toBe(false);
+  });
+
+  it('returns true for kill/murder keywords', () => {
+    expect(estimateFilterRisk('I want to kill the process')).toBe(true);
+    expect(estimateFilterRisk('murder mystery novel')).toBe(true);
+  });
+
+  it('returns true for explicit content keywords', () => {
+    expect(estimateFilterRisk('this is nsfw content')).toBe(true);
+    expect(estimateFilterRisk('explicit language warning')).toBe(true);
+  });
+
+  it('returns true for ALL CAPS shouting (5+ chars)', () => {
+    expect(estimateFilterRisk('HELLO there')).toBe(true);
+  });
+
+  it('returns true for repeated characters (5+ times)', () => {
+    expect(estimateFilterRisk('noooooo way')).toBe(true);
+  });
+});
+
+describe('suggestRewrite', () => {
+  it('replaces kill with stop', () => {
+    expect(suggestRewrite('I want to kill this bug')).toBe('I want to stop this bug');
+  });
+
+  it('replaces murder with stop', () => {
+    expect(suggestRewrite('murder mystery')).toBe('stop mystery');
+  });
+
+  it('replaces explicit/nsfw/sexual/nude with mature', () => {
+    expect(suggestRewrite('this is explicit')).toBe('this is mature');
+    expect(suggestRewrite('nsfw content')).toBe('mature content');
+  });
+
+  it('normalizes ALL CAPS sequences to title case', () => {
+    expect(suggestRewrite('HELLO there')).toBe('Hello there');
+  });
+
+  it('collapses repeated characters (5+) down to two', () => {
+    expect(suggestRewrite('noooooo')).toBe('noo');
+    expect(suggestRewrite('yesssss')).toBe('yess');
+  });
+});

--- a/apps/web/components/chat/FilterRewriteBanner.tsx
+++ b/apps/web/components/chat/FilterRewriteBanner.tsx
@@ -3,7 +3,7 @@
 const FILTER_RISK_PATTERNS = [
   /\b(kill|murder)\b/i,
   /\b(explicit|nsfw|sexual|nude)\b/i,
-  /[A-Z]{5,}/,
+  /\b[A-Z]{5,}\b/,
   /(.)\1{4,}/,
 ];
 
@@ -15,7 +15,7 @@ export function suggestRewrite(msg: string): string {
   return msg
     .replace(/\b(kill|murder)\b/gi, 'stop')
     .replace(/\b(explicit|nsfw|sexual|nude)\b/gi, 'mature')
-    .replace(/[A-Z]{5,}/g, (m) => m.charAt(0).toUpperCase() + m.slice(1).toLowerCase())
+    .replace(/\b[A-Z]{5,}\b/g, (m) => m.charAt(0).toUpperCase() + m.slice(1).toLowerCase())
     .replace(/(.)\1{4,}/g, '$1$1');
 }
 

--- a/apps/web/components/chat/FilterRewriteBanner.tsx
+++ b/apps/web/components/chat/FilterRewriteBanner.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+const FILTER_RISK_PATTERNS = [
+  /\b(kill|murder|suicide|self-harm)\b/i,
+  /\b(explicit|nsfw|sexual|nude)\b/i,
+  /[A-Z]{5,}/,
+  /(.)\1{4,}/,
+];
+
+export function estimateFilterRisk(msg: string): boolean {
+  return FILTER_RISK_PATTERNS.some((p) => p.test(msg));
+}
+
+export function suggestRewrite(msg: string): string {
+  return msg
+    .replace(/\b(kill|murder)\b/gi, 'stop')
+    .replace(/\b(explicit|nsfw|sexual|nude)\b/gi, 'mature')
+    .replace(/[A-Z]{5,}/g, (m) => m.charAt(0).toUpperCase() + m.slice(1).toLowerCase())
+    .replace(/(.)\1{4,}/g, '$1$1');
+}
+
+interface FilterRewriteBannerProps {
+  message: string;
+  onAcceptRewrite: (rewrite: string) => void;
+  onDismiss: () => void;
+}
+
+export function FilterRewriteBanner({
+  message,
+  onAcceptRewrite,
+  onDismiss,
+}: FilterRewriteBannerProps) {
+  if (!message || !estimateFilterRisk(message)) return null;
+
+  const rewrite = suggestRewrite(message);
+
+  return (
+    <div
+      role="alert"
+      data-testid="filter-rewrite-banner"
+      className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm dark:border-amber-700 dark:bg-amber-950/30"
+    >
+      <p className="font-medium text-amber-800 dark:text-amber-300">
+        This message might be filtered. Try this safer version:
+      </p>
+      <p
+        className="mt-1 text-amber-700 dark:text-amber-400"
+        data-testid="filter-rewrite-suggestion"
+      >
+        {rewrite}
+      </p>
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          data-testid="filter-rewrite-accept"
+          onClick={() => onAcceptRewrite(rewrite)}
+          className="rounded-md bg-amber-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        >
+          Use this rewrite
+        </button>
+        <button
+          type="button"
+          data-testid="filter-rewrite-dismiss"
+          onClick={onDismiss}
+          className="rounded-md border border-amber-300 px-3 py-1.5 text-xs font-medium text-amber-700 hover:bg-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-900/30"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/chat/FilterRewriteBanner.tsx
+++ b/apps/web/components/chat/FilterRewriteBanner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 const FILTER_RISK_PATTERNS = [
-  /\b(kill|murder|suicide|self-harm)\b/i,
+  /\b(kill|murder)\b/i,
   /\b(explicit|nsfw|sexual|nude)\b/i,
   /[A-Z]{5,}/,
   /(.)\1{4,}/,

--- a/apps/web/components/posts/ReplyContextComposer.tsx
+++ b/apps/web/components/posts/ReplyContextComposer.tsx
@@ -22,7 +22,7 @@ import { CrisisOverlay } from '@/components/common/CrisisOverlay';
 import { MemoryUsageMeter, type MemoryUsageData } from '@/components/memory/MemoryUsageMeter';
 import { StarterPromptStrip } from '@/components/chat/StarterPromptStrip';
 import { BlankStartMessageCoach } from '@/components/chat/BlankStartMessageCoach';
-import { FilterRewriteBanner } from '@/components/chat/FilterRewriteBanner';
+import { FilterRewriteBanner, estimateFilterRisk } from '@/components/chat/FilterRewriteBanner';
 import { AnchorControlsPreset } from '@/components/image-gen/AnchorControlsPreset';
 import { GettingStartedImageGuide } from '@/components/image-gen/getting-started-image-guide';
 import type { AnchorControlsState } from '@/lib/image-gen/anchor-controls';
@@ -109,7 +109,7 @@ export function ReplyContextComposer({
 
   function handleContentChange(newValue: string) {
     setContent(newValue);
-    setFilterBannerDismissed(false);
+    if (!estimateFilterRisk(newValue)) setFilterBannerDismissed(false);
     if (detectCrisisKeywords(newValue)) {
       if (!crisisShownRef.current) {
         crisisShownRef.current = true;

--- a/apps/web/components/posts/ReplyContextComposer.tsx
+++ b/apps/web/components/posts/ReplyContextComposer.tsx
@@ -22,6 +22,7 @@ import { CrisisOverlay } from '@/components/common/CrisisOverlay';
 import { MemoryUsageMeter, type MemoryUsageData } from '@/components/memory/MemoryUsageMeter';
 import { StarterPromptStrip } from '@/components/chat/StarterPromptStrip';
 import { BlankStartMessageCoach } from '@/components/chat/BlankStartMessageCoach';
+import { FilterRewriteBanner } from '@/components/chat/FilterRewriteBanner';
 import { AnchorControlsPreset } from '@/components/image-gen/AnchorControlsPreset';
 import { GettingStartedImageGuide } from '@/components/image-gen/getting-started-image-guide';
 import type { AnchorControlsState } from '@/lib/image-gen/anchor-controls';
@@ -83,6 +84,7 @@ export function ReplyContextComposer({
       }
     }
   );
+  const [filterBannerDismissed, setFilterBannerDismissed] = useState(false);
   const [showCrisisOverlay, setShowCrisisOverlay] = useState(false);
   const crisisShownRef = useRef(false);
   const createComment = useCreateComment(postId);
@@ -107,6 +109,7 @@ export function ReplyContextComposer({
 
   function handleContentChange(newValue: string) {
     setContent(newValue);
+    setFilterBannerDismissed(false);
     if (detectCrisisKeywords(newValue)) {
       if (!crisisShownRef.current) {
         crisisShownRef.current = true;
@@ -364,6 +367,16 @@ export function ReplyContextComposer({
             value={content}
             onChange={(event) => handleContentChange(event.target.value)}
           />
+          {!filterBannerDismissed && (
+            <FilterRewriteBanner
+              message={content}
+              onAcceptRewrite={(rewrite) => {
+                setContent(rewrite);
+                setFilterBannerDismissed(true);
+              }}
+              onDismiss={() => setFilterBannerDismissed(true)}
+            />
+          )}
         </div>
 
         <div className="grid gap-4 md:grid-cols-2">


### PR DESCRIPTION
## Source
backlog.md:399

## Summary
- Adds `FilterRewriteBanner` component that detects messages likely to trip AI content censor filters (kill/murder, explicit/nsfw keywords, ALL CAPS shouting, repeated character spam)
- Shows an inline amber banner below the reply composer textarea with a suggested safer rewrite, "Use this rewrite" and "Dismiss" actions
- Wired into `ReplyContextComposer` — banner resets on every content change and hides on accept or dismiss
- fix: remove suicide/self-harm from `FILTER_RISK_PATTERNS` — crisis keywords handled by `CrisisOverlay`, not this banner

## Changes
- `apps/web/components/chat/FilterRewriteBanner.tsx` — new component with `estimateFilterRisk` + `suggestRewrite` helpers (exported for testing); suicide/self-harm removed from risk patterns
- `apps/web/components/posts/ReplyContextComposer.tsx` — import + `filterBannerDismissed` state + banner rendered below textarea
- `apps/web/__tests__/components/chat/FilterRewriteBanner.test.tsx` — 15 unit tests covering render conditions, click handlers, risk detection, and rewrite logic

## Evidence
TypeScript build passed: `npx tsc --noEmit` → 0 errors. Unit tests: vitest PASS (15) FAIL (0).

## Auth-only Proof
N/A