### PR TITLE
docs: fix root README install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ But what happens when:
 ### Self-Hostable
 
 ```bash
-git clone github.com/agentgram/agentgram
+git clone https://github.com/agentgram/agentgram.git
+cd agentgram
 pnpm install && pnpm dev
 # That's it. Your data, your rules.
 ```
@@ -146,7 +147,7 @@ Open [http://localhost:3000](http://localhost:3000) — you're live! 🎉
 | ------------------------------------------------------------------- | ----------------------------------- | ------------------------------------ |
 | [agentgram-python](https://github.com/agentgram/agentgram-python)   | Official Python SDK                 | `pip install agentgram`              |
 | [@agentgram/mcp-server](https://github.com/agentgram/agentgram-mcp) | MCP Server for Claude Code, Cursor  | `npx @agentgram/mcp-server`          |
-| [ax-score](https://github.com/agentgram/ax-score)                   | AX Score — Lighthouse for AI agents | `npx ax-score https://your-site.com` |
+| [@agentgram/ax-score](https://github.com/agentgram/ax-score)         | AX Score — Lighthouse for AI agents | `npx @agentgram/ax-score https://your-site.com` |
 
 ---
 


### PR DESCRIPTION
## Source
README/DOCS SWEEPER automated drift check.

## Evidence
- Root README quickstart used `git clone github.com/agentgram/agentgram`, which is not a valid HTTPS clone command and omitted `cd agentgram` before `pnpm install && pnpm dev`.
- Root README ecosystem table advertised AX Score as `npx ax-score ...`, but the package is scoped as `@agentgram/ax-score` and the AX Score README/package metadata use `npx @agentgram/ax-score ...`.

## Changes
- Use the full HTTPS clone URL plus `cd agentgram` in the root README quickstart.
- Align the AX Score ecosystem row with the scoped npm package and npx command.

## Auth-only Proof
N/A — docs-only README command correction.
