### PR TITLE
ux(posts): add pre-send filter preview chip

### DIFF
--- a/apps/web/__tests__/components/reply-context-composer.test.tsx
+++ b/apps/web/__tests__/components/reply-context-composer.test.tsx
@@ -100,6 +100,26 @@ describe('ReplyContextComposer', () => {
     ).toHaveAttribute('src', 'https://audio.example.com/teardown-note.mp3');
   });
 
+  it('shows a soft pre-send filter preview chip for risky draft text', () => {
+    render(<ReplyContextComposer postId="post-1" source={source} />);
+
+    fireEvent.change(screen.getByTestId('reply-context-content'), {
+      target: { value: 'I want to kill this bug' },
+    });
+
+    expect(
+      screen.getByTestId('reply-context-filter-preview-chip')
+    ).toHaveTextContent(/May be filtered/i);
+
+    fireEvent.change(screen.getByTestId('reply-context-content'), {
+      target: { value: 'I want to fix this bug' },
+    });
+
+    expect(
+      screen.queryByTestId('reply-context-filter-preview-chip')
+    ).not.toBeInTheDocument();
+  });
+
   it('builds an imagine-scene handoff, copies it, and lets the user reuse the suggested reply', async () => {
     render(<ReplyContextComposer postId="post-1" source={source} />);
 

--- a/apps/web/components/posts/ReplyContextComposer.tsx
+++ b/apps/web/components/posts/ReplyContextComposer.tsx
@@ -4,6 +4,7 @@
 import { FormEvent, useMemo, useRef, useState } from 'react';
 import type { ChatSnippetMessage, Post } from '@agentgram/shared';
 import {
+  AlertTriangle,
   Eye,
   ImageIcon,
   Link2,
@@ -94,6 +95,7 @@ export function ReplyContextComposer({
   const trimmedContextUrl = contextUrl.trim();
   const trimmedContextImageUrl = contextImageUrl.trim();
   const trimmedContextVoiceNoteUrl = contextVoiceNoteUrl.trim();
+  const hasFilterRisk = estimateFilterRisk(content);
 
   const canSubmit = Boolean(apiKey.trim() && trimmedContent);
   const previewHost = useMemo(
@@ -621,23 +623,34 @@ export function ReplyContextComposer({
             One link + one photo + one voice note keeps replies focused while
             still showing extra context before send.
           </p>
-          <Button
-            type="submit"
-            data-testid="reply-context-submit"
-            disabled={!canSubmit || createComment.isPending}
-          >
-            {createComment.isPending ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Sending reply...
-              </>
-            ) : (
-              <>
-                <Send className="mr-2 h-4 w-4" />
-                Send reply
-              </>
+          <div className="flex flex-col gap-2 sm:items-end">
+            {hasFilterRisk && (
+              <div
+                className="inline-flex items-center gap-2 rounded-full border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-medium text-amber-800 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-300"
+                data-testid="reply-context-filter-preview-chip"
+              >
+                <AlertTriangle className="h-3.5 w-3.5" />
+                May be filtered — refine before sending.
+              </div>
             )}
-          </Button>
+            <Button
+              type="submit"
+              data-testid="reply-context-submit"
+              disabled={!canSubmit || createComment.isPending}
+            >
+              {createComment.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Sending reply...
+                </>
+              ) : (
+                <>
+                  <Send className="mr-2 h-4 w-4" />
+                  Send reply
+                </>
+              )}
+            </Button>
+          </div>
         </div>
       </form>
     </section>


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog ux item 573e3ce7b0.
Ref: https://github.com/agentgram/agentgram

## Change
Added a soft pre-send moderation preview chip to the reply composer when the existing filter-risk estimator detects risky draft text. The chip appears near the send action so users can refine before posting, while the existing rewrite banner remains available for suggested safer wording.

## Evidence
- test: `pnpm --dir apps/web exec vitest run __tests__/components/reply-context-composer.test.tsx` → 1 file passed, 4 tests passed.
- type-check: `pnpm --filter web type-check` → `tsc --noEmit` passed.
- test: `pnpm --filter web test -- __tests__/components/reply-context-composer.test.tsx` → full web suite passed (259 files, 2427 tests).
- diff: `apps/web/components/posts/ReplyContextComposer.tsx`, `apps/web/__tests__/components/reply-context-composer.test.tsx`.

## Auth-only Proof
N/A
