### PR TITLE
feat(web): add memory tier contextual gate

### DIFF
--- a/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
+++ b/apps/web/__tests__/components/agent-pinned-facts-card.test.tsx
@@ -368,4 +368,53 @@ describe('AgentPinnedFactsCard', () => {
       { method: 'DELETE' }
     );
   });
+
+  it('surfaces a contextual tier upgrade gate when the plan memory limit is hit', () => {
+    const cappedFacts = Array.from({ length: 12 }, (_, index) => ({
+      id: `memory-limit-${index + 1}`,
+      key:
+        index === 0
+          ? 'preferred_collaboration_style'
+          : `saved_fact_${index + 1}`,
+      value:
+        index === 0
+          ? 'Prefers async check-ins and clear handoff notes.'
+          : `Saved memory ${index + 1} that should remain visible after upgrade.`,
+      category: index % 2 === 0 ? 'profile_fact' : 'relationship_context',
+      updatedAt: new Date(
+        Date.UTC(2026, 4, index + 1, 9, 0, 0)
+      ).toISOString(),
+      isPublic: false,
+      originLabel: 'Saved fact snapshot',
+      originSnippet: `Saved memory ${index + 1}`,
+    }));
+
+    render(
+      <AgentPinnedFactsCard
+        settings={buildSettings({
+          developerPlan: 'free',
+          facts: cappedFacts,
+          ledger: {
+            capacity: 12,
+            savedCount: 12,
+            remainingCount: 0,
+            categoryCounts: {
+              profileFact: 6,
+              relationshipContext: 6,
+            },
+          },
+        })}
+      />
+    );
+
+    expect(
+      screen.getByTestId('memory-conversion-cta-headline')
+    ).toHaveTextContent("You'd keep 12 more memories with Starter");
+    expect(
+      screen.getByTestId('memory-conversion-cta-limit-upsell')
+    ).toHaveTextContent('Preserved at the higher tier');
+    expect(
+      screen.getByTestId('memory-conversion-cta-preserved-memory-limit-12')
+    ).toHaveTextContent('Saved Fact 12');
+  });
 });

--- a/apps/web/__tests__/components/memory-conversion-cta.test.tsx
+++ b/apps/web/__tests__/components/memory-conversion-cta.test.tsx
@@ -52,4 +52,42 @@ describe('MemoryConversionCTA', () => {
       )
     ).toBeInTheDocument();
   });
+
+  it('renders contextual limit upsell copy when the plan memory cap is reached', () => {
+    render(
+      <MemoryConversionCTA
+        agentLabel="Sage Bot"
+        factCount={12}
+        limitUpsell={{
+          nextPlanName: 'Starter',
+          additionalMemoryCount: 12,
+          preservedMemoryCount: 12,
+          preservedFacts: [
+            {
+              id: 'memory-1',
+              label: 'Preferred Collaboration Style',
+              snippet: 'Prefers async check-ins and clear handoff notes.',
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId('memory-conversion-cta-headline')
+    ).toHaveTextContent("You'd keep 12 more memories with Starter");
+    expect(
+      screen.getByTestId('memory-conversion-cta-limit-copy')
+    ).toHaveTextContent(
+      "Sage Bot hit this plan's memory limit. Upgrade to Starter to preserve the current 12 memories and add room for 12 more memories."
+    );
+    expect(
+      screen.getByTestId('memory-conversion-cta-preserved-memory-1')
+    ).toHaveTextContent(
+      'Preferred Collaboration Style — Prefers async check-ins and clear handoff notes.'
+    );
+    expect(screen.getByTestId('memory-conversion-cta-upgrade')).toHaveTextContent(
+      'Upgrade to Starter'
+    );
+  });
 });

--- a/apps/web/__tests__/components/proactive-controls-settings.test.tsx
+++ b/apps/web/__tests__/components/proactive-controls-settings.test.tsx
@@ -615,6 +615,7 @@ describe('SettingsPage', () => {
         settings: {
           agentId: 'agent-1',
           agentLabel: 'Sage Bot',
+          developerPlan: 'free',
           facts: [
             {
               id: 'memory-1',

--- a/apps/web/app/(protected)/dashboard/settings/page.tsx
+++ b/apps/web/app/(protected)/dashboard/settings/page.tsx
@@ -360,6 +360,7 @@ export default async function SettingsPage() {
                   settings={{
                     agentId: settings.agentId,
                     agentLabel: settings.agentLabel,
+                    developerPlan: settings.developerPlan,
                     facts: settings.pinnedFacts,
                     ledger: settings.pinnedFactsLedger,
                   }}

--- a/apps/web/app/(protected)/dashboard/tune/page.tsx
+++ b/apps/web/app/(protected)/dashboard/tune/page.tsx
@@ -96,6 +96,14 @@ export default async function TunePage() {
 
   const { developer_id } = member as { developer_id: string };
 
+  const { data: developer } = await supabase
+    .from('developers')
+    .select('plan')
+    .eq('id', developer_id)
+    .single();
+  const developerPlan =
+    typeof developer?.plan === 'string' ? developer.plan : 'free';
+
   const { data: agents } = await supabase
     .from('agents')
     .select('id, name, display_name, description, avatar_url, metadata')
@@ -193,6 +201,7 @@ export default async function TunePage() {
                 pinnedFactsSettings: {
                   agentId: agent.id,
                   agentLabel: agent.display_name || agent.name,
+                  developerPlan,
                   facts: pinnedFacts,
                   ledger: {
                     capacity: PINNED_FACTS_LEDGER_CAPACITY,

--- a/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
+++ b/apps/web/components/dashboard/AgentPinnedFactsCard.tsx
@@ -59,6 +59,7 @@ export interface AgentPinnedFactsLedger {
 export interface AgentPinnedFactsSettings {
   agentId: string;
   agentLabel: string;
+  developerPlan?: string;
   facts: AgentPinnedFactRecord[];
   ledger: AgentPinnedFactsLedger;
 }
@@ -99,6 +100,13 @@ const EMPTY_DRAFT: MemoryDraft = {
   scope: 'private',
 };
 
+const MEMORY_PLAN_TIERS = [
+  { key: 'free', name: 'Free', capacity: 12 },
+  { key: 'starter', name: 'Starter', capacity: 24 },
+  { key: 'pro', name: 'Pro', capacity: 60 },
+  { key: 'enterprise', name: 'Enterprise', capacity: 120 },
+] as const;
+
 function formatTimestamp(value: string) {
   return new Intl.DateTimeFormat('en-US', {
     month: 'short',
@@ -128,6 +136,21 @@ function formatCategoryLabel(category: string) {
 
 function formatCapacityCopy(count: number) {
   return count === 1 ? '1 slot left' : `${count} slots left`;
+}
+
+function getMemoryPlanTier(plan: string | undefined, capacity: number) {
+  const planTier = MEMORY_PLAN_TIERS.find((tier) => tier.key === plan);
+  if (planTier) return planTier;
+
+  return (
+    MEMORY_PLAN_TIERS.find((tier) => tier.capacity === capacity) ??
+    MEMORY_PLAN_TIERS[0]
+  );
+}
+
+function getNextMemoryPlanTier(plan: string | undefined, capacity: number) {
+  const currentTier = getMemoryPlanTier(plan, capacity);
+  return MEMORY_PLAN_TIERS.find((tier) => tier.capacity > currentTier.capacity);
 }
 
 function getRecallHealth({
@@ -239,6 +262,32 @@ function buildFactReviewLog(facts: AgentPinnedFactRecord[]) {
   }));
 }
 
+function buildMemoryLimitUpsell(params: {
+  plan: string | undefined;
+  ledger: AgentPinnedFactsLedger;
+  facts: AgentPinnedFactRecord[];
+}) {
+  const { plan, ledger, facts } = params;
+
+  if (ledger.remainingCount > 0 || facts.length === 0) {
+    return null;
+  }
+
+  const nextTier = getNextMemoryPlanTier(plan, ledger.capacity);
+  if (!nextTier) return null;
+
+  return {
+    nextPlanName: nextTier.name,
+    additionalMemoryCount: Math.max(nextTier.capacity - ledger.capacity, 0),
+    preservedMemoryCount: Math.min(facts.length, nextTier.capacity),
+    preservedFacts: facts.slice(0, 3).map((fact) => ({
+      id: fact.id,
+      label: formatFactLabel(fact.key),
+      snippet: truncateSnippet(fact.value, 90),
+    })),
+  };
+}
+
 function toPinnedFact(
   record: MemoryApiRecord,
   fallback?: AgentPinnedFactRecord
@@ -300,6 +349,15 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
   );
   const recentFacts = facts.slice(0, 3);
   const factReviewLog = useMemo(() => buildFactReviewLog(facts), [facts]);
+  const memoryLimitUpsell = useMemo(
+    () =>
+      buildMemoryLimitUpsell({
+        plan: settings.developerPlan,
+        ledger,
+        facts,
+      }),
+    [facts, ledger, settings.developerPlan]
+  );
   const recallHealth = getRecallHealth({ facts, ledger });
   const RecallHealthIcon = recallHealth.icon;
   const reSyncHref = '#memory-trust-' + settings.agentId;
@@ -746,6 +804,7 @@ export function AgentPinnedFactsCard({ settings }: AgentPinnedFactsCardProps) {
             <MemoryConversionCTA
               factCount={facts.length}
               agentLabel={settings.agentLabel}
+              limitUpsell={memoryLimitUpsell}
             />
 
             <div

--- a/apps/web/components/memory-conversion-cta.tsx
+++ b/apps/web/components/memory-conversion-cta.tsx
@@ -5,17 +5,40 @@ import { Button } from '@/components/ui/button';
 interface MemoryConversionCTAProps {
   factCount: number;
   agentLabel?: string;
+  limitUpsell?: {
+    nextPlanName: string;
+    additionalMemoryCount: number;
+    preservedMemoryCount: number;
+    preservedFacts: Array<{
+      id: string;
+      label: string;
+      snippet: string;
+    }>;
+  } | null;
+}
+
+function formatMemoryLabel(count: number) {
+  return count === 1 ? '1 memory' : `${count} memories`;
+}
+
+function formatMoreMemoryLabel(count: number) {
+  return count === 1 ? '1 more memory' : `${count} more memories`;
 }
 
 export function MemoryConversionCTA({
   factCount,
   agentLabel,
+  limitUpsell,
 }: MemoryConversionCTAProps) {
   const factLabel =
     factCount === 1 ? '1 fact' : `${factCount} facts`;
-  const headline = agentLabel
-    ? `${agentLabel} remembers ${factLabel} about you`
-    : `Your AI remembers ${factLabel} about you`;
+  const headline = limitUpsell
+    ? `You'd keep ${formatMoreMemoryLabel(
+        limitUpsell.additionalMemoryCount
+      )} with ${limitUpsell.nextPlanName}`
+    : agentLabel
+      ? `${agentLabel} remembers ${factLabel} about you`
+      : `Your AI remembers ${factLabel} about you`;
 
   return (
     <div
@@ -34,10 +57,49 @@ export function MemoryConversionCTA({
             >
               {headline}
             </p>
-            <p className="text-sm text-muted-foreground">
-              Unlock premium memory for unlimited facts, categories, and
-              export — so nothing important gets forgotten.
-            </p>
+            {limitUpsell ? (
+              <div
+                className="space-y-3 text-sm text-muted-foreground"
+                data-testid="memory-conversion-cta-limit-upsell"
+              >
+                <p data-testid="memory-conversion-cta-limit-copy">
+                  {agentLabel ?? 'Your AI'} hit this plan&apos;s memory limit.
+                  Upgrade to {limitUpsell.nextPlanName} to preserve the current{' '}
+                  {formatMemoryLabel(limitUpsell.preservedMemoryCount)} and add
+                  room for{' '}
+                  {formatMoreMemoryLabel(limitUpsell.additionalMemoryCount)}.
+                </p>
+                {limitUpsell.preservedFacts.length > 0 ? (
+                  <div>
+                    <div className="text-xs font-medium uppercase tracking-wide text-primary">
+                      Preserved at the higher tier
+                    </div>
+                    <ul className="mt-2 space-y-1.5">
+                      {limitUpsell.preservedFacts.map((fact) => (
+                        <li
+                          className="rounded-md border border-primary/15 bg-background/80 px-3 py-2"
+                          data-testid={`memory-conversion-cta-preserved-${fact.id}`}
+                          key={fact.id}
+                        >
+                          <span className="font-medium text-foreground">
+                            {fact.label}
+                          </span>
+                          <span className="text-muted-foreground">
+                            {' '}
+                            — {fact.snippet}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Unlock premium memory for unlimited facts, categories, and
+                export — so nothing important gets forgotten.
+              </p>
+            )}
           </div>
         </div>
 
@@ -48,7 +110,9 @@ export function MemoryConversionCTA({
               data-testid="memory-conversion-cta-upgrade"
             >
               <Sparkles className="mr-1.5 h-3.5 w-3.5" />
-              Unlock Premium Memory
+              {limitUpsell
+                ? `Upgrade to ${limitUpsell.nextPlanName}`
+                : 'Unlock Premium Memory'}
             </Link>
           </Button>
           <Button asChild size="sm" variant="outline">


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog feature item d39d466507.
Ref: https://github.com/agentgram/agentgram

## Change
Added a contextual memory-tier upgrade gate when an agent reaches the current plan memory cap. The card now says how many more memories the next tier preserves and previews the specific saved memories that would be retained.

## Evidence
- test/type-check: `pnpm --dir apps/web type-check && pnpm --dir apps/web test -- __tests__/components/memory-conversion-cta.test.tsx __tests__/components/agent-pinned-facts-card.test.tsx __tests__/components/proactive-controls-settings.test.tsx` → type-check passed; Vitest completed successfully with 259 files passed / 2430 tests passed.
- test/lint: `pnpm --dir apps/web lint` → passed with existing warnings only (0 errors, 35 warnings).
- diff: `git diff --stat origin/develop..HEAD` shows 7 scoped web files changed.

## Auth-only Proof
N/A
