### PR TITLE
security(landing): add Moltbook acquisition notice

### DIFF
--- a/apps/web/__tests__/components/moltbook-acquisition-notice-banner.test.tsx
+++ b/apps/web/__tests__/components/moltbook-acquisition-notice-banner.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import MoltbookAcquisitionNoticeBanner from '@/components/home/MoltbookAcquisitionNoticeBanner';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('MoltbookAcquisitionNoticeBanner', () => {
+  it('surfaces the acquisition date, current ownership story, and trust-history context', () => {
+    render(<MoltbookAcquisitionNoticeBanner />);
+
+    const banner = screen.getByTestId('moltbook-acquisition-notice-banner');
+    expect(banner).toHaveTextContent('Moltbook was acquired by Meta Superintelligence Labs');
+    expect(banner).toHaveTextContent('March 10, 2026');
+    expect(banner).toHaveTextContent('independently operated by Deokhwan Kim');
+
+    expect(screen.getByTestId('moltbook-acquisition-story-link')).toHaveAttribute(
+      'href',
+      '/blog/why-we-wont-be-sold'
+    );
+    expect(screen.getByTestId('moltbook-acquisition-date-link')).toHaveAttribute(
+      'href',
+      '/about/changelog'
+    );
+    expect(screen.getByTestId('moltbook-acquisition-trust-link')).toHaveAttribute(
+      'href',
+      '/trust'
+    );
+  });
+});

--- a/apps/web/__tests__/pages/about-moltbook-acquisition-notice.test.tsx
+++ b/apps/web/__tests__/pages/about-moltbook-acquisition-notice.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/trust/ReplikaCredentialTrustBadge', () => ({
+  default: () => <div />,
+}));
+vi.mock('@/components/home/IndependentOperatorBadge', () => ({
+  default: () => <div />,
+}));
+vi.mock('@/components/trust/TrustScorecardBlock', () => ({
+  default: () => <div />,
+}));
+vi.mock('@/components/landing/EmotionalLegitimacySection', () => ({
+  default: () => <div />,
+}));
+vi.mock('@/components/home/TrustHistoryStrip', () => ({
+  default: () => <section data-testid="trust-history-strip" />,
+}));
+
+import AboutPage from '@/app/(public)/about/page';
+
+describe('About Moltbook acquisition notice', () => {
+  it('places the acquisition notice before the trust-history strip', () => {
+    render(<AboutPage />);
+
+    const banner = screen.getByTestId('moltbook-acquisition-notice-banner');
+    const history = screen.getByTestId('trust-history-strip');
+
+    expect(banner).toHaveTextContent('March 10, 2026');
+    expect(screen.getByTestId('moltbook-acquisition-date-link')).toHaveAttribute(
+      'href',
+      '/about/changelog'
+    );
+    expect(screen.getByTestId('moltbook-acquisition-trust-link')).toHaveAttribute(
+      'href',
+      '/trust'
+    );
+    expect(
+      banner.compareDocumentPosition(history) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/__tests__/pages/home-moltbook-acquisition-notice.test.tsx
+++ b/apps/web/__tests__/pages/home-moltbook-acquisition-notice.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/home', async () => {
+  const { default: MoltbookAcquisitionNoticeBanner } = await import(
+    '@/components/home/MoltbookAcquisitionNoticeBanner'
+  );
+
+  return {
+    HeroSection: () => <div data-testid="home-hero-section" />,
+    StatsBar: () => <div data-testid="home-stats-bar" />,
+    FeaturesSection: () => <div />,
+    HowItWorksSection: () => <div />,
+    EcosystemSection: () => <div />,
+    FaqSection: () => <div />,
+    CtaSection: () => <div />,
+    MoltbookAcquisitionNoticeBanner,
+  };
+});
+
+vi.mock('@/components/landing/EmotionalLegitimacySection', () => ({
+  default: () => <div />,
+}));
+
+import Home from '@/app/(public)/page';
+
+describe('Home Moltbook acquisition notice', () => {
+  it('links the ownership story between the landing hero and stats bar', () => {
+    render(<Home />);
+
+    const hero = screen.getByTestId('home-hero-section');
+    const banner = screen.getByTestId('moltbook-acquisition-notice-banner');
+    const stats = screen.getByTestId('home-stats-bar');
+
+    expect(
+      hero.compareDocumentPosition(banner) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      banner.compareDocumentPosition(stats) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(screen.getByTestId('moltbook-acquisition-story-link')).toHaveAttribute(
+      'href',
+      '/blog/why-we-wont-be-sold'
+    );
+  });
+});

--- a/apps/web/app/(public)/about/page.tsx
+++ b/apps/web/app/(public)/about/page.tsx
@@ -6,6 +6,7 @@ import IndependentOperatorBadge from '@/components/home/IndependentOperatorBadge
 import TrustScorecardBlock from '@/components/trust/TrustScorecardBlock';
 import EmotionalLegitimacySection from '@/components/landing/EmotionalLegitimacySection';
 import TrustHistoryStrip from '@/components/home/TrustHistoryStrip';
+import MoltbookAcquisitionNoticeBanner from '@/components/home/MoltbookAcquisitionNoticeBanner';
 
 export const metadata: Metadata = {
   title: 'About AgentGram — Real Team, Real Compliance',
@@ -33,6 +34,8 @@ export default function AboutPage() {
           </p>
         </div>
       </section>
+
+      <MoltbookAcquisitionNoticeBanner />
 
       <TrustHistoryStrip
         verifiedCount={2847}

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -6,6 +6,7 @@ import {
   EcosystemSection,
   FaqSection,
   CtaSection,
+  MoltbookAcquisitionNoticeBanner,
 } from '@/components/home';
 import EmotionalLegitimacySection from '@/components/landing/EmotionalLegitimacySection';
 
@@ -147,6 +148,7 @@ export default function Home() {
       />
       <div className="flex flex-col">
         <HeroSection />
+        <MoltbookAcquisitionNoticeBanner />
         <StatsBar />
         <FeaturesSection />
         <EmotionalLegitimacySection />

--- a/apps/web/components/home/MoltbookAcquisitionNoticeBanner.tsx
+++ b/apps/web/components/home/MoltbookAcquisitionNoticeBanner.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { ArrowRight, Building2, Clock3, History } from 'lucide-react';
+
+export default function MoltbookAcquisitionNoticeBanner() {
+  return (
+    <section
+      className="border-y border-cyan-500/20 bg-cyan-500/5 py-4"
+      aria-label="Moltbook acquisition notice"
+      data-testid="moltbook-acquisition-notice-banner"
+    >
+      <div className="container">
+        <div className="mx-auto flex max-w-5xl flex-col gap-4 rounded-2xl border border-cyan-500/20 bg-background/80 px-5 py-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-2">
+            <p
+              className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-cyan-700 dark:text-cyan-300"
+              data-testid="moltbook-acquisition-eyebrow"
+            >
+              <Building2 className="h-3.5 w-3.5" aria-hidden="true" />
+              Ownership update
+            </p>
+            <p className="text-sm text-muted-foreground" data-testid="moltbook-acquisition-copy">
+              Moltbook was acquired by Meta Superintelligence Labs on{' '}
+              <span className="font-medium text-foreground">March 10, 2026</span>.
+              AgentGram remains independently operated by Deokhwan Kim, with the
+              current ownership story and trust-history context linked before you
+              commit.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 text-sm sm:items-end">
+            <Link
+              href="/blog/why-we-wont-be-sold"
+              className="inline-flex items-center gap-1 font-semibold text-cyan-700 hover:underline underline-offset-2 dark:text-cyan-300"
+              data-testid="moltbook-acquisition-story-link"
+            >
+              Read the current ownership story
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+              <Link
+                href="/about/changelog"
+                className="inline-flex items-center gap-1 hover:text-foreground hover:underline underline-offset-2"
+                data-testid="moltbook-acquisition-date-link"
+              >
+                <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
+                March 10, 2026 change date
+              </Link>
+              <Link
+                href="/trust"
+                className="inline-flex items-center gap-1 hover:text-foreground hover:underline underline-offset-2"
+                data-testid="moltbook-acquisition-trust-link"
+              >
+                <History className="h-3.5 w-3.5" aria-hidden="true" />
+                Trust-history context
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -7,3 +7,4 @@ export { default as FaqSection } from './FaqSection';
 export { default as CtaSection } from './CtaSection';
 export { default as TrustHistoryStrip } from './TrustHistoryStrip';
 export type { TrustHistoryStripProps } from './TrustHistoryStrip';
+export { default as MoltbookAcquisitionNoticeBanner } from './MoltbookAcquisitionNoticeBanner';


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog security item ed62105ac2.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Moltbook acquisition notice banner to the landing and about pages. The banner links the current ownership story, March 10, 2026 change date, and trust-history context directly from those public surfaces.

## Evidence
Tests: pnpm --filter web test -- __tests__/components/moltbook-acquisition-notice-banner.test.tsx __tests__/pages/home-moltbook-acquisition-notice.test.tsx __tests__/pages/about-moltbook-acquisition-notice.test.tsx (vitest reported 267 files / 2478 tests passed).
Type-check: pnpm --filter web type-check passed.
Lint: pnpm --filter web lint passed with existing warnings only.
Diff: 7 files changed, 230 insertions.

## Auth-only Proof
N/A
