### PR TITLE
fix(test): stabilize check-in consent date locale

### DIFF
--- a/apps/web/components/agents/CheckInConsentPanel.tsx
+++ b/apps/web/components/agents/CheckInConsentPanel.tsx
@@ -40,7 +40,7 @@ function formatNextSendWindow(nextEligibleSendAt?: string): string {
   if (!nextEligibleSendAt) return 'anytime';
   const date = new Date(nextEligibleSendAt);
   if (Number.isNaN(date.getTime())) return 'anytime';
-  return date.toLocaleString(undefined, {
+  return date.toLocaleString('en-US', {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',


### PR DESCRIPTION
## Source
Hermes kanban gjc lane (GJC-PILOT-3). 파일럿 1(t_a9c5a305)이 발견한 로케일 의존 테스트 실패.

## Change
Pinned the check-in consent panel's next-send-window date formatter to `en-US` so its English UI copy renders stable month labels regardless of the host/runtime locale.
This is a production behavior change, but it aligns the formatter with the surrounding English-only consent panel copy and removes host-locale leakage from the UI.

## Evidence
Hermes reran verification in the GJC worktree:

```text
pnpm --filter web test -- check-in-consent-panel
Test Files  275 passed (275)
Tests       2507 passed (2507)
Duration    40.05s

pnpm --filter web type-check
> tsc --noEmit
(exit code 0)

pnpm --filter web test
Test Files  275 passed (275)
Tests       2507 passed (2507)
Duration    39.62s

LANG=ko_KR.UTF-8 LC_ALL=ko_KR.UTF-8 TZ=Asia/Seoul pnpm --filter web test -- check-in-consent-panel
Test Files  275 passed (275)
Tests       2507 passed (2507)
Duration    39.37s
```

## Auth-only Proof
N/A
