### PR TITLE
strategic(auth): verify post mutation signatures

### DIFF
--- a/apps/web/__tests__/api/post-comments.test.ts
+++ b/apps/web/__tests__/api/post-comments.test.ts
@@ -41,6 +41,8 @@ vi.mock('@agentgram/db', () => ({
 vi.mock('@agentgram/auth', () => ({
   withAuth: <T extends (...args: never[]) => unknown>(handler: T) => handler,
   withRateLimit: (_key: string, handler: unknown) => handler,
+  withAgentSignature: <T extends (...args: never[]) => unknown>(handler: T) =>
+    handler,
 }));
 
 function makeReq(body: unknown) {

--- a/apps/web/__tests__/api/post-mutation-signatures.test.ts
+++ b/apps/web/__tests__/api/post-mutation-signatures.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { TIMESTAMP_HEADER } from '@agentgram/auth/src/request-signature';
+
+const mockHandlePostLike = vi.fn();
+const mockHandleRepost = vi.fn();
+const mockGetSupabaseServiceClient = vi.fn();
+
+vi.mock('@agentgram/db', () => ({
+  createNotification: vi.fn(),
+  getSupabaseServiceClient: mockGetSupabaseServiceClient,
+  handlePostLike: mockHandlePostLike,
+  handleRepost: mockHandleRepost,
+}));
+
+vi.mock('@agentgram/auth', async () => {
+  const requestSignature = await vi.importActual<
+    typeof import('@agentgram/auth/src/request-signature')
+  >('@agentgram/auth/src/request-signature');
+
+  return {
+    withAuth: <T extends (...args: never[]) => unknown>(handler: T) => handler,
+    withRateLimit: (_key: string, handler: unknown) => handler,
+    withAgentSignature: requestSignature.withAgentSignature,
+  };
+});
+
+function makeSignedHeaderOnlyRequest(url: string, body?: unknown) {
+  const init: RequestInit = {
+    method: 'POST',
+    headers: {
+      'x-agent-id': 'agent-1',
+      [TIMESTAMP_HEADER]: String(Date.now()),
+    },
+  };
+
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  return new NextRequest(url, init);
+}
+
+describe('post mutation request-signature middleware', () => {
+  it('rejects like mutations with incomplete signature headers before route work', async () => {
+    const { POST } = await import(
+      '../../app/api/v1/posts/[id]/like/route'
+    );
+
+    const response = await POST(
+      makeSignedHeaderOnlyRequest('http://localhost/api/v1/posts/post-1/like'),
+      { params: Promise.resolve({ id: 'post-1' }) }
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.error.code).toBe('SIGNATURE_INVALID');
+    expect(mockHandlePostLike).not.toHaveBeenCalled();
+    expect(mockGetSupabaseServiceClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects repost mutations with incomplete signature headers before route work', async () => {
+    const { POST } = await import(
+      '../../app/api/v1/posts/[id]/repost/route'
+    );
+
+    const response = await POST(
+      makeSignedHeaderOnlyRequest('http://localhost/api/v1/posts/post-1/repost', {
+        content: 'Signal boost',
+      }),
+      { params: Promise.resolve({ id: 'post-1' }) }
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.error.code).toBe('SIGNATURE_INVALID');
+    expect(mockHandleRepost).not.toHaveBeenCalled();
+  });
+
+  it('rejects comment creation with incomplete signature headers before route work', async () => {
+    const { POST } = await import(
+      '../../app/api/v1/posts/[id]/comments/route'
+    );
+
+    const response = await POST(
+      makeSignedHeaderOnlyRequest('http://localhost/api/v1/posts/post-1/comments', {
+        content: 'Verified reply',
+      }),
+      { params: Promise.resolve({ id: 'post-1' }) }
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.error.code).toBe('SIGNATURE_INVALID');
+    expect(mockGetSupabaseServiceClient).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/v1/posts/[id]/comments/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/comments/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseServiceClient } from '@agentgram/db';
-import { withAuth, withRateLimit } from '@agentgram/auth';
+import { withAgentSignature, withAuth, withRateLimit } from '@agentgram/auth';
 import type { CreateComment } from '@agentgram/shared';
 import {
   CONTENT_LIMITS,
@@ -269,4 +269,7 @@ async function createCommentHandler(
 }
 
 // Export with rate limiting (50 comments per hour)
-export const POST = withRateLimit('comment', withAuth(createCommentHandler));
+export const POST = withRateLimit(
+  'comment',
+  withAuth(withAgentSignature(createCommentHandler))
+);

--- a/apps/web/app/api/v1/posts/[id]/like/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/like/route.ts
@@ -4,7 +4,7 @@ import {
   getSupabaseServiceClient,
   handlePostLike,
 } from '@agentgram/db';
-import { withAuth, withRateLimit } from '@agentgram/auth';
+import { withAgentSignature, withAuth, withRateLimit } from '@agentgram/auth';
 import {
   ErrorResponses,
   jsonResponse,
@@ -96,4 +96,4 @@ async function handler(
   }
 }
 
-export const POST = withRateLimit('vote', withAuth(handler));
+export const POST = withRateLimit('vote', withAuth(withAgentSignature(handler)));

--- a/apps/web/app/api/v1/posts/[id]/repost/route.ts
+++ b/apps/web/app/api/v1/posts/[id]/repost/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { handleRepost } from '@agentgram/db';
-import { withAuth, withRateLimit } from '@agentgram/auth';
+import { withAgentSignature, withAuth, withRateLimit } from '@agentgram/auth';
 import {
   ErrorResponses,
   jsonResponse,
@@ -36,4 +36,4 @@ async function handler(
   }
 }
 
-export const POST = withRateLimit('post', withAuth(handler));
+export const POST = withRateLimit('post', withAuth(withAgentSignature(handler)));


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item 95db5d30cd.
Ref: https://github.com/agentgram/agentgram

## Change
Applied Ed25519 request-signature middleware to post like, repost, and comment-create mutation routes while preserving existing auth and rate-limit wrappers.
Added route-level rejection tests proving incomplete signed-request headers are rejected before mutation route work runs.

## Evidence
test: `pnpm --filter web exec vitest run __tests__/api/post-mutation-signatures.test.ts __tests__/api/post-comments.test.ts` → 2 files passed, 5 tests passed.
type-check: `pnpm --filter web type-check` → exit 0.
lint: `pnpm --filter web lint` → exit 0 (35 pre-existing warnings, 0 errors).
build: `pnpm --filter web build` → exit 0.
diff: 5 files changed, 108 insertions, 6 deletions.

## Auth-only Proof
N/A
