### PR TITLE
feat(pricing): add Kindroid transcript provider picker

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -201,6 +201,16 @@ describe('PricingPage', () => {
     expect(section).toHaveTextContent('Voice mode');
   });
 
+  it('renders the Kindroid transcript provider picker on the pricing page', () => {
+    render(<PricingPage />);
+
+    const section = screen.getByTestId('kindroid-transcript-provider-picker-section');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('AgentGram Live');
+    expect(section).toHaveTextContent('Bring your provider');
+    expect(section).toHaveTextContent('Local export only');
+  });
+
   it('renders Visual Memory mind map section with Nomi parity badge and Starter+ callout', () => {
     render(<PricingPage />);
 

--- a/apps/web/__tests__/components/pricing/KindroidTranscriptProviderPicker.test.tsx
+++ b/apps/web/__tests__/components/pricing/KindroidTranscriptProviderPicker.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { KindroidTranscriptProviderPicker } from '@/components/pricing/KindroidTranscriptProviderPicker';
+
+describe('KindroidTranscriptProviderPicker', () => {
+  it('renders the transcript provider picker without crashing', () => {
+    render(<KindroidTranscriptProviderPicker />);
+    expect(screen.getByTestId('kindroid-transcript-provider-picker')).toBeInTheDocument();
+  });
+
+  it('explains that transcript provider choice happens before the call starts', () => {
+    render(<KindroidTranscriptProviderPicker />);
+    expect(screen.getByTestId('kindroid-transcript-picker-eyebrow')).toHaveTextContent(
+      'Kindroid call transcript control'
+    );
+    expect(screen.getByTestId('kindroid-transcript-picker-heading')).toHaveTextContent(
+      'Pick the transcript provider before the call starts'
+    );
+  });
+
+  it('shows all three transcript provider routes', () => {
+    render(<KindroidTranscriptProviderPicker />);
+
+    expect(screen.getByTestId('kindroid-transcript-provider-agentgram')).toHaveTextContent(
+      'AgentGram Live'
+    );
+    expect(screen.getByTestId('kindroid-transcript-provider-byop')).toHaveTextContent(
+      'Bring your provider'
+    );
+    expect(screen.getByTestId('kindroid-transcript-provider-local')).toHaveTextContent(
+      'Local export only'
+    );
+    expect(screen.getByTestId('kindroid-transcript-provider-options').children).toHaveLength(3);
+  });
+
+  it('updates the selected provider detail when a provider is picked', () => {
+    render(<KindroidTranscriptProviderPicker />);
+
+    fireEvent.click(screen.getByTestId('kindroid-transcript-provider-byop'));
+
+    expect(screen.getByTestId('kindroid-transcript-picker-selected-summary')).toHaveTextContent(
+      'Bring your provider'
+    );
+    expect(screen.getByTestId('kindroid-transcript-provider-detail')).toHaveTextContent(
+      'vendor-specific transcription stack'
+    );
+    expect(screen.getByTestId('kindroid-transcript-provider-byop')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
+  it('keeps transcript trust signals visible', () => {
+    render(<KindroidTranscriptProviderPicker />);
+    const trustSignals = screen.getByTestId('kindroid-transcript-trust-signals');
+
+    expect(trustSignals.children).toHaveLength(3);
+    expect(trustSignals).toHaveTextContent('Provider choice is visible before joining a call');
+    expect(trustSignals).toHaveTextContent('memory review controls');
+    expect(trustSignals).toHaveTextContent('Fallback mode keeps notes exportable');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, KindroidTranscriptProviderPicker, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -583,6 +583,13 @@ export default function PricingPage() {
         data-testid="replika-voice-call-preflight-section"
       >
         <ReplikaVoiceCallPreflightCard />
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="kindroid-transcript-provider-picker-section"
+      >
+        <KindroidTranscriptProviderPicker />
       </section>
 
       <section

--- a/apps/web/components/pricing/KindroidTranscriptProviderPicker.tsx
+++ b/apps/web/components/pricing/KindroidTranscriptProviderPicker.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState } from 'react';
+import { CheckCircle2, Cloud, FileText, ShieldCheck, SlidersHorizontal } from 'lucide-react';
+
+const transcriptProviders = [
+  {
+    id: 'agentgram-live',
+    name: 'AgentGram Live',
+    badge: 'Default',
+    description: 'Realtime transcript with speaker turns, timestamps, and call-health markers saved to the session recap.',
+    detail: 'Best when you want a ready-to-share call summary as soon as the companion call ends.',
+    testId: 'kindroid-transcript-provider-agentgram',
+  },
+  {
+    id: 'bring-your-own',
+    name: 'Bring your provider',
+    badge: 'API key',
+    description: 'Route transcription through your preferred speech API while keeping AgentGram memory controls intact.',
+    detail: 'Useful for teams standardizing on a vendor-specific transcription stack or language model.',
+    testId: 'kindroid-transcript-provider-byop',
+  },
+  {
+    id: 'local-export',
+    name: 'Local export only',
+    badge: 'Private',
+    description: 'Keep call audio off third-party transcription and export the conversation notes manually after review.',
+    detail: 'A privacy-first option for sensitive calls, audits, or creator QA before anything enters long-term memory.',
+    testId: 'kindroid-transcript-provider-local',
+  },
+] as const;
+
+type TranscriptProviderId = (typeof transcriptProviders)[number]['id'];
+
+const trustSignals = [
+  'Provider choice is visible before joining a call',
+  'Transcript storage stays tied to memory review controls',
+  'Fallback mode keeps notes exportable when live captions fail',
+] as const;
+
+export function KindroidTranscriptProviderPicker() {
+  const [selectedProvider, setSelectedProvider] = useState<TranscriptProviderId>('agentgram-live');
+  const selected = transcriptProviders.find((provider) => provider.id === selectedProvider) ?? transcriptProviders[0];
+
+  return (
+    <div
+      className="mx-auto max-w-4xl rounded-2xl border border-amber-500/25 bg-amber-500/5 px-6 py-6 shadow-sm"
+      data-testid="kindroid-transcript-provider-picker"
+    >
+      <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-2xl space-y-2">
+          <p
+            className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300"
+            data-testid="kindroid-transcript-picker-eyebrow"
+          >
+            <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+            Kindroid call transcript control
+          </p>
+          <h2
+            className="text-xl font-bold text-foreground"
+            data-testid="kindroid-transcript-picker-heading"
+          >
+            Pick the transcript provider before the call starts
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Kindroid&apos;s live-call push makes transcription feel like a black box. AgentGram shows the caption route first, so creators know whether live transcripts, a preferred provider, or local-only notes will power the recap.
+          </p>
+        </div>
+
+        <div
+          className="shrink-0 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm"
+          data-testid="kindroid-transcript-picker-selected-summary"
+        >
+          <p className="flex items-center gap-1.5 font-semibold text-emerald-700 dark:text-emerald-400">
+            <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+            {selected.name}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">{selected.badge} transcript route selected</p>
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3" data-testid="kindroid-transcript-provider-options">
+        {transcriptProviders.map((provider) => {
+          const isSelected = provider.id === selectedProvider;
+
+          return (
+            <button
+              key={provider.id}
+              type="button"
+              aria-pressed={isSelected}
+              onClick={() => setSelectedProvider(provider.id)}
+              className={`rounded-xl border p-4 text-left transition ${
+                isSelected
+                  ? 'border-amber-500/60 bg-amber-500/15 shadow-sm'
+                  : 'border-border/40 bg-background/70 hover:border-amber-500/40'
+              }`}
+              data-testid={provider.testId}
+            >
+              <span className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-amber-500/10">
+                {provider.id === 'agentgram-live' ? (
+                  <FileText className="h-5 w-5 text-amber-700 dark:text-amber-300" aria-hidden="true" />
+                ) : provider.id === 'bring-your-own' ? (
+                  <Cloud className="h-5 w-5 text-amber-700 dark:text-amber-300" aria-hidden="true" />
+                ) : (
+                  <ShieldCheck className="h-5 w-5 text-amber-700 dark:text-amber-300" aria-hidden="true" />
+                )}
+              </span>
+              <span className="flex items-center justify-between gap-2">
+                <span className="text-sm font-semibold text-foreground">{provider.name}</span>
+                <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-300">
+                  {provider.badge}
+                </span>
+              </span>
+              <span className="mt-2 block text-xs leading-relaxed text-muted-foreground">
+                {provider.description}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        className="mt-5 rounded-xl border border-border/40 bg-background/70 p-4"
+        data-testid="kindroid-transcript-provider-detail"
+      >
+        <p className="text-sm font-semibold text-foreground">{selected.name} in practice</p>
+        <p className="mt-1 text-sm text-muted-foreground">{selected.detail}</p>
+      </div>
+
+      <ul
+        className="mt-5 grid gap-2 text-xs text-muted-foreground md:grid-cols-3"
+        data-testid="kindroid-transcript-trust-signals"
+      >
+        {trustSignals.map((signal) => (
+          <li key={signal} className="flex items-start gap-2 rounded-lg bg-background/60 px-3 py-2">
+            <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+            <span>{signal}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -6,6 +6,7 @@ export { CAIStatusEntitlementBanner } from './CAIStatusEntitlementBanner';
 export { PricingCompetitorAnchorRow } from './PricingCompetitorAnchorRow';
 export { ReplikaAdvancedAiComparisonCard } from './ReplikaAdvancedAiComparisonCard';
 export { ReplikaVoiceCallPreflightCard } from './ReplikaVoiceCallPreflightCard';
+export { KindroidTranscriptProviderPicker } from './KindroidTranscriptProviderPicker';
 export { ReplikaSavingsCalculator } from './ReplikaSavingsCalculator';
 export { PaidConversionSocialProofBlock } from './PaidConversionSocialProofBlock';
 export { ReplikaUltraFatigueFunnel } from './ReplikaUltraFatigueFunnel';

--- a/apps/web/docs/pr-evidence/kindroid-transcript-provider-picker.md
+++ b/apps/web/docs/pr-evidence/kindroid-transcript-provider-picker.md
@@ -1,0 +1,41 @@
+# PR Evidence: Kindroid Transcript Provider Picker
+
+## Summary
+
+Added `KindroidTranscriptProviderPicker` — an interactive pricing-page card that turns Kindroid live-call transcription uncertainty into an explicit pre-call provider choice.
+
+## Placement
+
+Inserted immediately after the existing `ReplikaVoiceCallPreflightCard` on the pricing page (`apps/web/app/(public)/pricing/page.tsx`) so call-readiness messaging flows into transcript-route selection.
+
+## Behavior
+
+The card exposes three selectable transcript routes:
+
+1. `AgentGram Live` — default realtime transcript with speaker turns, timestamps, and call-health markers.
+2. `Bring your provider` — route transcription through a preferred speech API while keeping memory controls intact.
+3. `Local export only` — privacy-first mode for manual notes/export when live captions are not desired.
+
+Selecting a provider updates the summary badge, detail panel, and `aria-pressed` state without navigating away from pricing.
+
+## Test Coverage
+
+5 unit tests in `apps/web/__tests__/components/pricing/KindroidTranscriptProviderPicker.test.tsx`:
+
+| Test | Assertion |
+|---|---|
+| Renders card | `data-testid="kindroid-transcript-provider-picker"` present |
+| Explains pre-call provider choice | eyebrow and heading copy present |
+| Shows provider routes | all three provider buttons render |
+| Updates selected route | click updates summary, detail copy, and `aria-pressed` |
+| Keeps trust signals visible | three transcript/memory/fallback trust signals render |
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `apps/web/components/pricing/KindroidTranscriptProviderPicker.tsx` | New interactive provider picker component |
+| `apps/web/components/pricing/index.ts` | Barrel export for the new component |
+| `apps/web/app/(public)/pricing/page.tsx` | Pricing-page placement section |
+| `apps/web/__tests__/components/pricing/KindroidTranscriptProviderPicker.test.tsx` | Unit coverage for render, copy, provider switching, and trust signals |
+| `apps/web/docs/pr-evidence/kindroid-transcript-provider-picker.md` | This evidence note |


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog feature item bff7cbae0b.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Kindroid transcript provider picker on the pricing page so live-call transcription is an explicit pre-call choice. The picker exposes AgentGram Live, bring-your-own provider, and local-export-only routes with trust signals tied to transcript/memory controls.

## Evidence
- test: `pnpm --filter web exec vitest run __tests__/components/pricing/KindroidTranscriptProviderPicker.test.tsx __tests__/components/pricing-page.test.tsx` → 2 files passed, 16 tests passed.
- type-check: `pnpm --filter web type-check` → `tsc --noEmit` passed.
- diff: `git diff --cached --stat` before commit showed 6 files changed, 266 insertions, 1 deletion.

## Auth-only Proof
N/A
