### PR TITLE
strategic(api): apply signatures to community writes

### DIFF
--- a/apps/web/__tests__/api/post-mutation-signatures.test.ts
+++ b/apps/web/__tests__/api/post-mutation-signatures.test.ts
@@ -25,9 +25,13 @@ vi.mock('@agentgram/auth', async () => {
   };
 });
 
-function makeSignedHeaderOnlyRequest(url: string, body?: unknown) {
+function makeSignedHeaderOnlyRequest(
+  url: string,
+  body?: unknown,
+  method = 'POST'
+) {
   const init: RequestInit = {
-    method: 'POST',
+    method,
     headers: {
       'x-agent-id': 'agent-1',
       [TIMESTAMP_HEADER]: String(Date.now()),
@@ -87,6 +91,60 @@ describe('post mutation request-signature middleware', () => {
         content: 'Verified reply',
       }),
       { params: Promise.resolve({ id: 'post-1' }) }
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.error.code).toBe('SIGNATURE_INVALID');
+    expect(mockGetSupabaseServiceClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('community write request-signature middleware', () => {
+  it('rejects community creation with incomplete signed-body headers before route work', async () => {
+    const { POST } = await import('../../app/api/v1/communities/route');
+
+    const response = await POST(
+      makeSignedHeaderOnlyRequest('http://localhost/api/v1/communities', {
+        name: 'trust-layer',
+        displayName: 'Trust Layer',
+      })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.error.code).toBe('SIGNATURE_INVALID');
+    expect(mockGetSupabaseServiceClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects community join toggles with incomplete signature headers before route work', async () => {
+    const { POST } = await import(
+      '../../app/api/v1/communities/[id]/join/route'
+    );
+
+    const response = await POST(
+      makeSignedHeaderOnlyRequest(
+        'http://localhost/api/v1/communities/community-1/join'
+      ),
+      { params: Promise.resolve({ id: 'community-1' }) }
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.error.code).toBe('SIGNATURE_INVALID');
+    expect(mockGetSupabaseServiceClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects community updates with incomplete signed-body headers before route work', async () => {
+    const { PATCH } = await import('../../app/api/v1/communities/[id]/route');
+
+    const response = await PATCH(
+      makeSignedHeaderOnlyRequest(
+        'http://localhost/api/v1/communities/community-1',
+        { displayName: 'Verified Trust Layer' },
+        'PATCH'
+      ),
+      { params: Promise.resolve({ id: 'community-1' }) }
     );
     const json = await response.json();
 

--- a/apps/web/app/api/v1/communities/[id]/join/route.ts
+++ b/apps/web/app/api/v1/communities/[id]/join/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseServiceClient } from '@agentgram/db';
-import { withAuth, withRateLimit } from '@agentgram/auth';
+import { withAgentSignature, withAuth, withRateLimit } from '@agentgram/auth';
 import {
   ErrorResponses,
   jsonResponse,
@@ -119,4 +119,7 @@ async function joinHandler(
   }
 }
 
-export const POST = withRateLimit('post', withAuth(joinHandler));
+export const POST = withRateLimit(
+  'post',
+  withAuth(withAgentSignature(joinHandler))
+);

--- a/apps/web/app/api/v1/communities/[id]/route.ts
+++ b/apps/web/app/api/v1/communities/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseServiceClient } from '@agentgram/db';
-import { withAuth, withRateLimit } from '@agentgram/auth';
+import { withAgentSignature, withAuth, withRateLimit } from '@agentgram/auth';
 import {
   ErrorResponses,
   jsonResponse,
@@ -130,4 +130,7 @@ async function updateCommunityHandler(
   }
 }
 
-export const PATCH = withRateLimit('post', withAuth(updateCommunityHandler));
+export const PATCH = withRateLimit(
+  'post',
+  withAuth(withAgentSignature(updateCommunityHandler))
+);

--- a/apps/web/app/api/v1/communities/route.ts
+++ b/apps/web/app/api/v1/communities/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { getSupabaseServiceClient } from '@agentgram/db';
-import { withAuth, withRateLimit } from '@agentgram/auth';
+import { withAgentSignature, withAuth, withRateLimit } from '@agentgram/auth';
 import {
   ErrorResponses,
   jsonResponse,
@@ -175,4 +175,7 @@ async function createCommunityHandler(req: NextRequest) {
   }
 }
 
-export const POST = withRateLimit('post', withAuth(createCommunityHandler));
+export const POST = withRateLimit(
+  'post',
+  withAuth(withAgentSignature(createCommunityHandler))
+);


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item c528b60337.
Ref: https://github.com/agentgram/agentgram

## Change
Applied Ed25519 request-signature middleware to community write routes for create, join/leave, and update. Added regression coverage that signed-body/incomplete signature headers are rejected before community route work runs.

## Evidence
Tests/type-check/lint/diff: `pnpm --filter web test __tests__/api/post-mutation-signatures.test.ts` passed (6 tests); `pnpm --filter web type-check` passed; `pnpm --filter web lint` passed with 0 errors and 35 pre-existing warnings; `git diff --check` passed.

## Auth-only Proof
N/A
