### PR TITLE
ux(pricing): add Kindroid bond continuity card

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -232,6 +232,16 @@ describe('PricingPage', () => {
     expect(section).toHaveTextContent('Troubleshooting pinned');
   });
 
+  it('renders the Kindroid bond continuity reassurance card with history, consent, and receipts', () => {
+    render(<PricingPage />);
+
+    const section = screen.getByTestId('kindroid-bond-continuity-section');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('Bond history');
+    expect(section).toHaveTextContent('Consent checkpoint');
+    expect(section).toHaveTextContent('Continuity receipt timeline');
+  });
+
   it('renders Visual Memory mind map section with Nomi parity badge and Starter+ callout', () => {
     render(<PricingPage />);
 

--- a/apps/web/__tests__/components/pricing/KindroidBondContinuityReassuranceCard.test.tsx
+++ b/apps/web/__tests__/components/pricing/KindroidBondContinuityReassuranceCard.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { KindroidBondContinuityReassuranceCard } from '@/components/pricing/KindroidBondContinuityReassuranceCard';
+
+describe('KindroidBondContinuityReassuranceCard', () => {
+  it('renders the bond continuity reassurance card without crashing', () => {
+    render(<KindroidBondContinuityReassuranceCard />);
+    expect(screen.getByTestId('kindroid-bond-continuity-card')).toBeInTheDocument();
+  });
+
+  it('reassures switchers that companion bonds will not reset', () => {
+    render(<KindroidBondContinuityReassuranceCard />);
+
+    expect(screen.getByTestId('bond-continuity-eyebrow')).toHaveTextContent(
+      'Bond continuity reassurance'
+    );
+    expect(screen.getByTestId('bond-continuity-heading')).toHaveTextContent(
+      'Reassure Kindroid switchers their companion bond will not reset'
+    );
+    expect(screen.getByTestId('bond-continuity-safe-badge')).toHaveTextContent(
+      'Same bond, safer upgrade'
+    );
+  });
+
+  it('shows bond history, consent, and reassurance signals', () => {
+    render(<KindroidBondContinuityReassuranceCard />);
+    const grid = screen.getByTestId('bond-continuity-signal-grid');
+
+    expect(grid.children).toHaveLength(3);
+    expect(screen.getByTestId('bond-continuity-history')).toHaveTextContent('Bond history');
+    expect(screen.getByTestId('bond-continuity-history')).toHaveTextContent(
+      'Shared moments stay attached to the same companion'
+    );
+    expect(screen.getByTestId('bond-continuity-consent')).toHaveTextContent(
+      'Nothing resets or rewrites the bond silently'
+    );
+    expect(screen.getByTestId('bond-continuity-reassurance')).toHaveTextContent(
+      'Continuity promise appears in plain language'
+    );
+  });
+
+  it('keeps the before, during, and after continuity timeline visible', () => {
+    render(<KindroidBondContinuityReassuranceCard />);
+    const timeline = screen.getByTestId('bond-continuity-timeline');
+
+    expect(timeline).toHaveTextContent('Continuity receipt timeline');
+    expect(timeline).toHaveTextContent('Before upgrade: preview saved bond context');
+    expect(timeline).toHaveTextContent('During upgrade: freeze memory and persona changes');
+    expect(timeline).toHaveTextContent('After upgrade: show a continuity receipt');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, KindroidLiveCallStabilityConsole, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, KindroidLiveCallStabilityConsole, KindroidBondContinuityReassuranceCard, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -604,6 +604,13 @@ export default function PricingPage() {
         data-testid="kindroid-live-call-stability-section"
       >
         <KindroidLiveCallStabilityConsole />
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="kindroid-bond-continuity-section"
+      >
+        <KindroidBondContinuityReassuranceCard />
       </section>
 
       <section

--- a/apps/web/components/pricing/KindroidBondContinuityReassuranceCard.tsx
+++ b/apps/web/components/pricing/KindroidBondContinuityReassuranceCard.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { HeartHandshake, History, LockKeyhole, ShieldCheck, Sparkles } from 'lucide-react';
+
+const continuitySignals = [
+  {
+    label: 'Bond history',
+    value: 'Shared moments stay attached to the same companion',
+    description:
+      'Users see the remembered milestones, tone notes, and relationship context that will carry into the next session before they upgrade.',
+    icon: History,
+    testId: 'bond-continuity-history',
+  },
+  {
+    label: 'Consent checkpoint',
+    value: 'Nothing resets or rewrites the bond silently',
+    description:
+      'Major persona, memory, or voice changes require a visible approval checkpoint instead of surprising users after checkout.',
+    icon: LockKeyhole,
+    testId: 'bond-continuity-consent',
+  },
+  {
+    label: 'Reassurance note',
+    value: 'Continuity promise appears in plain language',
+    description:
+      'A short memo explains what stays familiar, what may improve, and where to review the change log if the companion feels different.',
+    icon: ShieldCheck,
+    testId: 'bond-continuity-reassurance',
+  },
+] as const;
+
+const continuityTimeline = [
+  'Before upgrade: preview saved bond context and companion tone',
+  'During upgrade: freeze memory and persona changes until confirmed',
+  'After upgrade: show a continuity receipt with rollback guidance',
+] as const;
+
+export function KindroidBondContinuityReassuranceCard() {
+  return (
+    <div
+      className="mx-auto max-w-3xl rounded-2xl border border-fuchsia-500/25 bg-fuchsia-500/5 px-6 py-6 shadow-sm"
+      data-testid="kindroid-bond-continuity-card"
+    >
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p
+            className="inline-flex items-center gap-1.5 rounded-full border border-fuchsia-500/30 bg-fuchsia-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-fuchsia-700 dark:text-fuchsia-300"
+            data-testid="bond-continuity-eyebrow"
+          >
+            <HeartHandshake className="h-3.5 w-3.5" aria-hidden="true" />
+            Bond continuity reassurance
+          </p>
+          <h2
+            className="text-xl font-bold text-foreground"
+            data-testid="bond-continuity-heading"
+          >
+            Reassure Kindroid switchers their companion bond will not reset
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Kindroid-style companion buyers need to know an upgrade, model change,
+            or migration will not erase the relationship they have built. AgentGram
+            makes the continuity promise visible before checkout with history,
+            consent, and rollback cues in one reassurance card.
+          </p>
+        </div>
+        <div
+          className="shrink-0 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm"
+          data-testid="bond-continuity-safe-badge"
+        >
+          <p className="flex items-center gap-1.5 font-semibold text-emerald-700 dark:text-emerald-400">
+            <Sparkles className="h-4 w-4" aria-hidden="true" />
+            Same bond, safer upgrade
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Memory, tone, and change receipts stay reviewable
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="mb-4 grid gap-3 md:grid-cols-3"
+        data-testid="bond-continuity-signal-grid"
+      >
+        {continuitySignals.map((signal) => {
+          const Icon = signal.icon;
+
+          return (
+            <div
+              key={signal.label}
+              className="rounded-xl border border-border/40 bg-background/70 p-4"
+              data-testid={signal.testId}
+            >
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-fuchsia-500/10">
+                <Icon className="h-5 w-5 text-fuchsia-700 dark:text-fuchsia-300" aria-hidden="true" />
+              </div>
+              <p className="text-sm font-semibold text-foreground">{signal.label}</p>
+              <p className="mt-1 text-sm font-medium text-fuchsia-700 dark:text-fuchsia-300">
+                {signal.value}
+              </p>
+              <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                {signal.description}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        className="rounded-xl border border-border/40 bg-background/70 p-4"
+        data-testid="bond-continuity-timeline"
+      >
+        <p className="text-sm font-semibold text-foreground">Continuity receipt timeline</p>
+        <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+          {continuityTimeline.map((item) => (
+            <p key={item} className="rounded-lg border border-border/30 bg-background/60 px-3 py-2">
+              {item}
+            </p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -9,6 +9,7 @@ export { ReplikaVoiceCallPreflightCard } from './ReplikaVoiceCallPreflightCard';
 export { ReplikaUpdateChangeExplainerStrip } from './ReplikaUpdateChangeExplainerStrip';
 export { KindroidTranscriptProviderPicker } from './KindroidTranscriptProviderPicker';
 export { KindroidLiveCallStabilityConsole } from './KindroidLiveCallStabilityConsole';
+export { KindroidBondContinuityReassuranceCard } from './KindroidBondContinuityReassuranceCard';
 export { ReplikaSavingsCalculator } from './ReplikaSavingsCalculator';
 export { PaidConversionSocialProofBlock } from './PaidConversionSocialProofBlock';
 export { ReplikaUltraFatigueFunnel } from './ReplikaUltraFatigueFunnel';

--- a/apps/web/docs/pr-evidence/kindroid-bond-continuity-reassurance.md
+++ b/apps/web/docs/pr-evidence/kindroid-bond-continuity-reassurance.md
@@ -1,0 +1,36 @@
+# PR Evidence: Kindroid Bond Continuity Reassurance Card
+
+## Source
+
+Hermes kanban-dispatch dev lane — backlog ux item 7a8171b768.
+
+## Change
+
+Added `KindroidBondContinuityReassuranceCard`, a pricing-page reassurance card for Kindroid switchers who worry that an upgrade, model change, or migration will reset a companion relationship.
+
+## Placement
+
+The card is rendered on `/pricing` after the Kindroid live-call stability console and before the Nomi Aurora retirement notice so it sits with the competitor trust/continuity proof stack.
+
+## Test Coverage
+
+5 focused test assertions across the new component test and page integration:
+
+| Test | Assertion |
+|---|---|
+| `KindroidBondContinuityReassuranceCard.test.tsx` | Component renders |
+| `KindroidBondContinuityReassuranceCard.test.tsx` | Eyebrow, heading, and safe-upgrade badge reassure that the bond will not reset |
+| `KindroidBondContinuityReassuranceCard.test.tsx` | Bond history, consent checkpoint, and plain-language reassurance signals render |
+| `KindroidBondContinuityReassuranceCard.test.tsx` | Before/during/after continuity receipt timeline stays visible |
+| `pricing-page.test.tsx` | Pricing page renders the Kindroid bond continuity section |
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `apps/web/components/pricing/KindroidBondContinuityReassuranceCard.tsx` | New reassurance card component |
+| `apps/web/components/pricing/index.ts` | Barrel export for the new component |
+| `apps/web/app/(public)/pricing/page.tsx` | Pricing-page placement |
+| `apps/web/__tests__/components/pricing/KindroidBondContinuityReassuranceCard.test.tsx` | New component tests |
+| `apps/web/__tests__/components/pricing-page.test.tsx` | Page integration assertion |
+| `apps/web/docs/pr-evidence/kindroid-bond-continuity-reassurance.md` | This evidence note |


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog ux item 7a8171b768.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Kindroid bond continuity reassurance card to the pricing page so switchers can see that shared history, consent checkpoints, and continuity receipts protect the companion relationship through upgrades or migrations.

## Evidence
Test: `pnpm --filter web test __tests__/components/pricing/KindroidBondContinuityReassuranceCard.test.tsx __tests__/components/pricing-page.test.tsx` — 2 files passed, 18 tests passed.
Type-check: `pnpm --filter web type-check` — passed.
Diff: 6 scoped files changed for component, pricing placement, tests, and PR evidence.

## Auth-only Proof
N/A
