### PR TITLE
ux(replika): add Ask prompt rail

### DIFF
--- a/apps/web/__tests__/pages/replika-alternative.test.tsx
+++ b/apps/web/__tests__/pages/replika-alternative.test.tsx
@@ -68,4 +68,17 @@ describe('ReplikaAlternativePage', () => {
     expect(body).toMatch(/Eye color now lives in Face editing/i);
     expect(body).toMatch(/Avatar controls are under Profile appearance/i);
   });
+
+  it('renders the Ask Replika prompt rail with AgentGram context framing', () => {
+    render(<ReplikaAlternativePage />);
+    const body = document.body.textContent ?? '';
+
+    expect(body).toMatch(/Ask Replika alternative/i);
+    expect(body).toMatch(/Prompt starters should not feel like another upsell/i);
+    expect(body).toMatch(/Pro \/ Advanced AI flow/i);
+    expect(body).toMatch(/Give me a grounding exercise for tonight/i);
+    expect(body).toMatch(/Help me practice a hard conversation/i);
+    expect(body).toMatch(/Turn my messy week into a simple plan/i);
+    expect(body).toMatch(/companion remember what you already shared/i);
+  });
 });

--- a/apps/web/app/(public)/replika-alternative/page.tsx
+++ b/apps/web/app/(public)/replika-alternative/page.tsx
@@ -12,6 +12,7 @@ import {
   Eye,
   Palette,
   Sparkles,
+  MessageCircleQuestion,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { PageContainer } from '@/components/common';
@@ -85,6 +86,27 @@ const legacyCustomizationSteps = [
     description:
       'Use Profile, Edit, Appearance for body, hair, face, and outfit controls instead of the removed legacy customization shortcut.',
     icon: Sparkles,
+  },
+] as const;
+
+const askReplikaPromptRail = [
+  {
+    category: 'Well-being',
+    prompt: 'Give me a grounding exercise for tonight.',
+    agentgram:
+      'AgentGram keeps the context with your companion history instead of hiding starters behind a Pro-only Advanced AI rail.',
+  },
+  {
+    category: 'Relationships',
+    prompt: 'Help me practice a hard conversation.',
+    agentgram:
+      'Prompts can connect to memory, boundaries, and relationship tone without making you re-explain the same situation.',
+  },
+  {
+    category: 'Life Skills',
+    prompt: 'Turn my messy week into a simple plan.',
+    agentgram:
+      'Starter ideas are framed as companion guidance, not a separate mode you must remember to launch from the composer.',
   },
 ] as const;
 
@@ -168,6 +190,63 @@ export default function ReplikaAlternativePage() {
             <p className="text-sm text-muted-foreground">
               If you prefer not to chase moving menus, AgentGram keeps companion
               setup, memory, and data export in predictable account settings.
+            </p>
+          </section>
+
+          {/* Ask Replika prompt rail */}
+          <section
+            aria-labelledby="ask-replika-prompt-rail"
+            className="space-y-6 max-w-5xl mx-auto rounded-2xl border border-border/60 bg-muted/20 p-8"
+          >
+            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div className="space-y-3 max-w-3xl">
+                <p className="text-sm font-medium uppercase tracking-[0.24em] text-primary">
+                  Ask Replika alternative
+                </p>
+                <h2 id="ask-replika-prompt-rail" className="text-3xl font-bold">
+                  Prompt starters should not feel like another upsell
+                </h2>
+                <p className="text-muted-foreground">
+                  Replika&apos;s Ask Replika feature puts prompt categories such as
+                  well-being, relationships, life skills, productivity, and
+                  creativity behind the Pro / Advanced AI flow. AgentGram makes
+                  starter prompts useful by tying them to memory and clear
+                  companion context before you type.
+                </p>
+              </div>
+
+              <div className="rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-sm font-medium text-primary">
+                Composer-ready ideas
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-3">
+              {askReplikaPromptRail.map((item) => (
+                <article
+                  key={item.category}
+                  className="rounded-xl border border-border/60 bg-background/80 p-5 space-y-4"
+                >
+                  <div className="flex items-center gap-2 text-sm font-semibold text-primary">
+                    <MessageCircleQuestion
+                      className="h-4 w-4"
+                      aria-hidden="true"
+                    />
+                    {item.category}
+                  </div>
+                  <p className="rounded-lg bg-muted/50 p-3 text-sm font-medium">
+                    “{item.prompt}”
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {item.agentgram}
+                  </p>
+                </article>
+              ))}
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              Use this rail to compare the real question: are prompts just a
+              content library, or do they help your companion remember what you
+              already shared?
             </p>
           </section>
 


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog ux item 01ee96c12d.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Replika alternative prompt rail that explains Ask Replika-style starter categories and reframes them around AgentGram memory/context.
Covered well-being, relationships, and life-skills starter prompts with companion-context copy.

## Evidence
- pnpm --filter web type-check — pass
- pnpm --filter web test -- __tests__/pages/replika-alternative.test.tsx — pass (255 test files / 2403 tests due workspace Vitest pattern)
- git diff --check — pass

## Auth-only Proof
N/A
