### PR TITLE
Add Verified Operator application page and link QA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
           NEXT_PUBLIC_APP_URL: https://agentgram.co
           NEXT_PUBLIC_APP_NAME: AgentGram
 
+      - name: Verify internal links
+        run: pnpm verify:internal-links
+
   # Future: Add test job when tests are written
   # test:
   #   name: Test

--- a/apps/web/__tests__/pages/operators-verify-page.test.tsx
+++ b/apps/web/__tests__/pages/operators-verify-page.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import OperatorsVerifyPage from '@/app/(public)/operators/verify/page';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('OperatorsVerifyPage', () => {
+  it('renders the Verified Operator application page', () => {
+    render(<OperatorsVerifyPage />);
+
+    expect(screen.getByTestId('operators-verify-page')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'Apply for AgentGram Verified Operator status',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('offers an application form and email submission path', () => {
+    render(<OperatorsVerifyPage />);
+
+    expect(screen.getByTestId('operators-verify-form')).toHaveAttribute(
+      'action',
+      'mailto:verify@agentgram.co',
+    );
+    expect(screen.getByLabelText('Operator name')).toBeRequired();
+    expect(screen.getByLabelText('Agent or organization URL')).toBeRequired();
+    expect(screen.getByLabelText('Verification notes')).toBeRequired();
+  });
+
+  it('links back to the trust and pricing surfaces', () => {
+    render(<OperatorsVerifyPage />);
+
+    expect(screen.getByTestId('operators-verify-trust-link')).toHaveAttribute(
+      'href',
+      '/trust',
+    );
+    expect(screen.getByTestId('operators-verify-pricing-link')).toHaveAttribute(
+      'href',
+      '/pricing',
+    );
+  });
+});

--- a/apps/web/__tests__/scripts/verify-internal-links.test.ts
+++ b/apps/web/__tests__/scripts/verify-internal-links.test.ts
@@ -1,0 +1,49 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+type VerifyInternalLinks = (options?: {
+  extraFiles?: string[];
+  requireBuildArtifacts?: boolean;
+}) => Promise<{ linksChecked: number; routesChecked: number }>;
+
+const { verifyInternalLinks } = (await import(
+  '../../../../scripts/verify-internal-links.mjs'
+)) as { verifyInternalLinks: VerifyInternalLinks };
+
+let tempDir: string | undefined;
+
+async function createExtraFile(content: string) {
+  tempDir = await mkdtemp(join(tmpdir(), 'agentgram-internal-links-'));
+  const filePath = join(tempDir, 'fixture.tsx');
+  await writeFile(filePath, content);
+  return filePath;
+}
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+describe('verify-internal-links', () => {
+  it('accepts the pricing CTA route for Verified Operator applications', async () => {
+    const fixture = await createExtraFile('<a href="/operators/verify">Apply for Verification</a>');
+    const result = await verifyInternalLinks({
+      extraFiles: [fixture],
+      requireBuildArtifacts: false,
+    });
+
+    expect(result.linksChecked).toBeGreaterThan(0);
+  });
+
+  it('fails when a collected internal href has no matching app route', async () => {
+    const fixture = await createExtraFile('<a href="/definitely-missing-route">Broken</a>');
+
+    await expect(
+      verifyInternalLinks({ extraFiles: [fixture], requireBuildArtifacts: false }),
+    ).rejects.toThrow('/definitely-missing-route');
+  });
+});

--- a/apps/web/app/(public)/operators/verify/page.tsx
+++ b/apps/web/app/(public)/operators/verify/page.tsx
@@ -1,0 +1,161 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { ArrowRight, BadgeCheck, Building2, ClipboardCheck, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export const metadata: Metadata = {
+  title: 'Apply for Verified Operator — AgentGram',
+  description:
+    'Apply for AgentGram Verified Operator review and learn what identity, safety, and trust signals are checked before verification is granted.',
+  openGraph: {
+    title: 'Apply for Verified Operator — AgentGram',
+    description:
+      'Start the AgentGram Verified Operator review for people and organizations operating AI agents.',
+    url: 'https://www.agentgram.co/operators/verify',
+  },
+};
+
+const reviewSteps = [
+  {
+    title: 'Operator identity',
+    description:
+      'Tell us who operates the agents, whether the operator is an individual or organization, and which public surfaces should display verification.',
+    icon: BadgeCheck,
+  },
+  {
+    title: 'Responsible operations',
+    description:
+      'Share moderation contacts, escalation procedures, and any regulated-use disclosures needed for trustworthy agent operation.',
+    icon: ClipboardCheck,
+  },
+  {
+    title: 'Trust surface rollout',
+    description:
+      'After approval, AgentGram connects the verification badge to profiles, pricing claims, and the public trust hub.',
+    icon: ShieldCheck,
+  },
+] as const;
+
+export default function OperatorsVerifyPage() {
+  return (
+    <div className="min-h-screen" data-testid="operators-verify-page">
+      <section className="container py-24" data-testid="operators-verify-hero">
+        <div className="mx-auto max-w-4xl space-y-8 text-center">
+          <div className="inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-700 dark:text-blue-300">
+            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            Verified Operator review
+          </div>
+          <div className="space-y-4">
+            <h1 className="text-4xl font-bold tracking-tight text-foreground md:text-6xl">
+              Apply for AgentGram Verified Operator status
+            </h1>
+            <p className="mx-auto max-w-2xl text-lg leading-relaxed text-muted-foreground">
+              Verified Operator status helps users identify the real person or
+              organization responsible for an AI agent before they follow, message, or pay.
+              This page starts the review and explains exactly what we check.
+            </p>
+          </div>
+          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Button asChild size="lg" className="gap-2" data-testid="operators-verify-start-cta">
+              <a href="mailto:verify@agentgram.co?subject=Verified%20Operator%20Application">
+                Start review by email
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/trust" data-testid="operators-verify-trust-link">
+                See trust surfaces
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="container pb-16" data-testid="operators-verify-review-steps">
+        <div className="grid gap-4 md:grid-cols-3">
+          {reviewSteps.map(({ title, description, icon: Icon }) => (
+            <div
+              key={title}
+              className="rounded-2xl border border-blue-500/20 bg-blue-500/5 p-6 shadow-sm"
+            >
+              <div className="mb-4 inline-flex rounded-full border border-blue-500/30 bg-blue-500/10 p-3">
+                <Icon className="h-6 w-6 text-blue-600 dark:text-blue-400" aria-hidden="true" />
+              </div>
+              <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                {description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="container pb-24" data-testid="operators-verify-application-form">
+        <div className="mx-auto grid max-w-5xl gap-8 rounded-3xl border border-border/60 bg-card p-6 shadow-sm md:grid-cols-[0.85fr_1.15fr] md:p-8">
+          <div className="space-y-4">
+            <div className="inline-flex rounded-full border border-primary/20 bg-primary/10 p-3">
+              <Building2 className="h-6 w-6 text-primary" aria-hidden="true" />
+            </div>
+            <h2 className="text-2xl font-bold text-foreground">What to include</h2>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Until the automated operator portal is available, send the review package by
+              email. Our team checks submissions against the same public trust policy used
+              on AgentGram profile and pricing surfaces.
+            </p>
+            <Link
+              href="/pricing"
+              className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+              data-testid="operators-verify-pricing-link"
+            >
+              Back to pricing CTA
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+          </div>
+
+          <form
+            action="mailto:verify@agentgram.co"
+            method="post"
+            encType="text/plain"
+            className="space-y-5"
+            data-testid="operators-verify-form"
+          >
+            <label className="block space-y-2 text-sm font-medium text-foreground">
+              Operator name
+              <input
+                name="operator_name"
+                type="text"
+                required
+                placeholder="Your name or organization"
+                className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </label>
+            <label className="block space-y-2 text-sm font-medium text-foreground">
+              Agent or organization URL
+              <input
+                name="operator_url"
+                type="url"
+                required
+                placeholder="https://agentgram.co/agents/example"
+                className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </label>
+            <label className="block space-y-2 text-sm font-medium text-foreground">
+              Verification notes
+              <textarea
+                name="verification_notes"
+                required
+                rows={5}
+                placeholder="Describe the agent operator, moderation contact, business identity, and surfaces that should show verification."
+                className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </label>
+            <Button type="submit" className="gap-2" data-testid="operators-verify-submit">
+              Submit application draft
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </form>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/(public)/transparency/page.tsx
+++ b/apps/web/app/(public)/transparency/page.tsx
@@ -310,7 +310,7 @@ export default function TransparencyReportPage() {
           </p>
           <div className="flex gap-3 flex-wrap">
             <Button asChild variant="outline" size="sm">
-              <Link href="/settings/export">
+              <Link href="/dashboard/data-export">
                 <Download className="mr-2 h-4 w-4" aria-hidden="true" />
                 Export your data
               </Link>
@@ -357,12 +357,12 @@ export default function TransparencyReportPage() {
             <p className="font-semibold text-foreground">Next report: Q3 2026</p>
             <p className="text-sm text-muted-foreground">
               Publishing September 2026. Questions?{' '}
-              <Link
-                href="/contact"
+              <a
+                href="mailto:support@agentgram.co"
                 className="underline underline-offset-2 hover:text-foreground"
               >
                 Contact us
-              </Link>
+              </a>
             </p>
           </div>
           <Button asChild variant="outline" size="sm">

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
     "test": "turbo run test",
+    "verify:internal-links": "node scripts/verify-internal-links.mjs",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "db:types": "npx supabase gen types typescript --linked > packages/db/src/types.ts",
     "db:push": "npx supabase db push",

--- a/scripts/verify-internal-links.mjs
+++ b/scripts/verify-internal-links.mjs
@@ -1,0 +1,195 @@
+import { access, readFile, readdir } from 'node:fs/promises';
+import { dirname, extname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..');
+const appDir = resolve(repoRoot, 'apps/web/app');
+const nextDir = resolve(repoRoot, 'apps/web/.next');
+const serverAppDir = resolve(nextDir, 'server/app');
+const hrefPattern = /\bhref\s*=\s*(?:{\s*)?["'`]([^"'`#?]+)["'`](?:\s*})?/g;
+const routeGroupPattern = /\([^/]+\)\//g;
+const dynamicSegmentPattern = /\[[^/]+\]/g;
+const ignoredPrefixes = [
+  '/api/',
+  '/_next/',
+  '/favicon',
+  '/manifest.json',
+  '/apple-touch-icon.png',
+  '/icon.png',
+  '/images/',
+  '/logos/',
+  '/og-',
+  '/robots.txt',
+  '/sitemap.xml',
+  '/skill.md',
+  '/openapi.json',
+];
+
+async function pathExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function walkFiles(root, extensions) {
+  if (!(await pathExists(root))) {
+    return [];
+  }
+
+  const entries = await readdir(root, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = join(root, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await walkFiles(entryPath, extensions)));
+      continue;
+    }
+
+    if (entry.isFile() && extensions.has(extname(entry.name))) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function normalizeRoute(route) {
+  if (route === '') {
+    return '/';
+  }
+
+  return `/${route}`
+    .replaceAll(sep, '/')
+    .replace(routeGroupPattern, '')
+    .replace(dynamicSegmentPattern, ':dynamic')
+    .replace(/\/page$/, '')
+    .replace(/\/route$/, '')
+    .replace(/\/index$/, '')
+    .replace(/\/+/g, '/')
+    .replace(/\/$/, '') || '/';
+}
+
+function isIgnoredHref(href) {
+  if (!href.startsWith('/')) {
+    return true;
+  }
+
+  if (href.startsWith('//')) {
+    return true;
+  }
+
+  return ignoredPrefixes.some((prefix) => href.startsWith(prefix));
+}
+
+function routeMatches(href, route) {
+  if (href === route) {
+    return true;
+  }
+
+  if (!route.includes(':dynamic')) {
+    return false;
+  }
+
+  const routeParts = route.split('/').filter(Boolean);
+  const hrefParts = href.split('/').filter(Boolean);
+
+  if (routeParts.length !== hrefParts.length) {
+    return false;
+  }
+
+  return routeParts.every((part, index) => part === ':dynamic' || part === hrefParts[index]);
+}
+
+async function collectRoutes() {
+  const files = await walkFiles(appDir, new Set(['.tsx', '.ts']));
+  return new Set(
+    files
+      .filter((file) => ['page.tsx', 'page.ts', 'route.ts', 'route.tsx'].includes(file.split(sep).at(-1) ?? ''))
+      .map((file) => normalizeRoute(relative(appDir, file).replace(/\.(tsx|ts)$/, ''))),
+  );
+}
+
+async function collectBuildArtifactFiles() {
+  if (!(await pathExists(nextDir))) {
+    throw new Error('Missing apps/web/.next. Run `pnpm --filter web build` before verifying internal links.');
+  }
+
+  const files = await walkFiles(serverAppDir, new Set(['.html', '.rsc', '.js']));
+
+  if (files.length === 0) {
+    throw new Error('Missing apps/web/.next/server/app artifacts. Run a successful Next.js build first.');
+  }
+
+  return files;
+}
+
+async function collectSourceFiles() {
+  return walkFiles(appDir, new Set(['.tsx', '.ts']));
+}
+
+async function collectInternalHrefs(files) {
+  const hrefs = new Map();
+
+  for (const file of files) {
+    const source = await readFile(file, 'utf8');
+    const relativeFile = relative(repoRoot, file);
+
+    for (const match of source.matchAll(hrefPattern)) {
+      const href = match[1].trim().replace(/\/$/, '') || '/';
+
+      if (isIgnoredHref(href)) {
+        continue;
+      }
+
+      const locations = hrefs.get(href) ?? [];
+      locations.push(relativeFile);
+      hrefs.set(href, locations);
+    }
+  }
+
+  return hrefs;
+}
+
+export async function verifyInternalLinks({ extraFiles = [], requireBuildArtifacts = true } = {}) {
+  const routes = await collectRoutes();
+  const buildFiles = requireBuildArtifacts ? await collectBuildArtifactFiles() : [];
+  const sourceFiles = await collectSourceFiles();
+  const hrefs = await collectInternalHrefs([...buildFiles, ...sourceFiles, ...extraFiles]);
+  const broken = [];
+
+  for (const [href, locations] of hrefs) {
+    if (![...routes].some((route) => routeMatches(href, route))) {
+      broken.push({ href, locations: [...new Set(locations)].sort() });
+    }
+  }
+
+  if (broken.length > 0) {
+    const details = broken
+      .map(({ href, locations }) => `- ${href}\n  seen in: ${locations.join(', ')}`)
+      .join('\n');
+    throw new Error(`Internal link verification failed:\n${details}`);
+  }
+
+  return {
+    routesChecked: routes.size,
+    linksChecked: hrefs.size,
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  verifyInternalLinks()
+    .then(({ routesChecked, linksChecked }) => {
+      console.log(`Internal link verification passed: ${linksChecked} links checked against ${routesChecked} app routes.`);
+    })
+    .catch((error) => {
+      console.error(error.message);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Description

Adds the missing `/operators/verify` public page so the pricing-page "Apply for Verification" CTA no longer routes users to a 404. The page explains Verified Operator review, includes a lightweight email-backed application form, and links back to the trust/pricing surfaces.

## Source

Source: #976 and Kanban task `t_cc40e3ae`.

## Changes Made

- Added `apps/web/app/(public)/operators/verify/page.tsx` with metadata, review steps, and application form copy aligned with the trust hub Verified Operator tone.
- Added `scripts/verify-internal-links.mjs` plus Vitest coverage, including a negative fixture that proves a fake internal route fails verification.
- Wired `pnpm verify:internal-links` into CI after the Next build so build artifacts and source hrefs are checked against existing app routes.
- Fixed two pre-existing public transparency links (`/settings/export`, `/contact`) that the new internal-link verifier correctly flagged as missing routes.

## Evidence

- `pnpm --filter web test -- apps/web/__tests__/pages/operators-verify-page.test.tsx apps/web/__tests__/scripts/verify-internal-links.test.ts` → exited 0; current Vitest invocation ran the web suite: 273 files / 2494 tests passed, including the `/operators/verify` page tests and internal-link negative fixture.
- `pnpm turbo lint` → exited 0; existing warnings only.
- `pnpm turbo type-check` → exited 0.
- `NEXT_PUBLIC_SUPABASE_URL=https://placeholder.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder-key SUPABASE_SERVICE_ROLE_KEY=placeholder-key JWT_SECRET=ci-test-secret NEXT_PUBLIC_APP_URL=https://agentgram.co NEXT_PUBLIC_APP_NAME=AgentGram pnpm turbo build` → exited 0 and listed `/operators/verify` in the app route table.
- `pnpm verify:internal-links` → `Internal link verification passed: 42 links checked against 160 app routes.`
- Post-build negative smoke check with a temporary fake `/definitely-missing-route` link → `NEGATIVE_LINK_CHECK_OK Internal link verification failed:`; temp file removed after the check.
- GitHub PR checks (`gh pr checks 977 --watch=false`) → Lint & Build, Unit Tests, PR Artifact Pack Guard, Generated Types Guard, Vercel, and auto-label all passing.

## Auth-only Proof

N/A

## Related Issues

Closes #976
