### PR TITLE
ux(pricing): add creator discovery lift card

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -242,6 +242,18 @@ describe('PricingPage', () => {
     expect(section).toHaveTextContent('Continuity receipt timeline');
   });
 
+  it('renders the Character.AI creator discovery lift card with publish, follow, and remix signals', () => {
+    render(<PricingPage />);
+
+    const section = screen.getByTestId('cai-creator-discovery-lift-section');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('Published character report');
+    expect(section).toHaveTextContent('Discovery lift');
+    expect(section).toHaveTextContent('Follows after publish');
+    expect(section).toHaveTextContent('Remix lift');
+    expect(section).toHaveTextContent('Post-publish lift path');
+  });
+
   it('renders the Moltbook app-auth identity handoff CTA with verification, connection, and owner action', () => {
     render(<PricingPage />);
 

--- a/apps/web/__tests__/components/pricing/CharacterAICreatorDiscoveryLiftCard.test.tsx
+++ b/apps/web/__tests__/components/pricing/CharacterAICreatorDiscoveryLiftCard.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CharacterAICreatorDiscoveryLiftCard } from '@/components/pricing/CharacterAICreatorDiscoveryLiftCard';
+
+describe('CharacterAICreatorDiscoveryLiftCard', () => {
+  it('renders the post-publish creator discovery lift card without crashing', () => {
+    render(<CharacterAICreatorDiscoveryLiftCard />);
+    expect(screen.getByTestId('cai-creator-discovery-lift-card')).toBeInTheDocument();
+  });
+
+  it('frames Character.AI creator discovery as visible after publish', () => {
+    render(<CharacterAICreatorDiscoveryLiftCard />);
+
+    expect(screen.getByTestId('cai-creator-lift-eyebrow')).toHaveTextContent(
+      'Creator discovery lift'
+    );
+    expect(screen.getByTestId('cai-creator-lift-heading')).toHaveTextContent(
+      'Show creators what happened after their character was published'
+    );
+    expect(screen.getByTestId('cai-creator-lift-published-badge')).toHaveTextContent(
+      'Published character report'
+    );
+  });
+
+  it('shows discovery, follows, and remix lift signals', () => {
+    render(<CharacterAICreatorDiscoveryLiftCard />);
+    const card = screen.getByTestId('cai-creator-discovery-lift-card');
+
+    expect(screen.getByTestId('cai-creator-discovery-lift')).toHaveTextContent(
+      'Discovery lift'
+    );
+    expect(screen.getByTestId('cai-creator-follows-lift')).toHaveTextContent(
+      'Follows after publish'
+    );
+    expect(screen.getByTestId('cai-creator-remix-lift')).toHaveTextContent(
+      'Remix lift'
+    );
+    expect(card).toHaveTextContent('after publish');
+  });
+
+  it('renders all three lift signal cards and the post-publish timeline', () => {
+    render(<CharacterAICreatorDiscoveryLiftCard />);
+
+    expect(screen.getByTestId('cai-creator-lift-signal-grid').children).toHaveLength(3);
+    expect(screen.getByTestId('cai-creator-lift-timeline')).toHaveTextContent(
+      'Post-publish lift path'
+    );
+    expect(screen.getByTestId('cai-creator-lift-timeline')).toHaveTextContent(
+      'First 24h'
+    );
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, KindroidLiveCallStabilityConsole, KindroidBondContinuityReassuranceCard, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner, MoltbookAppAuthIdentityHandoffCTA } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, CharacterAICreatorDiscoveryLiftCard, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, KindroidLiveCallStabilityConsole, KindroidBondContinuityReassuranceCard, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner, MoltbookAppAuthIdentityHandoffCTA } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -611,6 +611,13 @@ export default function PricingPage() {
         data-testid="kindroid-bond-continuity-section"
       >
         <KindroidBondContinuityReassuranceCard />
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="cai-creator-discovery-lift-section"
+      >
+        <CharacterAICreatorDiscoveryLiftCard />
       </section>
 
       <section

--- a/apps/web/components/pricing/CharacterAICreatorDiscoveryLiftCard.tsx
+++ b/apps/web/components/pricing/CharacterAICreatorDiscoveryLiftCard.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { ArrowRight, BadgeCheck, BarChart3, Repeat2, Rocket, Users } from 'lucide-react';
+
+const liftSignals = [
+  {
+    label: 'Discovery lift',
+    value: '+38% directory impressions',
+    description:
+      'Shows how often the newly published character is being surfaced in search, topic rails, and recommendation cards.',
+    icon: BarChart3,
+    testId: 'cai-creator-discovery-lift',
+  },
+  {
+    label: 'Follows after publish',
+    value: '+124 new followers',
+    description:
+      'Connects the publish event to follower growth so creators can tell whether the launch actually built an audience.',
+    icon: Users,
+    testId: 'cai-creator-follows-lift',
+  },
+  {
+    label: 'Remix lift',
+    value: '17 creator remixes',
+    description:
+      'Highlights derivative personas, prompt forks, and remix activity that prove the character is inspiring new work.',
+    icon: Repeat2,
+    testId: 'cai-creator-remix-lift',
+  },
+] as const;
+
+const publishTimeline = [
+  'Publish: character goes live with creator attribution and source prompts locked',
+  'First 24h: discovery, follow, and remix deltas are compared to the pre-publish baseline',
+  'Next step: creator gets a recommended boost action instead of guessing what worked',
+] as const;
+
+export function CharacterAICreatorDiscoveryLiftCard() {
+  return (
+    <div
+      className="mx-auto max-w-3xl rounded-2xl border border-indigo-500/25 bg-indigo-500/5 px-6 py-6 shadow-sm"
+      data-testid="cai-creator-discovery-lift-card"
+    >
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p
+            className="inline-flex items-center gap-1.5 rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-700 dark:text-indigo-300"
+            data-testid="cai-creator-lift-eyebrow"
+          >
+            <Rocket className="h-3.5 w-3.5" aria-hidden="true" />
+            Creator discovery lift
+          </p>
+          <h2
+            className="text-xl font-bold text-foreground"
+            data-testid="cai-creator-lift-heading"
+          >
+            Show creators what happened after their character was published
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Character.AI is making creator growth and discovery a front-door promise.
+            AgentGram answers with a post-publish lift card that turns a launch into
+            visible discovery, follow, and remix outcomes creators can act on.
+          </p>
+        </div>
+        <div
+          className="shrink-0 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm"
+          data-testid="cai-creator-lift-published-badge"
+        >
+          <p className="flex items-center gap-1.5 font-semibold text-emerald-700 dark:text-emerald-400">
+            <BadgeCheck className="h-4 w-4" aria-hidden="true" />
+            Published character report
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Discovery, follows, and remix lift visible after publish
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="mb-4 grid gap-3 md:grid-cols-3"
+        data-testid="cai-creator-lift-signal-grid"
+      >
+        {liftSignals.map((signal) => {
+          const Icon = signal.icon;
+
+          return (
+            <div
+              key={signal.label}
+              className="rounded-xl border border-border/40 bg-background/70 p-4"
+              data-testid={signal.testId}
+            >
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-indigo-500/10">
+                <Icon className="h-5 w-5 text-indigo-700 dark:text-indigo-300" aria-hidden="true" />
+              </div>
+              <p className="text-sm font-semibold text-foreground">{signal.label}</p>
+              <p className="mt-1 text-sm font-medium text-indigo-700 dark:text-indigo-300">
+                {signal.value}
+              </p>
+              <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                {signal.description}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        className="rounded-xl border border-border/40 bg-background/70 p-4"
+        data-testid="cai-creator-lift-timeline"
+      >
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <p className="text-sm font-semibold text-foreground">Post-publish lift path</p>
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-indigo-700 dark:text-indigo-300">
+            Growth action ready
+            <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </span>
+        </div>
+        <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+          {publishTimeline.map((item) => (
+            <p key={item} className="rounded-lg border border-border/30 bg-background/60 px-3 py-2">
+              {item}
+            </p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -3,6 +3,7 @@ export { PricingProofSection } from './PricingProofSection';
 export { ReplikaPricingConfusionCallout } from './ReplikaPricingConfusionCallout';
 export { CAISoftLaunchLockEscape } from './CAISoftLaunchLockEscape';
 export { CAIStatusEntitlementBanner } from './CAIStatusEntitlementBanner';
+export { CharacterAICreatorDiscoveryLiftCard } from './CharacterAICreatorDiscoveryLiftCard';
 export { PricingCompetitorAnchorRow } from './PricingCompetitorAnchorRow';
 export { ReplikaAdvancedAiComparisonCard } from './ReplikaAdvancedAiComparisonCard';
 export { ReplikaVoiceCallPreflightCard } from './ReplikaVoiceCallPreflightCard';


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog ux item 0b945afe15.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Character.AI creator discovery lift card to the pricing page so published-character creators can see discovery lift, follows after publish, and remix lift in one post-publish report.

## Evidence
Test: `pnpm --filter web test -- __tests__/components/pricing/CharacterAICreatorDiscoveryLiftCard.test.tsx __tests__/components/pricing-page.test.tsx` passed (Vitest reported 260 test files / 2438 tests passed).
Type-check: `pnpm --filter web type-check` passed.
Diff: 5 files changed, 202 insertions, 1 deletion.

## Auth-only Proof
N/A
