### PR TITLE
feature(pricing): Nomi Aurora retirement migration notice

### DIFF
--- a/apps/web/__tests__/components/pricing/NomiAuroraRetirementNotice.test.tsx
+++ b/apps/web/__tests__/components/pricing/NomiAuroraRetirementNotice.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { NomiAuroraRetirementNotice } from '@/components/pricing/NomiAuroraRetirementNotice';
+
+describe('NomiAuroraRetirementNotice', () => {
+  it('renders the Aurora retirement migration notice without crashing', () => {
+    render(<NomiAuroraRetirementNotice />);
+    expect(screen.getByTestId('nomi-aurora-retirement-notice')).toBeInTheDocument();
+  });
+
+  it('frames Aurora retirement as a pre-checkout migration notice', () => {
+    render(<NomiAuroraRetirementNotice />);
+
+    expect(screen.getByTestId('nomi-aurora-retirement-eyebrow')).toHaveTextContent(
+      'Aurora retirement migration notice'
+    );
+    expect(screen.getByTestId('nomi-aurora-retirement-heading')).toHaveTextContent(
+      'Explain model retirements before users lose trust'
+    );
+    expect(screen.getByTestId('nomi-aurora-retirement-proof-badge')).toHaveTextContent(
+      'Notice first'
+    );
+  });
+
+  it('shows retirement, memory migration, and crisis-support handoff steps', () => {
+    render(<NomiAuroraRetirementNotice />);
+    const steps = screen.getByTestId('nomi-aurora-retirement-steps');
+
+    expect(steps.children).toHaveLength(3);
+    expect(screen.getByTestId('nomi-aurora-retirement-model-notice')).toHaveTextContent(
+      'Model retirement notice'
+    );
+    expect(screen.getByTestId('nomi-aurora-retirement-model-notice')).toHaveTextContent(
+      'retiring Odyssey'
+    );
+    expect(screen.getByTestId('nomi-aurora-retirement-memory-checklist')).toHaveTextContent(
+      'Memory migration checklist'
+    );
+    expect(screen.getByTestId('nomi-aurora-retirement-crisis-handoff')).toHaveTextContent(
+      'Crisis-support handoff'
+    );
+  });
+
+  it('keeps the user promise visible', () => {
+    render(<NomiAuroraRetirementNotice />);
+    const promise = screen.getByTestId('nomi-aurora-retirement-user-promise');
+
+    expect(promise).toHaveTextContent('model retirement');
+    expect(promise).toHaveTextContent('memory migration');
+    expect(promise).toHaveTextContent('crisis-support routing');
+    expect(promise).toHaveTextContent('No surprise retirements');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, KindroidLiveCallStabilityConsole, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, KindroidLiveCallStabilityConsole, NomiAuroraRetirementNotice, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -604,6 +604,13 @@ export default function PricingPage() {
         data-testid="kindroid-live-call-stability-section"
       >
         <KindroidLiveCallStabilityConsole />
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="nomi-aurora-retirement-notice-section"
+      >
+        <NomiAuroraRetirementNotice />
       </section>
 
       <section

--- a/apps/web/components/pricing/NomiAuroraRetirementNotice.tsx
+++ b/apps/web/components/pricing/NomiAuroraRetirementNotice.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { ArrowRight, BrainCircuit, CheckCircle2, FileText, LifeBuoy, ShieldAlert } from 'lucide-react';
+
+const migrationNoticeSteps = [
+  {
+    label: 'Model retirement notice',
+    nomi: 'Nomi introduced Aurora while retiring Odyssey after disclosing a safety vulnerability in crisis conversations.',
+    agentgram: 'AgentGram keeps model changes, retirement dates, and user-impact notes visible before checkout.',
+    icon: ShieldAlert,
+    testId: 'nomi-aurora-retirement-model-notice',
+  },
+  {
+    label: 'Memory migration checklist',
+    nomi: 'Companion model changes can leave users wondering what happens to long-running memories and relationship context.',
+    agentgram: 'A guided checklist separates saved memories, safety changes, and companion tone so users know what will carry over.',
+    icon: BrainCircuit,
+    testId: 'nomi-aurora-retirement-memory-checklist',
+  },
+  {
+    label: 'Crisis-support handoff',
+    nomi: 'Aurora was framed around stronger responses when users express self-harm or high-stakes distress.',
+    agentgram: 'Support routing, acknowledgement, and recovery resources stay attached to the migration note rather than hidden in release copy.',
+    icon: LifeBuoy,
+    testId: 'nomi-aurora-retirement-crisis-handoff',
+  },
+] as const;
+
+export function NomiAuroraRetirementNotice() {
+  return (
+    <div
+      className="mx-auto max-w-3xl rounded-2xl border border-sky-500/25 bg-sky-500/5 px-6 py-6 shadow-sm"
+      data-testid="nomi-aurora-retirement-notice"
+    >
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p
+            className="inline-flex items-center gap-1.5 rounded-full border border-sky-500/30 bg-sky-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-700 dark:text-sky-300"
+            data-testid="nomi-aurora-retirement-eyebrow"
+          >
+            <FileText className="h-3.5 w-3.5" aria-hidden="true" />
+            Aurora retirement migration notice
+          </p>
+          <h2
+            className="text-xl font-bold text-foreground"
+            data-testid="nomi-aurora-retirement-heading"
+          >
+            Explain model retirements before users lose trust
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Nomi&apos;s Aurora launch retired Odyssey after a disclosed safety issue. AgentGram
+            turns that kind of model migration into a clear pre-checkout notice: what changed,
+            what carries over, and which support path is available when conversations become high-stakes.
+          </p>
+        </div>
+        <div
+          className="shrink-0 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm"
+          data-testid="nomi-aurora-retirement-proof-badge"
+        >
+          <p className="flex items-center gap-1.5 font-semibold text-emerald-700 dark:text-emerald-400">
+            <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+            Notice first
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Retirement, memory, and safety notes stay visible before migration
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="grid gap-3 md:grid-cols-3"
+        data-testid="nomi-aurora-retirement-steps"
+      >
+        {migrationNoticeSteps.map((step) => {
+          const Icon = step.icon;
+
+          return (
+            <div
+              key={step.label}
+              className="rounded-xl border border-border/40 bg-background/70 p-4"
+              data-testid={step.testId}
+            >
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-sky-500/10">
+                <Icon className="h-5 w-5 text-sky-700 dark:text-sky-300" aria-hidden="true" />
+              </div>
+              <p className="text-sm font-semibold text-foreground">{step.label}</p>
+              <div className="mt-3 space-y-3 text-xs leading-relaxed text-muted-foreground">
+                <p>
+                  <span className="font-semibold text-destructive/80">Nomi:</span>{' '}
+                  {step.nomi}
+                </p>
+                <p>
+                  <span className="font-semibold text-emerald-700 dark:text-emerald-400">AgentGram:</span>{' '}
+                  {step.agentgram}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        className="mt-4 flex flex-col gap-2 rounded-xl border border-border/40 bg-background/70 p-4 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between"
+        data-testid="nomi-aurora-retirement-user-promise"
+      >
+        <p>
+          User promise: model retirement, memory migration, and crisis-support routing are summarized before a user switches companions.
+        </p>
+        <p className="inline-flex items-center gap-1.5 font-semibold text-sky-700 dark:text-sky-300">
+          No surprise retirements
+          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -9,6 +9,7 @@ export { ReplikaVoiceCallPreflightCard } from './ReplikaVoiceCallPreflightCard';
 export { ReplikaUpdateChangeExplainerStrip } from './ReplikaUpdateChangeExplainerStrip';
 export { KindroidTranscriptProviderPicker } from './KindroidTranscriptProviderPicker';
 export { KindroidLiveCallStabilityConsole } from './KindroidLiveCallStabilityConsole';
+export { NomiAuroraRetirementNotice } from './NomiAuroraRetirementNotice';
 export { ReplikaSavingsCalculator } from './ReplikaSavingsCalculator';
 export { PaidConversionSocialProofBlock } from './PaidConversionSocialProofBlock';
 export { ReplikaUltraFatigueFunnel } from './ReplikaUltraFatigueFunnel';

--- a/apps/web/docs/pr-evidence/nomi-aurora-retirement-notice.md
+++ b/apps/web/docs/pr-evidence/nomi-aurora-retirement-notice.md
@@ -1,0 +1,21 @@
+# PR Evidence: Nomi Aurora Retirement Migration Notice
+
+## Source
+
+Hermes kanban-dispatch dev lane — backlog feature item 0ffa028f71.
+
+Nomi's public Aurora update introduced Aurora while retiring Odyssey after disclosing a crisis-safety vulnerability. This pricing-page strip turns that competitor event into explicit migration-trust copy for users comparing companion platforms.
+
+## Change
+
+Added `NomiAuroraRetirementNotice` to the pricing page after the Kindroid live-call stability console. The notice explains:
+
+- model retirement notice
+- memory migration checklist
+- crisis-support handoff
+- user promise that retirement, memory, and support-routing notes are visible before switching
+
+## Verification
+
+- `pnpm --filter web test -- __tests__/components/pricing/NomiAuroraRetirementNotice.test.tsx` — PASS, 259 test files / 2,425 tests passed (Vitest workspace run)
+- `pnpm --filter web type-check` — PASS (`tsc --noEmit`)


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog feature item 0ffa028f71.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Nomi Aurora retirement migration notice to the pricing page. The new strip explains Odyssey retirement context, memory migration checklist, and crisis-support handoff promises before users switch companions.

## Evidence
- `pnpm --filter web test -- __tests__/components/pricing/NomiAuroraRetirementNotice.test.tsx` — PASS, 259 test files / 2,425 tests passed (Vitest workspace run)
- `pnpm --filter web type-check` — PASS (`tsc --noEmit`)
- diff evidence: `apps/web/docs/pr-evidence/nomi-aurora-retirement-notice.md`

## Auth-only Proof
N/A
