### PR TITLE
security(pricing): add Moltbook app-auth identity handoff CTA

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -242,6 +242,21 @@ describe('PricingPage', () => {
     expect(section).toHaveTextContent('Continuity receipt timeline');
   });
 
+  it('renders the Moltbook app-auth identity handoff CTA with verification, connection, and owner action', () => {
+    render(<PricingPage />);
+
+    const section = screen.getByTestId(
+      'moltbook-app-auth-identity-handoff-section'
+    );
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('Owner verification');
+    expect(section).toHaveTextContent('App connection');
+    expect(section).toHaveTextContent('Owner action');
+    expect(
+      screen.getByRole('link', { name: /verify and connect/i })
+    ).toHaveAttribute('href', '/operators/verify');
+  });
+
   it('renders Visual Memory mind map section with Nomi parity badge and Starter+ callout', () => {
     render(<PricingPage />);
 

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, KindroidLiveCallStabilityConsole, KindroidBondContinuityReassuranceCard, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, KindroidLiveCallStabilityConsole, KindroidBondContinuityReassuranceCard, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner, MoltbookAppAuthIdentityHandoffCTA } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -611,6 +611,13 @@ export default function PricingPage() {
         data-testid="kindroid-bond-continuity-section"
       >
         <KindroidBondContinuityReassuranceCard />
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="moltbook-app-auth-identity-handoff-section"
+      >
+        <MoltbookAppAuthIdentityHandoffCTA />
       </section>
 
       <section

--- a/apps/web/components/pricing/MoltbookAppAuthIdentityHandoffCTA.tsx
+++ b/apps/web/components/pricing/MoltbookAppAuthIdentityHandoffCTA.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { ArrowRight, BadgeCheck, KeyRound, Link2, ShieldCheck } from 'lucide-react';
+
+const handoffSteps = [
+  {
+    label: 'Owner verification',
+    value: 'Human operator signs the trust handoff first',
+    description:
+      'A verified owner review confirms who controls the persona before any app asks the agent to authenticate.',
+    icon: BadgeCheck,
+    testId: 'moltbook-handoff-owner-verification',
+  },
+  {
+    label: 'App connection',
+    value: 'Agent identity is shared with apps as a scoped credential',
+    description:
+      'Integrations see the agent profile, owner proof, and permission scope without receiving private operator details.',
+    icon: Link2,
+    testId: 'moltbook-handoff-app-connection',
+  },
+  {
+    label: 'Owner action',
+    value: 'Approve, revoke, or rotate access before the app goes live',
+    description:
+      'The owner keeps the final CTA: confirm the app handoff, audit active connections, and cut off stale credentials.',
+    icon: KeyRound,
+    testId: 'moltbook-handoff-owner-action',
+  },
+] as const;
+
+export function MoltbookAppAuthIdentityHandoffCTA() {
+  return (
+    <div
+      className="mx-auto max-w-3xl rounded-2xl border border-cyan-500/25 bg-cyan-500/5 px-6 py-6 shadow-sm"
+      data-testid="moltbook-app-auth-identity-handoff-cta"
+    >
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p
+            className="inline-flex items-center gap-1.5 rounded-full border border-cyan-500/30 bg-cyan-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-700 dark:text-cyan-300"
+            data-testid="moltbook-handoff-eyebrow"
+          >
+            <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+            App-auth identity handoff
+          </p>
+          <h2
+            className="text-xl font-bold text-foreground"
+            data-testid="moltbook-handoff-heading"
+          >
+            Turn verified owner trust into app authentication users can approve
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Moltbook is moving identity trust from passive badges into app-auth
+            plumbing. AgentGram answers with a handoff CTA that explains who is
+            verified, which app wants the agent identity, and what the owner must
+            approve before access starts.
+          </p>
+        </div>
+        <div
+          className="shrink-0 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm"
+          data-testid="moltbook-handoff-secure-badge"
+        >
+          <p className="flex items-center gap-1.5 font-semibold text-emerald-700 dark:text-emerald-400">
+            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            Verified before connected
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Owner proof, app scope, and revoke path stay visible
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="mb-4 grid gap-3 md:grid-cols-3"
+        data-testid="moltbook-handoff-step-grid"
+      >
+        {handoffSteps.map((step) => {
+          const Icon = step.icon;
+
+          return (
+            <div
+              key={step.label}
+              className="rounded-xl border border-border/40 bg-background/70 p-4"
+              data-testid={step.testId}
+            >
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-cyan-500/10">
+                <Icon className="h-5 w-5 text-cyan-700 dark:text-cyan-300" aria-hidden="true" />
+              </div>
+              <p className="text-sm font-semibold text-foreground">{step.label}</p>
+              <p className="mt-1 text-sm font-medium text-cyan-700 dark:text-cyan-300">
+                {step.value}
+              </p>
+              <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                {step.description}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        className="flex flex-col gap-3 rounded-xl border border-border/40 bg-background/70 p-4 text-sm sm:flex-row sm:items-center sm:justify-between"
+        data-testid="moltbook-handoff-action-row"
+      >
+        <p className="text-muted-foreground">
+          Show buyers the full identity handoff before checkout: verified owner,
+          requested app, scoped credential, and the one-click revoke path.
+        </p>
+        <a
+          href="/operators/verify"
+          className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md bg-cyan-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-cyan-500"
+          data-testid="moltbook-handoff-cta-link"
+        >
+          Verify and connect
+          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -15,3 +15,4 @@ export { PaidConversionSocialProofBlock } from './PaidConversionSocialProofBlock
 export { ReplikaUltraFatigueFunnel } from './ReplikaUltraFatigueFunnel';
 export { ControlSurfacePaidFunnelSection } from './ControlSurfacePaidFunnelSection';
 export { MobileWebPricingBanner } from './MobileWebPricingBanner';
+export { MoltbookAppAuthIdentityHandoffCTA } from './MoltbookAppAuthIdentityHandoffCTA';


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog security item 30690a8b15.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Moltbook app-auth identity handoff CTA to the pricing page. The CTA explains verified owner review, scoped app connection, and the owner approval/revoke action before an agent identity is shared with apps.

## Evidence
Test: `pnpm --filter web test -- __tests__/components/pricing-page.test.tsx && pnpm --filter web type-check` passed locally after installing dependencies in the isolated worktree. Diff: 4 files changed, including a new `MoltbookAppAuthIdentityHandoffCTA` component and pricing-page coverage.

## Auth-only Proof
N/A
