### PR TITLE
strategic(distribution): enable X live publishing

### DIFF
--- a/apps/web/__tests__/api/x-publish.test.ts
+++ b/apps/web/__tests__/api/x-publish.test.ts
@@ -1,14 +1,32 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
-function makeRequest(body: unknown) {
+const ORIGINAL_X_PUBLISH_SECRET = process.env.X_PUBLISH_SECRET;
+const ORIGINAL_X_BEARER_TOKEN = process.env.X_BEARER_TOKEN;
+
+function restoreEnv(name: 'X_PUBLISH_SECRET' | 'X_BEARER_TOKEN', value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+function makeRequest(body: unknown, authorization?: string) {
   return new NextRequest('http://localhost/api/v1/distribution/x/publish', {
     method: 'POST',
     body: JSON.stringify(body),
+    ...(authorization ? { headers: { authorization } } : {}),
   });
 }
 
 describe('POST /api/v1/distribution/x/publish', () => {
+  afterEach(() => {
+    restoreEnv('X_PUBLISH_SECRET', ORIGINAL_X_PUBLISH_SECRET);
+    restoreEnv('X_BEARER_TOKEN', ORIGINAL_X_BEARER_TOKEN);
+    vi.unstubAllGlobals();
+  });
+
   it('returns a validated dry-run X payload and does not send externally', async () => {
     const { POST } = await import('../../app/api/v1/distribution/x/publish/route');
 
@@ -40,19 +58,97 @@ describe('POST /api/v1/distribution/x/publish', () => {
     });
   });
 
-  it('rejects non-dry-run attempts instead of posting to X', async () => {
+  it('requires the operator publish secret for live X posts', async () => {
+    process.env.X_PUBLISH_SECRET = 'publish-secret';
+    process.env.X_BEARER_TOKEN = 'x-token';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
     const { POST } = await import('../../app/api/v1/distribution/x/publish/route');
 
     const response = await POST(
       makeRequest({
         dryRun: false,
-        text: 'Do not send yet.',
+        text: 'Do not publish without the operator secret.',
       })
     );
     const json = await response.json();
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(401);
     expect(json.success).toBe(false);
-    expect(json.error.message).toContain('Only dry-run X publishing is available');
+    expect(json.error.message).toContain('Valid X publish secret is required');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts a live text update to X when the operator secret and token are configured', async () => {
+    process.env.X_PUBLISH_SECRET = 'publish-secret';
+    process.env.X_BEARER_TOKEN = 'x-token';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            id: '1800000000000000002',
+            text: 'AgentGram external distribution is live.',
+            edit_history_tweet_ids: ['1800000000000000002'],
+          },
+        }),
+        { status: 201 }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { POST } = await import('../../app/api/v1/distribution/x/publish/route');
+
+    const response = await POST(
+      makeRequest(
+        {
+          dryRun: false,
+          text: 'AgentGram external distribution is live.',
+          tags: ['agentgram'],
+        },
+        'Bearer publish-secret'
+      )
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith('https://api.x.com/2/tweets', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer x-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ text: 'AgentGram external distribution is live.' }),
+    });
+    expect(json.data).toMatchObject({
+      channel: 'x',
+      mode: 'live',
+      status: 'sent',
+      external: {
+        postedTo: 'https://api.x.com/2/tweets',
+        sent: true,
+        tweetId: '1800000000000000002',
+      },
+    });
+  });
+
+  it('reports a configuration error when live publishing lacks an X bearer token', async () => {
+    process.env.X_PUBLISH_SECRET = 'publish-secret';
+    delete process.env.X_BEARER_TOKEN;
+    const { POST } = await import('../../app/api/v1/distribution/x/publish/route');
+
+    const response = await POST(
+      makeRequest(
+        {
+          dryRun: false,
+          text: 'Token missing.',
+        },
+        'Bearer publish-secret'
+      )
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.success).toBe(false);
+    expect(json.error.message).toContain('X_BEARER_TOKEN is not configured');
   });
 });

--- a/apps/web/__tests__/lib/x-publisher.test.ts
+++ b/apps/web/__tests__/lib/x-publisher.test.ts
@@ -1,12 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   X_DRY_RUN_ENDPOINT,
+  X_POST_ENDPOINT,
+  XPublishConfigurationError,
   buildXPublishDryRunPayload,
+  publishXPost,
 } from '@/lib/distribution/x-publisher';
 
 const VERIFIED_AT = new Date('2026-07-13T00:00:00.000Z');
 
-describe('X publishing dry-run payload builder', () => {
+describe('X publishing payload builder', () => {
   it('validates and returns the normalized payload without sending to X', () => {
     const result = buildXPublishDryRunPayload(
       {
@@ -56,13 +59,84 @@ describe('X publishing dry-run payload builder', () => {
     });
   });
 
-  it('rejects live-send requests until credentials and transport are implemented', () => {
-    expect(() =>
-      buildXPublishDryRunPayload({
+  it('publishes text-only live posts to X with the configured bearer token', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            id: '1800000000000000001',
+            text: 'AgentGram external publishing is live.',
+            edit_history_tweet_ids: ['1800000000000000001'],
+          },
+        }),
+        { status: 201 }
+      )
+    );
+
+    const result = await publishXPost(
+      {
+        dryRun: false,
+        text: ' AgentGram external publishing is live. ',
+        tags: ['agentgram'],
+      },
+      {
+        bearerToken: 'x-token',
+        fetcher,
+        verifiedAt: VERIFIED_AT,
+      }
+    );
+
+    expect(fetcher).toHaveBeenCalledWith(X_POST_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer x-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ text: 'AgentGram external publishing is live.' }),
+    });
+    expect(result).toEqual({
+      channel: 'x',
+      mode: 'live',
+      status: 'sent',
+      payload: {
+        text: 'AgentGram external publishing is live.',
+        characterCount: 38,
+        tags: ['agentgram'],
+        media: [],
+      },
+      validation: {
+        textLimit: 280,
+        mediaLimit: 4,
+        tagLimit: 6,
+      },
+      external: {
+        postedTo: X_POST_ENDPOINT,
+        sent: true,
+        tweetId: '1800000000000000001',
+        text: 'AgentGram external publishing is live.',
+        editHistoryTweetIds: ['1800000000000000001'],
+      },
+      verifiedAt: '2026-07-13T00:00:00.000Z',
+    });
+  });
+
+  it('requires an X bearer token before live publishing', async () => {
+    await expect(
+      publishXPost({
         dryRun: false,
         text: 'Send this for real',
       })
-    ).toThrow('Only dry-run X publishing is available in this slice');
+    ).rejects.toThrow(XPublishConfigurationError);
+  });
+
+  it('keeps media URL uploads out of the live channel until a media transport exists', async () => {
+    await expect(
+      publishXPost({
+        dryRun: false,
+        text: 'Post with media later',
+        media: [{ url: 'https://agentgram.co/preview.png' }],
+      })
+    ).rejects.toThrow('Live X publishing currently supports text-only posts');
   });
 
   it('rejects text that cannot fit in one X post', () => {
@@ -74,7 +148,7 @@ describe('X publishing dry-run payload builder', () => {
     ).toThrow('text must be 280 characters or fewer');
   });
 
-  it('rejects unsafe URLs before building a dry-run payload', () => {
+  it('rejects unsafe URLs before building a payload', () => {
     expect(() =>
       buildXPublishDryRunPayload({
         dryRun: true,

--- a/apps/web/app/api/v1/distribution/x/publish/route.ts
+++ b/apps/web/app/api/v1/distribution/x/publish/route.ts
@@ -1,24 +1,83 @@
+import crypto from 'node:crypto';
 import { NextRequest } from 'next/server';
 import {
+  ERROR_CODES,
   ErrorResponses,
+  createErrorResponse,
   createSuccessResponse,
   jsonResponse,
 } from '@agentgram/shared';
 import {
+  XPublishConfigurationError,
+  XPublishTransportError,
   buildXPublishDryRunPayload,
+  publishXPost,
   type XPublishDraftInput,
 } from '@/lib/distribution/x-publisher';
 
-// POST /api/v1/distribution/x/publish - Validate an X publish payload without sending it.
+function getBearerToken(req: NextRequest): string | undefined {
+  const authorization = req.headers.get('authorization');
+  if (!authorization?.startsWith('Bearer ')) {
+    return undefined;
+  }
+
+  return authorization.slice('Bearer '.length).trim();
+}
+
+function verifyPublishSecret(provided: string | undefined, expected: string | undefined): boolean {
+  if (!provided || !expected) {
+    return false;
+  }
+
+  const providedBuffer = Buffer.from(provided);
+  const expectedBuffer = Buffer.from(expected);
+  if (providedBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+// POST /api/v1/distribution/x/publish - Validate or publish an X distribution payload.
 export async function POST(req: NextRequest) {
   try {
     const body = (await req.json()) as XPublishDraftInput;
+
+    if (body.dryRun === false) {
+      if (!verifyPublishSecret(getBearerToken(req), process.env.X_PUBLISH_SECRET)) {
+        return jsonResponse(
+          ErrorResponses.unauthorized('Valid X publish secret is required'),
+          401
+        );
+      }
+
+      const published = await publishXPost(body, {
+        bearerToken: process.env.X_BEARER_TOKEN,
+      });
+
+      return jsonResponse(createSuccessResponse(published), 200);
+    }
+
     const dryRun = buildXPublishDryRunPayload(body);
 
     return jsonResponse(createSuccessResponse(dryRun), 200);
   } catch (error) {
     const message =
-      error instanceof Error ? error.message : 'Failed to validate X publish payload';
+      error instanceof Error ? error.message : 'Failed to process X publish payload';
+
+    if (error instanceof XPublishConfigurationError) {
+      return jsonResponse(
+        createErrorResponse(ERROR_CODES.INTERNAL_ERROR, message),
+        503
+      );
+    }
+
+    if (error instanceof XPublishTransportError) {
+      return jsonResponse(
+        createErrorResponse(ERROR_CODES.INTERNAL_ERROR, message),
+        502
+      );
+    }
 
     return jsonResponse(ErrorResponses.invalidInput(message), 400);
   }

--- a/apps/web/lib/distribution/x-publisher.ts
+++ b/apps/web/lib/distribution/x-publisher.ts
@@ -2,7 +2,8 @@ export const X_DISTRIBUTION_CHANNEL = 'x' as const;
 export const X_POST_TEXT_LIMIT = 280;
 export const X_MEDIA_LIMIT = 4;
 export const X_TAG_LIMIT = 6;
-export const X_DRY_RUN_ENDPOINT = 'https://api.x.com/2/tweets';
+export const X_POST_ENDPOINT = 'https://api.x.com/2/tweets';
+export const X_DRY_RUN_ENDPOINT = X_POST_ENDPOINT;
 
 export interface XPublishMediaInput {
   url: string;
@@ -18,18 +19,20 @@ export interface XPublishDraftInput {
   dryRun: boolean;
 }
 
+interface XPublishValidatedPayload {
+  text: string;
+  characterCount: number;
+  sourceUrl?: string;
+  agentHandle?: string;
+  tags: string[];
+  media: XPublishMediaInput[];
+}
+
 export interface XPublishDryRunPayload {
   channel: typeof X_DISTRIBUTION_CHANNEL;
   mode: 'dry-run';
   status: 'validated';
-  payload: {
-    text: string;
-    characterCount: number;
-    sourceUrl?: string;
-    agentHandle?: string;
-    tags: string[];
-    media: XPublishMediaInput[];
-  };
+  payload: XPublishValidatedPayload;
   validation: {
     textLimit: number;
     mediaLimit: number;
@@ -41,6 +44,49 @@ export interface XPublishDryRunPayload {
     reason: string;
   };
   verifiedAt: string;
+}
+
+export interface XPublishLivePayload {
+  channel: typeof X_DISTRIBUTION_CHANNEL;
+  mode: 'live';
+  status: 'sent';
+  payload: XPublishValidatedPayload;
+  validation: {
+    textLimit: number;
+    mediaLimit: number;
+    tagLimit: number;
+  };
+  external: {
+    postedTo: typeof X_POST_ENDPOINT;
+    sent: true;
+    tweetId: string;
+    text: string;
+    editHistoryTweetIds: string[];
+  };
+  verifiedAt: string;
+}
+
+export class XPublishConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'XPublishConfigurationError';
+  }
+}
+
+export class XPublishTransportError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'XPublishTransportError';
+    this.status = status;
+  }
+}
+
+export interface PublishXPostOptions {
+  bearerToken?: string;
+  fetcher?: typeof fetch;
+  verifiedAt?: Date;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -103,14 +149,15 @@ function normalizeMedia(media: unknown): XPublishMediaInput[] {
   });
 }
 
-export function buildXPublishDryRunPayload(
-  input: XPublishDraftInput,
-  verifiedAt: Date = new Date()
-): XPublishDryRunPayload {
-  if (input.dryRun !== true) {
-    throw new Error('Only dry-run X publishing is available in this slice');
-  }
+function buildValidationMetadata() {
+  return {
+    textLimit: X_POST_TEXT_LIMIT,
+    mediaLimit: X_MEDIA_LIMIT,
+    tagLimit: X_TAG_LIMIT,
+  };
+}
 
+function buildValidatedPayload(input: XPublishDraftInput): XPublishValidatedPayload {
   const text = normalizeOptionalString(input.text);
   if (!text) {
     throw new Error('text is required');
@@ -129,27 +176,123 @@ export function buildXPublishDryRunPayload(
   const media = normalizeMedia(input.media);
 
   return {
+    text,
+    characterCount,
+    ...(sourceUrl ? { sourceUrl } : {}),
+    ...(agentHandle ? { agentHandle } : {}),
+    tags,
+    media,
+  };
+}
+
+function parseXPostResponse(value: unknown): {
+  tweetId: string;
+  text: string;
+  editHistoryTweetIds: string[];
+} {
+  if (!isRecord(value) || !isRecord(value.data)) {
+    throw new XPublishTransportError('X publish response did not include data', 502);
+  }
+
+  const tweetId = value.data.id;
+  const text = value.data.text;
+  const editHistoryTweetIds = value.data.edit_history_tweet_ids;
+
+  if (typeof tweetId !== 'string' || tweetId.trim().length === 0) {
+    throw new XPublishTransportError('X publish response did not include a tweet id', 502);
+  }
+
+  return {
+    tweetId,
+    text: typeof text === 'string' ? text : '',
+    editHistoryTweetIds: Array.isArray(editHistoryTweetIds)
+      ? editHistoryTweetIds.filter((id): id is string => typeof id === 'string')
+      : [],
+  };
+}
+
+async function readErrorText(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 500);
+  } catch {
+    return '';
+  }
+}
+
+export function buildXPublishDryRunPayload(
+  input: XPublishDraftInput,
+  verifiedAt: Date = new Date()
+): XPublishDryRunPayload {
+  if (input.dryRun !== true) {
+    throw new Error('Set dryRun=true to validate without sending, or use publishXPost for live X publishing');
+  }
+
+  return {
     channel: X_DISTRIBUTION_CHANNEL,
     mode: 'dry-run',
     status: 'validated',
-    payload: {
-      text,
-      characterCount,
-      ...(sourceUrl ? { sourceUrl } : {}),
-      ...(agentHandle ? { agentHandle } : {}),
-      tags,
-      media,
-    },
-    validation: {
-      textLimit: X_POST_TEXT_LIMIT,
-      mediaLimit: X_MEDIA_LIMIT,
-      tagLimit: X_TAG_LIMIT,
-    },
+    payload: buildValidatedPayload(input),
+    validation: buildValidationMetadata(),
     external: {
       wouldPostTo: X_DRY_RUN_ENDPOINT,
       sent: false,
       reason: 'Dry-run mode validates and returns the payload without calling X APIs.',
     },
     verifiedAt: verifiedAt.toISOString(),
+  };
+}
+
+export async function publishXPost(
+  input: XPublishDraftInput,
+  options: PublishXPostOptions = {}
+): Promise<XPublishLivePayload> {
+  if (input.dryRun !== false) {
+    throw new Error('Set dryRun=false to publish to X');
+  }
+
+  const payload = buildValidatedPayload(input);
+  if (payload.media.length > 0) {
+    throw new Error('Live X publishing currently supports text-only posts');
+  }
+
+  const bearerToken = normalizeOptionalString(options.bearerToken);
+  if (!bearerToken) {
+    throw new XPublishConfigurationError('X_BEARER_TOKEN is not configured');
+  }
+
+  const fetcher = options.fetcher ?? fetch;
+  const response = await fetcher(X_POST_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${bearerToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ text: payload.text }),
+  });
+
+  if (!response.ok) {
+    const errorText = await readErrorText(response);
+    throw new XPublishTransportError(
+      `X publish failed with status ${response.status}${errorText ? `: ${errorText}` : ''}`,
+      response.status
+    );
+  }
+
+  const parsed = parseXPostResponse(await response.json());
+
+  return {
+    channel: X_DISTRIBUTION_CHANNEL,
+    mode: 'live',
+    status: 'sent',
+    payload,
+    validation: buildValidationMetadata(),
+    external: {
+      postedTo: X_POST_ENDPOINT,
+      sent: true,
+      tweetId: parsed.tweetId,
+      text: parsed.text,
+      editHistoryTweetIds: parsed.editHistoryTweetIds,
+    },
+    verifiedAt: (options.verifiedAt ?? new Date()).toISOString(),
   };
 }


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item df1140d4d6.
Ref: https://github.com/agentgram/agentgram

## Change
Enabled the existing X distribution endpoint to perform authenticated live text publishing when an operator publish secret and X bearer token are configured. Dry-run validation remains public and non-sending, while live posting now returns tweet IDs and transport errors without leaking credentials.

## Evidence
Tests: pnpm --dir apps/web exec vitest run __tests__/lib/x-publisher.test.ts __tests__/api/x-publish.test.ts (11 passed); pnpm --filter web type-check (passed); pnpm --filter web lint (0 errors, 35 pre-existing warnings); pnpm --filter web build (passed). Diff: 4 files changed, 416 insertions, 44 deletions.

## Auth-only Proof
N/A
