### PR TITLE
ux(pricing): show Replika Advanced AI comparison

### DIFF
--- a/apps/web/__tests__/components/pricing/ReplikaAdvancedAiComparisonCard.test.tsx
+++ b/apps/web/__tests__/components/pricing/ReplikaAdvancedAiComparisonCard.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ReplikaAdvancedAiComparisonCard } from '@/components/pricing/ReplikaAdvancedAiComparisonCard';
+
+describe('ReplikaAdvancedAiComparisonCard', () => {
+  it('renders the comparison card without crashing', () => {
+    render(<ReplikaAdvancedAiComparisonCard />);
+    expect(screen.getByTestId('replika-advanced-ai-comparison-card')).toBeInTheDocument();
+  });
+
+  it('explains the Advanced AI mode preview before switching modes', () => {
+    render(<ReplikaAdvancedAiComparisonCard />);
+    expect(screen.getByTestId('advanced-ai-eyebrow')).toHaveTextContent('Advanced AI mode preview');
+    expect(screen.getByTestId('advanced-ai-heading')).toHaveTextContent(
+      'See what improves before you switch modes'
+    );
+  });
+
+  it('shows the response and memory improvements AgentGram previews up front', () => {
+    render(<ReplikaAdvancedAiComparisonCard />);
+    const card = screen.getByTestId('replika-advanced-ai-comparison-card');
+    expect(card).toHaveTextContent('response');
+    expect(card).toHaveTextContent('memory');
+    expect(card).toHaveTextContent('before checkout');
+  });
+
+  it('renders all comparison rows', () => {
+    render(<ReplikaAdvancedAiComparisonCard />);
+    expect(screen.getByTestId('advanced-ai-response-depth')).toBeInTheDocument();
+    expect(screen.getByTestId('advanced-ai-memory-carryover')).toBeInTheDocument();
+    expect(screen.getByTestId('advanced-ai-switching-confidence')).toBeInTheDocument();
+  });
+
+  it('compares Replika Advanced AI against AgentGram in each row', () => {
+    render(<ReplikaAdvancedAiComparisonCard />);
+    expect(screen.getAllByText('Replika Advanced AI')).toHaveLength(3);
+    expect(screen.getAllByText('AgentGram')).toHaveLength(3);
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -569,6 +569,13 @@ export default function PricingPage() {
         data-testid="paid-conversion-social-proof-section"
       >
         <PaidConversionSocialProofBlock onUpgrade={() => handleSubscribe('Pro')} />
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="replika-advanced-ai-comparison-section"
+      >
+        <ReplikaAdvancedAiComparisonCard />
       </section>
 
       <section

--- a/apps/web/components/pricing/ReplikaAdvancedAiComparisonCard.tsx
+++ b/apps/web/components/pricing/ReplikaAdvancedAiComparisonCard.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { BrainCircuit, CheckCircle2, MessageSquareText, Sparkles, X } from 'lucide-react';
+
+const comparisonRows = [
+  {
+    feature: 'Response depth',
+    replikaMode: 'Advanced AI mode promises richer replies after switching modes.',
+    agentgramMode: 'Richer reasoning stays visible before checkout: longer context, explainable tone, and no hidden mode flip.',
+    testId: 'advanced-ai-response-depth',
+  },
+  {
+    feature: 'Memory carryover',
+    replikaMode: 'Users have to trust how memories will behave once Advanced AI is enabled.',
+    agentgramMode: 'Memory continuity is previewed up front: saved facts, corrections, and relationship context stay inspectable.',
+    testId: 'advanced-ai-memory-carryover',
+  },
+  {
+    feature: 'Switching confidence',
+    replikaMode: 'Mode names describe the upgrade, but not the exact conversational improvement.',
+    agentgramMode: 'The comparison spells out what improves in responses and memory before you choose a paid plan.',
+    testId: 'advanced-ai-switching-confidence',
+  },
+] as const;
+
+export function ReplikaAdvancedAiComparisonCard() {
+  return (
+    <div
+      className="mx-auto max-w-3xl rounded-2xl border border-blue-500/20 bg-blue-500/5 px-6 py-6 shadow-sm"
+      data-testid="replika-advanced-ai-comparison-card"
+    >
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p
+            className="inline-flex items-center gap-1.5 rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700 dark:text-blue-300"
+            data-testid="advanced-ai-eyebrow"
+          >
+            <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+            Advanced AI mode preview
+          </p>
+          <h2
+            className="text-xl font-bold text-foreground"
+            data-testid="advanced-ai-heading"
+          >
+            See what improves before you switch modes
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Replika asks users to switch into Advanced AI mode to discover whether replies and memory feel
+            better. AgentGram shows the response and memory upgrades up front so the upgrade decision is clear.
+          </p>
+        </div>
+        <div
+          className="shrink-0 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm"
+          data-testid="advanced-ai-agentgram-proof"
+        >
+          <p className="flex items-center gap-1.5 font-semibold text-emerald-700 dark:text-emerald-400">
+            <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+            Preview first
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Responses + memory explained before checkout
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="grid gap-3"
+        data-testid="advanced-ai-comparison-rows"
+      >
+        {comparisonRows.map((row) => (
+          <div
+            key={row.feature}
+            className="rounded-xl border border-border/40 bg-background/70 p-4"
+            data-testid={row.testId}
+          >
+            <p className="mb-3 text-sm font-semibold text-foreground">{row.feature}</p>
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-3">
+                <p className="mb-1 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-destructive/80">
+                  <X className="h-3.5 w-3.5" aria-hidden="true" />
+                  Replika Advanced AI
+                </p>
+                <p className="text-xs leading-relaxed text-muted-foreground">{row.replikaMode}</p>
+              </div>
+              <div className="rounded-lg border border-emerald-500/25 bg-emerald-500/10 p-3">
+                <p className="mb-1 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-400">
+                  {row.feature === 'Response depth' ? (
+                    <MessageSquareText className="h-3.5 w-3.5" aria-hidden="true" />
+                  ) : (
+                    <BrainCircuit className="h-3.5 w-3.5" aria-hidden="true" />
+                  )}
+                  AgentGram
+                </p>
+                <p className="text-xs leading-relaxed text-muted-foreground">{row.agentgramMode}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -4,6 +4,7 @@ export { ReplikaPricingConfusionCallout } from './ReplikaPricingConfusionCallout
 export { CAISoftLaunchLockEscape } from './CAISoftLaunchLockEscape';
 export { CAIStatusEntitlementBanner } from './CAIStatusEntitlementBanner';
 export { PricingCompetitorAnchorRow } from './PricingCompetitorAnchorRow';
+export { ReplikaAdvancedAiComparisonCard } from './ReplikaAdvancedAiComparisonCard';
 export { ReplikaSavingsCalculator } from './ReplikaSavingsCalculator';
 export { PaidConversionSocialProofBlock } from './PaidConversionSocialProofBlock';
 export { ReplikaUltraFatigueFunnel } from './ReplikaUltraFatigueFunnel';


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog ux item 10a286db8e.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Replika Advanced AI mode comparison card to the pricing page that previews what improves in response depth, memory carryover, and switching confidence before users choose a mode or paid plan.

## Evidence
Tests/type-check/diff verified locally:
- pnpm --filter web exec vitest run __tests__/components/pricing/ReplikaAdvancedAiComparisonCard.test.tsx — 5 tests passed.
- pnpm --filter web exec vitest run __tests__/components/pricing/ReplicaUltraFeatureDeltaCard.test.tsx __tests__/components/pricing/ReplikaAdvancedAiComparisonCard.test.tsx — 16 tests passed.
- pnpm --filter web type-check — passed.
- pnpm --filter web exec eslint components/pricing/ReplikaAdvancedAiComparisonCard.tsx __tests__/components/pricing/ReplikaAdvancedAiComparisonCard.test.tsx app/\(public\)/pricing/page.tsx — passed.
- git diff --cached --stat before commit showed 4 scoped files changed.

## Auth-only Proof
N/A
