### PR TITLE
ux(explore): add release diff comparison panel

### DIFF
--- a/apps/web/__tests__/components/update-digest-rail.test.tsx
+++ b/apps/web/__tests__/components/update-digest-rail.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import {
   UpdateDigestRail,
   DEFAULT_UPDATE_ENTRIES,
+  DEFAULT_RELEASE_DIFF_PROFILE,
   type UpdateDigestEntry,
 } from '../../components/explore/UpdateDigestRail';
 
@@ -52,41 +53,73 @@ const MOCK_ENTRIES: UpdateDigestEntry[] = [
 describe('UpdateDigestRail', () => {
   it('renders the "What\'s new" heading', () => {
     render(<UpdateDigestRail entries={MOCK_ENTRIES} />);
-    expect(screen.getByTestId('update-digest-heading')).toHaveTextContent("What's new");
+    expect(screen.getByTestId('update-digest-heading')).toHaveTextContent(
+      "What's new"
+    );
   });
 
   it('renders a card for each entry', () => {
     render(<UpdateDigestRail entries={MOCK_ENTRIES} />);
-    expect(screen.getByTestId('update-digest-card-voice-test')).toBeInTheDocument();
-    expect(screen.getByTestId('update-digest-card-image-test')).toBeInTheDocument();
-    expect(screen.getByTestId('update-digest-card-memory-test')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('update-digest-card-voice-test')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('update-digest-card-image-test')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('update-digest-card-memory-test')
+    ).toBeInTheDocument();
   });
 
   it('shows "New" badge only for entries with isNew=true', () => {
     render(<UpdateDigestRail entries={MOCK_ENTRIES} />);
-    expect(screen.getByTestId('update-digest-new-badge-voice-test')).toBeInTheDocument();
-    expect(screen.getByTestId('update-digest-new-badge-memory-test')).toBeInTheDocument();
-    expect(screen.queryByTestId('update-digest-new-badge-image-test')).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('update-digest-new-badge-voice-test')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('update-digest-new-badge-memory-test')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('update-digest-new-badge-image-test')
+    ).not.toBeInTheDocument();
   });
 
   it('renders category badges with correct labels', () => {
     render(<UpdateDigestRail entries={MOCK_ENTRIES} />);
-    expect(screen.getByTestId('update-digest-category-badge-voice-test')).toHaveTextContent('Voice');
-    expect(screen.getByTestId('update-digest-category-badge-image-test')).toHaveTextContent('Image');
-    expect(screen.getByTestId('update-digest-category-badge-memory-test')).toHaveTextContent('Memory');
+    expect(
+      screen.getByTestId('update-digest-category-badge-voice-test')
+    ).toHaveTextContent('Voice');
+    expect(
+      screen.getByTestId('update-digest-category-badge-image-test')
+    ).toHaveTextContent('Image');
+    expect(
+      screen.getByTestId('update-digest-category-badge-memory-test')
+    ).toHaveTextContent('Memory');
   });
 
   it('renders entry titles', () => {
     render(<UpdateDigestRail entries={MOCK_ENTRIES} />);
-    expect(screen.getByTestId('update-digest-title-voice-test')).toHaveTextContent('Voice latency cut by 40%');
-    expect(screen.getByTestId('update-digest-title-image-test')).toHaveTextContent('Selfie engine v2');
-    expect(screen.getByTestId('update-digest-title-memory-test')).toHaveTextContent('Relationship timeline');
+    expect(
+      screen.getByTestId('update-digest-title-voice-test')
+    ).toHaveTextContent('Voice latency cut by 40%');
+    expect(
+      screen.getByTestId('update-digest-title-image-test')
+    ).toHaveTextContent('Selfie engine v2');
+    expect(
+      screen.getByTestId('update-digest-title-memory-test')
+    ).toHaveTextContent('Relationship timeline');
   });
 
   it('links each card to its href', () => {
     render(<UpdateDigestRail entries={MOCK_ENTRIES} />);
-    expect(screen.getByTestId('update-digest-card-voice-test')).toHaveAttribute('href', '/explore#voice');
-    expect(screen.getByTestId('update-digest-card-image-test')).toHaveAttribute('href', '/explore#image');
+    expect(screen.getByTestId('update-digest-card-voice-test')).toHaveAttribute(
+      'href',
+      '/explore#voice'
+    );
+    expect(screen.getByTestId('update-digest-card-image-test')).toHaveAttribute(
+      'href',
+      '/explore#image'
+    );
   });
 
   it('renders the "See all" link', () => {
@@ -106,7 +139,9 @@ describe('UpdateDigestRail', () => {
 
   it('uses DEFAULT_UPDATE_ENTRIES when no entries prop is passed', () => {
     render(<UpdateDigestRail />);
-    expect(screen.getAllByTestId(/^update-digest-card-/).length).toBe(DEFAULT_UPDATE_ENTRIES.length);
+    expect(screen.getAllByTestId(/^update-digest-card-/).length).toBe(
+      DEFAULT_UPDATE_ENTRIES.length
+    );
   });
 
   it('covers all three categories in default entries', () => {
@@ -114,5 +149,49 @@ describe('UpdateDigestRail', () => {
     expect(screen.getAllByText('Voice').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Image').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Memory').length).toBeGreaterThan(0);
+  });
+
+  it('opens a side-by-side release diff comparison modal', () => {
+    render(<UpdateDigestRail entries={MOCK_ENTRIES} />);
+
+    fireEvent.click(screen.getByTestId('release-diff-open-button'));
+
+    expect(
+      screen.getByTestId('release-diff-comparison-modal')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('release-diff-profile-label')).toHaveTextContent(
+      'Your usage profile'
+    );
+    expect(screen.getAllByText('Nomi V3:')).toHaveLength(3);
+    expect(screen.getAllByText('Nomi V5:')).toHaveLength(3);
+    expect(screen.getByText('Generic update strip')).toBeInTheDocument();
+    expect(
+      screen.getByText('Profile-specific improvement')
+    ).toBeInTheDocument();
+  });
+
+  it('shows profile-specific memory, voice, and image improvements', () => {
+    render(<UpdateDigestRail />);
+
+    fireEvent.click(screen.getByTestId('release-diff-open-button'));
+
+    expect(
+      screen.getByTestId('release-diff-row-memory-depth')
+    ).toHaveTextContent('Memory depth');
+    expect(
+      screen.getByTestId('release-diff-row-voice-quality')
+    ).toHaveTextContent('Voice quality');
+    expect(
+      screen.getByTestId('release-diff-row-image-anchors')
+    ).toHaveTextContent('Image anchors');
+    expect(
+      screen.getByTestId('release-diff-profile-image-anchors')
+    ).toHaveTextContent('mind-map anchors');
+  });
+
+  it('exports default release diff data for all visible improvement dimensions', () => {
+    expect(
+      DEFAULT_RELEASE_DIFF_PROFILE.dimensions.map((dimension) => dimension.id)
+    ).toEqual(['memory-depth', 'voice-quality', 'image-anchors']);
   });
 });

--- a/apps/web/components/explore/UpdateDigestRail.tsx
+++ b/apps/web/components/explore/UpdateDigestRail.tsx
@@ -1,8 +1,24 @@
 'use client';
 
+import { useState, type ElementType } from 'react';
 import Link from 'next/link';
-import { ChevronRight, ImageIcon, Mic, BrainCircuit, Sparkles } from 'lucide-react';
+import {
+  ChevronRight,
+  ImageIcon,
+  Mic,
+  BrainCircuit,
+  Sparkles,
+  GitCompareArrows,
+} from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
 export type UpdateCategory = 'voice' | 'image' | 'memory';
@@ -18,25 +34,28 @@ export interface UpdateDigestEntry {
 
 const CATEGORY_META: Record<
   UpdateCategory,
-  { label: string; icon: React.ElementType; colorClass: string; badgeClass: string }
+  { label: string; icon: ElementType; colorClass: string; badgeClass: string }
 > = {
   voice: {
     label: 'Voice',
     icon: Mic,
     colorClass: 'from-violet-500/20 to-purple-500/20',
-    badgeClass: 'border-violet-400/30 bg-violet-400/10 text-violet-700 dark:text-violet-300',
+    badgeClass:
+      'border-violet-400/30 bg-violet-400/10 text-violet-700 dark:text-violet-300',
   },
   image: {
     label: 'Image',
     icon: ImageIcon,
     colorClass: 'from-sky-500/20 to-cyan-500/20',
-    badgeClass: 'border-sky-400/30 bg-sky-400/10 text-sky-700 dark:text-sky-300',
+    badgeClass:
+      'border-sky-400/30 bg-sky-400/10 text-sky-700 dark:text-sky-300',
   },
   memory: {
     label: 'Memory',
     icon: BrainCircuit,
     colorClass: 'from-emerald-500/20 to-teal-500/20',
-    badgeClass: 'border-emerald-400/30 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300',
+    badgeClass:
+      'border-emerald-400/30 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300',
   },
 };
 
@@ -45,7 +64,8 @@ export const DEFAULT_UPDATE_ENTRIES: UpdateDigestEntry[] = [
     id: 'voice-latency-v2',
     category: 'voice',
     title: 'Voice latency cut by 40%',
-    description: 'Sub-200 ms response on mobile — smoother real-time conversations.',
+    description:
+      'Sub-200 ms response on mobile — smoother real-time conversations.',
     href: '/explore?tab=explore#voice',
     isNew: true,
   },
@@ -53,14 +73,16 @@ export const DEFAULT_UPDATE_ENTRIES: UpdateDigestEntry[] = [
     id: 'voice-long-session',
     category: 'voice',
     title: 'Long-session continuity',
-    description: 'Voice sessions now persist context across pauses without resetting.',
+    description:
+      'Voice sessions now persist context across pauses without resetting.',
     href: '/explore?tab=explore#voice',
   },
   {
     id: 'image-selfie-engine',
     category: 'image',
     title: 'Selfie engine v2',
-    description: 'Consistent character faces across lighting, angle, and style prompts.',
+    description:
+      'Consistent character faces across lighting, angle, and style prompts.',
     href: '/explore?tab=explore#image',
     isNew: true,
   },
@@ -68,7 +90,8 @@ export const DEFAULT_UPDATE_ENTRIES: UpdateDigestEntry[] = [
     id: 'image-style-transfer',
     category: 'image',
     title: 'Style transfer controls',
-    description: 'Lock a visual aesthetic and apply it to any generated image in-session.',
+    description:
+      'Lock a visual aesthetic and apply it to any generated image in-session.',
     href: '/explore?tab=explore#image',
   },
   {
@@ -83,10 +106,71 @@ export const DEFAULT_UPDATE_ENTRIES: UpdateDigestEntry[] = [
     id: 'memory-multilingual',
     category: 'memory',
     title: 'Multilingual memory',
-    description: 'Memories now persist across language switches in a single session.',
+    description:
+      'Memories now persist across language switches in a single session.',
     href: '/explore?tab=explore#memory',
   },
 ];
+
+export interface ReleaseDiffDimension {
+  id: string;
+  label: string;
+  previousRelease: string;
+  latestRelease: string;
+  genericSignal: string;
+  profileSignal: string;
+}
+
+export interface ReleaseDiffProfile {
+  title: string;
+  previousVersion: string;
+  latestVersion: string;
+  usagePattern: string;
+  dimensions: ReleaseDiffDimension[];
+}
+
+export const DEFAULT_RELEASE_DIFF_PROFILE: ReleaseDiffProfile = {
+  title: 'Companion builder profile',
+  previousVersion: 'Nomi V3',
+  latestVersion: 'Nomi V5',
+  usagePattern:
+    'High-memory chats with voice check-ins and repeated image anchors',
+  dimensions: [
+    {
+      id: 'memory-depth',
+      label: 'Memory depth',
+      previousRelease:
+        'Recent-message recall plus manual notes for recurring lore.',
+      latestRelease:
+        'Relationship timeline and multilingual memory carry arcs across sessions.',
+      genericSignal: 'Memory improvements shipped.',
+      profileSignal:
+        'Long-running companions keep milestones visible instead of restarting after each digest.',
+    },
+    {
+      id: 'voice-quality',
+      label: 'Voice quality',
+      previousRelease:
+        'Readable voice replies, but pauses could reset context during long calls.',
+      latestRelease:
+        'Lower-latency voice with long-session continuity after interruptions.',
+      genericSignal: 'Voice is faster.',
+      profileSignal:
+        'Voice-heavy users hear smoother turns and fewer “what were we saying?” resets.',
+    },
+    {
+      id: 'image-anchors',
+      label: 'Image anchors',
+      previousRelease:
+        'Image prompts needed repeated character and style reminders.',
+      latestRelease:
+        'Selfie engine v2 plus style locks preserve visual anchors between prompts.',
+      genericSignal: 'Image generation was upgraded.',
+      profileSignal:
+        'Image-first companions can reuse faces, poses, and mind-map anchors consistently.',
+    },
+  ],
+};
 
 interface UpdateDigestCardProps {
   entry: UpdateDigestEntry;
@@ -126,7 +210,10 @@ function UpdateDigestCard({ entry }: UpdateDigestCardProps) {
 
       <Badge
         variant="outline"
-        className={cn('w-fit text-[10px] font-semibold uppercase tracking-wide', meta.badgeClass)}
+        className={cn(
+          'w-fit text-[10px] font-semibold uppercase tracking-wide',
+          meta.badgeClass
+        )}
         data-testid={`update-digest-category-badge-${entry.id}`}
       >
         {meta.label}
@@ -147,11 +234,107 @@ function UpdateDigestCard({ entry }: UpdateDigestCardProps) {
   );
 }
 
-interface UpdateDigestRailProps {
-  entries?: UpdateDigestEntry[];
+interface ReleaseDiffComparisonModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  profile: ReleaseDiffProfile;
 }
 
-export function UpdateDigestRail({ entries = DEFAULT_UPDATE_ENTRIES }: UpdateDigestRailProps) {
+function ReleaseDiffComparisonModal({
+  open,
+  onOpenChange,
+  profile,
+}: ReleaseDiffComparisonModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-h-[85vh] max-w-3xl overflow-y-auto"
+        data-testid="release-diff-comparison-modal"
+      >
+        <DialogHeader>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary" data-testid="release-diff-profile-label">
+              Your usage profile
+            </Badge>
+            <Badge variant="outline">
+              {profile.previousVersion} → {profile.latestVersion}
+            </Badge>
+          </div>
+          <DialogTitle className="mt-2 flex items-center gap-2">
+            <GitCompareArrows className="h-5 w-5 text-primary" aria-hidden />
+            Last-two-releases diff for {profile.title}
+          </DialogTitle>
+          <DialogDescription data-testid="release-diff-usage-pattern">
+            {profile.usagePattern}. This compares the generic update strip with
+            the concrete improvements that matter for this profile.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3">
+          <div className="grid gap-2 rounded-xl border border-border/70 bg-muted/30 p-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground sm:grid-cols-[1fr_1fr_1fr]">
+            <span>Dimension</span>
+            <span>Generic update strip</span>
+            <span>Profile-specific improvement</span>
+          </div>
+
+          {profile.dimensions.map((dimension) => (
+            <div
+              key={dimension.id}
+              className="grid gap-3 rounded-xl border border-border/70 bg-card p-4 sm:grid-cols-[1fr_1fr_1fr]"
+              data-testid={`release-diff-row-${dimension.id}`}
+            >
+              <div className="space-y-2">
+                <p className="text-sm font-semibold text-foreground">
+                  {dimension.label}
+                </p>
+                <div className="space-y-1 text-xs text-muted-foreground">
+                  <p>
+                    <span className="font-semibold text-foreground/80">
+                      {profile.previousVersion}:
+                    </span>{' '}
+                    {dimension.previousRelease}
+                  </p>
+                  <p>
+                    <span className="font-semibold text-foreground/80">
+                      {profile.latestVersion}:
+                    </span>{' '}
+                    {dimension.latestRelease}
+                  </p>
+                </div>
+              </div>
+
+              <div
+                className="rounded-lg border border-border/60 bg-background/70 p-3 text-sm text-muted-foreground"
+                data-testid={`release-diff-generic-${dimension.id}`}
+              >
+                {dimension.genericSignal}
+              </div>
+
+              <div
+                className="rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm text-foreground"
+                data-testid={`release-diff-profile-${dimension.id}`}
+              >
+                {dimension.profileSignal}
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface UpdateDigestRailProps {
+  entries?: UpdateDigestEntry[];
+  releaseDiffProfile?: ReleaseDiffProfile;
+}
+
+export function UpdateDigestRail({
+  entries = DEFAULT_UPDATE_ENTRIES,
+  releaseDiffProfile = DEFAULT_RELEASE_DIFF_PROFILE,
+}: UpdateDigestRailProps) {
+  const [releaseDiffOpen, setReleaseDiffOpen] = useState(false);
+
   if (entries.length === 0) return null;
 
   return (
@@ -159,7 +342,7 @@ export function UpdateDigestRail({ entries = DEFAULT_UPDATE_ENTRIES }: UpdateDig
       aria-label="What's new — voice, image, and memory updates"
       data-testid="update-digest-rail"
     >
-      <div className="mb-3 flex items-center justify-between">
+      <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2">
           <Sparkles className="h-4 w-4 text-primary" aria-hidden />
           <h2
@@ -172,14 +355,27 @@ export function UpdateDigestRail({ entries = DEFAULT_UPDATE_ENTRIES }: UpdateDig
             — voice, image &amp; memory releases
           </p>
         </div>
-        <Link
-          href="/explore?tab=explore"
-          className="flex items-center gap-0.5 text-xs text-muted-foreground transition hover:text-primary"
-          data-testid="update-digest-see-all"
-        >
-          See all
-          <ChevronRight className="h-3.5 w-3.5" />
-        </Link>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs"
+            onClick={() => setReleaseDiffOpen(true)}
+            data-testid="release-diff-open-button"
+          >
+            <GitCompareArrows className="h-3.5 w-3.5" aria-hidden />
+            Compare releases
+          </Button>
+          <Link
+            href="/explore?tab=explore"
+            className="flex items-center gap-0.5 text-xs text-muted-foreground transition hover:text-primary"
+            data-testid="update-digest-see-all"
+          >
+            See all
+            <ChevronRight className="h-3.5 w-3.5" />
+          </Link>
+        </div>
       </div>
 
       <div
@@ -190,6 +386,12 @@ export function UpdateDigestRail({ entries = DEFAULT_UPDATE_ENTRIES }: UpdateDig
           <UpdateDigestCard key={entry.id} entry={entry} />
         ))}
       </div>
+
+      <ReleaseDiffComparisonModal
+        open={releaseDiffOpen}
+        onOpenChange={setReleaseDiffOpen}
+        profile={releaseDiffProfile}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog ux item 928f1c44cc.
Ref: https://github.com/agentgram/agentgram

## Change
Added a personalized last-two-releases comparison modal to the explore update digest rail. The modal compares Nomi V3 → Nomi V5 side by side for a companion-builder usage profile across memory depth, voice quality, and image anchors, while keeping the existing generic update strip intact.

## Evidence
- test: `pnpm --filter web exec vitest run __tests__/components/update-digest-rail.test.tsx` → 14 tests passed.
- type-check: `pnpm --filter web type-check` → passed.
- lint: `pnpm --filter web lint` → passed with existing warnings only.
- diff: `apps/web/components/explore/UpdateDigestRail.tsx`, `apps/web/__tests__/components/update-digest-rail.test.tsx`.

## Auth-only Proof
N/A
