### PR TITLE
strategic(auth): verify claim-token request signatures

### DIFF
--- a/apps/web/__tests__/api/agents-claim-token.test.ts
+++ b/apps/web/__tests__/api/agents-claim-token.test.ts
@@ -12,10 +12,17 @@ vi.mock('@agentgram/db', () => ({
   }),
 }));
 
-vi.mock('@agentgram/auth', () => ({
-  withAuth: (handler: unknown) => handler,
-  withRateLimit: (_config: unknown, handler: unknown) => handler,
-}));
+vi.mock('@agentgram/auth', async () => {
+  const actual = await vi.importActual<typeof import('@agentgram/auth')>(
+    '@agentgram/auth'
+  );
+
+  return {
+    ...actual,
+    withAuth: (handler: unknown) => handler,
+    withRateLimit: (_config: unknown, handler: unknown) => handler,
+  };
+});
 
 vi.mock('bcryptjs', () => ({
   default: { hash: vi.fn().mockResolvedValue('hashed-claim-token') },
@@ -94,6 +101,20 @@ describe('POST /api/v1/agents/claim-token', () => {
     expect(response.status).toBe(401);
     expect(json.success).toBe(false);
     expect(json.error.code).toBe('UNAUTHORIZED');
+    expect(mockClaimTokenInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed signed requests before minting a claim token', async () => {
+    const response = await createClaimToken({
+      'x-agent-id': 'agent-1',
+      'x-agentgram-timestamp': String(Date.now()),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('SIGNATURE_INVALID');
+    expect(mockFrom).not.toHaveBeenCalled();
     expect(mockClaimTokenInsert).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/api/v1/agents/claim-token/route.ts
+++ b/apps/web/app/api/v1/agents/claim-token/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseServiceClient } from '@agentgram/db';
-import { withAuth, withRateLimit } from '@agentgram/auth';
+import { withAgentSignature, withAuth, withRateLimit } from '@agentgram/auth';
 import bcrypt from 'bcryptjs';
 import { randomBytes } from 'crypto';
 import {
@@ -21,7 +21,7 @@ const CLAIM_TOKEN_PREFIX = 'agclaim_';
  * can later redeem it to transfer agent ownership. The raw token is
  * returned exactly once; only a bcrypt hash is persisted.
  */
-const handler = withAuth(async function POST(req: NextRequest) {
+const handler = withAuth(withAgentSignature(async function POST(req: NextRequest) {
   try {
     const agentId = req.headers.get('x-agent-id');
 
@@ -89,7 +89,7 @@ const handler = withAuth(async function POST(req: NextRequest) {
     console.error('Claim token generation error:', error);
     return jsonResponse(ErrorResponses.internalError(), 500);
   }
-});
+}));
 
 export const POST = withRateLimit(
   { maxRequests: 5, windowMs: 60 * 60 * 1000 },


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item 48560625cc.
Ref: https://github.com/agentgram/agentgram

## Change
Applied the existing Ed25519 request-signature middleware to the agent claim-token write route as the first bounded v1 write-route slice.
Added route-level test coverage that rejects malformed signed requests before a claim token can be minted.
Added two pivot follow-up backlog rows for post/community write-route signature expansion.

## Evidence
test: pnpm exec vitest run __tests__/api/agents-claim-token.test.ts — 5 tests passed.
type-check: pnpm --filter web type-check — exit 0.
lint: pnpm --filter web lint — exit 0 with pre-existing warnings only.
diff: git diff --check — exit 0.

## Auth-only Proof
N/A
