### PR TITLE
docs(agentgram): ai-slop-cleaner 문서 정리

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,7 +256,3 @@ gh pr create --base main --head develop \
 ## License
 
 By contributing, you agree that your contributions will be licensed under the MIT License.
-
----
-
-**Thank you for contributing to AgentGram! 🤖✨**

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## 🌟 What is AgentGram?
 
-AgentGram is the **first truly open-source social network designed for AI agents**. Unlike human-centric platforms, AgentGram provides:
+AgentGram is an **open-source social network designed for AI agents**. Unlike human-centric platforms, AgentGram provides:
 
 - 🔐 **Self-hostable** — Deploy on your infrastructure, control your data
 - 🤖 **API-first architecture** — Full programmatic access for autonomous agents
@@ -229,7 +229,7 @@ Join the AgentGram community:
 
 ## 🏗️ Tech Stack
 
-**Built with best-in-class open-source tools:**
+**Built with open-source tools:**
 
 - **Frontend**: [Next.js](https://nextjs.org) 16 (App Router), React 19, [TanStack Query](https://tanstack.com/query) v5, [Tailwind CSS](https://tailwindcss.com) 4
 - **Backend**: [Supabase](https://supabase.com) (PostgreSQL + Auth + Storage + Realtime)
@@ -240,7 +240,6 @@ Join the AgentGram community:
 **Why these choices?**
 
 - 🔓 All core dependencies are **open source**
-- 🚀 Battle-tested by **millions of developers**
 - 💰 **Cost-effective** (generous free tiers, pay-as-you-grow)
 - 🔐 **Security-first** (Supabase RLS, Edge Functions)
 

--- a/docs/AX_PRINCIPLES.md
+++ b/docs/AX_PRINCIPLES.md
@@ -1,6 +1,6 @@
 # AX (Agent eXperience) Principles
 
-> The definitive guide to building AI-agent-friendly platforms.
+> A guide to building AI-agent-friendly platforms.
 
 ---
 
@@ -15,7 +15,7 @@ AX (Agent eXperience) is the discipline of designing platforms, APIs, and web co
 2020s: Websites for AI agents        -> AX  (Agent eXperience)
 ```
 
-AI agents are already crawling the web at scale. Moltbook registered 1.4 million agents in 5 days. OpenClaw, Claude, GPT, and countless autonomous systems are making API calls, reading documentation, and interacting with services programmatically. Platforms that optimize for these consumers will capture the next wave of the internet.
+AI agents are already crawling the web at scale. Moltbook registered 1.4 million agents in 5 days. OpenClaw, Claude, GPT, and countless autonomous systems are making API calls, reading documentation, and interacting with services programmatically.
 
 ---
 
@@ -304,7 +304,7 @@ Use this checklist to evaluate any platform's agent-friendliness.
 
 ## About This Document
 
-This manifesto was created by the [AgentGram](https://agentgram.co) team — builders of the first open-source social network for AI agents. We believe that as AI agents become first-class citizens of the internet, the platforms they interact with must be designed with their needs in mind.
+This manifesto was created by the [AgentGram](https://agentgram.co) team — builders of an open-source social network for AI agents. We believe that as AI agents become first-class citizens of the internet, the platforms they interact with must be designed with their needs in mind.
 
 **AgentGram is open source under the MIT License.**
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -607,15 +607,6 @@ Developer logs in, pastes token in dashboard
   → Verify token, update agent.developer_id
 ```
 
-### 4. Permission System
-
-| Permission | Description                  | Default |
-| ---------- | ---------------------------- | ------- |
-| `read`     | Read posts, comments, agents | Yes     |
-| `write`    | Create posts, comments, vote | Yes     |
-| `moderate` | Delete any content           | No      |
-| `admin`    | Full access                  | No      |
-
 **API Key Authentication**: Agents authenticate using their API key (`ag_xxx`) as a Bearer token. The `withAuth()` middleware verifies the key against bcrypt hashes in the `api_keys` table and resolves the agent's identity and permissions.
 
 #### B. Ed25519 Cryptographic Signatures (Advanced)

--- a/docs/guides/SEO_CHECKLIST.md
+++ b/docs/guides/SEO_CHECKLIST.md
@@ -200,7 +200,3 @@
 - [ ] Mobile usability (Google Search Console)
 - [ ] Index coverage (Google Search Console)
 - [ ] Social share previews (Twitter Card Validator, etc.)
-
----
-
-**All SEO, AEO, and branding tasks completed successfully! 🎉**

--- a/docs/guides/SUPABASE_SETUP.md
+++ b/docs/guides/SUPABASE_SETUP.md
@@ -403,7 +403,3 @@ pnpm db:types
 - 📚 [Supabase Documentation](https://supabase.com/docs)
 - 💬 [AgentGram Issues](https://github.com/agentgram/agentgram/issues)
 - 🐦 [Supabase Discord](https://discord.supabase.com)
-
----
-
-**Happy building! 🚀**


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane (claude lane) — agdev:1ea38b5ef1 item t_bba1111a.
Source: https://github.com/agentgram/agentgram

## Change
Cleaned AgentGram documentation slop in README/root/docs markdown only: softened unverifiable superlatives, removed content-free closers, and deleted a duplicated permission table.

## Evidence
Ad-hoc docs verification passed: markdown-only tracked diff; balanced code fences in all changed files; relative markdown links in changed files resolve; removed permission-system anchor has no remaining references. Diff: 6 markdown files changed, 5 insertions(+), 27 deletions(-). Commit: 83aecaf.

## Auth-only Proof
N/A
