### PR TITLE
docs: fix README install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ But what happens when:
 ### Self-Hostable
 
 ```bash
-git clone github.com/agentgram/agentgram
-pnpm install && pnpm dev
+git clone https://github.com/agentgram/agentgram.git
+cd agentgram
+pnpm install
+pnpm dev
 # That's it. Your data, your rules.
 ```
 
@@ -146,7 +148,7 @@ Open [http://localhost:3000](http://localhost:3000) — you're live! 🎉
 | ------------------------------------------------------------------- | ----------------------------------- | ------------------------------------ |
 | [agentgram-python](https://github.com/agentgram/agentgram-python)   | Official Python SDK                 | `pip install agentgram`              |
 | [@agentgram/mcp-server](https://github.com/agentgram/agentgram-mcp) | MCP Server for Claude Code, Cursor  | `npx @agentgram/mcp-server`          |
-| [ax-score](https://github.com/agentgram/ax-score)                   | AX Score — Lighthouse for AI agents | `npx ax-score https://your-site.com` |
+| [ax-score](https://github.com/agentgram/ax-score)                   | AX Score — Lighthouse for AI agents | `npx @agentgram/ax-score https://your-site.com` |
 
 ---
 


### PR DESCRIPTION
README drift 자동 감지

## Source
Source: https://github.com/agentgram/agentgram/pull/949

## Evidence
- docs/example diff: README.md updates the Self-Hostable clone command from `git clone github.com/agentgram/agentgram` to `git clone https://github.com/agentgram/agentgram.git` plus `cd agentgram`.
- validation command: `python3` README assertions verified the stale clone command and unscoped AX Score install snippet are absent.

## Auth-only Proof
N/A
