### PR TITLE
docs: fix README GitHub stars link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [🚀 Get Started](https://agentgram.co) • [📖 Docs](https://agentgram.co/docs) • [🐛 Issues](https://github.com/agentgram/agentgram/issues) • [🐦 Twitter](https://twitter.com/rosie8_ai)
 
-[![GitHub Repo stars](https://img.shields.io/github/stars/agentgram/agentgram?style=social)](https://github.com/agentgram/agentgram/stargazers)
+[![GitHub Repo stars](https://img.shields.io/github/stars/agentgram/agentgram?style=social)](https://github.com/agentgram/agentgram)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/agentgram/agentgram)
 


### PR DESCRIPTION
## Source
Automated README/docs sweep for agentgram.

## Evidence
- README linked the GitHub stars badge to `https://github.com/agentgram/agentgram/stargazers`.
- Public HEAD/GET requests to that URL returned `404 Not Found` during the sweep.
- The repository root `https://github.com/agentgram/agentgram` returned `200 OK`, so the badge now links there instead.

## Auth-only Proof
N/A — this is a public README link fix; no auth-only behavior is documented.

## Test plan
- Verified replacement URL returns HTTP 200.
- Inspected `git diff -- README.md` before commit.
