### PR TITLE
feat(distribution): persist X publish receipts

### DIFF
--- a/apps/web/__tests__/api/x-publish.test.ts
+++ b/apps/web/__tests__/api/x-publish.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
 
 const ORIGINAL_X_PUBLISH_SECRET = process.env.X_PUBLISH_SECRET;
 const ORIGINAL_X_BEARER_TOKEN = process.env.X_BEARER_TOKEN;
@@ -7,6 +8,8 @@ const ORIGINAL_X_API_KEY = process.env.X_API_KEY;
 const ORIGINAL_X_API_SECRET = process.env.X_API_SECRET;
 const ORIGINAL_X_ACCESS_TOKEN = process.env.X_ACCESS_TOKEN;
 const ORIGINAL_X_ACCESS_TOKEN_SECRET = process.env.X_ACCESS_TOKEN_SECRET;
+const ORIGINAL_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const ORIGINAL_SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 type XPublishEnvName =
   | 'X_PUBLISH_SECRET'
@@ -14,7 +17,15 @@ type XPublishEnvName =
   | 'X_API_KEY'
   | 'X_API_SECRET'
   | 'X_ACCESS_TOKEN'
-  | 'X_ACCESS_TOKEN_SECRET';
+  | 'X_ACCESS_TOKEN_SECRET'
+  | 'NEXT_PUBLIC_SUPABASE_URL'
+  | 'SUPABASE_SERVICE_ROLE_KEY';
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(),
+}));
+
+const createClientMock = vi.mocked(createClient);
 
 function restoreEnv(name: XPublishEnvName, value: string | undefined) {
   if (value === undefined) {
@@ -22,6 +33,14 @@ function restoreEnv(name: XPublishEnvName, value: string | undefined) {
   } else {
     process.env[name] = value;
   }
+}
+
+function mockReceiptInsert() {
+  const insert = vi.fn().mockResolvedValue({ error: null });
+  const from = vi.fn().mockReturnValue({ insert });
+  createClientMock.mockReturnValue({ from } as never);
+
+  return { from, insert };
 }
 
 function makeRequest(body: unknown, authorization?: string) {
@@ -40,6 +59,9 @@ describe('POST /api/v1/distribution/x/publish', () => {
     restoreEnv('X_API_SECRET', ORIGINAL_X_API_SECRET);
     restoreEnv('X_ACCESS_TOKEN', ORIGINAL_X_ACCESS_TOKEN);
     restoreEnv('X_ACCESS_TOKEN_SECRET', ORIGINAL_X_ACCESS_TOKEN_SECRET);
+    restoreEnv('NEXT_PUBLIC_SUPABASE_URL', ORIGINAL_SUPABASE_URL);
+    restoreEnv('SUPABASE_SERVICE_ROLE_KEY', ORIGINAL_SUPABASE_SERVICE_ROLE_KEY);
+    createClientMock.mockReset();
     vi.unstubAllGlobals();
   });
 
@@ -143,6 +165,7 @@ describe('POST /api/v1/distribution/x/publish', () => {
         postedTo: 'https://api.x.com/2/tweets',
         sent: true,
         tweetId: '1800000000000000002',
+        tweetUrl: 'https://x.com/i/web/status/1800000000000000002',
       },
     });
   });
@@ -183,15 +206,109 @@ describe('POST /api/v1/distribution/x/publish', () => {
     expect(response.status).toBe(200);
     expect(json.success).toBe(true);
     const [, requestInit] = fetchMock.mock.calls[0];
-    expect(requestInit.headers.Authorization).toMatch(/^OAuth /);
-    expect(requestInit.headers.Authorization).toContain('oauth_consumer_key="api-key"');
-    expect(requestInit.headers.Authorization).toContain('oauth_token="access-token"');
-    expect(requestInit.headers.Authorization).not.toContain('api-secret');
-    expect(requestInit.headers.Authorization).not.toContain('access-token-secret');
+    const headers = requestInit?.headers as Record<string, string>;
+    expect(headers.Authorization).toMatch(/^OAuth /);
+    expect(headers.Authorization).toContain('oauth_consumer_key="api-key"');
+    expect(headers.Authorization).toContain('oauth_token="access-token"');
+    expect(headers.Authorization).not.toContain('api-secret');
+    expect(headers.Authorization).not.toContain('access-token-secret');
     expect(json.data.external.tweetId).toBe('1800000000000000004');
   });
 
-  it('reports a configuration error when live publishing lacks an X bearer token', async () => {
+  it('persists the X tweet id and URL for live AgentGram post receipts', async () => {
+    process.env.X_PUBLISH_SECRET = 'publish-secret';
+    process.env.X_BEARER_TOKEN = 'x-token';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+    const receiptDb = mockReceiptInsert();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: {
+              id: '1800000000000000003',
+              text: 'AgentGram external receipts are durable.',
+              edit_history_tweet_ids: ['1800000000000000003'],
+            },
+          }),
+          { status: 201 }
+        )
+      )
+    );
+    const { POST } = await import('../../app/api/v1/distribution/x/publish/route');
+
+    const response = await POST(
+      makeRequest(
+        {
+          dryRun: false,
+          postId: '9a94f4e2-f27b-4b02-8405-b496904bea95',
+          text: 'AgentGram external receipts are durable.',
+          tags: ['agentgram'],
+        },
+        'Bearer publish-secret'
+      )
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data.receipt).toMatchObject({
+      persisted: true,
+      table: 'post_distribution_receipts',
+      channelStatus: 'sent',
+      externalId: '1800000000000000003',
+      externalUrl: 'https://x.com/i/web/status/1800000000000000003',
+    });
+    expect(receiptDb.from).toHaveBeenCalledWith('post_distribution_receipts');
+    expect(receiptDb.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        post_id: '9a94f4e2-f27b-4b02-8405-b496904bea95',
+        channel: 'x',
+        channel_status: 'sent',
+        external_id: '1800000000000000003',
+        external_url: 'https://x.com/i/web/status/1800000000000000003',
+        retryable: false,
+      })
+    );
+  });
+
+  it('persists retryable error receipts when X returns a transient failure', async () => {
+    process.env.X_PUBLISH_SECRET = 'publish-secret';
+    process.env.X_BEARER_TOKEN = 'x-token';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+    const receiptDb = mockReceiptInsert();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 }))
+    );
+    const { POST } = await import('../../app/api/v1/distribution/x/publish/route');
+
+    const response = await POST(
+      makeRequest(
+        {
+          dryRun: false,
+          postId: '9a94f4e2-f27b-4b02-8405-b496904bea95',
+          text: 'Retry this external post later.',
+        },
+        'Bearer publish-secret'
+      )
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(json.success).toBe(false);
+    expect(receiptDb.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        post_id: '9a94f4e2-f27b-4b02-8405-b496904bea95',
+        channel_status: 'retryable_error',
+        error_status: 429,
+        retryable: true,
+      })
+    );
+  });
+
+  it('reports a configuration error when live publishing lacks X credentials', async () => {
     process.env.X_PUBLISH_SECRET = 'publish-secret';
     delete process.env.X_BEARER_TOKEN;
     delete process.env.X_API_KEY;

--- a/apps/web/__tests__/lib/x-publisher.test.ts
+++ b/apps/web/__tests__/lib/x-publisher.test.ts
@@ -3,6 +3,7 @@ import {
   X_DRY_RUN_ENDPOINT,
   X_POST_ENDPOINT,
   XPublishConfigurationError,
+  buildXTweetUrl,
   buildXPublishDryRunPayload,
   publishXPost,
 } from '@/lib/distribution/x-publisher';
@@ -113,6 +114,7 @@ describe('X publishing payload builder', () => {
         postedTo: X_POST_ENDPOINT,
         sent: true,
         tweetId: '1800000000000000001',
+        tweetUrl: 'https://x.com/i/web/status/1800000000000000001',
         text: 'AgentGram external publishing is live.',
         editHistoryTweetIds: ['1800000000000000001'],
       },
@@ -176,6 +178,12 @@ describe('X publishing payload builder', () => {
         text: 'Send this for real',
       })
     ).rejects.toThrow(XPublishConfigurationError);
+  });
+
+  it('builds a durable X URL from the external tweet id', () => {
+    expect(buildXTweetUrl('1800000000000000001')).toBe(
+      'https://x.com/i/web/status/1800000000000000001'
+    );
   });
 
   it('keeps media URL uploads out of the live channel until a media transport exists', async () => {

--- a/apps/web/app/api/v1/distribution/x/publish/route.ts
+++ b/apps/web/app/api/v1/distribution/x/publish/route.ts
@@ -12,8 +12,14 @@ import {
   XPublishTransportError,
   buildXPublishDryRunPayload,
   publishXPost,
+  X_POST_ENDPOINT,
   type XPublishDraftInput,
 } from '@/lib/distribution/x-publisher';
+import {
+  extractReceiptPostId,
+  persistXPublishReceipt,
+  type XPublishChannelStatus,
+} from '@/lib/distribution/publish-receipts';
 
 function getBearerToken(req: NextRequest): string | undefined {
   const authorization = req.headers.get('authorization');
@@ -38,10 +44,19 @@ function verifyPublishSecret(provided: string | undefined, expected: string | un
   return crypto.timingSafeEqual(providedBuffer, expectedBuffer);
 }
 
+function isRetryablePublishError(error: unknown): boolean {
+  return error instanceof XPublishTransportError && (error.status === 429 || error.status >= 500);
+}
+
+function getFailedChannelStatus(error: unknown): XPublishChannelStatus {
+  return isRetryablePublishError(error) ? 'retryable_error' : 'failed';
+}
+
 // POST /api/v1/distribution/x/publish - Validate or publish an X distribution payload.
 export async function POST(req: NextRequest) {
+  let body: XPublishDraftInput | undefined;
   try {
-    const body = (await req.json()) as XPublishDraftInput;
+    body = (await req.json()) as XPublishDraftInput;
 
     if (body.dryRun === false) {
       if (!verifyPublishSecret(getBearerToken(req), process.env.X_PUBLISH_SECRET)) {
@@ -60,8 +75,29 @@ export async function POST(req: NextRequest) {
           accessTokenSecret: process.env.X_ACCESS_TOKEN_SECRET,
         },
       });
+      const postId = extractReceiptPostId(body);
+      const receipt = postId
+        ? await persistXPublishReceipt({
+            postId,
+            channel: published.channel,
+            channelStatus: 'sent',
+            externalId: published.external.tweetId,
+            externalUrl: published.external.tweetUrl,
+            endpoint: X_POST_ENDPOINT,
+            requestPayload: published.payload,
+            responsePayload: published.external,
+            retryable: false,
+            verifiedAt: published.verifiedAt,
+          })
+        : undefined;
 
-      return jsonResponse(createSuccessResponse(published), 200);
+      return jsonResponse(
+        createSuccessResponse({
+          ...published,
+          ...(receipt ? { receipt } : {}),
+        }),
+        200
+      );
     }
 
     const dryRun = buildXPublishDryRunPayload(body);
@@ -70,6 +106,26 @@ export async function POST(req: NextRequest) {
   } catch (error) {
     const message =
       error instanceof Error ? error.message : 'Failed to process X publish payload';
+
+    const postId = body?.dryRun === false ? extractReceiptPostId(body) : undefined;
+    if (postId) {
+      await persistXPublishReceipt({
+        postId,
+        channel: 'x',
+        channelStatus: getFailedChannelStatus(error),
+        endpoint: X_POST_ENDPOINT,
+        requestPayload: {
+          text: body?.text,
+          sourceUrl: body?.sourceUrl,
+          agentHandle: body?.agentHandle,
+          tags: body?.tags,
+        },
+        errorMessage: message,
+        errorStatus: error instanceof XPublishTransportError ? error.status : undefined,
+        retryable: isRetryablePublishError(error),
+        verifiedAt: new Date().toISOString(),
+      });
+    }
 
     if (error instanceof XPublishConfigurationError) {
       return jsonResponse(

--- a/apps/web/lib/distribution/publish-receipts.ts
+++ b/apps/web/lib/distribution/publish-receipts.ts
@@ -1,0 +1,101 @@
+import { createClient } from '@supabase/supabase-js';
+import type { X_DISTRIBUTION_CHANNEL, X_POST_ENDPOINT } from '@/lib/distribution/x-publisher';
+
+export type XPublishChannelStatus = 'sent' | 'failed' | 'retryable_error';
+
+export interface XPublishReceiptInput {
+  postId: string;
+  channel: typeof X_DISTRIBUTION_CHANNEL;
+  channelStatus: XPublishChannelStatus;
+  externalId?: string;
+  externalUrl?: string;
+  requestPayload: unknown;
+  responsePayload?: unknown;
+  errorMessage?: string;
+  errorStatus?: number;
+  retryable: boolean;
+  endpoint: typeof X_POST_ENDPOINT;
+  verifiedAt: string;
+}
+
+export interface XPublishReceiptResult {
+  persisted: boolean;
+  table: 'post_distribution_receipts';
+  channelStatus: XPublishChannelStatus;
+  externalId?: string;
+  externalUrl?: string;
+  skippedReason?: string;
+}
+
+function normalizePostId(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function getReceiptClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceKey) {
+    return undefined;
+  }
+
+  return createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+export function extractReceiptPostId(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return normalizePostId((value as { postId?: unknown }).postId);
+}
+
+export async function persistXPublishReceipt(
+  input: XPublishReceiptInput
+): Promise<XPublishReceiptResult> {
+  const client = getReceiptClient();
+  const resultBase = {
+    table: 'post_distribution_receipts' as const,
+    channelStatus: input.channelStatus,
+    ...(input.externalId ? { externalId: input.externalId } : {}),
+    ...(input.externalUrl ? { externalUrl: input.externalUrl } : {}),
+  };
+
+  if (!client) {
+    return {
+      ...resultBase,
+      persisted: false,
+      skippedReason: 'Supabase service env is not configured',
+    };
+  }
+
+  const { error } = await client.from('post_distribution_receipts').insert({
+    post_id: input.postId,
+    channel: input.channel,
+    channel_status: input.channelStatus,
+    external_id: input.externalId ?? null,
+    external_url: input.externalUrl ?? null,
+    endpoint: input.endpoint,
+    request_payload: input.requestPayload,
+    response_payload: input.responsePayload ?? null,
+    error_message: input.errorMessage ?? null,
+    error_status: input.errorStatus ?? null,
+    retryable: input.retryable,
+    verified_at: input.verifiedAt,
+  });
+
+  if (error) {
+    return {
+      ...resultBase,
+      persisted: false,
+      skippedReason: error.message,
+    };
+  }
+
+  return {
+    ...resultBase,
+    persisted: true,
+  };
+}

--- a/apps/web/lib/distribution/x-publisher.ts
+++ b/apps/web/lib/distribution/x-publisher.ts
@@ -13,6 +13,7 @@ export interface XPublishMediaInput {
 }
 
 export interface XPublishDraftInput {
+  postId?: string;
   text: string;
   sourceUrl?: string;
   agentHandle?: string;
@@ -62,6 +63,7 @@ export interface XPublishLivePayload {
     postedTo: typeof X_POST_ENDPOINT;
     sent: true;
     tweetId: string;
+    tweetUrl: string;
     text: string;
     editHistoryTweetIds: string[];
   };
@@ -289,6 +291,7 @@ function buildValidatedPayload(input: XPublishDraftInput): XPublishValidatedPayl
 
 function parseXPostResponse(value: unknown): {
   tweetId: string;
+  tweetUrl: string;
   text: string;
   editHistoryTweetIds: string[];
 } {
@@ -306,11 +309,16 @@ function parseXPostResponse(value: unknown): {
 
   return {
     tweetId,
+    tweetUrl: buildXTweetUrl(tweetId),
     text: typeof text === 'string' ? text : '',
     editHistoryTweetIds: Array.isArray(editHistoryTweetIds)
       ? editHistoryTweetIds.filter((id): id is string => typeof id === 'string')
       : [],
   };
+}
+
+export function buildXTweetUrl(tweetId: string): string {
+  return `https://x.com/i/web/status/${encodeURIComponent(tweetId)}`;
 }
 
 async function readErrorText(response: Response): Promise<string> {
@@ -389,6 +397,7 @@ export async function publishXPost(
       postedTo: X_POST_ENDPOINT,
       sent: true,
       tweetId: parsed.tweetId,
+      tweetUrl: parsed.tweetUrl,
       text: parsed.text,
       editHistoryTweetIds: parsed.editHistoryTweetIds,
     },

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -728,6 +728,65 @@ export type Database = {
           },
         ];
       };
+      post_distribution_receipts: {
+        Row: {
+          channel: string;
+          channel_status: string;
+          created_at: string;
+          endpoint: string;
+          error_message: string | null;
+          error_status: number | null;
+          external_id: string | null;
+          external_url: string | null;
+          id: string;
+          post_id: string;
+          request_payload: Json;
+          response_payload: Json | null;
+          retryable: boolean;
+          verified_at: string;
+        };
+        Insert: {
+          channel: string;
+          channel_status: string;
+          created_at?: string;
+          endpoint: string;
+          error_message?: string | null;
+          error_status?: number | null;
+          external_id?: string | null;
+          external_url?: string | null;
+          id?: string;
+          post_id: string;
+          request_payload?: Json;
+          response_payload?: Json | null;
+          retryable?: boolean;
+          verified_at?: string;
+        };
+        Update: {
+          channel?: string;
+          channel_status?: string;
+          created_at?: string;
+          endpoint?: string;
+          error_message?: string | null;
+          error_status?: number | null;
+          external_id?: string | null;
+          external_url?: string | null;
+          id?: string;
+          post_id?: string;
+          request_payload?: Json;
+          response_payload?: Json | null;
+          retryable?: boolean;
+          verified_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'post_distribution_receipts_post_id_fkey';
+            columns: ['post_id'];
+            isOneToOne: false;
+            referencedRelation: 'posts';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       posts: {
         Row: {
           author_id: string | null;

--- a/supabase/migrations/20260720000000_post_distribution_receipts.sql
+++ b/supabase/migrations/20260720000000_post_distribution_receipts.sql
@@ -1,0 +1,42 @@
+-- Store append-only external distribution receipts for published AgentGram posts.
+-- Each live publish attempt creates one receipt so retries and provider errors remain auditable.
+CREATE TABLE post_distribution_receipts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  channel TEXT NOT NULL CHECK (channel IN ('x')),
+  channel_status TEXT NOT NULL CHECK (channel_status IN ('sent', 'failed', 'retryable_error')),
+  external_id TEXT,
+  external_url TEXT,
+  endpoint TEXT NOT NULL,
+  request_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  response_payload JSONB,
+  error_message TEXT,
+  error_status INTEGER,
+  retryable BOOLEAN NOT NULL DEFAULT false,
+  verified_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_post_distribution_receipts_post_channel
+  ON post_distribution_receipts(post_id, channel, created_at DESC);
+
+CREATE INDEX idx_post_distribution_receipts_external_id
+  ON post_distribution_receipts(channel, external_id)
+  WHERE external_id IS NOT NULL;
+
+CREATE INDEX idx_post_distribution_receipts_retryable
+  ON post_distribution_receipts(channel, channel_status, created_at DESC)
+  WHERE retryable = true;
+
+ALTER TABLE post_distribution_receipts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role can manage post distribution receipts"
+  ON post_distribution_receipts
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+COMMENT ON TABLE post_distribution_receipts IS 'Append-only receipts for external post distribution attempts, including X tweet ids/urls and retryable errors.';
+COMMENT ON COLUMN post_distribution_receipts.channel_status IS 'Provider channel status for this attempt: sent, failed, or retryable_error.';
+COMMENT ON COLUMN post_distribution_receipts.external_id IS 'External provider post id, such as an X tweet id, when the attempt succeeds.';
+COMMENT ON COLUMN post_distribution_receipts.external_url IS 'Durable external provider URL for audit evidence, when available.';


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item 30497481fe.
Ref: https://github.com/agentgram/agentgram

## Change
Persist live X publish receipts for AgentGram posts, including external tweet id/url, channel status, endpoint, sanitized request/response payloads, and retryable error records.
Added the `post_distribution_receipts` migration plus route-level success/error receipt writes for live publishes carrying `postId`.

## Evidence
Test/type-check/diff evidence:
- `pnpm type-check` — passed (turbo type-check, 4 successful tasks).
- `pnpm --filter web type-check` — passed.
- `pnpm --filter web test -- __tests__/lib/x-publisher.test.ts __tests__/api/x-publish.test.ts` — passed; Vitest executed 275 test files / 2510 tests successfully.
- `pnpm --filter web lint` — passed with existing warnings only (0 errors, 35 warnings).
- `git diff --check` — passed.

## Auth-only Proof
N/A
