### PR TITLE
fix(scripts): accept dev-lane kanban markers as valid PR Source

### DIFF
--- a/scripts/__tests__/validate-pr-body.test.mjs
+++ b/scripts/__tests__/validate-pr-body.test.mjs
@@ -87,3 +87,17 @@ curl -H "Authorization: Bearer $SESSION_TOKEN" https://agentgram.local/api/priva
   assert.equal(result.ok, true);
   assert.equal(result.authGated, true);
 });
+
+test('passes a PR whose source cites dev-lane kanban markers', () => {
+  const result = validatePrArtifactPack({
+    title: 'docs: dev-lane handoff note',
+    body: nonAuthBody.replace(
+      'Source: backlog.md:97',
+      'Source: Hermes kanban-dispatch dev lane — agdev:1ea38b5ef1 item t_bba1111a'
+    ),
+    labels: ['type: docs'],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.authGated, false);
+});

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -15,7 +15,7 @@ const PLACEHOLDER_LINE_PATTERNS = [
   /^coming soon$/i,
 ];
 const SOURCE_REFERENCE_PATTERN =
-  /(Source:\s*)?(backlog\.md:\d+|#\d+|https?:\/\/\S+)/i;
+  /(Source:\s*)?(backlog\.md:\d+|#\d+|https?:\/\/\S+|agdev:[0-9a-f]{6,}|t_[0-9a-f]{6,})/i;
 const EVIDENCE_SIGNAL_PATTERN =
   /(docs\/|\.png\b|\.jpe?g\b|\.gif\b|\.webp\b|\.html\b|\.md\b|screenshot|live[- ]proof|docs\/example diff|diff|validation|test)/i;
 const AUTH_SNIPPET_SIGNAL_PATTERN =


### PR DESCRIPTION
## Source
Source: backlog.md:49

## Change
Extend validate-pr-body SOURCE_REFERENCE_PATTERN to accept dev-lane kanban markers (agdev:<key>, t_<id>) as a valid ## Source, fixing the review-card livelock where every dev-lane docs PR failed the Validate PR verification artifact pack check. Adds a regression test.

## Evidence
scripts/__tests__/validate-pr-body.test.mjs updated; local test run green: `node --test scripts/__tests__/validate-pr-body.test.mjs` -> tests 6, pass 6, fail 0. Manual check: a dev-lane-marker Source body now passes validation (PR artifact pack validation passed); a reference-less Source still fails (existing test "fails when source does not cite a backlog row or issue").

## Auth-only Proof
N/A
