### PR TITLE
fix(web): gate notifications query behind auth (logged-out 401)

### DIFF
--- a/apps/web/__tests__/components/notification-bell.test.tsx
+++ b/apps/web/__tests__/components/notification-bell.test.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { render, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationBell } from '@/components/common/NotificationBell';
 import { useNotifications } from '@/hooks/use-notifications';
+
+const mockGetSession = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: { getSession: mockGetSession },
+  }),
+}));
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -23,6 +32,7 @@ function createWrapper() {
 describe('useNotifications', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockGetSession.mockReset();
   });
 
   it('does not fetch when disabled for unauthenticated surfaces', async () => {
@@ -56,5 +66,20 @@ describe('useNotifications', () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0]?.[0]).toMatch(/\/api\/v1\/notifications/);
+  });
+
+  it('keeps the bell query disabled for logged-out users', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null } });
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ data: [] }), { status: 200 }));
+
+    render(<NotificationBell />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(mockGetSession).toHaveBeenCalledTimes(1);
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/common/NotificationBell.tsx
+++ b/apps/web/components/common/NotificationBell.tsx
@@ -13,7 +13,10 @@ export function NotificationBell() {
   const [isOpen, setIsOpen] = useState(false);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  const { data, isLoading } = useNotifications({ limit: 5 });
+  const { data, isLoading } = useNotifications({
+    limit: 5,
+    enabled: isAuthenticated,
+  });
   const markRead = useMarkNotificationsRead();
 
   useEffect(() => {


### PR DESCRIPTION
Source: backlog 401 canary / navi t_0bf57974

## Root cause
비로그인 상태 notifications 쿼리 실행 → 401 x2.

## Fix
enabled 조건으로 auth 뒤 게이팅.

## Evidence
- apps/web/components/common/NotificationBell.tsx now passes enabled: isAuthenticated to useNotifications.
- apps/web/__tests__/components/notification-bell.test.tsx covers logged-out bell rendering with zero /api/v1/notifications fetches.
- pnpm --filter web test __tests__/components/notification-bell.test.tsx: 3 passed.
- pnpm --filter web type-check: passed.
- pnpm --filter web lint -- components/common/NotificationBell.tsx __tests__/components/notification-bell.test.tsx: exit 0 (repo has pre-existing warnings).