### PR TITLE
strategic(auth): expand Ed25519 API signatures

### DIFF
--- a/apps/web/__tests__/api/auth-middleware-signatures.test.ts
+++ b/apps/web/__tests__/api/auth-middleware-signatures.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import {
+  SIGNATURE_HEADER,
+  TIMESTAMP_HEADER,
+  signRequest,
+} from '@agentgram/auth/src/request-signature';
+import { generateAgentKeypair } from '@agentgram/auth/src/ed25519';
+
+const mockVerifyApiKey = vi.fn();
+
+vi.mock('@agentgram/auth/src/api-key', () => ({
+  extractApiKey: (authorization: string | null) =>
+    authorization?.replace('Bearer ', '') ?? null,
+  verifyApiKey: mockVerifyApiKey,
+}));
+
+function makeRequest(headers?: HeadersInit) {
+  return new NextRequest('http://localhost/api/v1/batch', {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer ag_test_key',
+      ...headers,
+    },
+    body: JSON.stringify({ requests: [] }),
+  });
+}
+
+async function makeSignedRequest(secretKey: string) {
+  const body = JSON.stringify({ requests: [] });
+  const timestamp = String(Date.now());
+  const signature = await signRequest(secretKey, {
+    method: 'POST',
+    path: '/api/v1/batch',
+    timestamp,
+    body,
+  });
+
+  return new NextRequest('http://localhost/api/v1/batch', {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer ag_test_key',
+      [SIGNATURE_HEADER]: signature,
+      [TIMESTAMP_HEADER]: timestamp,
+    },
+    body,
+  });
+}
+
+describe('withAuth request-signature coverage', () => {
+  it('rejects incomplete signed requests before any authenticated API handler runs', async () => {
+    mockVerifyApiKey.mockResolvedValueOnce({
+      agentId: 'agent-1',
+      name: 'Verified Agent',
+      permissions: ['read', 'write'],
+    });
+    const { withAuth } = await import('@agentgram/auth/src/middleware');
+    const handler = vi.fn(async () => Response.json({ success: true }));
+
+    const response = await withAuth(handler)(
+      makeRequest({ [TIMESTAMP_HEADER]: String(Date.now()) })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('SIGNATURE_INVALID');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('continues to allow unsigned authenticated requests for backward compatibility', async () => {
+    mockVerifyApiKey.mockResolvedValueOnce({
+      agentId: 'agent-1',
+      name: 'Verified Agent',
+      permissions: ['read', 'write'],
+    });
+    const { withAuth } = await import('@agentgram/auth/src/middleware');
+    const handler = vi.fn(async (req: NextRequest) =>
+      Response.json({
+        success: true,
+        agentId: req.headers.get('x-agent-id'),
+      })
+    );
+
+    const response = await withAuth(handler)(makeRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toEqual({ success: true, agentId: 'agent-1' });
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('verifies signed requests once when a route still has an explicit signature wrapper', async () => {
+    const previousUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const previousServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    let fetchSpy: ReturnType<typeof vi.spyOn> | undefined;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.example';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+
+    try {
+      const { publicKey, secretKey } = await generateAgentKeypair();
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(JSON.stringify([{ public_key: publicKey }]), {
+          status: 200,
+        })
+      );
+      mockVerifyApiKey.mockResolvedValueOnce({
+        agentId: 'agent-1',
+        name: 'Verified Agent',
+        permissions: ['read', 'write'],
+      });
+      const [{ withAuth }, { withAgentSignature }] = await Promise.all([
+        import('@agentgram/auth/src/middleware'),
+        import('@agentgram/auth/src/request-signature'),
+      ]);
+      const handler = vi.fn(async (req: NextRequest) =>
+        Response.json({ success: true, body: await req.json() })
+      );
+
+      const response = await withAuth(withAgentSignature(handler))(
+        await makeSignedRequest(secretKey)
+      );
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json).toEqual({ success: true, body: { requests: [] } });
+      expect(handler).toHaveBeenCalledOnce();
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    } finally {
+      if (previousUrl === undefined) {
+        delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+      } else {
+        process.env.NEXT_PUBLIC_SUPABASE_URL = previousUrl;
+      }
+      if (previousServiceKey === undefined) {
+        delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+      } else {
+        process.env.SUPABASE_SERVICE_ROLE_KEY = previousServiceKey;
+      }
+      fetchSpy?.mockRestore();
+    }
+  });
+});

--- a/packages/auth/src/middleware.ts
+++ b/packages/auth/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { extractApiKey, verifyApiKey } from './api-key';
+import { withAgentSignature } from './request-signature';
 import type { ApiResponse } from '@agentgram/shared';
 
 export function withAuth<T extends unknown[]>(
@@ -47,6 +48,6 @@ export function withAuth<T extends unknown[]>(
       body: req.body,
     });
 
-    return handler(authedReq, ...args);
+    return withAgentSignature(handler)(authedReq, ...args);
   };
 }

--- a/packages/auth/src/request-signature.ts
+++ b/packages/auth/src/request-signature.ts
@@ -28,6 +28,7 @@ export const TIMESTAMP_HEADER = 'x-agentgram-timestamp';
 
 const SIGNATURE_HEX_REGEX = /^[0-9a-f]{128}$/i;
 const TIMESTAMP_REGEX = /^\d{1,15}$/;
+const signatureVerifiedRequests = new WeakSet<NextRequest>();
 
 export interface SignableRequest {
   method: string;
@@ -172,6 +173,10 @@ export function withAgentSignature<T extends unknown[]>(
   handler: (req: NextRequest, ...args: T) => Promise<Response>
 ) {
   return async (req: NextRequest, ...args: T): Promise<Response> => {
+    if (signatureVerifiedRequests.has(req)) {
+      return handler(req, ...args);
+    }
+
     const signature = req.headers.get(SIGNATURE_HEADER);
     const timestamp = req.headers.get(TIMESTAMP_HEADER);
 
@@ -228,6 +233,7 @@ export function withAgentSignature<T extends unknown[]>(
       headers: req.headers,
       ...(body.length > 0 ? { body } : {}),
     });
+    signatureVerifiedRequests.add(verifiedReq);
 
     return handler(verifiedReq, ...args);
   };


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item ddb7bf1013.
Ref: https://github.com/agentgram/agentgram

## Change
Expanded Ed25519 request-signature verification from explicitly wrapped routes to every agent-authenticated API route by running the optional verifier inside withAuth.
Kept already-wrapped routes idempotent with an internal WeakSet marker so valid signed requests are verified once while unsigned backward-compatible requests still pass.
Added middleware regression tests for incomplete signed requests, unsigned compatibility, and existing explicit wrapper composition.

## Evidence
Tests: pnpm exec vitest run __tests__/api/auth-middleware-signatures.test.ts — 1 file passed, 3 tests passed.
Tests: pnpm --filter web test -- __tests__/api/auth-middleware-signatures.test.ts __tests__/api/post-mutation-signatures.test.ts — 275 files passed, 2503 tests passed.
Type-check: pnpm type-check — 4 successful tasks.
Lint: pnpm lint — passed with existing warnings only (0 errors, 35 warnings).
Build: pnpm build — passed; Next.js compiled successfully and generated 122 static pages.
Diff: 3 files changed, 151 insertions, 1 deletion.

## Auth-only Proof
N/A
