### PR TITLE
feat(pricing): add Kindroid transcript provider picker

### DIFF
--- a/apps/web/__tests__/components/pricing/KindroidTranscriptProviderPicker.test.tsx
+++ b/apps/web/__tests__/components/pricing/KindroidTranscriptProviderPicker.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { KindroidTranscriptProviderPicker } from '@/components/pricing/KindroidTranscriptProviderPicker';
+
+describe('KindroidTranscriptProviderPicker', () => {
+  it('renders the transcript provider picker without crashing', () => {
+    render(<KindroidTranscriptProviderPicker />);
+    expect(screen.getByTestId('kindroid-transcript-provider-picker')).toBeInTheDocument();
+  });
+
+  it('explains that transcript routing is selected before the call starts', () => {
+    render(<KindroidTranscriptProviderPicker />);
+    expect(screen.getByTestId('transcript-provider-eyebrow')).toHaveTextContent(
+      'Transcript provider picker'
+    );
+    expect(screen.getByTestId('transcript-provider-heading')).toHaveTextContent(
+      'Pick the transcript route before your companion call starts'
+    );
+  });
+
+  it('shows all transcript provider route options', () => {
+    render(<KindroidTranscriptProviderPicker />);
+    const options = screen.getByTestId('transcript-provider-options');
+
+    expect(options.children).toHaveLength(3);
+    expect(screen.getByTestId('transcript-provider-agentgram-live')).toHaveTextContent(
+      'AgentGram Live'
+    );
+    expect(screen.getByTestId('transcript-provider-bring-your-provider')).toHaveTextContent(
+      'Bring your provider'
+    );
+    expect(screen.getByTestId('transcript-provider-local-export-only')).toHaveTextContent(
+      'Local export only'
+    );
+  });
+
+  it('updates the selected provider summary, detail, and pressed state', () => {
+    render(<KindroidTranscriptProviderPicker />);
+    const bringProvider = screen.getByTestId('transcript-provider-bring-your-provider');
+
+    fireEvent.click(bringProvider);
+
+    expect(bringProvider).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('transcript-provider-selected-summary')).toHaveTextContent(
+      'Bring your provider'
+    );
+    expect(screen.getByTestId('transcript-provider-detail')).toHaveTextContent(
+      'Use your preferred transcript provider without losing memory controls.'
+    );
+  });
+
+  it('keeps transcript memory and fallback trust signals visible', () => {
+    render(<KindroidTranscriptProviderPicker />);
+    const signals = screen.getByTestId('transcript-provider-trust-signals');
+
+    expect(signals.children).toHaveLength(3);
+    expect(signals).toHaveTextContent('Provider choice locked before connect');
+    expect(signals).toHaveTextContent('Speaker turns stay attached to memory permissions');
+    expect(signals).toHaveTextContent('Fallback export path remains visible');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, KindroidTranscriptProviderPicker, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -583,6 +583,13 @@ export default function PricingPage() {
         data-testid="replika-voice-call-preflight-section"
       >
         <ReplikaVoiceCallPreflightCard />
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="kindroid-transcript-provider-section"
+      >
+        <KindroidTranscriptProviderPicker />
       </section>
 
       <section

--- a/apps/web/components/pricing/KindroidTranscriptProviderPicker.tsx
+++ b/apps/web/components/pricing/KindroidTranscriptProviderPicker.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState } from 'react';
+import { Captions, CheckCircle2, Download, PlugZap, RadioTower } from 'lucide-react';
+
+const transcriptProviders = [
+  {
+    id: 'agentgram-live',
+    label: 'AgentGram Live',
+    badge: 'Default live captions',
+    summary: 'Realtime transcript is ready before the call connects.',
+    detail:
+      'AgentGram Live captures speaker turns, timestamps, and call-health markers in one route so users know the transcript will be usable before they start talking.',
+    icon: RadioTower,
+  },
+  {
+    id: 'bring-your-provider',
+    label: 'Bring your provider',
+    badge: 'Route your own speech API',
+    summary: 'Use your preferred transcript provider without losing memory controls.',
+    detail:
+      'Choose an external speech stack for captions while AgentGram keeps the provider choice, memory permissions, and export controls visible in the same pre-call panel.',
+    icon: PlugZap,
+  },
+  {
+    id: 'local-export-only',
+    label: 'Local export only',
+    badge: 'Manual notes fallback',
+    summary: 'Skip live captions and keep a privacy-first export path.',
+    detail:
+      'When a live transcript is not appropriate, users can keep call notes local and export only the final transcript package they approve.',
+    icon: Download,
+  },
+] as const;
+
+const trustSignals = [
+  'Provider choice locked before connect',
+  'Speaker turns stay attached to memory permissions',
+  'Fallback export path remains visible',
+] as const;
+
+type TranscriptProviderId = (typeof transcriptProviders)[number]['id'];
+
+export function KindroidTranscriptProviderPicker() {
+  const [selectedProviderId, setSelectedProviderId] = useState<TranscriptProviderId>(
+    transcriptProviders[0].id
+  );
+  const selectedProvider =
+    transcriptProviders.find((provider) => provider.id === selectedProviderId) ??
+    transcriptProviders[0];
+
+  return (
+    <div
+      className="mx-auto max-w-3xl rounded-2xl border border-amber-500/25 bg-amber-500/5 px-6 py-6 shadow-sm"
+      data-testid="kindroid-transcript-provider-picker"
+    >
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p
+            className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300"
+            data-testid="transcript-provider-eyebrow"
+          >
+            <Captions className="h-3.5 w-3.5" aria-hidden="true" />
+            Transcript provider picker
+          </p>
+          <h2
+            className="text-xl font-bold text-foreground"
+            data-testid="transcript-provider-heading"
+          >
+            Pick the transcript route before your companion call starts
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Kindroid-style call transcripts can feel opaque when users do not know
+            which caption route is active. AgentGram makes the provider choice,
+            fallback, and memory handoff visible up front.
+          </p>
+        </div>
+        <div
+          className="shrink-0 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm"
+          data-testid="transcript-provider-selected-summary"
+        >
+          <p className="flex items-center gap-1.5 font-semibold text-emerald-700 dark:text-emerald-400">
+            <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+            {selectedProvider.label}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {selectedProvider.summary}
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="mb-5 grid gap-3 md:grid-cols-3"
+        data-testid="transcript-provider-options"
+        aria-label="Choose transcript provider route"
+      >
+        {transcriptProviders.map((provider) => {
+          const Icon = provider.icon;
+          const isSelected = provider.id === selectedProvider.id;
+
+          return (
+            <button
+              key={provider.id}
+              type="button"
+              className={`rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 ${
+                isSelected
+                  ? 'border-amber-500/60 bg-amber-500/15 shadow-sm'
+                  : 'border-border/40 bg-background/70 hover:border-amber-500/40'
+              }`}
+              aria-pressed={isSelected}
+              data-testid={`transcript-provider-${provider.id}`}
+              onClick={() => setSelectedProviderId(provider.id)}
+            >
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-amber-500/10">
+                <Icon className="h-5 w-5 text-amber-700 dark:text-amber-300" aria-hidden="true" />
+              </div>
+              <p className="text-sm font-semibold text-foreground">{provider.label}</p>
+              <p className="mt-1 text-xs font-medium text-amber-700 dark:text-amber-300">
+                {provider.badge}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        className="rounded-xl border border-border/40 bg-background/70 p-4"
+        data-testid="transcript-provider-detail"
+      >
+        <p className="text-sm font-semibold text-foreground">
+          {selectedProvider.summary}
+        </p>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          {selectedProvider.detail}
+        </p>
+      </div>
+
+      <div
+        className="mt-4 grid gap-2 text-xs text-muted-foreground sm:grid-cols-3"
+        data-testid="transcript-provider-trust-signals"
+      >
+        {trustSignals.map((signal) => (
+          <p key={signal} className="rounded-lg border border-border/40 bg-background/60 px-3 py-2">
+            {signal}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -6,6 +6,7 @@ export { CAIStatusEntitlementBanner } from './CAIStatusEntitlementBanner';
 export { PricingCompetitorAnchorRow } from './PricingCompetitorAnchorRow';
 export { ReplikaAdvancedAiComparisonCard } from './ReplikaAdvancedAiComparisonCard';
 export { ReplikaVoiceCallPreflightCard } from './ReplikaVoiceCallPreflightCard';
+export { KindroidTranscriptProviderPicker } from './KindroidTranscriptProviderPicker';
 export { ReplikaSavingsCalculator } from './ReplikaSavingsCalculator';
 export { PaidConversionSocialProofBlock } from './PaidConversionSocialProofBlock';
 export { ReplikaUltraFatigueFunnel } from './ReplikaUltraFatigueFunnel';

--- a/apps/web/docs/pr-evidence/kindroid-transcript-provider-picker.md
+++ b/apps/web/docs/pr-evidence/kindroid-transcript-provider-picker.md
@@ -1,0 +1,41 @@
+# PR Evidence: Kindroid Transcript Provider Picker
+
+## Summary
+
+Added `KindroidTranscriptProviderPicker` — an interactive pricing-page card that turns Kindroid live-call transcription uncertainty into an explicit pre-call provider choice.
+
+## Placement
+
+Inserted immediately after the existing `ReplikaVoiceCallPreflightCard` on the pricing page (`apps/web/app/(public)/pricing/page.tsx`) so call-readiness messaging flows into transcript-route selection.
+
+## Behavior
+
+The card exposes three selectable transcript routes:
+
+1. `AgentGram Live` — default realtime transcript with speaker turns, timestamps, and call-health markers.
+2. `Bring your provider` — route transcription through a preferred speech API while keeping memory controls intact.
+3. `Local export only` — privacy-first mode for manual notes/export when live captions are not desired.
+
+Selecting a provider updates the summary badge, detail panel, and `aria-pressed` state without navigating away from pricing.
+
+## Test Coverage
+
+5 unit tests in `apps/web/__tests__/components/pricing/KindroidTranscriptProviderPicker.test.tsx`:
+
+| Test | Assertion |
+|---|---|
+| Renders card | `data-testid="kindroid-transcript-provider-picker"` present |
+| Explains pre-call provider choice | eyebrow and heading copy present |
+| Shows provider routes | all three provider buttons render |
+| Updates selected route | click updates summary, detail copy, and `aria-pressed` |
+| Keeps trust signals visible | three transcript/memory/fallback trust signals render |
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `apps/web/components/pricing/KindroidTranscriptProviderPicker.tsx` | New interactive provider picker component |
+| `apps/web/components/pricing/index.ts` | Barrel export for the new component |
+| `apps/web/app/(public)/pricing/page.tsx` | Pricing-page placement section |
+| `apps/web/__tests__/components/pricing/KindroidTranscriptProviderPicker.test.tsx` | Unit coverage for render, copy, provider switching, and trust signals |
+| `apps/web/docs/pr-evidence/kindroid-transcript-provider-picker.md` | This evidence note |


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog feature item bff7cbae0b.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Kindroid transcript provider picker to the pricing page so users can choose AgentGram Live, bring-your-provider, or local-export-only transcript routes before starting a companion call. The card updates its selected summary/detail state and keeps transcript memory/fallback trust signals visible.

## Evidence
- test: `pnpm --filter web test -- KindroidTranscriptProviderPicker` → 256 files / 2410 tests passed
- test: `pnpm --filter web test -- __tests__/components/pricing/KindroidTranscriptProviderPicker.test.tsx` → 256 files / 2410 tests passed; includes new picker coverage
- type-check: `pnpm --filter web type-check` → passed
- diff: `git diff --check` → passed

## Auth-only Proof
N/A
