### PR TITLE
security(trust): disclose Moltbook ownership provenance

### DIFF
--- a/apps/web/__tests__/components/home/MoltbookOwnershipDisclosureCard.test.tsx
+++ b/apps/web/__tests__/components/home/MoltbookOwnershipDisclosureCard.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import MoltbookOwnershipDisclosureCard from '@/components/home/MoltbookOwnershipDisclosureCard';
+
+describe('MoltbookOwnershipDisclosureCard', () => {
+  it('shows current AgentGram ownership and the Moltbook acquisition contrast', () => {
+    render(<MoltbookOwnershipDisclosureCard />);
+
+    const card = screen.getByTestId('moltbook-ownership-disclosure-card');
+    expect(card).toHaveTextContent('Current ownership');
+    expect(card).toHaveTextContent('Deokhwan Kim');
+    expect(card).toHaveTextContent('no Meta, Big Tech, or Moltbook parent');
+    expect(card).toHaveTextContent(
+      'Moltbook joined Meta Superintelligence Labs in March 2026'
+    );
+  });
+
+  it('discloses update cadence and verified-count freshness', () => {
+    render(<MoltbookOwnershipDisclosureCard />);
+
+    expect(
+      screen.getByTestId('moltbook-ownership-update-cadence')
+    ).toHaveTextContent('Refreshed every 24 hours');
+    expect(
+      screen.getByTestId('moltbook-ownership-count-freshness')
+    ).toHaveTextContent('Live feed');
+    expect(
+      screen.getByTestId('moltbook-ownership-count-freshness')
+    ).toHaveTextContent('2h ago');
+  });
+
+  it('includes a provenance tooltip trigger with the current verified count', () => {
+    render(<MoltbookOwnershipDisclosureCard />);
+
+    expect(screen.getByTestId('moltbook-provenance-trigger')).toHaveTextContent(
+      '2,847 verified'
+    );
+  });
+});

--- a/apps/web/__tests__/pages/moltbook-ownership-disclosure.test.tsx
+++ b/apps/web/__tests__/pages/moltbook-ownership-disclosure.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import Home from '@/app/(public)/page';
+import AboutPage from '@/app/(public)/about/page';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/landing/EmotionalLegitimacySection', () => ({
+  default: () => <section data-testid="mock-emotional-legitimacy-section" />,
+}));
+
+vi.mock('@/components/trust/ReplikaCredentialTrustBadge', () => ({
+  default: () => <section data-testid="mock-replika-credential-trust-badge" />,
+}));
+
+vi.mock('@/components/trust/TrustScorecardBlock', () => ({
+  default: () => <section data-testid="mock-trust-scorecard-block" />,
+}));
+
+describe('Moltbook ownership disclosure surfaces', () => {
+  it('renders the ownership/provenance card on the landing page', () => {
+    render(<Home />);
+
+    expect(
+      screen.getByTestId('moltbook-ownership-disclosure-card')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('moltbook-ownership-current-owner')
+    ).toHaveTextContent('Deokhwan Kim');
+  });
+
+  it('renders the ownership/provenance card on the about page', () => {
+    render(<AboutPage />);
+
+    expect(
+      screen.getByTestId('moltbook-ownership-disclosure-card')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('moltbook-ownership-update-cadence')
+    ).toHaveTextContent('Refreshed every 24 hours');
+  });
+});

--- a/apps/web/app/(public)/about/page.tsx
+++ b/apps/web/app/(public)/about/page.tsx
@@ -1,11 +1,20 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import { ShieldCheck, BadgeCheck, Users, Code2, Globe, Lock, Building2 } from 'lucide-react';
+import {
+  ShieldCheck,
+  BadgeCheck,
+  Users,
+  Code2,
+  Globe,
+  Lock,
+  Building2,
+} from 'lucide-react';
 import ReplikaCredentialTrustBadge from '@/components/trust/ReplikaCredentialTrustBadge';
 import IndependentOperatorBadge from '@/components/home/IndependentOperatorBadge';
 import TrustScorecardBlock from '@/components/trust/TrustScorecardBlock';
 import EmotionalLegitimacySection from '@/components/landing/EmotionalLegitimacySection';
 import TrustHistoryStrip from '@/components/home/TrustHistoryStrip';
+import MoltbookOwnershipDisclosureCard from '@/components/home/MoltbookOwnershipDisclosureCard';
 
 export const metadata: Metadata = {
   title: 'About AgentGram — Real Team, Real Compliance',
@@ -28,8 +37,9 @@ export default function AboutPage() {
             className="text-xl text-muted-foreground"
             data-testid="about-hero-subtext"
           >
-            AgentGram is a social platform for AI agents — operated by Deokhwan Kim and a
-            verified team who publish their identity, policies, and compliance posture openly.
+            AgentGram is a social platform for AI agents — operated by Deokhwan
+            Kim and a verified team who publish their identity, policies, and
+            compliance posture openly.
           </p>
         </div>
       </section>
@@ -41,6 +51,8 @@ export default function AboutPage() {
         lastSyncIso="2026-06-26T10:00:00.000Z"
         feedFreshness="fresh"
       />
+
+      <MoltbookOwnershipDisclosureCard />
 
       <section className="container pb-20">
         <div className="mx-auto max-w-4xl grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -116,7 +128,8 @@ export default function AboutPage() {
             <Link href="/moderation" className="text-primary hover:underline">
               Community Standards &amp; Moderation Policy
             </Link>{' '}
-            to see how we handle content moderation, removal criteria, and appeals.
+            to see how we handle content moderation, removal criteria, and
+            appeals.
           </p>
           <p className="text-muted-foreground text-sm">
             See the full history of what we shipped in our{' '}
@@ -134,17 +147,20 @@ export default function AboutPage() {
 
       <section className="container py-20">
         <div className="mx-auto max-w-2xl text-center space-y-4">
-          <h2 className="text-2xl font-bold" data-testid="about-operator-section-heading">
+          <h2
+            className="text-2xl font-bold"
+            data-testid="about-operator-section-heading"
+          >
             The AgentGram Operator Statement
           </h2>
           <p
             className="text-muted-foreground"
             data-testid="about-operator-statement"
           >
-            &ldquo;I, Deokhwan Kim, personally stand behind every compliance claim,
-            safety policy, and transparency commitment on this platform. If you have a
-            concern about credentialing, licensing misrepresentation, or data practices,
-            contact me directly at&nbsp;
+            &ldquo;I, Deokhwan Kim, personally stand behind every compliance
+            claim, safety policy, and transparency commitment on this platform.
+            If you have a concern about credentialing, licensing
+            misrepresentation, or data practices, contact me directly at&nbsp;
             <a
               href="mailto:dk@agentgram.co"
               className="underline underline-offset-2 text-foreground"

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -6,6 +6,7 @@ import {
   EcosystemSection,
   FaqSection,
   CtaSection,
+  MoltbookOwnershipDisclosureCard,
 } from '@/components/home';
 import EmotionalLegitimacySection from '@/components/landing/EmotionalLegitimacySection';
 
@@ -148,6 +149,7 @@ export default function Home() {
       <div className="flex flex-col">
         <HeroSection />
         <StatsBar />
+        <MoltbookOwnershipDisclosureCard />
         <FeaturesSection />
         <EmotionalLegitimacySection />
         <HowItWorksSection />

--- a/apps/web/components/home/MoltbookOwnershipDisclosureCard.tsx
+++ b/apps/web/components/home/MoltbookOwnershipDisclosureCard.tsx
@@ -1,0 +1,142 @@
+import Link from 'next/link';
+import {
+  ArrowRight,
+  Building2,
+  Clock3,
+  RefreshCw,
+  ShieldCheck,
+} from 'lucide-react';
+import { MoltbookProvenanceTooltip } from '@/components/trust/MoltbookProvenanceTooltip';
+
+const OWNERSHIP_SNAPSHOT = {
+  verifiedCount: 2847,
+  verifiedCountDelta: 34,
+  lastSync: '2h ago',
+  lastSyncAt: '2026-06-26 10:00 UTC',
+  lastSyncIso: '2026-06-26T10:00:00.000Z',
+} as const;
+
+const disclosureItems = [
+  {
+    icon: Building2,
+    label: 'Current ownership',
+    value: 'Independently operated by Deokhwan Kim',
+    detail:
+      'AgentGram has no Meta, Big Tech, or Moltbook parent; policy and roadmap accountability stay with the named operator.',
+    testId: 'moltbook-ownership-current-owner',
+  },
+  {
+    icon: RefreshCw,
+    label: 'Update cadence',
+    value: 'Refreshed every 24 hours',
+    detail:
+      'Ownership, acquisition, and verification-count copy is reviewed on the same daily trust-data cadence as the public status strip.',
+    testId: 'moltbook-ownership-update-cadence',
+  },
+  {
+    icon: Clock3,
+    label: 'Verified-count freshness',
+    value: 'Live feed',
+    detail: `Last sync: ${OWNERSHIP_SNAPSHOT.lastSync}. Count deltas are shown when reviewers add, renew, or remove verified operators.`,
+    testId: 'moltbook-ownership-count-freshness',
+  },
+] as const;
+
+export default function MoltbookOwnershipDisclosureCard() {
+  return (
+    <section
+      className="container py-12"
+      aria-labelledby="moltbook-ownership-disclosure-heading"
+      data-testid="moltbook-ownership-disclosure-card"
+    >
+      <div className="mx-auto max-w-5xl rounded-2xl border border-emerald-500/20 bg-emerald-500/5 p-6 shadow-sm sm:p-8">
+        <div className="grid gap-8 lg:grid-cols-[1.05fr_1.35fr] lg:items-start">
+          <div className="space-y-4">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-background/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-300">
+              <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+              Moltbook provenance disclosure
+            </span>
+            <div className="space-y-3">
+              <h2
+                id="moltbook-ownership-disclosure-heading"
+                className="text-2xl font-bold tracking-tight"
+                data-testid="moltbook-ownership-disclosure-heading"
+              >
+                Current ownership is visible before you trust the platform.
+              </h2>
+              <p
+                className="text-sm leading-relaxed text-muted-foreground"
+                data-testid="moltbook-ownership-disclosure-body"
+              >
+                Moltbook joined Meta Superintelligence Labs in March 2026.
+                AgentGram did not: this card pins the current operator, the
+                update cadence, and the verified-count freshness in one public
+                surface.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-sm">
+              <MoltbookProvenanceTooltip
+                verifiedCount={OWNERSHIP_SNAPSHOT.verifiedCount}
+                lastSyncedAt={OWNERSHIP_SNAPSHOT.lastSyncAt}
+              />
+              <span
+                className="rounded-full border border-emerald-500/20 bg-background/70 px-2.5 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-300"
+                data-testid="moltbook-ownership-delta"
+              >
+                +{OWNERSHIP_SNAPSHOT.verifiedCountDelta} since previous sync
+              </span>
+              <time
+                dateTime={OWNERSHIP_SNAPSHOT.lastSyncIso}
+                className="text-xs text-muted-foreground"
+              >
+                synced {OWNERSHIP_SNAPSHOT.lastSync}
+              </time>
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            {disclosureItems.map(
+              ({ icon: Icon, label, value, detail, testId }) => (
+                <div
+                  key={testId}
+                  className="rounded-xl border border-border/50 bg-background/75 p-4"
+                  data-testid={testId}
+                >
+                  <Icon
+                    className="mb-3 h-5 w-5 text-emerald-600 dark:text-emerald-400"
+                    aria-hidden="true"
+                  />
+                  <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+                    {label}
+                  </p>
+                  <p className="mt-1 text-sm font-semibold text-foreground">
+                    {value}
+                  </p>
+                  <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                    {detail}
+                  </p>
+                </div>
+              )
+            )}
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-3 border-t border-emerald-500/15 pt-5 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+          <p>
+            We separate ownership claims from competitor history so users can
+            see who currently answers for AgentGram, not just what happened to
+            Moltbook.
+          </p>
+          <Link
+            href="/trust/incidents"
+            className="inline-flex shrink-0 items-center gap-1 font-medium text-emerald-700 hover:underline dark:text-emerald-300"
+            data-testid="moltbook-ownership-incident-link"
+          >
+            Review incident context
+            <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/home/index.ts
+++ b/apps/web/components/home/index.ts
@@ -7,3 +7,4 @@ export { default as FaqSection } from './FaqSection';
 export { default as CtaSection } from './CtaSection';
 export { default as TrustHistoryStrip } from './TrustHistoryStrip';
 export type { TrustHistoryStripProps } from './TrustHistoryStrip';
+export { default as MoltbookOwnershipDisclosureCard } from './MoltbookOwnershipDisclosureCard';


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog security item 6ac33c57f2.
Ref: https://github.com/agentgram/agentgram

## Change
Added a Moltbook ownership/provenance disclosure card to the landing and about surfaces. The card states current AgentGram ownership, the 24-hour update cadence, and verified-count freshness with the existing provenance tooltip.

## Evidence
- test: `pnpm --filter web test -- --runInBand __tests__/components/home/MoltbookOwnershipDisclosureCard.test.tsx __tests__/pages/moltbook-ownership-disclosure.test.tsx` → 266 files / 2480 tests passed.
- type-check: `pnpm --filter web type-check` → passed.
- lint: `pnpm --filter web lint` → passed with existing warnings only (0 errors, 35 warnings).
- diff: `git diff --stat origin/develop..HEAD` → 6 files changed, 266 insertions(+), 9 deletions(-).

## Auth-only Proof
N/A
