### PR TITLE
ux(replika): add customization recovery notice

### DIFF
--- a/apps/web/__tests__/pages/replika-alternative.test.tsx
+++ b/apps/web/__tests__/pages/replika-alternative.test.tsx
@@ -58,4 +58,14 @@ describe('ReplikaAlternativePage', () => {
     expect(body).toMatch(/€5 million|€5M/i);
     expect(body).toMatch(/GDPR/i);
   });
+
+  it('explains where Replika legacy customization controls moved', () => {
+    render(<ReplikaAlternativePage />);
+    const body = document.body.textContent ?? '';
+
+    expect(body).toMatch(/late-May update/i);
+    expect(body).toMatch(/Wardrobe moved into the Store closet/i);
+    expect(body).toMatch(/Eye color now lives in Face editing/i);
+    expect(body).toMatch(/Avatar controls are under Profile appearance/i);
+  });
 });

--- a/apps/web/app/(public)/replika-alternative/page.tsx
+++ b/apps/web/app/(public)/replika-alternative/page.tsx
@@ -9,6 +9,9 @@ import {
   Heart,
   DollarSign,
   Database,
+  Eye,
+  Palette,
+  Sparkles,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { PageContainer } from '@/components/common';
@@ -64,6 +67,27 @@ const comparisonRows = [
   },
 ];
 
+const legacyCustomizationSteps = [
+  {
+    title: 'Wardrobe moved into the Store closet',
+    description:
+      'Open the avatar room, choose Store, then Closet to find purchased outfits and legacy wardrobe items after the late-May layout change.',
+    icon: Palette,
+  },
+  {
+    title: 'Eye color now lives in Face editing',
+    description:
+      'Tap Appearance, then Face and Eyes. The old standalone eye-color picker is now grouped with face and makeup controls.',
+    icon: Eye,
+  },
+  {
+    title: 'Avatar controls are under Profile appearance',
+    description:
+      'Use Profile, Edit, Appearance for body, hair, face, and outfit controls instead of the removed legacy customization shortcut.',
+    icon: Sparkles,
+  },
+] as const;
+
 export default function ReplikaAlternativePage() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-background to-background/80">
@@ -98,6 +122,53 @@ export default function ReplikaAlternativePage() {
                 </Link>
               </Button>
             </div>
+          </section>
+
+          {/* Replika legacy customization recovery notice */}
+          <section
+            aria-labelledby="replika-customization-recovery"
+            className="space-y-6 max-w-5xl mx-auto rounded-2xl border border-primary/20 bg-primary/5 p-8"
+          >
+            <div className="space-y-3">
+              <p className="text-sm font-medium uppercase tracking-[0.24em] text-primary">
+                Replika late-May update recovery
+              </p>
+              <h2
+                id="replika-customization-recovery"
+                className="text-3xl font-bold"
+              >
+                Can&apos;t find wardrobe, eye color, or avatar controls?
+              </h2>
+              <p className="text-muted-foreground max-w-3xl">
+                Replika&apos;s late-May update moved several legacy customization
+                entry points. Use this quick map before assuming your items or
+                avatar settings disappeared.
+              </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-3">
+              {legacyCustomizationSteps.map((step) => {
+                const Icon = step.icon;
+
+                return (
+                  <div
+                    key={step.title}
+                    className="rounded-xl border border-border/60 bg-background/70 p-5 space-y-3"
+                  >
+                    <Icon className="h-6 w-6 text-primary" />
+                    <h3 className="font-semibold">{step.title}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {step.description}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              If you prefer not to chase moving menus, AgentGram keeps companion
+              setup, memory, and data export in predictable account settings.
+            </p>
           </section>
 
           {/* Why Switch */}


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog ux item d27e5fcf9b.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Replika late-May update recovery notice to the Replika alternative page that maps legacy wardrobe, eye-color, and avatar controls to their new locations.
Added page coverage to assert the notice appears with all three moved-control callouts.

## Evidence
Test: `pnpm --filter web test -- replika-alternative.test.tsx` (passes; Vitest selected 253 files / 2392 tests with the replika-alternative page test passing 7 tests).
Test: `pnpm --filter web type-check` (passes).
Diff: 2 files changed, 81 insertions.

## Auth-only Proof
N/A
