### PR TITLE
test(web): guard API v1 auth coverage

### DIFF
--- a/apps/web/__tests__/api/auth-coverage.test.ts
+++ b/apps/web/__tests__/api/auth-coverage.test.ts
@@ -1,0 +1,163 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const API_ROOT = join(process.cwd(), 'app/api/v1');
+const ROUTE_METHODS = [
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+] as const;
+type RouteMethod = (typeof ROUTE_METHODS)[number];
+type RouteExport = {
+  method: RouteMethod;
+  expression: string;
+  kind: 'const' | 'function';
+};
+
+const PUBLIC_API_ROUTE_EXPORTS = new Set([
+  'activity/live-stats/route.ts#GET',
+  'agents/[agentId]/lorebook/preview/route.ts#GET',
+  'agents/[agentId]/remixes/route.ts#GET',
+  'agents/[id]/analytics/stickiness/route.ts#GET',
+  'agents/[id]/api-access-request/route.ts#POST',
+  'agents/[id]/followers/route.ts#GET',
+  'agents/[id]/following/route.ts#GET',
+  'agents/[id]/personas/route.ts#GET',
+  'agents/register/route.ts#POST',
+  'agents/route.ts#GET',
+  'agents/trending/route.ts#GET',
+  'auth/refresh/route.ts#POST',
+  'ax-score/cron/monthly-reports/route.ts#POST',
+  'ax-score/cron/weekly-alerts/route.ts#POST',
+  'billing/webhook/route.ts#POST',
+  'communities/[id]/members/route.ts#GET',
+  'communities/[id]/posts/route.ts#GET',
+  'communities/[id]/route.ts#GET',
+  'communities/route.ts#GET',
+  'creator/[agentId]/reach/route.ts#GET',
+  'creator/discovery-stats/route.ts#GET',
+  'creators/discover/route.ts#GET',
+  'distribution/x/publish/route.ts#POST',
+  'embed/route.ts#GET',
+  'hashtags/[tag]/posts/route.ts#GET',
+  'hashtags/trending/route.ts#GET',
+  'health/route.ts#GET',
+  'posts/[id]/comments/route.ts#GET',
+  'posts/[id]/route.ts#GET',
+  'posts/route.ts#GET',
+  'reply-composer/imagine-scene/route.ts#POST',
+  'search/route.ts#GET',
+  'stats/route.ts#GET',
+  'stats/social-proof/route.ts#GET',
+  'translate/route.ts#POST',
+  'trust/badge/[agentId]/route.ts#GET',
+  'user/return-context/route.ts#GET',
+]);
+
+function findRouteFiles(directory: string): string[] {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  const routeFiles: string[] = [];
+
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      routeFiles.push(...findRouteFiles(path));
+    } else if (entry.isFile() && entry.name === 'route.ts') {
+      routeFiles.push(path);
+    }
+  }
+
+  return routeFiles.sort();
+}
+
+function extractRouteExports(source: string): RouteExport[] {
+  const exports: RouteExport[] = [];
+
+  for (const method of ROUTE_METHODS) {
+    const constMatch = source.match(
+      new RegExp(`export\\s+const\\s+${method}\\s*=([\\s\\S]*?);`)
+    );
+    if (constMatch) {
+      exports.push({ method, expression: constMatch[1], kind: 'const' });
+      continue;
+    }
+
+    const functionMatch = source.match(
+      new RegExp(`export\\s+(?:async\\s+)?function\\s+${method}\\s*\\(`)
+    );
+    if (functionMatch) {
+      exports.push({ method, expression: functionMatch[0], kind: 'function' });
+    }
+  }
+
+  return exports;
+}
+
+function extractProtectedHandlerNames(source: string): Set<string> {
+  const protectedHandlerNames = new Set<string>();
+  const protectedHandlerPattern =
+    /const\s+([A-Za-z_$][\w$]*)\s*=\s*with(?:Developer)?Auth\s*\(/g;
+
+  for (const match of source.matchAll(protectedHandlerPattern)) {
+    protectedHandlerNames.add(match[1]);
+  }
+
+  return protectedHandlerNames;
+}
+
+function isProtectedRouteExport(
+  routeExport: RouteExport,
+  protectedHandlerNames: Set<string>
+): boolean {
+  if (routeExport.kind === 'function') {
+    return false;
+  }
+
+  if (/\bwith(?:Developer)?Auth\s*\(/.test(routeExport.expression)) {
+    return true;
+  }
+
+  return [...protectedHandlerNames].some((handlerName) =>
+    new RegExp(`\\b${handlerName}\\b`).test(routeExport.expression)
+  );
+}
+
+describe('API v1 auth coverage', () => {
+  it('keeps every route export either auth-wrapped or explicitly public', () => {
+    expect(existsSync(API_ROOT)).toBe(true);
+
+    const routeFiles = findRouteFiles(API_ROOT);
+    const seenRouteExports = new Set<string>();
+    const unguardedExports: string[] = [];
+
+    for (const routeFile of routeFiles) {
+      const relativeRouteFile = relative(API_ROOT, routeFile);
+      const source = readFileSync(routeFile, 'utf8');
+      const protectedHandlerNames = extractProtectedHandlerNames(source);
+
+      for (const routeExport of extractRouteExports(source)) {
+        const exportKey = `${relativeRouteFile}#${routeExport.method}`;
+        seenRouteExports.add(exportKey);
+
+        if (
+          !isProtectedRouteExport(routeExport, protectedHandlerNames) &&
+          !PUBLIC_API_ROUTE_EXPORTS.has(exportKey)
+        ) {
+          unguardedExports.push(exportKey);
+        }
+      }
+    }
+
+    const stalePublicEntries = [...PUBLIC_API_ROUTE_EXPORTS].filter(
+      (exportKey) => !seenRouteExports.has(exportKey)
+    );
+
+    expect(stalePublicEntries).toEqual([]);
+    expect(unguardedExports).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Source
Kanban task t_506c76e2: infra M2 AgentGram central auth gate / CI coverage regression guard.

## Summary
- Adds a Vitest CI guard that scans every `apps/web/app/api/v1/**/route.ts` route export.
- Fails new route exports unless they are protected by `withAuth` / `withDeveloperAuth` directly or through a protected handler, or explicitly listed in the public API whitelist.
- Keeps currently intentional public routes explicit, including health, embed, public feed/directory reads, billing webhook, cron/webhook-style endpoints, and registration/refresh flows.

## Evidence
- `pnpm install --frozen-lockfile`
- `pnpm --filter web exec vitest run __tests__/api/auth-coverage.test.ts` -> 1 test passed
- `pnpm --filter web type-check` -> passed
- `pnpm --filter web lint` -> passed with 0 errors / 35 pre-existing warnings
- `pnpm --filter web test` -> 270 files passed / 2487 tests passed
- `pnpm --filter web build` -> Next.js production build compiled successfully
- GitHub Actions after PR open: `Lint & Build`, `Unit Tests`, and `Verify generated database types` passed on the initial commit; artifact-pack check failed only because this required section was missing.

## Auth-only Proof
N/A — this is a CI-only regression guard and does not change runtime authenticated behavior or expose a new auth-gated UI/API path. The guard itself verifies auth coverage by scanning route exports for `withAuth` / `withDeveloperAuth` wrappers or explicit public-route whitelist entries.

## Risk / Rollout
- Low-risk CI-only change; no runtime middleware behavior changed.
- Public API surface is intentionally enumerated so future unauthenticated `/api/v1` additions require a conscious whitelist edit during review.
