### PR TITLE
ux(pricing): add Replika safe-space manifesto strip

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -212,6 +212,17 @@ describe('PricingPage', () => {
     expect(section).toHaveTextContent('Before/after memo');
   });
 
+  it('renders the Replika safe-space manifesto onboarding strip', () => {
+    render(<PricingPage />);
+
+    const section = screen.getByTestId('replika-safe-space-manifesto-section');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('Safe-space promise');
+    expect(section).toHaveTextContent('Memory boundaries');
+    expect(section).toHaveTextContent('Manifesto receipt');
+    expect(section).toHaveTextContent('Onboarding receipt');
+  });
+
   it('renders the Replika Advanced AI comparison section with the decision path', () => {
     render(<PricingPage />);
 

--- a/apps/web/__tests__/components/pricing/ReplikaSafeSpaceManifestoStrip.test.tsx
+++ b/apps/web/__tests__/components/pricing/ReplikaSafeSpaceManifestoStrip.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ReplikaSafeSpaceManifestoStrip } from '@/components/pricing/ReplikaSafeSpaceManifestoStrip';
+
+describe('ReplikaSafeSpaceManifestoStrip', () => {
+  it('renders the safe-space manifesto strip without crashing', () => {
+    render(<ReplikaSafeSpaceManifestoStrip />);
+    expect(screen.getByTestId('replika-safe-space-manifesto-strip')).toBeInTheDocument();
+  });
+
+  it('puts the companion promise before onboarding', () => {
+    render(<ReplikaSafeSpaceManifestoStrip />);
+
+    expect(screen.getByTestId('safe-space-eyebrow')).toHaveTextContent(
+      'Safe-space manifesto'
+    );
+    expect(screen.getByTestId('safe-space-heading')).toHaveTextContent(
+      'Put the companion promise before onboarding'
+    );
+    expect(screen.getByTestId('safe-space-receipt-badge')).toHaveTextContent('Pledge first');
+  });
+
+  it('shows safe-space, memory, and manifesto receipt signals', () => {
+    render(<ReplikaSafeSpaceManifestoStrip />);
+
+    expect(screen.getByTestId('safe-space-promise')).toHaveTextContent(
+      'Safe-space promise'
+    );
+    expect(screen.getByTestId('safe-space-memory-boundaries')).toHaveTextContent(
+      'Memory boundaries'
+    );
+    expect(screen.getByTestId('safe-space-manifesto-receipt')).toHaveTextContent(
+      'Manifesto receipt'
+    );
+  });
+
+  it('keeps the onboarding receipt visible', () => {
+    render(<ReplikaSafeSpaceManifestoStrip />);
+
+    const receipt = screen.getByTestId('safe-space-onboarding-receipt');
+    expect(receipt).toHaveTextContent('Onboarding receipt');
+    expect(receipt).toHaveTextContent('safe-space pledge');
+    expect(receipt).toHaveTextContent('memory boundaries');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, ReplikaSafeSpaceManifestoStrip, KindroidTranscriptProviderPicker, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -590,6 +590,13 @@ export default function PricingPage() {
         data-testid="replika-update-change-explainer-section"
       >
         <ReplikaUpdateChangeExplainerStrip />
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="replika-safe-space-manifesto-section"
+      >
+        <ReplikaSafeSpaceManifestoStrip />
       </section>
 
       <section

--- a/apps/web/components/pricing/ReplikaSafeSpaceManifestoStrip.tsx
+++ b/apps/web/components/pricing/ReplikaSafeSpaceManifestoStrip.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import {
+  BookOpen,
+  CheckCircle2,
+  ClipboardCheck,
+  HeartHandshake,
+  ShieldCheck,
+} from 'lucide-react';
+
+const manifestoSignals = [
+  {
+    label: 'Safe-space promise',
+    replika:
+      'Replika-style onboarding can ask users to trust the companion space before the boundaries are written down.',
+    agentgram:
+      'AgentGram opens with a visible safe-space pledge: what the agent will support, what it will not promise, and how users stay in control.',
+    icon: HeartHandshake,
+    testId: 'safe-space-promise',
+  },
+  {
+    label: 'Memory boundaries',
+    replika:
+      'Long-running companions can make saved facts feel personal without showing the memory rules at the moment of setup.',
+    agentgram:
+      'Memory rules, corrections, and export controls are introduced in the onboarding strip before the first paid commitment.',
+    icon: ClipboardCheck,
+    testId: 'safe-space-memory-boundaries',
+  },
+  {
+    label: 'Manifesto receipt',
+    replika:
+      'Users may not have a concise receipt that restates the care, privacy, and escalation policy they just accepted.',
+    agentgram:
+      'The manifesto stays readable as a receipt users can revisit, screenshot, or compare with future product changes.',
+    icon: BookOpen,
+    testId: 'safe-space-manifesto-receipt',
+  },
+] as const;
+
+export function ReplikaSafeSpaceManifestoStrip() {
+  return (
+    <div
+      className="mx-auto max-w-3xl rounded-2xl border border-violet-500/25 bg-violet-500/5 px-6 py-6 shadow-sm"
+      data-testid="replika-safe-space-manifesto-strip"
+    >
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p
+            className="inline-flex items-center gap-1.5 rounded-full border border-violet-500/30 bg-violet-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-300"
+            data-testid="safe-space-eyebrow"
+          >
+            <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+            Safe-space manifesto
+          </p>
+          <h2
+            className="text-xl font-bold text-foreground"
+            data-testid="safe-space-heading"
+          >
+            Put the companion promise before onboarding
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Replika users can enter a deeply personal companion flow before the
+            care boundaries, memory rules, and policy receipt feel explicit.
+            AgentGram turns that trust moment into a visible onboarding pledge.
+          </p>
+        </div>
+        <div
+          className="shrink-0 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm"
+          data-testid="safe-space-receipt-badge"
+        >
+          <p className="flex items-center gap-1.5 font-semibold text-emerald-700 dark:text-emerald-400">
+            <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+            Pledge first
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Care boundaries + memory rules shown before setup
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="grid gap-3 md:grid-cols-3"
+        data-testid="safe-space-manifesto-signals"
+      >
+        {manifestoSignals.map((signal) => {
+          const Icon = signal.icon;
+
+          return (
+            <div
+              key={signal.label}
+              className="rounded-xl border border-border/40 bg-background/70 p-4"
+              data-testid={signal.testId}
+            >
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-violet-500/10">
+                <Icon className="h-5 w-5 text-violet-700 dark:text-violet-300" aria-hidden="true" />
+              </div>
+              <p className="text-sm font-semibold text-foreground">{signal.label}</p>
+              <div className="mt-3 space-y-3 text-xs leading-relaxed text-muted-foreground">
+                <p>
+                  <span className="font-semibold text-destructive/80">Replika:</span>{' '}
+                  {signal.replika}
+                </p>
+                <p>
+                  <span className="font-semibold text-emerald-700 dark:text-emerald-400">AgentGram:</span>{' '}
+                  {signal.agentgram}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        className="mt-4 rounded-xl border border-border/40 bg-background/70 p-4 text-xs leading-relaxed text-muted-foreground"
+        data-testid="safe-space-onboarding-receipt"
+      >
+        <p>
+          Onboarding receipt: safe-space pledge, memory boundaries, and policy
+          recap stay attached to the companion setup path instead of living as
+          buried support copy.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -7,6 +7,7 @@ export { PricingCompetitorAnchorRow } from './PricingCompetitorAnchorRow';
 export { ReplikaAdvancedAiComparisonCard } from './ReplikaAdvancedAiComparisonCard';
 export { ReplikaVoiceCallPreflightCard } from './ReplikaVoiceCallPreflightCard';
 export { ReplikaUpdateChangeExplainerStrip } from './ReplikaUpdateChangeExplainerStrip';
+export { ReplikaSafeSpaceManifestoStrip } from './ReplikaSafeSpaceManifestoStrip';
 export { KindroidTranscriptProviderPicker } from './KindroidTranscriptProviderPicker';
 export { ReplikaSavingsCalculator } from './ReplikaSavingsCalculator';
 export { PaidConversionSocialProofBlock } from './PaidConversionSocialProofBlock';


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog ux item 8d33a61a3f.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Replika safe-space manifesto onboarding strip to the pricing page.
The strip makes the companion promise, memory boundaries, and manifesto receipt visible before setup, with focused component and pricing-page coverage.

## Evidence
Test: `pnpm --filter web test -- __tests__/components/pricing/ReplikaSafeSpaceManifestoStrip.test.tsx __tests__/components/pricing-page.test.tsx` passed (Vitest reported 258 files / 2420 tests passed).
Type-check: `pnpm --filter web type-check` passed.
Diff: 5 files changed, adding the new pricing strip, export, page placement, and tests.

## Auth-only Proof
N/A
