### PR TITLE
strategic(x): add X live publish credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,20 @@ NEXT_PUBLIC_APP_NAME=AgentGram
 # NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=your-verification-code
 
 # ============================================================
+# OPTIONAL — X/Twitter External Distribution
+# ============================================================
+# Live publishing is disabled unless API callers send dryRun=false AND include
+# Authorization: Bearer $X_PUBLISH_SECRET on the server-only publish endpoint.
+# Configure either an OAuth 2 user-context bearer token OR all OAuth 1.0a keys.
+# Never expose these variables with NEXT_PUBLIC_ prefixes.
+# X_PUBLISH_SECRET=replace-with-random-operator-secret
+# X_BEARER_TOKEN=your-x-oauth2-user-context-bearer-token
+# X_API_KEY=your-x-api-key
+# X_API_SECRET=your-x-api-secret
+# X_ACCESS_TOKEN=your-x-access-token
+# X_ACCESS_TOKEN_SECRET=your-x-access-token-secret
+
+# ============================================================
 # OPTIONAL — Social links & branding
 # ============================================================
 # NEXT_PUBLIC_GITHUB_URL=https://github.com/agentgram/agentgram

--- a/apps/web/__tests__/api/x-publish.test.ts
+++ b/apps/web/__tests__/api/x-publish.test.ts
@@ -3,8 +3,20 @@ import { NextRequest } from 'next/server';
 
 const ORIGINAL_X_PUBLISH_SECRET = process.env.X_PUBLISH_SECRET;
 const ORIGINAL_X_BEARER_TOKEN = process.env.X_BEARER_TOKEN;
+const ORIGINAL_X_API_KEY = process.env.X_API_KEY;
+const ORIGINAL_X_API_SECRET = process.env.X_API_SECRET;
+const ORIGINAL_X_ACCESS_TOKEN = process.env.X_ACCESS_TOKEN;
+const ORIGINAL_X_ACCESS_TOKEN_SECRET = process.env.X_ACCESS_TOKEN_SECRET;
 
-function restoreEnv(name: 'X_PUBLISH_SECRET' | 'X_BEARER_TOKEN', value: string | undefined) {
+type XPublishEnvName =
+  | 'X_PUBLISH_SECRET'
+  | 'X_BEARER_TOKEN'
+  | 'X_API_KEY'
+  | 'X_API_SECRET'
+  | 'X_ACCESS_TOKEN'
+  | 'X_ACCESS_TOKEN_SECRET';
+
+function restoreEnv(name: XPublishEnvName, value: string | undefined) {
   if (value === undefined) {
     delete process.env[name];
   } else {
@@ -24,6 +36,10 @@ describe('POST /api/v1/distribution/x/publish', () => {
   afterEach(() => {
     restoreEnv('X_PUBLISH_SECRET', ORIGINAL_X_PUBLISH_SECRET);
     restoreEnv('X_BEARER_TOKEN', ORIGINAL_X_BEARER_TOKEN);
+    restoreEnv('X_API_KEY', ORIGINAL_X_API_KEY);
+    restoreEnv('X_API_SECRET', ORIGINAL_X_API_SECRET);
+    restoreEnv('X_ACCESS_TOKEN', ORIGINAL_X_ACCESS_TOKEN);
+    restoreEnv('X_ACCESS_TOKEN_SECRET', ORIGINAL_X_ACCESS_TOKEN_SECRET);
     vi.unstubAllGlobals();
   });
 
@@ -131,9 +147,57 @@ describe('POST /api/v1/distribution/x/publish', () => {
     });
   });
 
+  it('uses OAuth API-key credentials for live X posts when no bearer token is configured', async () => {
+    process.env.X_PUBLISH_SECRET = 'publish-secret';
+    delete process.env.X_BEARER_TOKEN;
+    process.env.X_API_KEY = 'api-key';
+    process.env.X_API_SECRET = 'api-secret';
+    process.env.X_ACCESS_TOKEN = 'access-token';
+    process.env.X_ACCESS_TOKEN_SECRET = 'access-token-secret';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            id: '1800000000000000004',
+            text: 'AgentGram external distribution can use OAuth credentials.',
+            edit_history_tweet_ids: ['1800000000000000004'],
+          },
+        }),
+        { status: 201 }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { POST } = await import('../../app/api/v1/distribution/x/publish/route');
+
+    const response = await POST(
+      makeRequest(
+        {
+          dryRun: false,
+          text: 'AgentGram external distribution can use OAuth credentials.',
+        },
+        'Bearer publish-secret'
+      )
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    const [, requestInit] = fetchMock.mock.calls[0];
+    expect(requestInit.headers.Authorization).toMatch(/^OAuth /);
+    expect(requestInit.headers.Authorization).toContain('oauth_consumer_key="api-key"');
+    expect(requestInit.headers.Authorization).toContain('oauth_token="access-token"');
+    expect(requestInit.headers.Authorization).not.toContain('api-secret');
+    expect(requestInit.headers.Authorization).not.toContain('access-token-secret');
+    expect(json.data.external.tweetId).toBe('1800000000000000004');
+  });
+
   it('reports a configuration error when live publishing lacks an X bearer token', async () => {
     process.env.X_PUBLISH_SECRET = 'publish-secret';
     delete process.env.X_BEARER_TOKEN;
+    delete process.env.X_API_KEY;
+    delete process.env.X_API_SECRET;
+    delete process.env.X_ACCESS_TOKEN;
+    delete process.env.X_ACCESS_TOKEN_SECRET;
     const { POST } = await import('../../app/api/v1/distribution/x/publish/route');
 
     const response = await POST(
@@ -149,6 +213,6 @@ describe('POST /api/v1/distribution/x/publish', () => {
 
     expect(response.status).toBe(503);
     expect(json.success).toBe(false);
-    expect(json.error.message).toContain('X_BEARER_TOKEN is not configured');
+    expect(json.error.message).toContain('Configure X_BEARER_TOKEN or X_API_KEY');
   });
 });

--- a/apps/web/__tests__/lib/x-publisher.test.ts
+++ b/apps/web/__tests__/lib/x-publisher.test.ts
@@ -120,6 +120,55 @@ describe('X publishing payload builder', () => {
     });
   });
 
+  it('signs live posts with OAuth 1.0a user credentials when no bearer token is configured', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            id: '1800000000000000003',
+            text: 'AgentGram external publishing can use OAuth credentials.',
+            edit_history_tweet_ids: ['1800000000000000003'],
+          },
+        }),
+        { status: 201 }
+      )
+    );
+
+    const result = await publishXPost(
+      {
+        dryRun: false,
+        text: 'AgentGram external publishing can use OAuth credentials.',
+      },
+      {
+        oauth1: {
+          apiKey: 'api-key',
+          apiSecret: 'api-secret',
+          accessToken: 'access-token',
+          accessTokenSecret: 'access-token-secret',
+        },
+        fetcher,
+        nonce: 'fixed-nonce',
+        timestamp: '1784550000',
+        verifiedAt: VERIFIED_AT,
+      }
+    );
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [, requestInit] = fetcher.mock.calls[0];
+    const headers = requestInit?.headers as Record<string, string>;
+    expect(headers.Authorization).toMatch(/^OAuth /);
+    expect(headers.Authorization).toContain('oauth_consumer_key="api-key"');
+    expect(headers.Authorization).toContain('oauth_token="access-token"');
+    expect(headers.Authorization).toContain('oauth_nonce="fixed-nonce"');
+    expect(headers.Authorization).toContain('oauth_timestamp="1784550000"');
+    expect(headers.Authorization).not.toContain('api-secret');
+    expect(headers.Authorization).not.toContain('access-token-secret');
+    expect(requestInit?.body).toBe(
+      JSON.stringify({ text: 'AgentGram external publishing can use OAuth credentials.' })
+    );
+    expect(result.external.tweetId).toBe('1800000000000000003');
+  });
+
   it('requires an X bearer token before live publishing', async () => {
     await expect(
       publishXPost({

--- a/apps/web/app/api/v1/distribution/x/publish/route.ts
+++ b/apps/web/app/api/v1/distribution/x/publish/route.ts
@@ -53,6 +53,12 @@ export async function POST(req: NextRequest) {
 
       const published = await publishXPost(body, {
         bearerToken: process.env.X_BEARER_TOKEN,
+        oauth1: {
+          apiKey: process.env.X_API_KEY,
+          apiSecret: process.env.X_API_SECRET,
+          accessToken: process.env.X_ACCESS_TOKEN,
+          accessTokenSecret: process.env.X_ACCESS_TOKEN_SECRET,
+        },
       });
 
       return jsonResponse(createSuccessResponse(published), 200);

--- a/apps/web/lib/distribution/x-publisher.ts
+++ b/apps/web/lib/distribution/x-publisher.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 export const X_DISTRIBUTION_CHANNEL = 'x' as const;
 export const X_POST_TEXT_LIMIT = 280;
 export const X_MEDIA_LIMIT = 4;
@@ -83,9 +85,19 @@ export class XPublishTransportError extends Error {
   }
 }
 
+export interface XOAuth1Credentials {
+  apiKey?: string;
+  apiSecret?: string;
+  accessToken?: string;
+  accessTokenSecret?: string;
+}
+
 export interface PublishXPostOptions {
   bearerToken?: string;
+  oauth1?: XOAuth1Credentials;
   fetcher?: typeof fetch;
+  nonce?: string;
+  timestamp?: string;
   verifiedAt?: Date;
 }
 
@@ -112,6 +124,96 @@ function normalizeOptionalString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim().length > 0
     ? value.trim()
     : undefined;
+}
+
+function encodeOAuth(value: string): string {
+  return encodeURIComponent(value).replace(/[!'()*]/g, (char) =>
+    `%${char.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+}
+
+function getOAuthCredentialValue(
+  credentials: XOAuth1Credentials | undefined,
+  key: keyof XOAuth1Credentials
+): string | undefined {
+  return normalizeOptionalString(credentials?.[key]);
+}
+
+function hasCompleteOAuth1Credentials(
+  credentials: XOAuth1Credentials | undefined
+): credentials is Required<XOAuth1Credentials> {
+  return Boolean(
+    getOAuthCredentialValue(credentials, 'apiKey') &&
+      getOAuthCredentialValue(credentials, 'apiSecret') &&
+      getOAuthCredentialValue(credentials, 'accessToken') &&
+      getOAuthCredentialValue(credentials, 'accessTokenSecret')
+  );
+}
+
+function buildOAuth1AuthorizationHeader(
+  credentials: XOAuth1Credentials,
+  nonce: string,
+  timestamp: string
+): string {
+  const apiKey = getOAuthCredentialValue(credentials, 'apiKey');
+  const apiSecret = getOAuthCredentialValue(credentials, 'apiSecret');
+  const accessToken = getOAuthCredentialValue(credentials, 'accessToken');
+  const accessTokenSecret = getOAuthCredentialValue(credentials, 'accessTokenSecret');
+
+  if (!apiKey || !apiSecret || !accessToken || !accessTokenSecret) {
+    throw new XPublishConfigurationError(
+      'X OAuth credentials are incomplete; configure X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, and X_ACCESS_TOKEN_SECRET'
+    );
+  }
+
+  const oauthParameters: Record<string, string> = {
+    oauth_consumer_key: apiKey,
+    oauth_nonce: nonce,
+    oauth_signature_method: 'HMAC-SHA1',
+    oauth_timestamp: timestamp,
+    oauth_token: accessToken,
+    oauth_version: '1.0',
+  };
+  const parameterString = Object.entries(oauthParameters)
+    .map(([key, value]) => [encodeOAuth(key), encodeOAuth(value)] as const)
+    .sort(([leftKey, leftValue], [rightKey, rightValue]) =>
+      leftKey === rightKey ? leftValue.localeCompare(rightValue) : leftKey.localeCompare(rightKey)
+    )
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+  const signatureBaseString = ['POST', X_POST_ENDPOINT, parameterString]
+    .map(encodeOAuth)
+    .join('&');
+  const signingKey = `${encodeOAuth(apiSecret)}&${encodeOAuth(accessTokenSecret)}`;
+  const oauthSignature = crypto
+    .createHmac('sha1', signingKey)
+    .update(signatureBaseString)
+    .digest('base64');
+
+  return `OAuth ${Object.entries({ ...oauthParameters, oauth_signature: oauthSignature })
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([key, value]) => `${encodeOAuth(key)}="${encodeOAuth(value)}"`)
+    .join(', ')}`;
+}
+
+function buildXAuthorizationHeader(options: PublishXPostOptions): string {
+  const bearerToken = normalizeOptionalString(options.bearerToken);
+  if (bearerToken) {
+    return `Bearer ${bearerToken}`;
+  }
+
+  const oauth1 = options.oauth1;
+  if (hasCompleteOAuth1Credentials(oauth1)) {
+    return buildOAuth1AuthorizationHeader(
+      oauth1,
+      options.nonce ?? crypto.randomBytes(16).toString('hex'),
+      options.timestamp ?? Math.floor(Date.now() / 1000).toString()
+    );
+  }
+
+  throw new XPublishConfigurationError(
+    'Configure X_BEARER_TOKEN or X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, and X_ACCESS_TOKEN_SECRET for live X publishing'
+  );
 }
 
 function normalizeTags(tags: unknown): string[] {
@@ -255,16 +357,13 @@ export async function publishXPost(
     throw new Error('Live X publishing currently supports text-only posts');
   }
 
-  const bearerToken = normalizeOptionalString(options.bearerToken);
-  if (!bearerToken) {
-    throw new XPublishConfigurationError('X_BEARER_TOKEN is not configured');
-  }
+  const authorizationHeader = buildXAuthorizationHeader(options);
 
   const fetcher = options.fetcher ?? fetch;
   const response = await fetcher(X_POST_ENDPOINT, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${bearerToken}`,
+      Authorization: authorizationHeader,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ text: payload.text }),


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item 58491bf277.
Ref: https://github.com/agentgram/agentgram

## Change
Added server-only X live publish credential configuration for both OAuth 2 bearer tokens and OAuth 1.0a API-key/access-token credentials. The live transport still requires dryRun=false plus the operator publish secret, and the OAuth header path avoids leaking signing secrets.

## Evidence
- test: `pnpm --filter web exec vitest run __tests__/lib/x-publisher.test.ts __tests__/api/x-publish.test.ts` → 2 files passed, 13 tests passed.
- type-check: `pnpm --filter web type-check` → passed.
- lint: `pnpm --filter web lint -- lib/distribution/x-publisher.ts app/api/v1/distribution/x/publish/route.ts __tests__/lib/x-publisher.test.ts __tests__/api/x-publish.test.ts` → passed with existing repo warnings only (0 errors, 35 warnings).
- diff: `git diff --cached --stat` before commit showed 5 files changed.

## Auth-only Proof
- test: `__tests__/api/x-publish.test.ts` verifies live publish returns 401 without `Authorization: Bearer $X_PUBLISH_SECRET`, sends with a mocked operator secret, and can authenticate outbound X transport with OAuth API-key credentials without exposing `X_API_SECRET` or `X_ACCESS_TOKEN_SECRET` in the Authorization header.
