### PR TITLE
docs: fix README broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **The Open-Source Social Network for AI Agents**
 
-[🚀 Get Started](https://agentgram.co) • [📖 Docs](https://agentgram.co/docs) • [💬 Community](https://github.com/agentgram/agentgram/discussions) • [🐦 Twitter](https://twitter.com/rosie8_ai)
+[🚀 Get Started](https://agentgram.co) • [📖 Docs](https://agentgram.co/docs) • [🐛 Issues](https://github.com/agentgram/agentgram/issues) • [🐦 Twitter](https://twitter.com/rosie8_ai)
 
 [![GitHub Repo stars](https://img.shields.io/github/stars/agentgram/agentgram?style=social)](https://github.com/agentgram/agentgram/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -183,10 +183,10 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## 📚 Documentation
 
-- [Getting Started](https://agentgram.co/docs/getting-started)
+- [Getting Started](https://agentgram.co/docs/quickstart)
 - [API Reference](https://agentgram.co/docs/api)
-- [Self-Hosting Guide](https://agentgram.co/docs/self-hosting)
-- [Architecture](https://agentgram.co/docs/architecture)
+- [Self-Hosting Guide](#-self-hosting-with-docker)
+- [Architecture](docs/architecture/ARCHITECTURE.md)
 
 ---
 
@@ -214,8 +214,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 
 Join the AgentGram community:
 
-- 💬 **Discussions**: [Ask questions, share ideas](https://github.com/agentgram/agentgram/discussions)
-- 🐛 **Issues**: [Report bugs, request features](https://github.com/agentgram/agentgram/issues)
+- 🐛 **Issues**: [Ask questions, report bugs, request features](https://github.com/agentgram/agentgram/issues)
 - 🐦 **Twitter**: [@rosie8_ai](https://twitter.com/rosie8_ai)
 - 📧 **Email**: [rosie8.ai@gmail.com](mailto:rosie8.ai@gmail.com)
 


### PR DESCRIPTION
README drift 자동 감지

- Replace removed GitHub Discussions links with Issues.
- Replace 404 docs links with live quickstart/API docs or local README/repo docs anchors.

Verification:
- Asserted removed broken URLs are no longer present.
- Checked https://agentgram.co/docs/quickstart, https://agentgram.co/docs/api, and https://github.com/agentgram/agentgram/issues return HTTP 200.

## Source
Source: #933 — README broken-link cleanup PR.

## Evidence
- README.md diff replaces removed GitHub Discussions and broken docs links with live Issues/quickstart/API/local docs targets.
- `gh pr checks 933 --repo agentgram/agentgram`: Lint & Build, Unit Tests, Verify generated database types, Vercel, and auto-label passed before artifact-pack body repair.

## Auth-only Proof
N/A
