### PR TITLE
ux(pricing): clarify Replika Advanced AI comparison

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -201,6 +201,16 @@ describe('PricingPage', () => {
     expect(section).toHaveTextContent('Voice mode');
   });
 
+  it('renders the Replika Advanced AI comparison section with the decision path', () => {
+    render(<PricingPage />);
+
+    const section = screen.getByTestId('replika-advanced-ai-comparison-section');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('Replika standard chat');
+    expect(section).toHaveTextContent('Advanced AI upgrade');
+    expect(section).toHaveTextContent('AgentGram preview');
+  });
+
   it('renders Visual Memory mind map section with Nomi parity badge and Starter+ callout', () => {
     render(<PricingPage />);
 

--- a/apps/web/__tests__/components/pricing/ReplikaAdvancedAiComparisonCard.test.tsx
+++ b/apps/web/__tests__/components/pricing/ReplikaAdvancedAiComparisonCard.test.tsx
@@ -25,6 +25,15 @@ describe('ReplikaAdvancedAiComparisonCard', () => {
     expect(card).toHaveTextContent('before checkout');
   });
 
+  it('shows the decision path from standard chat to AgentGram preview', () => {
+    render(<ReplikaAdvancedAiComparisonCard />);
+    const steps = screen.getByTestId('advanced-ai-decision-steps');
+
+    expect(steps).toHaveTextContent('Replika standard chat');
+    expect(steps).toHaveTextContent('Advanced AI upgrade');
+    expect(steps).toHaveTextContent('AgentGram preview');
+  });
+
   it('renders all comparison rows', () => {
     render(<ReplikaAdvancedAiComparisonCard />);
     expect(screen.getByTestId('advanced-ai-response-depth')).toBeInTheDocument();

--- a/apps/web/components/pricing/ReplikaAdvancedAiComparisonCard.tsx
+++ b/apps/web/components/pricing/ReplikaAdvancedAiComparisonCard.tsx
@@ -23,6 +23,21 @@ const comparisonRows = [
   },
 ] as const;
 
+const decisionSteps = [
+  {
+    label: 'Replika standard chat',
+    detail: 'Baseline replies before the upgrade toggle.',
+  },
+  {
+    label: 'Advanced AI upgrade',
+    detail: 'Richer mode, but the improvement is mostly discovered after switching.',
+  },
+  {
+    label: 'AgentGram preview',
+    detail: 'Response depth and memory behavior are explained before checkout.',
+  },
+] as const;
+
 export function ReplikaAdvancedAiComparisonCard() {
   return (
     <div
@@ -67,6 +82,20 @@ export function ReplikaAdvancedAiComparisonCard() {
         className="grid gap-3"
         data-testid="advanced-ai-comparison-rows"
       >
+        <div
+          className="grid gap-3 rounded-xl border border-blue-500/20 bg-background/80 p-4 md:grid-cols-3"
+          data-testid="advanced-ai-decision-steps"
+        >
+          {decisionSteps.map((step) => (
+            <div key={step.label} className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700 dark:text-blue-300">
+                {step.label}
+              </p>
+              <p className="text-xs leading-relaxed text-muted-foreground">{step.detail}</p>
+            </div>
+          ))}
+        </div>
+
         {comparisonRows.map((row) => (
           <div
             key={row.feature}


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog ux item 643dffe22f.
Ref: https://github.com/agentgram/agentgram

## Change
Clarified the Replika Advanced AI comparison card with a decision-path strip from standard chat to AgentGram preview.
Added regression coverage for the card-level decision path and the pricing-page section render.

## Evidence
pnpm --filter web type-check — passed.
pnpm --filter web exec vitest run __tests__/components/pricing/ReplikaAdvancedAiComparisonCard.test.tsx __tests__/components/pricing-page.test.tsx — passed (17 tests). diff: 3 files changed, 48 insertions.

## Auth-only Proof
N/A
