### PR TITLE
strategic(proof-gate): restore publish receipt guard

### DIFF
--- a/docs/pr-evidence/row-97-verification-artifact-pack.md
+++ b/docs/pr-evidence/row-97-verification-artifact-pack.md
@@ -5,6 +5,7 @@ Source: backlog.md:97
 ## What this refactor enforces
 
 - Every PR must declare a concrete source: backlog row or issue.
+- Every PR must summarize the concrete operator-facing change being shipped.
 - Every PR must attach reviewer-facing evidence: screenshot/live-proof or docs/example diff.
 - Every PR must fill `## Auth-only Proof` with either:
   - an authenticated curl/test snippet for auth-gated lanes, or
@@ -25,6 +26,12 @@ Auth-gated PRs cannot leave `## Auth-only Proof` as `N/A`.
 - Docs/example diff: `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/pr-artifact-pack.yml`, `scripts/validate-pr-body.mjs`
 - Screenshot/live-proof: `docs/pr-evidence/pr-446-live-explore.png`
 - Validation command: `node --test scripts/__tests__/validate-pr-body.test.mjs`
+
+## Required change summary
+
+`## Change` is mandatory and must contain non-placeholder text. It gives reviewers
+the short human handoff that PR #901 lacked: what changed, not just where the
+proof came from.
 
 ## Auth-only Proof examples
 

--- a/docs/pr-evidence/strategic-publish-proof-gate-recovery.md
+++ b/docs/pr-evidence/strategic-publish-proof-gate-recovery.md
@@ -1,0 +1,50 @@
+# Strategic publish proof gate recovery
+
+Source: Hermes kanban-dispatch dev lane — agdev:788ff8b9c1 item t_d23e7f2a.
+
+## Change restored
+
+This slice closes the proof-pack gap exposed by PR #901 and makes the publish recovery path reviewable again:
+
+- The PR artifact-pack guard now requires all four sections used by the dev-lane handoff contract: `## Source`, `## Change`, `## Evidence`, and `## Auth-only Proof`.
+- `## Change` cannot be omitted or filled with placeholder-only text, so reviewers can distinguish a real publish/verification recovery from an evidence-only note.
+- The recovery runbook now has an operator receipt path for live AgentGram publish attempts, including separate receipt fields for `approval_missing`, post ID discovery, and YouTube OAuth status.
+
+## PR #901 failure mode
+
+PR #901 (`docs: publish gate recovery runbook`) was merged with a narrative body but without the artifact-pack sections that are now mandatory for review automation. The recovered gate must reject equivalent PR bodies until they include the four-section proof pack.
+
+Expected validator behavior after this change:
+
+```text
+PR artifact pack validation failed:
+- ## Source must cite a backlog row or issue (for example `Source: backlog.md:97` or `Source: #123`).
+- ## Change must summarize the concrete user/operator-facing change being shipped.
+- ## Evidence must be filled with screenshot/live-proof or docs/example diff details.
+- ## Auth-only Proof is required. Use an authenticated curl/test snippet for auth-gated lanes, otherwise write explicit `N/A`.
+```
+
+## Publish receipt path
+
+For an external distribution recovery, attach a receipt in `## Evidence` or in the runbook incident log with these fields:
+
+```yaml
+publish_receipt:
+  source: agentgram-live-publish
+  approved_issue: "<issue-or-pr-url>"
+  plan_file: "<plan-json-path>"
+  approval_gate: cleared | blocked:approval_missing
+  agentgram_post_id: "<post-id-or-n/a>"
+  youtube_oauth: ok | blocked:invalid_grant | n/a
+  external_channel: agentgram | youtube | x
+  external_receipt_url: "<agentgram-post-or-video-or-x-url>"
+  checked_at: "<iso-8601>"
+```
+
+`approval_missing` is no longer considered a mystery blocker when the receipt records either `cleared` or `blocked:approval_missing` with the missing approval field. YouTube OAuth is no longer considered a publish blocker for AgentGram-only receipts when the receipt explicitly marks it `n/a`; for YouTube receipts it must be `ok` before external reach is claimed.
+
+## Verification commands
+
+- `node --test scripts/__tests__/validate-pr-body.test.mjs`
+- `node scripts/validate-pr-body.mjs --title "strategic: publish proof gate recovery" --body-file /tmp/agentgram-pr-body.md`
+- `pnpm type-check`

--- a/docs/runbooks/publish-gate-recovery.md
+++ b/docs/runbooks/publish-gate-recovery.md
@@ -192,3 +192,38 @@ YouTube 스튜디오에서 `output/<name>.mp4`를 수동 업로드한 뒤
 | `~/.openclaw/agents/kkami/agent/skills/video-pipeline/SKILL.md` | YouTube 업로드 파이프라인 |
 | `~/.openclaw/credentials/youtube-token.json` | YouTube OAuth 토큰 |
 | `~/.openclaw/agents/cheese/agent/docs/agentgram-live-approval-flow.md` | 승인 플로우 SoT |
+
+---
+
+## 4. Artifact-pack recovery and live receipt proof
+
+PR #901 originally documented this recovery path, but its PR body did not carry
+the four-section verification artifact pack that the repository now requires.
+Future publish-gate recovery PRs must include all of these sections:
+
+- `## Source` with a backlog row, issue, PR, or kanban task reference.
+- `## Change` with the concrete operator-facing change.
+- `## Evidence` with the runbook diff, test command, screenshot, or live-proof URL.
+- `## Auth-only Proof` with `N/A` for non-auth work or an authenticated curl/test
+  snippet for auth-gated work.
+
+When a live AgentGram publish attempt is repaired, attach a receipt with this
+shape in the PR evidence or incident log:
+
+```yaml
+publish_receipt:
+  source: agentgram-live-publish
+  approved_issue: "<issue-or-pr-url>"
+  plan_file: "<plan-json-path>"
+  approval_gate: cleared | blocked:approval_missing
+  agentgram_post_id: "<post-id-or-n/a>"
+  youtube_oauth: ok | blocked:invalid_grant | n/a
+  external_channel: agentgram | youtube | x
+  external_receipt_url: "<agentgram-post-or-video-or-x-url>"
+  checked_at: "<iso-8601>"
+```
+
+Use `youtube_oauth: n/a` for AgentGram-only publishes so an unrelated YouTube
+token refresh cannot block AgentGram external reach. Use `approval_gate: cleared`
+only after the live run includes both approval proof and an approved plan file;
+otherwise keep the receipt explicit as `blocked:approval_missing`.

--- a/scripts/__tests__/validate-pr-body.test.mjs
+++ b/scripts/__tests__/validate-pr-body.test.mjs
@@ -6,6 +6,9 @@ import { validatePrArtifactPack } from '../validate-pr-body.mjs';
 const nonAuthBody = `## Source
 Source: backlog.md:97
 
+## Change
+Require every PR to describe the operator-facing change being shipped.
+
 ## Evidence
 - Docs/example diff: docs/pr-evidence/row-97-verification-artifact-pack.md
 - Validation: \`node --test scripts/__tests__/validate-pr-body.test.mjs\`
@@ -41,6 +44,32 @@ test('fails when source does not cite a backlog row or issue', () => {
   );
 });
 
+test('fails when the required change summary is missing', () => {
+  const result = validatePrArtifactPack({
+    title: 'refactor: require verification artifact pack in PRs',
+    body: nonAuthBody.replace(
+      '\n## Change\nRequire every PR to describe the operator-facing change being shipped.\n',
+      '\n'
+    ),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /## Change must summarize/);
+});
+
+test('fails when the change summary is placeholder-only', () => {
+  const result = validatePrArtifactPack({
+    title: 'refactor: require verification artifact pack in PRs',
+    body: nonAuthBody.replace(
+      'Require every PR to describe the operator-facing change being shipped.',
+      'TBD'
+    ),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /## Change must summarize/);
+});
+
 test('fails when evidence is placeholder-only', () => {
   const result = validatePrArtifactPack({
     title: 'refactor: require verification artifact pack in PRs',
@@ -72,6 +101,9 @@ test('passes auth-gated PRs with an authenticated curl snippet', () => {
     labels: ['area: auth'],
     body: `## Source
 Source: #97
+
+## Change
+Require auth-gated PRs to include authenticated proof snippets.
 
 ## Evidence
 - Screenshot/live-proof: docs/pr-evidence/pr-446-live-explore.png

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -4,7 +4,12 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const REQUIRED_SECTION_TITLES = ['Source', 'Evidence', 'Auth-only Proof'];
+const REQUIRED_SECTION_TITLES = [
+  'Source',
+  'Change',
+  'Evidence',
+  'Auth-only Proof',
+];
 const PLACEHOLDER_LINE_PATTERNS = [
   /^[-*]\s*$/,
   /^tbd$/i,
@@ -158,6 +163,13 @@ export function validatePrArtifactPack({
   ) {
     errors.push(
       '## Source must cite a backlog row or issue (for example `Source: backlog.md:97` or `Source: #123`).'
+    );
+  }
+
+  const change = sections.Change;
+  if (!change || isPlaceholderOnly(change)) {
+    errors.push(
+      '## Change must summarize the concrete user/operator-facing change being shipped.'
     );
   }
 


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item 788ff8b9c1; task t_d23e7f2a.
Ref: https://github.com/agentgram/agentgram/pull/901

## Change
Restores the PR artifact-pack proof gate so all PRs must include Source, Change, Evidence, and Auth-only Proof sections, with non-placeholder Change summaries.
Documents a live publish receipt path that separates AgentGram approval_missing state from YouTube OAuth state so AgentGram-only external reach is not blocked by unrelated YouTube reauth.

## Evidence
- Test: `node --test scripts/__tests__/validate-pr-body.test.mjs` → 8 pass / 0 fail.
- Type-check: `pnpm type-check` → 4 turbo type-check tasks successful.
- Diff/docs evidence: `docs/pr-evidence/strategic-publish-proof-gate-recovery.md`, `docs/runbooks/publish-gate-recovery.md`, `scripts/validate-pr-body.mjs`.
- Historical proof: `gh pr view 901 --json body -q .body | node scripts/validate-pr-body.mjs --body-file <file>` now fails with missing Source/Change/Evidence/Auth-only Proof errors.

## Auth-only Proof
N/A
