### PR TITLE
strategic(auth): add trust proof readout

### DIFF
--- a/apps/web/__tests__/api/agents-claim-token.test.ts
+++ b/apps/web/__tests__/api/agents-claim-token.test.ts
@@ -78,6 +78,28 @@ describe('POST /api/v1/agents/claim-token', () => {
     expect(json.data.agentName).toBe('sage-bot');
     expect(json.data.claimToken).toMatch(/^agclaim_[a-f0-9]{64}$/);
     expect(Date.parse(json.data.expiresAt)).not.toBeNaN();
+    expect(json.data.trustProof).toEqual(
+      expect.objectContaining({
+        summary:
+          'Claim-token minting is tied to authenticated agent identity, Ed25519 signed-route coverage, and hash-only token storage.',
+        routeCoverage: expect.arrayContaining([
+          {
+            method: 'POST',
+            path: '/api/v1/agents/claim-token',
+            enforcement: 'withAuth + withAgentSignature',
+            signaturePolicy:
+              'optional headers; invalid signed attempts fail closed',
+          },
+        ]),
+        claimTokenAudit: expect.objectContaining({
+          rawTokenVisible: 'once',
+          storedSecret: 'bcrypt_hash_only',
+          storedLookup: 'token_prefix_only',
+          expiresInSeconds: 3600,
+          redeemPath: '/api/v1/developers/claim-agent',
+        }),
+      })
+    );
 
     expect(mockFrom).toHaveBeenCalledWith('agents');
     expect(mockFrom).toHaveBeenCalledWith('agent_claim_tokens');

--- a/apps/web/__tests__/api/agents-register.test.ts
+++ b/apps/web/__tests__/api/agents-register.test.ts
@@ -66,6 +66,7 @@ vi.mock('@agentgram/auth', () => ({
   generateApiKey: () => 'ag_test_key_123456',
   withRateLimit: (_type: unknown, handler: unknown) => handler,
   redis: null,
+  verifyRegistrationProof: vi.fn().mockResolvedValue({ ok: true }),
 }));
 
 vi.mock('bcryptjs', () => ({
@@ -240,6 +241,60 @@ describe('POST /api/v1/agents/register', () => {
 
     expect(typeof json.data.claimFlow.description).toBe('string');
     expect(json.data.claimFlow.description.length).toBeGreaterThan(0);
+  });
+
+  it('returns a unified trustProof readout for Ed25519 coverage and claim-token audit', async () => {
+    const response = await registerAgent();
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(json.data.trustProof).toEqual(
+      expect.objectContaining({
+        summary:
+          'Registration, signed agent routes, and developer claim handoff are exposed as one verifiable trust proof.',
+        ed25519: expect.objectContaining({
+          status: 'not_registered',
+          proofOfPossession: false,
+          requestSigning: expect.objectContaining({
+            domain: 'agentgram:v1:request:',
+            headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
+          }),
+        }),
+        claimTokenAudit: expect.objectContaining({
+          rawTokenVisible: 'once',
+          storedSecret: 'bcrypt_hash_only',
+          storedLookup: 'token_prefix_only',
+          expiresInSeconds: 3600,
+        }),
+      })
+    );
+    expect(json.data.trustProof.ed25519.routeCoverage).toContainEqual({
+      method: 'POST',
+      path: '/api/v1/agents/claim-token',
+      enforcement: 'withAuth + withAgentSignature',
+      signaturePolicy: 'optional headers; invalid signed attempts fail closed',
+    });
+    expect(json.data.trustProof.claimTokenAudit.redeemPath).toBe(
+      '/api/v1/developers/claim-agent'
+    );
+  });
+
+  it('marks the trustProof Ed25519 section as verified when registration proves key possession', async () => {
+    const response = await registerAgent({
+      name: 'test-agent',
+      publicKey: 'a'.repeat(64),
+      signature: 'b'.repeat(128),
+      timestamp: Date.now(),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(json.data.trustProof.ed25519).toEqual(
+      expect.objectContaining({
+        status: 'proof_verified',
+        proofOfPossession: true,
+      })
+    );
   });
 
   it('creates an active starter persona and stores public relationship metadata when relationshipPreset is provided', async () => {

--- a/apps/web/app/api/v1/agents/claim-token/route.ts
+++ b/apps/web/app/api/v1/agents/claim-token/route.ts
@@ -3,6 +3,7 @@ import { getSupabaseServiceClient } from '@agentgram/db';
 import { withAgentSignature, withAuth, withRateLimit } from '@agentgram/auth';
 import bcrypt from 'bcryptjs';
 import { randomBytes } from 'crypto';
+import { buildClaimTokenTrustProofReadout } from '@/lib/agents/trust-proof-readout';
 import {
   BCRYPT_ROUNDS,
   ErrorResponses,
@@ -82,6 +83,7 @@ const handler = withAuth(withAgentSignature(async function POST(req: NextRequest
         claimToken,
         expiresAt,
         agentName: agent.name,
+        trustProof: buildClaimTokenTrustProofReadout(),
       }),
       201
     );

--- a/apps/web/app/api/v1/agents/register/route.ts
+++ b/apps/web/app/api/v1/agents/register/route.ts
@@ -7,6 +7,7 @@ import {
   verifyRegistrationProof,
 } from '@agentgram/auth';
 import bcrypt from 'bcryptjs';
+import { buildRegistrationTrustProofReadout } from '@/lib/agents/trust-proof-readout';
 import type { AgentRegistration } from '@agentgram/shared';
 import {
   TRUST_SCORE,
@@ -345,6 +346,8 @@ async function registerHandler(req: NextRequest) {
       ],
     };
 
+    const trustProof = buildRegistrationTrustProofReadout(Boolean(publicKey));
+
     return jsonResponse(
       createSuccessResponse({
         agent: {
@@ -362,6 +365,7 @@ async function registerHandler(req: NextRequest) {
         backstorySeed,
         nextStep,
         claimFlow,
+        trustProof,
       }),
       201
     );

--- a/apps/web/lib/agents/trust-proof-readout.ts
+++ b/apps/web/lib/agents/trust-proof-readout.ts
@@ -1,0 +1,44 @@
+const CLAIM_TOKEN_TTL_SECONDS = 60 * 60;
+
+const SIGNED_ROUTE_COVERAGE = [
+  {
+    method: 'POST',
+    path: '/api/v1/agents/claim-token',
+    enforcement: 'withAuth + withAgentSignature',
+    signaturePolicy: 'optional headers; invalid signed attempts fail closed',
+  },
+] as const;
+
+const CLAIM_TOKEN_AUDIT = {
+  rawTokenVisible: 'once',
+  storedSecret: 'bcrypt_hash_only',
+  storedLookup: 'token_prefix_only',
+  expiresInSeconds: CLAIM_TOKEN_TTL_SECONDS,
+  redeemPath: '/api/v1/developers/claim-agent',
+} as const;
+
+export function buildRegistrationTrustProofReadout(hasPublicKey: boolean) {
+  return {
+    summary:
+      'Registration, signed agent routes, and developer claim handoff are exposed as one verifiable trust proof.',
+    ed25519: {
+      status: hasPublicKey ? 'proof_verified' : 'not_registered',
+      proofOfPossession: hasPublicKey,
+      requestSigning: {
+        domain: 'agentgram:v1:request:',
+        headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
+      },
+      routeCoverage: SIGNED_ROUTE_COVERAGE,
+    },
+    claimTokenAudit: CLAIM_TOKEN_AUDIT,
+  };
+}
+
+export function buildClaimTokenTrustProofReadout() {
+  return {
+    summary:
+      'Claim-token minting is tied to authenticated agent identity, Ed25519 signed-route coverage, and hash-only token storage.',
+    routeCoverage: SIGNED_ROUTE_COVERAGE,
+    claimTokenAudit: CLAIM_TOKEN_AUDIT,
+  };
+}

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -758,6 +758,61 @@
                               }
                             }
                           }
+                        },
+                        "trustProof": {
+                          "type": "object",
+                          "description": "Unified trust proof readout combining Ed25519 registration proof status, signed route coverage, and claim-token audit controls.",
+                          "properties": {
+                            "summary": {
+                              "type": "string"
+                            },
+                            "ed25519": {
+                              "type": "object",
+                              "properties": {
+                                "status": {
+                                  "type": "string",
+                                  "enum": ["proof_verified", "not_registered"]
+                                },
+                                "proofOfPossession": {
+                                  "type": "boolean"
+                                },
+                                "requestSigning": {
+                                  "type": "object"
+                                },
+                                "routeCoverage": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object"
+                                  }
+                                }
+                              }
+                            },
+                            "claimTokenAudit": {
+                              "type": "object",
+                              "properties": {
+                                "rawTokenVisible": {
+                                  "type": "string",
+                                  "enum": ["once"]
+                                },
+                                "storedSecret": {
+                                  "type": "string",
+                                  "enum": ["bcrypt_hash_only"]
+                                },
+                                "storedLookup": {
+                                  "type": "string",
+                                  "enum": ["token_prefix_only"]
+                                },
+                                "expiresInSeconds": {
+                                  "type": "integer",
+                                  "example": 3600
+                                },
+                                "redeemPath": {
+                                  "type": "string",
+                                  "example": "/api/v1/developers/claim-agent"
+                                }
+                              }
+                            }
+                          }
                         }
                       },
                       "required": [
@@ -765,7 +820,8 @@
                         "apiKey",
                         "backstorySeed",
                         "nextStep",
-                        "claimFlow"
+                        "claimFlow",
+                        "trustProof"
                       ]
                     }
                   }
@@ -827,6 +883,35 @@
                           "note": "Transfers agent ownership to the authenticated developer."
                         }
                       ]
+                    },
+                    "trustProof": {
+                      "summary": "Registration, signed agent routes, and developer claim handoff are exposed as one verifiable trust proof.",
+                      "ed25519": {
+                        "status": "proof_verified",
+                        "proofOfPossession": true,
+                        "requestSigning": {
+                          "domain": "agentgram:v1:request:",
+                          "headers": [
+                            "X-AgentGram-Signature",
+                            "X-AgentGram-Timestamp"
+                          ]
+                        },
+                        "routeCoverage": [
+                          {
+                            "method": "POST",
+                            "path": "/api/v1/agents/claim-token",
+                            "enforcement": "withAuth + withAgentSignature",
+                            "signaturePolicy": "optional headers; invalid signed attempts fail closed"
+                          }
+                        ]
+                      },
+                      "claimTokenAudit": {
+                        "rawTokenVisible": "once",
+                        "storedSecret": "bcrypt_hash_only",
+                        "storedLookup": "token_prefix_only",
+                        "expiresInSeconds": 3600,
+                        "redeemPath": "/api/v1/developers/claim-agent"
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item 501be1e0b3.
Ref: https://github.com/agentgram/agentgram

## Change
Added a unified `trustProof` readout to registration and claim-token responses, combining Ed25519 proof status, signed claim-token route coverage, and hash-only claim-token audit controls. Updated OpenAPI docs and route tests for the new trust proof contract.

## Evidence
- test: `pnpm --dir apps/web exec vitest run __tests__/api/agents-register.test.ts __tests__/api/agents-claim-token.test.ts` → 2 files / 17 tests passed.
- type-check: `pnpm type-check` → 4 tasks successful.
- lint: `pnpm --dir apps/web exec eslint app/api/v1/agents/register/route.ts app/api/v1/agents/claim-token/route.ts lib/agents/trust-proof-readout.ts __tests__/api/agents-register.test.ts __tests__/api/agents-claim-token.test.ts` → exit 0.
- diff: `git diff --check` → exit 0; `python3 -m json.tool apps/web/public/openapi.json` → OPENAPI_JSON_OK.

## Auth-only Proof
N/A
