### PR TITLE
fix(web): escape avatar_url in embed to prevent stored XSS

### DIFF
--- a/apps/web/__tests__/api/embed.test.ts
+++ b/apps/web/__tests__/api/embed.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSingle = vi.fn();
+const mockEq = vi.fn(() => ({ single: mockSingle }));
+const mockSelect = vi.fn(() => ({ eq: mockEq }));
+
+vi.mock('@agentgram/db', () => ({
+  getSupabaseServiceClient: () => ({
+    from: () => ({
+      select: mockSelect,
+    }),
+  }),
+}));
+
+describe('GET /api/v1/embed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSingle.mockResolvedValue({
+      data: {
+        name: 'xss-agent',
+        display_name: 'XSS <Agent>',
+        description: 'Helpful "assistant" <script>alert(2)</script>',
+        axp: 42,
+        avatar_url: 'x" onerror="alert(1)',
+      },
+      error: null,
+    });
+  });
+
+  it('escapes stored avatar_url before rendering it into the embed HTML', async () => {
+    const { GET } = await import('../../app/api/v1/embed/route');
+
+    const response = await GET(
+      new Request('http://localhost/api/v1/embed?agent=xss-agent') as Parameters<typeof GET>[0]
+    );
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('src="x&quot; onerror=&quot;alert(1)"');
+    expect(html).not.toContain('src="x" onerror="alert(1)"');
+  });
+
+  it('escapes text fields rendered into the embed HTML', async () => {
+    const { GET } = await import('../../app/api/v1/embed/route');
+
+    const response = await GET(
+      new Request('http://localhost/api/v1/embed?agent=xss-agent') as Parameters<typeof GET>[0]
+    );
+    const html = await response.text();
+
+    expect(html).toContain('XSS &lt;Agent&gt;');
+    expect(html).toContain('Helpful &quot;assistant&quot; &lt;script&gt;alert(2)&lt;/script&gt;');
+    expect(html).not.toContain('<script>alert(2)</script>');
+  });
+});

--- a/apps/web/app/api/v1/embed/route.ts
+++ b/apps/web/app/api/v1/embed/route.ts
@@ -1,6 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseServiceClient } from '@agentgram/db';
 
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return char;
+    }
+  });
+}
+
 /**
  * GET /api/v1/embed?agent=<name>
  *
@@ -31,6 +50,13 @@ export async function GET(req: NextRequest) {
     );
   }
 
+  const safeDisplayName = escapeHtml(agent.display_name || agent.name);
+  const safeDescription = escapeHtml(
+    (agent.description || '').substring(0, 120)
+  );
+  const safeAvatarUrl = agent.avatar_url ? escapeHtml(agent.avatar_url) : null;
+  const safeInitial = escapeHtml(agent.name.charAt(0).toUpperCase());
+
   const html = `<!DOCTYPE html>
 <html>
 <head>
@@ -54,11 +80,11 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;b
 <body>
 <a class="card" href="https://agentgram.co/agents/${encodeURIComponent(agent.name)}" target="_blank" rel="noopener">
   <div class="avatar">
-    ${agent.avatar_url ? `<img src="${agent.avatar_url}" alt="">` : agent.name.charAt(0).toUpperCase()}
+    ${safeAvatarUrl ? `<img src="${safeAvatarUrl}" alt="">` : safeInitial}
   </div>
   <div class="info">
-    <div class="name">${agent.display_name || agent.name}</div>
-    <div class="desc">${(agent.description || '').substring(0, 120)}</div>
+    <div class="name">${safeDisplayName}</div>
+    <div class="desc">${safeDescription}</div>
     <div class="badge">AXP ${agent.axp || 0}</div>
   </div>
 </a>


### PR DESCRIPTION
## Source
Kanban task t_750b43e5: verified stored-XSS risk in `/api/v1/embed` where `avatar_url` was interpolated into an HTML attribute without escaping.

## Change
- Added a small local HTML escaping helper in `apps/web/app/api/v1/embed/route.ts`.
- Escaped `avatar_url` before placing it in `<img src=...>`, preventing payloads like `x" onerror="alert(1)` from breaking out of the `src` attribute.
- Also escaped embed text fields (`display_name`, `description`, fallback initial) because the same HTML template renders stored profile data.
- Checked API write paths for `avatar_url`; no agent create/update route in `apps/web/app/api` currently accepts or persists `avatar_url`, so write-time HTTPS validation was not applicable in this patch.
- Reviewed CSP location: `apps/web/proxy.ts` still includes `script-src 'unsafe-inline'`; removing it is broader regression-prone header work and should be handled separately.

## Evidence
- `pnpm install --frozen-lockfile`
- `pnpm --filter web test -- apps/web/__tests__/api/embed.test.ts` (Vitest ran full web suite: 270 files / 2488 tests passed; includes new embed regression tests)
- `pnpm --filter web test -- __tests__/api/embed.test.ts` (Vitest again ran full web suite: 270 files / 2488 tests passed; includes new embed regression tests)
- `pnpm --filter web type-check`
- `pnpm --filter web lint` (0 errors, existing warnings only)
- `pnpm --filter web build`

## Auth-only Proof
N/A