### PR TITLE
feature(pricing): add Kindroid live-call stability console

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -222,6 +222,16 @@ describe('PricingPage', () => {
     expect(section).toHaveTextContent('AgentGram preview');
   });
 
+  it('renders the Kindroid live-call stability console with readiness, transcript, and troubleshooting', () => {
+    render(<PricingPage />);
+
+    const section = screen.getByTestId('kindroid-live-call-stability-section');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('Readiness');
+    expect(section).toHaveTextContent('Live transcript');
+    expect(section).toHaveTextContent('Troubleshooting pinned');
+  });
+
   it('renders Visual Memory mind map section with Nomi parity badge and Starter+ callout', () => {
     render(<PricingPage />);
 

--- a/apps/web/__tests__/components/pricing/KindroidLiveCallStabilityConsole.test.tsx
+++ b/apps/web/__tests__/components/pricing/KindroidLiveCallStabilityConsole.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { KindroidLiveCallStabilityConsole } from '@/components/pricing/KindroidLiveCallStabilityConsole';
+
+describe('KindroidLiveCallStabilityConsole', () => {
+  it('renders the live-call stability console without crashing', () => {
+    render(<KindroidLiveCallStabilityConsole />);
+    expect(screen.getByTestId('kindroid-live-call-stability-console')).toBeInTheDocument();
+  });
+
+  it('explains that readiness, captions, and fixes are visible before failure', () => {
+    render(<KindroidLiveCallStabilityConsole />);
+
+    expect(screen.getByTestId('stability-console-eyebrow')).toHaveTextContent(
+      'Live-call stability console'
+    );
+    expect(screen.getByTestId('stability-console-heading')).toHaveTextContent(
+      'Show readiness, captions, and fixes before the video call fails'
+    );
+    expect(screen.getByTestId('stability-console-ready-badge')).toHaveTextContent(
+      'Ready + live'
+    );
+  });
+
+  it('shows readiness, connection, and fallback status cards', () => {
+    render(<KindroidLiveCallStabilityConsole />);
+    const grid = screen.getByTestId('stability-console-readiness-grid');
+
+    expect(grid.children).toHaveLength(3);
+    expect(screen.getByTestId('stability-console-readiness')).toHaveTextContent('Readiness');
+    expect(screen.getByTestId('stability-console-readiness')).toHaveTextContent(
+      'Camera, mic, and transcript route verified'
+    );
+    expect(screen.getByTestId('stability-console-connection')).toHaveTextContent(
+      'Stable video route selected'
+    );
+    expect(screen.getByTestId('stability-console-fallbacks')).toHaveTextContent(
+      'Voice-only + retry guidance ready'
+    );
+  });
+
+  it('keeps the live transcript visible during the call', () => {
+    render(<KindroidLiveCallStabilityConsole />);
+    const transcript = screen.getByTestId('stability-console-live-transcript');
+
+    expect(transcript).toHaveTextContent('Live transcript');
+    expect(transcript).toHaveTextContent('Mina');
+    expect(transcript).toHaveTextContent('Live transcript synced');
+  });
+
+  it('pins troubleshooting guidance before and during video calls', () => {
+    render(<KindroidLiveCallStabilityConsole />);
+    const troubleshooting = screen.getByTestId('stability-console-troubleshooting');
+
+    expect(troubleshooting).toHaveTextContent('Troubleshooting pinned');
+    expect(troubleshooting).toHaveTextContent('Refresh camera permission without leaving the call');
+    expect(troubleshooting).toHaveTextContent('Switch to voice-only if video drops twice');
+    expect(troubleshooting).toHaveTextContent('Export transcript and stability log after disconnect');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, KindroidLiveCallStabilityConsole, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -597,6 +597,13 @@ export default function PricingPage() {
         data-testid="kindroid-transcript-provider-section"
       >
         <KindroidTranscriptProviderPicker />
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="kindroid-live-call-stability-section"
+      >
+        <KindroidLiveCallStabilityConsole />
       </section>
 
       <section

--- a/apps/web/components/pricing/KindroidLiveCallStabilityConsole.tsx
+++ b/apps/web/components/pricing/KindroidLiveCallStabilityConsole.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { Activity, Captions, CheckCircle2, LifeBuoy, SignalHigh, Wifi } from 'lucide-react';
+
+const readinessChecks = [
+  {
+    label: 'Readiness',
+    value: 'Camera, mic, and transcript route verified',
+    description: 'Shows pre-call pass/fail state before a Kindroid-style video call opens.',
+    icon: CheckCircle2,
+    testId: 'stability-console-readiness',
+  },
+  {
+    label: 'Connection',
+    value: 'Stable video route selected',
+    description: 'Keeps latency, packet-loss, and reconnect status visible while the call is live.',
+    icon: SignalHigh,
+    testId: 'stability-console-connection',
+  },
+  {
+    label: 'Fallbacks',
+    value: 'Voice-only + retry guidance ready',
+    description: 'Gives users a next step before they abandon a broken call.',
+    icon: LifeBuoy,
+    testId: 'stability-console-fallbacks',
+  },
+] as const;
+
+const transcriptLines = [
+  {
+    speaker: 'Mina',
+    timestamp: '00:08',
+    text: 'I can see you clearly now — the call is stable.',
+  },
+  {
+    speaker: 'You',
+    timestamp: '00:12',
+    text: 'Great, keep captions on and save the troubleshooting note.',
+  },
+  {
+    speaker: 'Console',
+    timestamp: '00:14',
+    text: 'Live transcript synced; reconnect tips remain pinned.',
+  },
+] as const;
+
+const troubleshootingSteps = [
+  'Refresh camera permission without leaving the call',
+  'Switch to voice-only if video drops twice',
+  'Export transcript and stability log after disconnect',
+] as const;
+
+export function KindroidLiveCallStabilityConsole() {
+  return (
+    <div
+      className="mx-auto max-w-3xl rounded-2xl border border-indigo-500/25 bg-indigo-500/5 px-6 py-6 shadow-sm"
+      data-testid="kindroid-live-call-stability-console"
+    >
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p
+            className="inline-flex items-center gap-1.5 rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:text-indigo-300"
+            data-testid="stability-console-eyebrow"
+          >
+            <Activity className="h-3.5 w-3.5" aria-hidden="true" />
+            Live-call stability console
+          </p>
+          <h2
+            className="text-xl font-bold text-foreground"
+            data-testid="stability-console-heading"
+          >
+            Show readiness, captions, and fixes before the video call fails
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Kindroid-style live calls can feel fragile when users lose track of readiness,
+            captions, or what to try next. AgentGram keeps the video-call status,
+            live transcript, and troubleshooting path in one visible console before and
+            during the call.
+          </p>
+        </div>
+        <div
+          className="shrink-0 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm"
+          data-testid="stability-console-ready-badge"
+        >
+          <p className="flex items-center gap-1.5 font-semibold text-emerald-700 dark:text-emerald-400">
+            <Wifi className="h-4 w-4" aria-hidden="true" />
+            Ready + live
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Preflight, captions, and recovery guidance stay pinned
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="mb-4 grid gap-3 md:grid-cols-3"
+        data-testid="stability-console-readiness-grid"
+      >
+        {readinessChecks.map((check) => {
+          const Icon = check.icon;
+
+          return (
+            <div
+              key={check.label}
+              className="rounded-xl border border-border/40 bg-background/70 p-4"
+              data-testid={check.testId}
+            >
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-indigo-500/10">
+                <Icon className="h-5 w-5 text-indigo-700 dark:text-indigo-300" aria-hidden="true" />
+              </div>
+              <p className="text-sm font-semibold text-foreground">{check.label}</p>
+              <p className="mt-1 text-sm font-medium text-indigo-700 dark:text-indigo-300">
+                {check.value}
+              </p>
+              <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                {check.description}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-[1.2fr_0.8fr]">
+        <div
+          className="rounded-xl border border-border/40 bg-background/70 p-4"
+          data-testid="stability-console-live-transcript"
+        >
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <p className="inline-flex items-center gap-1.5 text-sm font-semibold text-foreground">
+              <Captions className="h-4 w-4 text-indigo-700 dark:text-indigo-300" aria-hidden="true" />
+              Live transcript
+            </p>
+            <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-400">
+              syncing
+            </span>
+          </div>
+          <div className="space-y-2">
+            {transcriptLines.map((line) => (
+              <p key={`${line.timestamp}-${line.speaker}`} className="rounded-lg border border-border/30 bg-background/60 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+                <span className="font-semibold text-foreground">{line.speaker}</span>{' '}
+                <span className="text-indigo-700 dark:text-indigo-300">{line.timestamp}</span>{' '}
+                {line.text}
+              </p>
+            ))}
+          </div>
+        </div>
+
+        <div
+          className="rounded-xl border border-border/40 bg-background/70 p-4"
+          data-testid="stability-console-troubleshooting"
+        >
+          <p className="text-sm font-semibold text-foreground">Troubleshooting pinned</p>
+          <div className="mt-3 space-y-2 text-xs text-muted-foreground">
+            {troubleshootingSteps.map((step) => (
+              <p key={step} className="rounded-lg border border-border/30 bg-background/60 px-3 py-2">
+                {step}
+              </p>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -8,6 +8,7 @@ export { ReplikaAdvancedAiComparisonCard } from './ReplikaAdvancedAiComparisonCa
 export { ReplikaVoiceCallPreflightCard } from './ReplikaVoiceCallPreflightCard';
 export { ReplikaUpdateChangeExplainerStrip } from './ReplikaUpdateChangeExplainerStrip';
 export { KindroidTranscriptProviderPicker } from './KindroidTranscriptProviderPicker';
+export { KindroidLiveCallStabilityConsole } from './KindroidLiveCallStabilityConsole';
 export { ReplikaSavingsCalculator } from './ReplikaSavingsCalculator';
 export { PaidConversionSocialProofBlock } from './PaidConversionSocialProofBlock';
 export { ReplikaUltraFatigueFunnel } from './ReplikaUltraFatigueFunnel';

--- a/apps/web/docs/pr-evidence/kindroid-live-call-stability-console.md
+++ b/apps/web/docs/pr-evidence/kindroid-live-call-stability-console.md
@@ -1,0 +1,39 @@
+# PR Evidence: Kindroid Live-call Stability Console
+
+## Source
+
+Hermes kanban-dispatch dev lane — backlog feature item b41ac7a700.
+
+## Change
+
+Added `KindroidLiveCallStabilityConsole`, a pricing-page console that keeps Kindroid-style video-call readiness, live transcript status, and troubleshooting visible before and during companion calls.
+
+The console surfaces:
+
+- Readiness: camera, mic, and transcript route verified before connect.
+- Connection: stable video route, latency, packet-loss, and reconnect status cues while live.
+- Fallbacks: voice-only retry guidance and recovery steps when video drops.
+- Live transcript: sample speaker turns with sync status.
+- Troubleshooting: pinned camera permission, voice-only fallback, and transcript/stability export guidance.
+
+## Verification
+
+Local verification run:
+
+```text
+pnpm --filter web test -- __tests__/components/pricing/KindroidLiveCallStabilityConsole.test.tsx __tests__/components/pricing-page.test.tsx
+Test Files 259 passed (259); Tests 2425 passed (2425)
+pnpm --filter web type-check
+exit 0
+```
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `apps/web/components/pricing/KindroidLiveCallStabilityConsole.tsx` | New live-call stability console component |
+| `apps/web/__tests__/components/pricing/KindroidLiveCallStabilityConsole.test.tsx` | Component coverage for readiness, transcript, and troubleshooting copy |
+| `apps/web/__tests__/components/pricing-page.test.tsx` | Pricing page integration coverage |
+| `apps/web/app/(public)/pricing/page.tsx` | Renders the console after the transcript provider picker |
+| `apps/web/components/pricing/index.ts` | Exports the component |
+| `apps/web/docs/pr-evidence/kindroid-live-call-stability-console.md` | This evidence note |


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog feature item b41ac7a700.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Kindroid live-call stability console to the pricing page so users can see readiness, live transcript status, and troubleshooting guidance before or during video calls.

## Evidence
pnpm --filter web test -- __tests__/components/pricing/KindroidLiveCallStabilityConsole.test.tsx __tests__/components/pricing-page.test.tsx → Test Files 259 passed (259); Tests 2425 passed (2425).
pnpm --filter web type-check → exit 0.
diff: 6 files changed, 283 insertions(+), 1 deletion(-).

## Auth-only Proof
N/A