### PR TITLE
ux(pricing): add Replika update-change explainer

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -201,6 +201,17 @@ describe('PricingPage', () => {
     expect(section).toHaveTextContent('Voice mode');
   });
 
+  it('renders the Replika update-change explainer strip with plan, memory, and voice deltas', () => {
+    render(<PricingPage />);
+
+    const section = screen.getByTestId('replika-update-change-explainer-section');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('Plan changes');
+    expect(section).toHaveTextContent('Memory changes');
+    expect(section).toHaveTextContent('Voice changes');
+    expect(section).toHaveTextContent('Before/after memo');
+  });
+
   it('renders the Replika Advanced AI comparison section with the decision path', () => {
     render(<PricingPage />);
 

--- a/apps/web/__tests__/components/pricing/ReplikaUpdateChangeExplainerStrip.test.tsx
+++ b/apps/web/__tests__/components/pricing/ReplikaUpdateChangeExplainerStrip.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ReplikaUpdateChangeExplainerStrip } from '@/components/pricing/ReplikaUpdateChangeExplainerStrip';
+
+describe('ReplikaUpdateChangeExplainerStrip', () => {
+  it('renders the update-change explainer strip without crashing', () => {
+    render(<ReplikaUpdateChangeExplainerStrip />);
+    expect(screen.getByTestId('replika-update-change-explainer-strip')).toBeInTheDocument();
+  });
+
+  it('explains update changes before users bounce', () => {
+    render(<ReplikaUpdateChangeExplainerStrip />);
+
+    expect(screen.getByTestId('update-change-eyebrow')).toHaveTextContent(
+      'Update-change explainer'
+    );
+    expect(screen.getByTestId('update-change-heading')).toHaveTextContent(
+      'Show what changed before users bounce'
+    );
+    expect(screen.getByTestId('update-change-memo-badge')).toHaveTextContent('Memo first');
+  });
+
+  it('shows plan differences, memory changes, and voice changes', () => {
+    render(<ReplikaUpdateChangeExplainerStrip />);
+
+    expect(screen.getByTestId('update-change-plan-differences')).toHaveTextContent(
+      'Plan changes'
+    );
+    expect(screen.getByTestId('update-change-plan-differences')).toHaveTextContent(
+      'Plan differences'
+    );
+    expect(screen.getByTestId('update-change-memory-changes')).toHaveTextContent(
+      'Memory changes'
+    );
+    expect(screen.getByTestId('update-change-voice-changes')).toHaveTextContent(
+      'Voice changes'
+    );
+  });
+
+  it('keeps the before and after memo visible', () => {
+    render(<ReplikaUpdateChangeExplainerStrip />);
+
+    const memo = screen.getByTestId('update-change-before-after-memo');
+    expect(memo).toHaveTextContent('Before/after memo');
+    expect(memo).toHaveTextContent('current plan benefits');
+    expect(memo).toHaveTextContent('voice readiness');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, KindroidTranscriptProviderPicker, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -583,6 +583,13 @@ export default function PricingPage() {
         data-testid="replika-voice-call-preflight-section"
       >
         <ReplikaVoiceCallPreflightCard />
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="replika-update-change-explainer-section"
+      >
+        <ReplikaUpdateChangeExplainerStrip />
       </section>
 
       <section

--- a/apps/web/components/pricing/ReplikaUpdateChangeExplainerStrip.tsx
+++ b/apps/web/components/pricing/ReplikaUpdateChangeExplainerStrip.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { ArrowRight, BrainCircuit, CheckCircle2, Mic2, RefreshCw, ShieldCheck } from 'lucide-react';
+
+const changeSteps = [
+  {
+    label: 'Plan changes',
+    replika: 'Users often discover Pro, Plus, or Ultra differences only after an update changes the paywall copy.',
+    agentgram: 'Plan differences stay listed in one strip before checkout, including what is included now and what never moves tiers.',
+    icon: ShieldCheck,
+    testId: 'update-change-plan-differences',
+  },
+  {
+    label: 'Memory changes',
+    replika: 'Memory dashboards can shift how saved facts feel without a concise before/after summary.',
+    agentgram: 'Memory notes call out saved facts, corrections, and export controls before a user commits to a plan.',
+    icon: BrainCircuit,
+    testId: 'update-change-memory-changes',
+  },
+  {
+    label: 'Voice changes',
+    replika: 'Voice quality, mode, and latency changes are easy to miss until the next call starts.',
+    agentgram: 'Voice readiness shows quality, mode, and latency in the same explainer so users know what changed first.',
+    icon: Mic2,
+    testId: 'update-change-voice-changes',
+  },
+] as const;
+
+export function ReplikaUpdateChangeExplainerStrip() {
+  return (
+    <div
+      className="mx-auto max-w-3xl rounded-2xl border border-rose-500/25 bg-rose-500/5 px-6 py-6 shadow-sm"
+      data-testid="replika-update-change-explainer-strip"
+    >
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p
+            className="inline-flex items-center gap-1.5 rounded-full border border-rose-500/30 bg-rose-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-700 dark:text-rose-300"
+            data-testid="update-change-eyebrow"
+          >
+            <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+            Update-change explainer
+          </p>
+          <h2
+            className="text-xl font-bold text-foreground"
+            data-testid="update-change-heading"
+          >
+            Show what changed before users bounce
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Replika-style updates can leave users comparing plan copy, memory behavior,
+            and voice controls after the fact. AgentGram surfaces the delta in one
+            pre-checkout memo so the upgrade feels predictable.
+          </p>
+        </div>
+        <div
+          className="shrink-0 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm"
+          data-testid="update-change-memo-badge"
+        >
+          <p className="flex items-center gap-1.5 font-semibold text-emerald-700 dark:text-emerald-400">
+            <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+            Memo first
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Plan + memory + voice deltas summarized before checkout
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="grid gap-3 md:grid-cols-3"
+        data-testid="update-change-explainer-columns"
+      >
+        {changeSteps.map((step) => {
+          const Icon = step.icon;
+
+          return (
+            <div
+              key={step.label}
+              className="rounded-xl border border-border/40 bg-background/70 p-4"
+              data-testid={step.testId}
+            >
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-rose-500/10">
+                <Icon className="h-5 w-5 text-rose-700 dark:text-rose-300" aria-hidden="true" />
+              </div>
+              <p className="text-sm font-semibold text-foreground">{step.label}</p>
+              <div className="mt-3 space-y-3 text-xs leading-relaxed text-muted-foreground">
+                <p>
+                  <span className="font-semibold text-destructive/80">Replika:</span>{' '}
+                  {step.replika}
+                </p>
+                <p>
+                  <span className="font-semibold text-emerald-700 dark:text-emerald-400">AgentGram:</span>{' '}
+                  {step.agentgram}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        className="mt-4 flex flex-col gap-2 rounded-xl border border-border/40 bg-background/70 p-4 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between"
+        data-testid="update-change-before-after-memo"
+      >
+        <p>
+          Before/after memo: current plan benefits, memory handling, and voice readiness stay visible in one place.
+        </p>
+        <p className="inline-flex items-center gap-1.5 font-semibold text-rose-700 dark:text-rose-300">
+          Fewer surprise updates
+          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -6,6 +6,7 @@ export { CAIStatusEntitlementBanner } from './CAIStatusEntitlementBanner';
 export { PricingCompetitorAnchorRow } from './PricingCompetitorAnchorRow';
 export { ReplikaAdvancedAiComparisonCard } from './ReplikaAdvancedAiComparisonCard';
 export { ReplikaVoiceCallPreflightCard } from './ReplikaVoiceCallPreflightCard';
+export { ReplikaUpdateChangeExplainerStrip } from './ReplikaUpdateChangeExplainerStrip';
 export { KindroidTranscriptProviderPicker } from './KindroidTranscriptProviderPicker';
 export { ReplikaSavingsCalculator } from './ReplikaSavingsCalculator';
 export { PaidConversionSocialProofBlock } from './PaidConversionSocialProofBlock';


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog ux item 23483422d8.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Replika update-change explainer strip to pricing so users can compare plan differences, memory changes, and voice changes before checkout.
The strip includes a before/after memo and is covered by a component test plus pricing page regression coverage.

## Evidence
Test: `pnpm --filter web exec vitest run __tests__/components/pricing/ReplikaUpdateChangeExplainerStrip.test.tsx __tests__/components/pricing-page.test.tsx` — 2 files / 16 tests passed.
Type-check: `pnpm --filter web type-check` — passed.
Diff: 5 files changed, 185 insertions, 1 deletion.

## Auth-only Proof
N/A
