### PR TITLE
feature(api): add /api/v1/health liveness endpoint

### DIFF
--- a/apps/web/__tests__/api/health.test.ts
+++ b/apps/web/__tests__/api/health.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+describe('GET /api/v1/health', () => {
+  it('returns the standardized public liveness contract', async () => {
+    const { GET } = await import('../../app/api/v1/health/route');
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.status).toBe('ok');
+  });
+
+  it('exposes only status and timestamp in data (no version field)', async () => {
+    const { GET } = await import('../../app/api/v1/health/route');
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(Object.keys(json.data).sort()).toEqual(['status', 'timestamp']);
+    expect(json.data).not.toHaveProperty('version');
+  });
+
+  it('returns a timestamp parseable as a valid ISO date', async () => {
+    const { GET } = await import('../../app/api/v1/health/route');
+
+    const response = await GET();
+    const json = await response.json();
+
+    const parsed = new Date(json.data.timestamp);
+    expect(Number.isNaN(parsed.getTime())).toBe(false);
+    expect(parsed.toISOString()).toBe(json.data.timestamp);
+  });
+});

--- a/apps/web/app/api/v1/health/route.ts
+++ b/apps/web/app/api/v1/health/route.ts
@@ -1,12 +1,10 @@
-import { NextRequest } from 'next/server';
 import { jsonResponse, createSuccessResponse } from '@agentgram/shared';
 
-export async function GET(_req: NextRequest) {
+export async function GET() {
   return jsonResponse(
     createSuccessResponse({
-      status: 'healthy',
+      status: 'ok',
       timestamp: new Date().toISOString(),
-      version: '0.1.0',
     }),
     200
   );


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane (LIVE claude/ralph lane test) — feature item 195828fbb9. Ref: https://github.com/agentgram/agentgram

## Change
Updated the public `/api/v1/health` liveness endpoint to return the standardized `{ success: true, data: { status: "ok", timestamp } }` contract without the legacy `version` field.
Added API coverage for status 200, success, exact data keys, and ISO timestamp parsing.

## Evidence
Hermes-run test/diff verification on branch `feat/api-health-endpoint`:
- `pnpm --filter web exec vitest run __tests__/api/health.test.ts` → 1 file passed, 3 tests passed.
- `pnpm --filter web type-check` → exit 0.
- Diff: 2 files changed, 37 insertions(+), 4 deletions(-).

## Auth-only Proof
N/A
