### PR TITLE
fix(ci): exempt dependency and docs PRs from artifact guard

### DIFF
--- a/.github/workflows/pr-artifact-pack.yml
+++ b/.github/workflows/pr-artifact-pack.yml
@@ -23,9 +23,24 @@ jobs:
         with:
           node-version: 22
 
+      - name: Collect changed files
+        id: pr-files
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            core.setOutput('files', JSON.stringify(files.map((file) => file.filename)));
+
       - name: Validate PR body
         run: node scripts/validate-pr-body.mjs
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          PR_CHANGED_FILES_JSON: ${{ steps.pr-files.outputs.files }}

--- a/scripts/__tests__/validate-pr-body.test.mjs
+++ b/scripts/__tests__/validate-pr-body.test.mjs
@@ -154,6 +154,32 @@ test('skips artifact pack validation for docs and package metadata only changes'
   assert.equal(result.skipReason, 'docs/package metadata only changes');
 });
 
+test('skips artifact pack validation for root README-only changes', () => {
+  const result = validatePrArtifactPack({
+    title: 'docs: refresh root readme',
+    body: '',
+    author: 'human-maintainer',
+    changedFiles: ['README.md'],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.skipReason, 'docs/package metadata only changes');
+});
+
+test('skips artifact pack validation for markdown-only changes outside docs', () => {
+  const result = validatePrArtifactPack({
+    title: 'docs: refresh app readme',
+    body: '',
+    author: 'human-maintainer',
+    changedFiles: ['README.md', 'apps/web/README.md'],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.skipReason, 'docs/package metadata only changes');
+});
+
 test('keeps artifact pack validation for non-exempt dev-lane bot PRs', () => {
   const result = validatePrArtifactPack({
     title: 'feat: dev-lane implementation',

--- a/scripts/__tests__/validate-pr-body.test.mjs
+++ b/scripts/__tests__/validate-pr-body.test.mjs
@@ -79,7 +79,7 @@ Source: #97
 
 ## Auth-only Proof
 \`\`\`bash
-curl -H "Authorization: Bearer $SESSION_TOKEN" https://agentgram.local/api/private/me
+curl -H "Authorization: Bearer ***" https://agentgram.local/api/private/me
 \`\`\`
 `,
   });
@@ -100,4 +100,83 @@ test('passes a PR whose source cites dev-lane kanban markers', () => {
 
   assert.equal(result.ok, true);
   assert.equal(result.authGated, false);
+});
+
+test('skips artifact pack validation for dependabot PRs', () => {
+  const result = validatePrArtifactPack({
+    title: 'chore(deps): bump eslint',
+    body: '',
+    author: 'dependabot[bot]',
+    labels: [],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.skipReason, 'dependabot author');
+});
+
+test('skips artifact pack validation for dependencies and documentation labels', () => {
+  const dependenciesResult = validatePrArtifactPack({
+    title: 'chore(deps): bump turbo',
+    body: '',
+    author: 'human-maintainer',
+    labels: ['dependencies'],
+  });
+  const documentationResult = validatePrArtifactPack({
+    title: 'docs: update deployment guide',
+    body: '',
+    author: 'human-maintainer',
+    labels: ['documentation'],
+  });
+
+  assert.equal(dependenciesResult.ok, true);
+  assert.equal(dependenciesResult.skipped, true);
+  assert.equal(dependenciesResult.skipReason, 'dependencies label');
+  assert.equal(documentationResult.ok, true);
+  assert.equal(documentationResult.skipped, true);
+  assert.equal(documentationResult.skipReason, 'documentation label');
+});
+
+test('skips artifact pack validation for docs and package metadata only changes', () => {
+  const result = validatePrArtifactPack({
+    title: 'docs: refresh setup notes',
+    body: '',
+    author: 'human-maintainer',
+    changedFiles: [
+      'docs/development/setup.md',
+      'apps/web/package.json',
+      'pnpm-lock.yaml',
+    ],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.skipReason, 'docs/package metadata only changes');
+});
+
+test('keeps artifact pack validation for non-exempt dev-lane bot PRs', () => {
+  const result = validatePrArtifactPack({
+    title: 'feat: dev-lane implementation',
+    body: '',
+    author: 'agentgram-dev-lane[bot]',
+    labels: ['type: feature'],
+    changedFiles: ['apps/web/app/page.tsx'],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.skipped, false);
+  assert.match(result.errors.join('\n'), /PR body is empty/);
+});
+
+test('does not skip mixed product code changes without an exempt label or author', () => {
+  const result = validatePrArtifactPack({
+    title: 'docs: update setup and homepage copy',
+    body: '',
+    author: 'human-maintainer',
+    changedFiles: ['docs/development/setup.md', 'apps/web/app/page.tsx'],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.skipped, false);
+  assert.match(result.errors.join('\n'), /PR body is empty/);
 });

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -145,8 +145,8 @@ function normalizeChangedFile(file) {
   return '';
 }
 
-function isDocsMarkdownFile(file) {
-  return /^docs\/.+\.md$/i.test(file);
+function isMarkdownDocumentFile(file) {
+  return /(^|\/)[^/]+\.md$/i.test(file);
 }
 
 function isPackageMetadataFile(file) {
@@ -179,7 +179,7 @@ function isArtifactPackExempt({
   if (
     normalizedFiles.length > 0 &&
     normalizedFiles.every(
-      (file) => isDocsMarkdownFile(file) || isPackageMetadataFile(file)
+      (file) => isMarkdownDocumentFile(file) || isPackageMetadataFile(file)
     )
   ) {
     return { exempt: true, reason: 'docs/package metadata only changes' };

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -22,6 +22,9 @@ const AUTH_SNIPPET_SIGNAL_PATTERN =
   /```[\s\S]+```|`[^`]+`|\bcurl\b|\bpnpm\b|\bvitest\b|\bplaywright\b|\bauthorization\b|\bbearer\b|\bcookie\b|\bsession\b|\btoken\b/i;
 const EXPLICIT_NA_PATTERN =
   /^(?:[-*]\s*)?(?:`)?(?:n\/a|na|not applicable)(?:`)?$/i;
+const ARTIFACT_PACK_EXEMPT_LABELS = new Set(['dependencies', 'documentation']);
+const PACKAGE_METADATA_FILE_PATTERN =
+  /(^|\/)(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|package-lock\.json|yarn\.lock|bun\.lockb?)$/;
 
 function stripComments(text) {
   return text.replace(/<!--[\s\S]*?-->/g, '').trim();
@@ -120,13 +123,92 @@ function isAuthGated({
   );
 }
 
+function normalizeLabels(labels) {
+  return labels.map((label) => String(label).trim().toLowerCase());
+}
+
+function normalizeAuthor(author) {
+  return String(author || '')
+    .trim()
+    .toLowerCase();
+}
+
+function normalizeChangedFile(file) {
+  if (typeof file === 'string') {
+    return file;
+  }
+
+  if (file && typeof file === 'object' && typeof file.filename === 'string') {
+    return file.filename;
+  }
+
+  return '';
+}
+
+function isDocsMarkdownFile(file) {
+  return /^docs\/.+\.md$/i.test(file);
+}
+
+function isPackageMetadataFile(file) {
+  return PACKAGE_METADATA_FILE_PATTERN.test(file);
+}
+
+function isArtifactPackExempt({
+  author = '',
+  labels = [],
+  changedFiles = [],
+} = {}) {
+  const normalizedAuthor = normalizeAuthor(author);
+  if (
+    normalizedAuthor === 'dependabot[bot]' ||
+    normalizedAuthor === 'dependabot'
+  ) {
+    return { exempt: true, reason: 'dependabot author' };
+  }
+
+  const exemptLabel = normalizeLabels(labels).find((label) =>
+    ARTIFACT_PACK_EXEMPT_LABELS.has(label)
+  );
+  if (exemptLabel) {
+    return { exempt: true, reason: `${exemptLabel} label` };
+  }
+
+  const normalizedFiles = changedFiles
+    .map(normalizeChangedFile)
+    .filter(Boolean);
+  if (
+    normalizedFiles.length > 0 &&
+    normalizedFiles.every(
+      (file) => isDocsMarkdownFile(file) || isPackageMetadataFile(file)
+    )
+  ) {
+    return { exempt: true, reason: 'docs/package metadata only changes' };
+  }
+
+  return { exempt: false, reason: null };
+}
+
 export function validatePrArtifactPack({
   title = '',
   body = '',
   labels = [],
+  author = '',
+  changedFiles = [],
   requireAuthProof,
 } = {}) {
   const errors = [];
+  const exemption = isArtifactPackExempt({ author, labels, changedFiles });
+  if (exemption.exempt) {
+    return {
+      ok: true,
+      authGated: isAuthGated({ title, body, labels, requireAuthProof }),
+      errors,
+      sections: parseSections(String(body || '')),
+      skipped: true,
+      skipReason: exemption.reason,
+    };
+  }
+
   const normalizedBody = String(body || '')
     .replace(/\r/g, '')
     .trim();
@@ -139,6 +221,8 @@ export function validatePrArtifactPack({
         'PR body is empty. Fill out the required verification artifact pack sections.',
       ],
       sections: parseSections(''),
+      skipped: false,
+      skipReason: null,
     };
   }
 
@@ -187,15 +271,22 @@ export function validatePrArtifactPack({
         '## Auth-only Proof must include an authenticated curl/test snippet when the PR is auth-gated.'
       );
     }
-  } else if (
-    !(isExplicitNa(authProof) || AUTH_SNIPPET_SIGNAL_PATTERN.test(authProof))
-  ) {
+  } else if (!(
+    isExplicitNa(authProof) || AUTH_SNIPPET_SIGNAL_PATTERN.test(authProof)
+  )) {
     errors.push(
       '## Auth-only Proof must be explicit `N/A` for non-auth lanes or include an authenticated curl/test snippet.'
     );
   }
 
-  return { ok: errors.length === 0, authGated, errors, sections };
+  return {
+    ok: errors.length === 0,
+    authGated,
+    errors,
+    sections,
+    skipped: false,
+    skipReason: null,
+  };
 }
 
 function parseArgs(argv) {
@@ -238,6 +329,15 @@ function coerceBoolean(value) {
   return value === 'true';
 }
 
+function parseJsonArray(value) {
+  if (!value) {
+    return [];
+  }
+
+  const parsed = JSON.parse(value);
+  return Array.isArray(parsed) ? parsed : [];
+}
+
 function loadInput(argv) {
   const args = parseArgs(argv);
   const event = loadEventPayload();
@@ -246,14 +346,20 @@ function loadInput(argv) {
     ? readFileSync(resolve(args['body-file']), 'utf8')
     : undefined;
   const labelsFromJson = args['labels-json'] ?? process.env.PR_LABELS_JSON;
+  const changedFilesFromJson =
+    args['changed-files-json'] ?? process.env.PR_CHANGED_FILES_JSON;
 
   return {
     title: args.title ?? process.env.PR_TITLE ?? eventPr?.title ?? '',
     body:
       bodyFromFile ?? args.body ?? process.env.PR_BODY ?? eventPr?.body ?? '',
     labels: labelsFromJson
-      ? JSON.parse(labelsFromJson)
+      ? parseJsonArray(labelsFromJson)
       : (eventPr?.labels ?? []).map((label) => label.name),
+    author: args.author ?? process.env.PR_AUTHOR ?? eventPr?.user?.login ?? '',
+    changedFiles: changedFilesFromJson
+      ? parseJsonArray(changedFilesFromJson)
+      : [],
     requireAuthProof: coerceBoolean(
       args['auth-gated'] ?? process.env.PR_AUTH_GATED
     ),
@@ -273,7 +379,9 @@ function main() {
   }
 
   console.log(
-    `PR artifact pack validation passed (${result.authGated ? 'auth-gated' : 'non-auth'} lane).`
+    result.skipped
+      ? `PR artifact pack validation skipped (${result.skipReason}).`
+      : `PR artifact pack validation passed (${result.authGated ? 'auth-gated' : 'non-auth'} lane).`
   );
 }
 


### PR DESCRIPTION
## Summary
- Exempt Dependabot-authored PRs, `dependencies`/`documentation` labeled PRs, and docs/package-metadata-only changes from the PR artifact pack guard.
- Keep the artifact pack mandatory for normal implementation/dev-lane bot PRs.
- Pass PR author and changed-file metadata into the guard workflow so exemptions are data-driven.

## Source
Source: Hermes kanban task t_60da97c4

## Evidence
- Validation: `node --test scripts/__tests__/validate-pr-body.test.mjs` (11/11 passing)
- Validation: `PR_AUTHOR='dependabot[bot]' PR_BODY='' node scripts/validate-pr-body.mjs`
- Validation: `PR_LABELS_JSON='["documentation"]' PR_BODY='' node scripts/validate-pr-body.mjs`
- Validation: `PR_CHANGED_FILES_JSON='["docs/development/setup.md","apps/web/package.json","pnpm-lock.yaml"]' PR_BODY='' node scripts/validate-pr-body.mjs`
- Formatting: `pnpm exec prettier --check scripts/validate-pr-body.mjs scripts/__tests__/validate-pr-body.test.mjs .github/workflows/pr-artifact-pack.yml`

## Auth-only Proof
N/A
