### PR TITLE
ux(pricing): explain Kindroid Lite transition path

### DIFF
--- a/apps/web/__tests__/components/pricing-page.test.tsx
+++ b/apps/web/__tests__/components/pricing-page.test.tsx
@@ -242,6 +242,19 @@ describe('PricingPage', () => {
     expect(section).toHaveTextContent('Continuity receipt timeline');
   });
 
+  it('renders the Kindroid free-tier transition explainer with Lite path and policy FAQ', () => {
+    render(<PricingPage />);
+
+    const section = screen.getByTestId('kindroid-free-tier-transition-section');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('bounded Lite path');
+    expect(section).toHaveTextContent('Lite starts as a preview');
+    expect(section).toHaveTextContent('Transition date is explicit');
+    expect(section).toHaveTextContent(
+      'What happens when free access is no longer permanent?'
+    );
+  });
+
   it('renders the Character.AI creator discovery lift card with publish, follow, and remix signals', () => {
     render(<PricingPage />);
 

--- a/apps/web/__tests__/components/pricing/KindroidFreeTierTransitionExplainer.test.tsx
+++ b/apps/web/__tests__/components/pricing/KindroidFreeTierTransitionExplainer.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { KindroidFreeTierTransitionExplainer } from '@/components/pricing/KindroidFreeTierTransitionExplainer';
+
+describe('KindroidFreeTierTransitionExplainer', () => {
+  it('renders the free-tier transition explainer without crashing', () => {
+    render(<KindroidFreeTierTransitionExplainer />);
+    expect(
+      screen.getByTestId('kindroid-free-tier-transition-explainer')
+    ).toBeInTheDocument();
+  });
+
+  it('explains that Lite is a bounded path instead of permanent free access', () => {
+    render(<KindroidFreeTierTransitionExplainer />);
+
+    expect(screen.getByTestId('kindroid-free-tier-eyebrow')).toHaveTextContent(
+      'Free-tier transition explainer'
+    );
+    expect(screen.getByTestId('kindroid-free-tier-heading')).toHaveTextContent(
+      'Explain the bounded Lite path before free access stops feeling permanent'
+    );
+    expect(
+      screen.getByTestId('kindroid-free-tier-policy-badge')
+    ).toHaveTextContent('No surprise lockout');
+  });
+
+  it('shows the preview, transition date, and bounded upgrade impact steps', () => {
+    render(<KindroidFreeTierTransitionExplainer />);
+    const grid = screen.getByTestId('kindroid-lite-path-grid');
+
+    expect(grid.children).toHaveLength(3);
+    expect(screen.getByTestId('kindroid-lite-path-preview')).toHaveTextContent(
+      'Lite starts as a preview'
+    );
+    expect(screen.getByTestId('kindroid-lite-path-date')).toHaveTextContent(
+      'Transition date is explicit'
+    );
+    expect(screen.getByTestId('kindroid-lite-path-impact')).toHaveTextContent(
+      'Upgrade impact is bounded'
+    );
+  });
+
+  it('answers what happens when free access is no longer permanent', () => {
+    render(<KindroidFreeTierTransitionExplainer />);
+    const faq = screen.getByTestId('kindroid-free-tier-policy-faq');
+
+    expect(faq).toHaveTextContent(
+      'What happens when free access is no longer permanent?'
+    );
+    expect(faq).toHaveTextContent('Lite conversations stay readable');
+    expect(faq).toHaveTextContent('save, export, and upgrade choices');
+    expect(faq).toHaveTextContent('never presented as a surprise lock');
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { Zap, Building2, Sparkles, Rocket, ArrowRight, ShieldCheck, Lock, BookOpen, Palette, Brain, ImageIcon, Infinity as InfinityIcon } from 'lucide-react';
-import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, CharacterAICreatorDiscoveryLiftCard, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, KindroidLiveCallStabilityConsole, KindroidBondContinuityReassuranceCard, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner, MoltbookAppAuthIdentityHandoffCTA } from '@/components/pricing';
+import { PricingCard, PricingProofSection, ReplikaPricingConfusionCallout, CAISoftLaunchLockEscape, CAIStatusEntitlementBanner, CharacterAICreatorDiscoveryLiftCard, PricingCompetitorAnchorRow, ReplikaAdvancedAiComparisonCard, ReplikaVoiceCallPreflightCard, ReplikaUpdateChangeExplainerStrip, KindroidTranscriptProviderPicker, KindroidLiveCallStabilityConsole, KindroidBondContinuityReassuranceCard, KindroidFreeTierTransitionExplainer, ReplikaSavingsCalculator, PaidConversionSocialProofBlock, ReplikaUltraFatigueFunnel, ControlSurfacePaidFunnelSection, MobileWebPricingBanner, MoltbookAppAuthIdentityHandoffCTA } from '@/components/pricing';
 import CAILorebookEscapeCTA from '@/components/home/CAILorebookEscapeCTA';
 import CAIChatStyleRescueCTA from '@/components/home/CAIChatStyleRescueCTA';
 import CaiMemoryFreeCounterBadge from '@/components/home/CaiMemoryFreeCounterBadge';
@@ -611,6 +611,13 @@ export default function PricingPage() {
         data-testid="kindroid-bond-continuity-section"
       >
         <KindroidBondContinuityReassuranceCard />
+      </section>
+
+      <section
+        className="container pb-10"
+        data-testid="kindroid-free-tier-transition-section"
+      >
+        <KindroidFreeTierTransitionExplainer />
       </section>
 
       <section

--- a/apps/web/components/pricing/KindroidFreeTierTransitionExplainer.tsx
+++ b/apps/web/components/pricing/KindroidFreeTierTransitionExplainer.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import {
+  AlertCircle,
+  CalendarClock,
+  CheckCircle2,
+  Route,
+  ShieldCheck,
+} from 'lucide-react';
+
+const litePathSteps = [
+  {
+    label: '1. Lite starts as a preview',
+    value:
+      'Core chat stays available while usage, memory, and media limits are visible upfront.',
+    description:
+      'Users can decide whether the companion is worth keeping before any checkout screen appears.',
+    icon: Route,
+    testId: 'kindroid-lite-path-preview',
+  },
+  {
+    label: '2. Transition date is explicit',
+    value:
+      'If free access becomes time-boxed, the end date and next checkpoint are shown together.',
+    description:
+      'No one has to infer whether Lite is still a permanent home, a trial, or a paid-plan bridge.',
+    icon: CalendarClock,
+    testId: 'kindroid-lite-path-date',
+  },
+  {
+    label: '3. Upgrade impact is bounded',
+    value:
+      'Memories, persona tone, and export options are listed before a user chooses to upgrade.',
+    description:
+      'The decision is framed around what remains safe, what changes, and what can be downloaded.',
+    icon: ShieldCheck,
+    testId: 'kindroid-lite-path-impact',
+  },
+] as const;
+
+const policyAnswers = [
+  'Lite conversations stay readable during the transition window.',
+  'Before a free access window ends, users see save, export, and upgrade choices in one place.',
+  'Paid access is never presented as a surprise lock; the CTA explains which limits lift and which safeguards remain.',
+] as const;
+
+export function KindroidFreeTierTransitionExplainer() {
+  return (
+    <div
+      className="mx-auto max-w-3xl rounded-2xl border border-amber-500/25 bg-amber-500/5 px-6 py-6 shadow-sm"
+      data-testid="kindroid-free-tier-transition-explainer"
+    >
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p
+            className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300"
+            data-testid="kindroid-free-tier-eyebrow"
+          >
+            <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
+            Free-tier transition explainer
+          </p>
+          <h2
+            className="text-xl font-bold text-foreground"
+            data-testid="kindroid-free-tier-heading"
+          >
+            Explain the bounded Lite path before free access stops feeling
+            permanent
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Kindroid is reframing indefinite free Lite access as a bounded
+            trial. AgentGram answers that anxiety directly: users see how long
+            the free path lasts, what happens when it changes, and which
+            companion data stays safe before choosing a paid plan.
+          </p>
+        </div>
+        <div
+          className="shrink-0 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm"
+          data-testid="kindroid-free-tier-policy-badge"
+        >
+          <p className="flex items-center gap-1.5 font-semibold text-emerald-700 dark:text-emerald-400">
+            <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+            No surprise lockout
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Trial limits, transition dates, and save/export options stay visible
+          </p>
+        </div>
+      </div>
+
+      <div
+        className="mb-4 grid gap-3 md:grid-cols-3"
+        data-testid="kindroid-lite-path-grid"
+      >
+        {litePathSteps.map((step) => {
+          const Icon = step.icon;
+
+          return (
+            <div
+              key={step.label}
+              className="rounded-xl border border-border/40 bg-background/70 p-4"
+              data-testid={step.testId}
+            >
+              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-amber-500/10">
+                <Icon
+                  className="h-5 w-5 text-amber-700 dark:text-amber-300"
+                  aria-hidden="true"
+                />
+              </div>
+              <p className="text-sm font-semibold text-foreground">
+                {step.label}
+              </p>
+              <p className="mt-1 text-sm font-medium text-amber-700 dark:text-amber-300">
+                {step.value}
+              </p>
+              <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                {step.description}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        className="rounded-xl border border-border/40 bg-background/70 p-4"
+        data-testid="kindroid-free-tier-policy-faq"
+      >
+        <p className="text-sm font-semibold text-foreground">
+          What happens when free access is no longer permanent?
+        </p>
+        <div className="mt-3 space-y-2 text-xs text-muted-foreground">
+          {policyAnswers.map((answer) => (
+            <p
+              key={answer}
+              className="rounded-lg border border-border/30 bg-background/60 px-3 py-2"
+            >
+              {answer}
+            </p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/pricing/index.ts
+++ b/apps/web/components/pricing/index.ts
@@ -11,6 +11,7 @@ export { ReplikaUpdateChangeExplainerStrip } from './ReplikaUpdateChangeExplaine
 export { KindroidTranscriptProviderPicker } from './KindroidTranscriptProviderPicker';
 export { KindroidLiveCallStabilityConsole } from './KindroidLiveCallStabilityConsole';
 export { KindroidBondContinuityReassuranceCard } from './KindroidBondContinuityReassuranceCard';
+export { KindroidFreeTierTransitionExplainer } from './KindroidFreeTierTransitionExplainer';
 export { ReplikaSavingsCalculator } from './ReplikaSavingsCalculator';
 export { PaidConversionSocialProofBlock } from './PaidConversionSocialProofBlock';
 export { ReplikaUltraFatigueFunnel } from './ReplikaUltraFatigueFunnel';

--- a/apps/web/docs/pr-evidence/kindroid-free-tier-transition-explainer.md
+++ b/apps/web/docs/pr-evidence/kindroid-free-tier-transition-explainer.md
@@ -1,0 +1,41 @@
+# PR Evidence: Kindroid Free-tier Transition Explainer
+
+## Summary
+
+Added `KindroidFreeTierTransitionExplainer` — a pricing-page card that explains how a Kindroid-style indefinite free Lite plan can become a bounded trial and what happens when free access is no longer permanent.
+
+The card makes the free-to-paid transition explicit before checkout:
+
+- Lite starts as a preview with visible usage, memory, and media limits.
+- Any free-access transition date is shown as a checkpoint rather than a surprise lockout.
+- Upgrade impact is bounded with memory, persona tone, save/export, and paid-plan effects explained before the user chooses.
+
+## Source
+
+Backlog item: `Kindroid free-tier transition explainer — explain the bounded Lite path and what happens when free access is no longer permanent`
+
+Research reference: `2026-06-27-agentgram-research.md` §핵심 발견 2 — Kindroid is reframing indefinite free Lite access as a bounded trial, so AgentGram should add a free-tier transition explainer and policy-change FAQ.
+
+## Test Coverage
+
+Unit tests in `apps/web/__tests__/components/pricing/KindroidFreeTierTransitionExplainer.test.tsx` cover:
+
+| Test              | Assertion                                                                     |
+| ----------------- | ----------------------------------------------------------------------------- |
+| Renders card      | `data-testid="kindroid-free-tier-transition-explainer"` present               |
+| Bounded Lite copy | Heading explains bounded Lite path before free access stops feeling permanent |
+| Transition steps  | Preview, transition date, and bounded upgrade impact steps render             |
+| Policy FAQ        | Explains readable conversations, save/export choices, and no surprise lockout |
+
+Pricing-page coverage in `apps/web/__tests__/components/pricing-page.test.tsx` verifies the card is rendered on `/pricing` with the bounded Lite path and policy FAQ copy.
+
+## Files Changed
+
+| File                                                                                 | Purpose                                             |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------- |
+| `apps/web/components/pricing/KindroidFreeTierTransitionExplainer.tsx`                | New pricing-page explainer card                     |
+| `apps/web/components/pricing/index.ts`                                               | Export new component                                |
+| `apps/web/app/(public)/pricing/page.tsx`                                             | Render the card in the Kindroid pricing proof stack |
+| `apps/web/__tests__/components/pricing/KindroidFreeTierTransitionExplainer.test.tsx` | Component test coverage                             |
+| `apps/web/__tests__/components/pricing-page.test.tsx`                                | Page-level render coverage                          |
+| `apps/web/docs/pr-evidence/kindroid-free-tier-transition-explainer.md`               | This evidence note                                  |


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog ux item b62e7af030.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Kindroid free-tier transition explainer to the pricing page that frames Lite as a bounded preview path, shows transition-date expectations, and explains save/export/upgrade outcomes when free access is no longer permanent.

## Evidence
- test: `pnpm --filter web test -- __tests__/components/pricing/KindroidFreeTierTransitionExplainer.test.tsx __tests__/components/pricing-page.test.tsx` → PASS, 261 files / 2444 tests passed.
- type-check: `pnpm --filter web type-check` → PASS.
- diff: `git diff --check` → PASS.

## Auth-only Proof
N/A
