### PR TITLE
strategic(distribution): add X dry-run publisher

### DIFF
--- a/apps/web/__tests__/api/x-publish.test.ts
+++ b/apps/web/__tests__/api/x-publish.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+
+function makeRequest(body: unknown) {
+  return new NextRequest('http://localhost/api/v1/distribution/x/publish', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/v1/distribution/x/publish', () => {
+  it('returns a validated dry-run X payload and does not send externally', async () => {
+    const { POST } = await import('../../app/api/v1/distribution/x/publish/route');
+
+    const response = await POST(
+      makeRequest({
+        dryRun: true,
+        text: 'AgentGram can now validate X launch copy before credentials land.',
+        sourceUrl: 'https://agentgram.co/posts/post-1',
+        tags: ['#AgentGram', 'launch'],
+      })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data).toMatchObject({
+      channel: 'x',
+      mode: 'dry-run',
+      status: 'validated',
+      payload: {
+        text: 'AgentGram can now validate X launch copy before credentials land.',
+        sourceUrl: 'https://agentgram.co/posts/post-1',
+        tags: ['agentgram', 'launch'],
+      },
+      external: {
+        wouldPostTo: 'https://api.x.com/2/tweets',
+        sent: false,
+      },
+    });
+  });
+
+  it('rejects non-dry-run attempts instead of posting to X', async () => {
+    const { POST } = await import('../../app/api/v1/distribution/x/publish/route');
+
+    const response = await POST(
+      makeRequest({
+        dryRun: false,
+        text: 'Do not send yet.',
+      })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.message).toContain('Only dry-run X publishing is available');
+  });
+});

--- a/apps/web/__tests__/lib/x-publisher.test.ts
+++ b/apps/web/__tests__/lib/x-publisher.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  X_DRY_RUN_ENDPOINT,
+  buildXPublishDryRunPayload,
+} from '@/lib/distribution/x-publisher';
+
+const VERIFIED_AT = new Date('2026-07-13T00:00:00.000Z');
+
+describe('X publishing dry-run payload builder', () => {
+  it('validates and returns the normalized payload without sending to X', () => {
+    const result = buildXPublishDryRunPayload(
+      {
+        dryRun: true,
+        text: ' AgentGram agents can now preview X distribution. ',
+        sourceUrl: 'https://agentgram.co/posts/abc',
+        agentHandle: '@agentgram_ai',
+        tags: ['#AgentGram', 'AI_Agents', 'AgentGram', 'bad tag'],
+        media: [
+          {
+            url: 'https://agentgram.co/preview.png',
+            altText: 'Dry-run preview card',
+          },
+        ],
+      },
+      VERIFIED_AT
+    );
+
+    expect(result).toEqual({
+      channel: 'x',
+      mode: 'dry-run',
+      status: 'validated',
+      payload: {
+        text: 'AgentGram agents can now preview X distribution.',
+        characterCount: 48,
+        sourceUrl: 'https://agentgram.co/posts/abc',
+        agentHandle: 'agentgram_ai',
+        tags: ['agentgram', 'ai_agents'],
+        media: [
+          {
+            url: 'https://agentgram.co/preview.png',
+            altText: 'Dry-run preview card',
+          },
+        ],
+      },
+      validation: {
+        textLimit: 280,
+        mediaLimit: 4,
+        tagLimit: 6,
+      },
+      external: {
+        wouldPostTo: X_DRY_RUN_ENDPOINT,
+        sent: false,
+        reason: 'Dry-run mode validates and returns the payload without calling X APIs.',
+      },
+      verifiedAt: '2026-07-13T00:00:00.000Z',
+    });
+  });
+
+  it('rejects live-send requests until credentials and transport are implemented', () => {
+    expect(() =>
+      buildXPublishDryRunPayload({
+        dryRun: false,
+        text: 'Send this for real',
+      })
+    ).toThrow('Only dry-run X publishing is available in this slice');
+  });
+
+  it('rejects text that cannot fit in one X post', () => {
+    expect(() =>
+      buildXPublishDryRunPayload({
+        dryRun: true,
+        text: 'x'.repeat(281),
+      })
+    ).toThrow('text must be 280 characters or fewer');
+  });
+
+  it('rejects unsafe URLs before building a dry-run payload', () => {
+    expect(() =>
+      buildXPublishDryRunPayload({
+        dryRun: true,
+        text: 'Preview with unsafe media URL',
+        media: [{ url: 'javascript:alert(1)' }],
+      })
+    ).toThrow('media[0].url must be a valid http(s) URL');
+  });
+
+  it('caps tags and media to X-compatible limits', () => {
+    const result = buildXPublishDryRunPayload(
+      {
+        dryRun: true,
+        text: 'Preview with bounded tags and media.',
+        tags: ['one', 'two', 'three', 'four', 'five', 'six', 'seven'],
+        media: [
+          { url: 'https://agentgram.co/1.png' },
+          { url: 'https://agentgram.co/2.png' },
+          { url: 'https://agentgram.co/3.png' },
+          { url: 'https://agentgram.co/4.png' },
+          { url: 'https://agentgram.co/5.png' },
+        ],
+      },
+      VERIFIED_AT
+    );
+
+    expect(result.payload.tags).toEqual([
+      'one',
+      'two',
+      'three',
+      'four',
+      'five',
+      'six',
+    ]);
+    expect(result.payload.media).toHaveLength(4);
+  });
+});

--- a/apps/web/app/api/v1/distribution/x/publish/route.ts
+++ b/apps/web/app/api/v1/distribution/x/publish/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest } from 'next/server';
+import {
+  ErrorResponses,
+  createSuccessResponse,
+  jsonResponse,
+} from '@agentgram/shared';
+import {
+  buildXPublishDryRunPayload,
+  type XPublishDraftInput,
+} from '@/lib/distribution/x-publisher';
+
+// POST /api/v1/distribution/x/publish - Validate an X publish payload without sending it.
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json()) as XPublishDraftInput;
+    const dryRun = buildXPublishDryRunPayload(body);
+
+    return jsonResponse(createSuccessResponse(dryRun), 200);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to validate X publish payload';
+
+    return jsonResponse(ErrorResponses.invalidInput(message), 400);
+  }
+}

--- a/apps/web/lib/distribution/x-publisher.ts
+++ b/apps/web/lib/distribution/x-publisher.ts
@@ -1,0 +1,155 @@
+export const X_DISTRIBUTION_CHANNEL = 'x' as const;
+export const X_POST_TEXT_LIMIT = 280;
+export const X_MEDIA_LIMIT = 4;
+export const X_TAG_LIMIT = 6;
+export const X_DRY_RUN_ENDPOINT = 'https://api.x.com/2/tweets';
+
+export interface XPublishMediaInput {
+  url: string;
+  altText?: string;
+}
+
+export interface XPublishDraftInput {
+  text: string;
+  sourceUrl?: string;
+  agentHandle?: string;
+  tags?: string[];
+  media?: XPublishMediaInput[];
+  dryRun: boolean;
+}
+
+export interface XPublishDryRunPayload {
+  channel: typeof X_DISTRIBUTION_CHANNEL;
+  mode: 'dry-run';
+  status: 'validated';
+  payload: {
+    text: string;
+    characterCount: number;
+    sourceUrl?: string;
+    agentHandle?: string;
+    tags: string[];
+    media: XPublishMediaInput[];
+  };
+  validation: {
+    textLimit: number;
+    mediaLimit: number;
+    tagLimit: number;
+  };
+  external: {
+    wouldPostTo: typeof X_DRY_RUN_ENDPOINT;
+    sent: false;
+    reason: string;
+  };
+  verifiedAt: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function assertHttpUrl(value: string, fieldName: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${fieldName} must be a valid http(s) URL`);
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(`${fieldName} must be a valid http(s) URL`);
+  }
+
+  return parsed.toString();
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function normalizeTags(tags: unknown): string[] {
+  if (!Array.isArray(tags)) {
+    return [];
+  }
+
+  const normalized = tags
+    .map((tag) => normalizeOptionalString(tag)?.replace(/^#/, '').toLowerCase())
+    .filter((tag): tag is string => Boolean(tag))
+    .filter((tag) => /^[a-z0-9_]{1,30}$/.test(tag));
+
+  return Array.from(new Set(normalized)).slice(0, X_TAG_LIMIT);
+}
+
+function normalizeMedia(media: unknown): XPublishMediaInput[] {
+  if (!Array.isArray(media)) {
+    return [];
+  }
+
+  return media.slice(0, X_MEDIA_LIMIT).map((item, index) => {
+    if (!isRecord(item) || typeof item.url !== 'string') {
+      throw new Error(`media[${index}].url is required`);
+    }
+
+    const normalized: XPublishMediaInput = {
+      url: assertHttpUrl(item.url, `media[${index}].url`),
+    };
+    const altText = normalizeOptionalString(item.altText);
+    if (altText) {
+      normalized.altText = altText.slice(0, 1000);
+    }
+
+    return normalized;
+  });
+}
+
+export function buildXPublishDryRunPayload(
+  input: XPublishDraftInput,
+  verifiedAt: Date = new Date()
+): XPublishDryRunPayload {
+  if (input.dryRun !== true) {
+    throw new Error('Only dry-run X publishing is available in this slice');
+  }
+
+  const text = normalizeOptionalString(input.text);
+  if (!text) {
+    throw new Error('text is required');
+  }
+
+  const characterCount = Array.from(text).length;
+  if (characterCount > X_POST_TEXT_LIMIT) {
+    throw new Error(`text must be ${X_POST_TEXT_LIMIT} characters or fewer`);
+  }
+
+  const sourceUrl = input.sourceUrl
+    ? assertHttpUrl(input.sourceUrl, 'sourceUrl')
+    : undefined;
+  const agentHandle = normalizeOptionalString(input.agentHandle)?.replace(/^@/, '');
+  const tags = normalizeTags(input.tags);
+  const media = normalizeMedia(input.media);
+
+  return {
+    channel: X_DISTRIBUTION_CHANNEL,
+    mode: 'dry-run',
+    status: 'validated',
+    payload: {
+      text,
+      characterCount,
+      ...(sourceUrl ? { sourceUrl } : {}),
+      ...(agentHandle ? { agentHandle } : {}),
+      tags,
+      media,
+    },
+    validation: {
+      textLimit: X_POST_TEXT_LIMIT,
+      mediaLimit: X_MEDIA_LIMIT,
+      tagLimit: X_TAG_LIMIT,
+    },
+    external: {
+      wouldPostTo: X_DRY_RUN_ENDPOINT,
+      sent: false,
+      reason: 'Dry-run mode validates and returns the payload without calling X APIs.',
+    },
+    verifiedAt: verifiedAt.toISOString(),
+  };
+}


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item c49410d678.
Ref: https://github.com/agentgram/agentgram

## Change
Added an X/Twitter distribution dry-run slice: a payload builder that validates text, URLs, tags, media bounds, and explicitly rejects live-send attempts.
Exposed the dry-run validator through POST /api/v1/distribution/x/publish and covered both module and route behavior with tests.

## Evidence
diff: 4 files changed, 352 insertions.
test: pnpm --dir apps/web exec vitest run __tests__/lib/x-publisher.test.ts __tests__/api/x-publish.test.ts — PASS (2 files, 7 tests).
type-check: pnpm --filter web type-check — PASS.
lint: pnpm --filter web lint — PASS with existing warnings only.
note: pnpm --filter web test -- __tests__/lib/x-publisher.test.ts __tests__/api/x-publish.test.ts currently runs the full suite in this workspace and hits an unrelated existing locale assertion in __tests__/components/check-in-consent-panel.test.tsx expecting "Jun" while the environment formats Korean "6월".

## Auth-only Proof
N/A
