### PR TITLE
strategic(ops): install release promote cron runner

### DIFF
--- a/scripts/__tests__/install_agentgram_release_promote_cron_test.py
+++ b/scripts/__tests__/install_agentgram_release_promote_cron_test.py
@@ -1,0 +1,138 @@
+import importlib.util
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "install_agentgram_release_promote_cron.py"
+spec = importlib.util.spec_from_file_location("install_agentgram_release_promote_cron", SCRIPT_PATH)
+assert spec is not None
+installer = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = installer
+spec.loader.exec_module(installer)
+
+
+class InstallReleasePromoteCronTests(unittest.TestCase):
+    def test_prompt_prefers_repo_script_and_keeps_workspace_fallback(self):
+        prompt = installer.build_repo_backed_prompt(
+            repo_script=Path("/repo/scripts/agentgram_release_promote.py"),
+            workspace_script=Path("/profile/workspace/scripts/agentgram_release_promote.py"),
+            release_log=Path("/shared/release-log.md"),
+        )
+
+        self.assertLess(
+            prompt.index("/repo/scripts/agentgram_release_promote.py"),
+            prompt.index("/profile/workspace/scripts/agentgram_release_promote.py"),
+        )
+        self.assertIn("repo-backed release promote script", prompt)
+        self.assertIn("If neither script path exists", prompt)
+        self.assertIn("Do not force-push `main`", prompt)
+
+    def test_install_workspace_copy_preserves_script_and_marks_executable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "source.py"
+            target = Path(tmpdir) / "profile" / "scripts" / "agentgram_release_promote.py"
+            source.write_text("#!/usr/bin/env python3\nprint('ok')\n", encoding="utf-8")
+
+            installer.install_workspace_copy(source_script=source, workspace_script=target, dry_run=False)
+
+            self.assertEqual(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+            self.assertTrue(target.stat().st_mode & stat.S_IXUSR)
+
+    def test_update_cron_registry_changes_only_release_promote_prompt(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jobs_json = Path(tmpdir) / "jobs.json"
+            payload = {
+                "jobs": [
+                    {"id": "other", "name": "other-job", "prompt": "keep me"},
+                    {
+                        "id": installer.JOB_ID,
+                        "name": installer.JOB_NAME,
+                        "prompt": "old missing workspace copy prompt",
+                        "schedule_display": "0 6 * * *",
+                    },
+                ]
+            }
+            jobs_json.write_text(json.dumps(payload), encoding="utf-8")
+
+            changed = installer.update_cron_registry(
+                jobs_json=jobs_json,
+                repo_script=Path("/repo/scripts/agentgram_release_promote.py"),
+                workspace_script=Path("/profile/workspace/scripts/agentgram_release_promote.py"),
+                release_log=Path("/shared/release-log.md"),
+                dry_run=False,
+            )
+
+            updated = json.loads(jobs_json.read_text(encoding="utf-8"))
+            self.assertTrue(changed)
+            self.assertEqual(updated["jobs"][0]["prompt"], "keep me")
+            self.assertIn("/repo/scripts/agentgram_release_promote.py", updated["jobs"][1]["prompt"])
+            self.assertEqual(updated["jobs"][1]["schedule_display"], "0 6 * * *")
+            self.assertTrue((Path(tmpdir) / "jobs.json.bak-release-promote-cron").exists())
+
+    def test_full_install_dry_run_does_not_write_targets(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "agentgram_release_promote.py"
+            workspace_script = Path(tmpdir) / "workspace" / "scripts" / "agentgram_release_promote.py"
+            jobs_json = Path(tmpdir) / "jobs.json"
+            source.write_text("print('ok')\n", encoding="utf-8")
+            original = {
+                "jobs": [
+                    {
+                        "id": installer.JOB_ID,
+                        "name": installer.JOB_NAME,
+                        "prompt": "old",
+                    }
+                ]
+            }
+            jobs_json.write_text(json.dumps(original), encoding="utf-8")
+
+            result = installer.install(
+                source_script=source,
+                workspace_script=workspace_script,
+                repo_script=Path(tmpdir) / "repo" / "scripts" / "agentgram_release_promote.py",
+                jobs_json=jobs_json,
+                release_log=Path(tmpdir) / "release-log.md",
+                dry_run=True,
+            )
+
+            self.assertTrue(result.changed_prompt)
+            self.assertFalse(workspace_script.exists())
+            self.assertEqual(json.loads(jobs_json.read_text(encoding="utf-8")), original)
+
+    def test_main_uses_provided_argv(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "agentgram_release_promote.py"
+            workspace_script = Path(tmpdir) / "workspace" / "scripts" / "agentgram_release_promote.py"
+            jobs_json = Path(tmpdir) / "jobs.json"
+            source.write_text("print('ok')\n", encoding="utf-8")
+            jobs_json.write_text(
+                json.dumps({"jobs": [{"id": installer.JOB_ID, "name": installer.JOB_NAME, "prompt": "old"}]}),
+                encoding="utf-8",
+            )
+
+            exit_code = installer.main(
+                [
+                    "--source-script",
+                    os.fspath(source),
+                    "--workspace-script",
+                    os.fspath(workspace_script),
+                    "--repo-script",
+                    os.fspath(Path(tmpdir) / "repo" / "scripts" / "agentgram_release_promote.py"),
+                    "--jobs-json",
+                    os.fspath(jobs_json),
+                    "--release-log",
+                    os.fspath(Path(tmpdir) / "release-log.md"),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(workspace_script.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/install_agentgram_release_promote_cron.py
+++ b/scripts/install_agentgram_release_promote_cron.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Install the AgentGram release-promote cron runner for kkami.
+
+This installer is intentionally dependency-free because it patches the Hermes
+profile cron registry in the operator workspace. It installs the restored
+release-promote script into kkami's cron workspace as a fallback, then rewrites
+the release-promote cron prompt to prefer the repo-backed script path once the
+restored script has landed in the canonical checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+JOB_ID = "ca3cc60e24bb"
+JOB_NAME = "hermes-kkami-agentgram-release-promote"
+DEFAULT_JOBS_JSON = Path(
+    os.environ.get(
+        "AGENTGRAM_RELEASE_PROMOTE_JOBS_JSON",
+        "/Users/sweetheart/.hermes/profiles/kkami/cron/jobs.json",
+    )
+)
+DEFAULT_WORKSPACE_SCRIPT = Path(
+    os.environ.get(
+        "AGENTGRAM_RELEASE_PROMOTE_WORKSPACE_SCRIPT",
+        "/Users/sweetheart/.hermes/profiles/kkami/workspace/scripts/agentgram_release_promote.py",
+    )
+)
+DEFAULT_REPO_SCRIPT = Path(
+    os.environ.get(
+        "AGENTGRAM_RELEASE_PROMOTE_REPO_SCRIPT",
+        "/Users/sweetheart/.hermes/projects/agentgram/agentgram/scripts/agentgram_release_promote.py",
+    )
+)
+DEFAULT_SOURCE_SCRIPT = Path(
+    os.environ.get(
+        "AGENTGRAM_RELEASE_PROMOTE_SOURCE_SCRIPT",
+        Path(__file__).resolve().with_name("agentgram_release_promote.py"),
+    )
+)
+DEFAULT_RELEASE_LOG = Path(
+    os.environ.get(
+        "AGENTGRAM_RELEASE_LOG",
+        "/Users/sweetheart/.hermes/shared/knowledge/agentgram/release-log.md",
+    )
+)
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    copied_to: Path
+    jobs_json: Path
+    job_id: str
+    dry_run: bool
+    changed_prompt: bool
+
+
+def build_repo_backed_prompt(*, repo_script: Path, workspace_script: Path, release_log: Path) -> str:
+    return f"""## Hermes Runtime Policy
+- Document handoff only: communicate with other agents through Markdown/JSON files under ~/.hermes/shared/knowledge or profile workspaces.
+- Do not create/contact another agent through direct runtime handoff tools, Discord bot mentions, or ad-hoc CLI agent calls.
+- Do not create Discord threads for agent-to-agent coordination.
+
+AgentGram release promote run.
+
+1. Prefer the repo-backed release promote script after merge: `{repo_script}`. If it exists, execute `python3 {repo_script}`.
+2. If the repo-backed script is not present yet, fall back to the installed kkami cron workspace copy: `{workspace_script}`. If it exists, execute `python3 {workspace_script}`.
+3. If neither script path exists, do not run promotion; append exactly one BLOCKED line to `{release_log}` with both missing paths and the next action to merge/sync the restored repo script, then exit cleanly.
+4. If the selected script exits non-zero, inspect the output. If `{release_log}` was not updated for this run, append exactly one blocked/error line with the concrete reason.
+5. Do not force-push `main`.
+6. If `Enforce develop-only merge to main` is failing, do not attempt merge; leave a BLOCKED log line only.
+7. End with a concise outcome summary referencing the release PR number, selected script path, or skip reason.
+"""
+
+
+def load_jobs(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def dump_jobs(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+
+
+def find_release_promote_job(payload: dict[str, Any]) -> dict[str, Any]:
+    jobs = payload.get("jobs")
+    if not isinstance(jobs, list):
+        raise ValueError("cron registry does not contain a jobs list")
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        if job.get("id") == JOB_ID or job.get("name") == JOB_NAME:
+            return job
+    raise ValueError(f"release promote job not found: {JOB_ID} / {JOB_NAME}")
+
+
+def install_workspace_copy(*, source_script: Path, workspace_script: Path, dry_run: bool) -> None:
+    if not source_script.exists():
+        raise FileNotFoundError(f"source script does not exist: {source_script}")
+    if dry_run:
+        return
+    workspace_script.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_script, workspace_script)
+    current_mode = workspace_script.stat().st_mode
+    workspace_script.chmod(current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def update_cron_registry(
+    *,
+    jobs_json: Path,
+    repo_script: Path,
+    workspace_script: Path,
+    release_log: Path,
+    dry_run: bool,
+) -> bool:
+    payload = load_jobs(jobs_json)
+    job = find_release_promote_job(payload)
+    prompt = build_repo_backed_prompt(
+        repo_script=repo_script,
+        workspace_script=workspace_script,
+        release_log=release_log,
+    )
+    changed = job.get("prompt") != prompt
+    if changed:
+        job["prompt"] = prompt
+    if not dry_run and changed:
+        backup = jobs_json.with_name(f"{jobs_json.name}.bak-release-promote-cron")
+        shutil.copy2(jobs_json, backup)
+        jobs_json.write_text(dump_jobs(payload), encoding="utf-8")
+    return changed
+
+
+def install(
+    *,
+    source_script: Path,
+    workspace_script: Path,
+    repo_script: Path,
+    jobs_json: Path,
+    release_log: Path,
+    dry_run: bool,
+) -> InstallResult:
+    source_script = source_script.expanduser().resolve()
+    workspace_script = workspace_script.expanduser().resolve()
+    repo_script = repo_script.expanduser().resolve()
+    jobs_json = jobs_json.expanduser().resolve()
+    release_log = release_log.expanduser().resolve()
+
+    install_workspace_copy(source_script=source_script, workspace_script=workspace_script, dry_run=dry_run)
+    changed_prompt = update_cron_registry(
+        jobs_json=jobs_json,
+        repo_script=repo_script,
+        workspace_script=workspace_script,
+        release_log=release_log,
+        dry_run=dry_run,
+    )
+    return InstallResult(
+        copied_to=workspace_script,
+        jobs_json=jobs_json,
+        job_id=JOB_ID,
+        dry_run=dry_run,
+        changed_prompt=changed_prompt,
+    )
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-script", type=Path, default=DEFAULT_SOURCE_SCRIPT)
+    parser.add_argument("--workspace-script", type=Path, default=DEFAULT_WORKSPACE_SCRIPT)
+    parser.add_argument("--repo-script", type=Path, default=DEFAULT_REPO_SCRIPT)
+    parser.add_argument("--jobs-json", type=Path, default=DEFAULT_JOBS_JSON)
+    parser.add_argument("--release-log", type=Path, default=DEFAULT_RELEASE_LOG)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    result = install(
+        source_script=args.source_script,
+        workspace_script=args.workspace_script,
+        repo_script=args.repo_script,
+        jobs_json=args.jobs_json,
+        release_log=args.release_log,
+        dry_run=args.dry_run,
+    )
+    print(f"JOB={result.job_id}")
+    print(f"WORKSPACE_SCRIPT={result.copied_to}")
+    print(f"JOBS_JSON={result.jobs_json}")
+    print(f"PROMPT_CHANGED={str(result.changed_prompt).upper()}")
+    print(f"DRY_RUN={str(result.dry_run).upper()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item 1b925c24dc.
Ref: https://github.com/agentgram/agentgram

## Change
Added a dependency-free installer for the kkami AgentGram release-promote cron runner.
The installer copies the restored release-promote script into kkami's cron workspace and rewrites the cron prompt to prefer the repo-backed script path after merge, with a workspace fallback until the canonical checkout catches up.

## Evidence
- test: `python3 scripts/__tests__/agentgram_release_promote_test.py && python3 scripts/__tests__/install_agentgram_release_promote_cron_test.py` => OK (10 tests)
- test: `pnpm type-check` => OK (4 successful, FULL TURBO)
- diff: `git diff --cached --check` => OK before commit
- operator verification: installed `/Users/sweetheart/.hermes/profiles/kkami/workspace/scripts/agentgram_release_promote.py`, verified kkami cron prompt contains both the repo-backed path and workspace fallback, and dry-ran the workspace script successfully (`STATUS=WOULD_PROMOTE`, ahead=9)

## Auth-only Proof
N/A
