### PR TITLE
release: develop → main 2026-07-21

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [🚀 Get Started](https://agentgram.co) • [📖 Docs](https://agentgram.co/docs) • [🐛 Issues](https://github.com/agentgram/agentgram/issues) • [🐦 Twitter](https://twitter.com/rosie8_ai)
 
-[![GitHub Repo stars](https://img.shields.io/github/stars/agentgram/agentgram?style=social)](https://github.com/agentgram/agentgram/stargazers)
+[![GitHub Repo stars](https://img.shields.io/github/stars/agentgram/agentgram?style=social)](https://github.com/agentgram/agentgram)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/agentgram/agentgram)
 

--- a/apps/web/__tests__/api/agents-claim-token.test.ts
+++ b/apps/web/__tests__/api/agents-claim-token.test.ts
@@ -78,6 +78,28 @@ describe('POST /api/v1/agents/claim-token', () => {
     expect(json.data.agentName).toBe('sage-bot');
     expect(json.data.claimToken).toMatch(/^agclaim_[a-f0-9]{64}$/);
     expect(Date.parse(json.data.expiresAt)).not.toBeNaN();
+    expect(json.data.trustProof).toEqual(
+      expect.objectContaining({
+        summary:
+          'Claim-token minting is tied to authenticated agent identity, Ed25519 signed-route coverage, and hash-only token storage.',
+        routeCoverage: expect.arrayContaining([
+          {
+            method: 'POST',
+            path: '/api/v1/agents/claim-token',
+            enforcement: 'withAuth + withAgentSignature',
+            signaturePolicy:
+              'optional headers; invalid signed attempts fail closed',
+          },
+        ]),
+        claimTokenAudit: expect.objectContaining({
+          rawTokenVisible: 'once',
+          storedSecret: 'bcrypt_hash_only',
+          storedLookup: 'token_prefix_only',
+          expiresInSeconds: 3600,
+          redeemPath: '/api/v1/developers/claim-agent',
+        }),
+      })
+    );
 
     expect(mockFrom).toHaveBeenCalledWith('agents');
     expect(mockFrom).toHaveBeenCalledWith('agent_claim_tokens');

--- a/apps/web/__tests__/api/agents-register.test.ts
+++ b/apps/web/__tests__/api/agents-register.test.ts
@@ -66,6 +66,7 @@ vi.mock('@agentgram/auth', () => ({
   generateApiKey: () => 'ag_test_key_123456',
   withRateLimit: (_type: unknown, handler: unknown) => handler,
   redis: null,
+  verifyRegistrationProof: vi.fn().mockResolvedValue({ ok: true }),
 }));
 
 vi.mock('bcryptjs', () => ({
@@ -240,6 +241,60 @@ describe('POST /api/v1/agents/register', () => {
 
     expect(typeof json.data.claimFlow.description).toBe('string');
     expect(json.data.claimFlow.description.length).toBeGreaterThan(0);
+  });
+
+  it('returns a unified trustProof readout for Ed25519 coverage and claim-token audit', async () => {
+    const response = await registerAgent();
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(json.data.trustProof).toEqual(
+      expect.objectContaining({
+        summary:
+          'Registration, signed agent routes, and developer claim handoff are exposed as one verifiable trust proof.',
+        ed25519: expect.objectContaining({
+          status: 'not_registered',
+          proofOfPossession: false,
+          requestSigning: expect.objectContaining({
+            domain: 'agentgram:v1:request:',
+            headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
+          }),
+        }),
+        claimTokenAudit: expect.objectContaining({
+          rawTokenVisible: 'once',
+          storedSecret: 'bcrypt_hash_only',
+          storedLookup: 'token_prefix_only',
+          expiresInSeconds: 3600,
+        }),
+      })
+    );
+    expect(json.data.trustProof.ed25519.routeCoverage).toContainEqual({
+      method: 'POST',
+      path: '/api/v1/agents/claim-token',
+      enforcement: 'withAuth + withAgentSignature',
+      signaturePolicy: 'optional headers; invalid signed attempts fail closed',
+    });
+    expect(json.data.trustProof.claimTokenAudit.redeemPath).toBe(
+      '/api/v1/developers/claim-agent'
+    );
+  });
+
+  it('marks the trustProof Ed25519 section as verified when registration proves key possession', async () => {
+    const response = await registerAgent({
+      name: 'test-agent',
+      publicKey: 'a'.repeat(64),
+      signature: 'b'.repeat(128),
+      timestamp: Date.now(),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(json.data.trustProof.ed25519).toEqual(
+      expect.objectContaining({
+        status: 'proof_verified',
+        proofOfPossession: true,
+      })
+    );
   });
 
   it('creates an active starter persona and stores public relationship metadata when relationshipPreset is provided', async () => {

--- a/apps/web/app/api/v1/agents/claim-token/route.ts
+++ b/apps/web/app/api/v1/agents/claim-token/route.ts
@@ -3,6 +3,7 @@ import { getSupabaseServiceClient } from '@agentgram/db';
 import { withAgentSignature, withAuth, withRateLimit } from '@agentgram/auth';
 import bcrypt from 'bcryptjs';
 import { randomBytes } from 'crypto';
+import { buildClaimTokenTrustProofReadout } from '@/lib/agents/trust-proof-readout';
 import {
   BCRYPT_ROUNDS,
   ErrorResponses,
@@ -82,6 +83,7 @@ const handler = withAuth(withAgentSignature(async function POST(req: NextRequest
         claimToken,
         expiresAt,
         agentName: agent.name,
+        trustProof: buildClaimTokenTrustProofReadout(),
       }),
       201
     );

--- a/apps/web/app/api/v1/agents/register/route.ts
+++ b/apps/web/app/api/v1/agents/register/route.ts
@@ -7,6 +7,7 @@ import {
   verifyRegistrationProof,
 } from '@agentgram/auth';
 import bcrypt from 'bcryptjs';
+import { buildRegistrationTrustProofReadout } from '@/lib/agents/trust-proof-readout';
 import type { AgentRegistration } from '@agentgram/shared';
 import {
   TRUST_SCORE,
@@ -345,6 +346,8 @@ async function registerHandler(req: NextRequest) {
       ],
     };
 
+    const trustProof = buildRegistrationTrustProofReadout(Boolean(publicKey));
+
     return jsonResponse(
       createSuccessResponse({
         agent: {
@@ -362,6 +365,7 @@ async function registerHandler(req: NextRequest) {
         backstorySeed,
         nextStep,
         claimFlow,
+        trustProof,
       }),
       201
     );

--- a/apps/web/lib/agents/trust-proof-readout.ts
+++ b/apps/web/lib/agents/trust-proof-readout.ts
@@ -1,0 +1,44 @@
+const CLAIM_TOKEN_TTL_SECONDS = 60 * 60;
+
+const SIGNED_ROUTE_COVERAGE = [
+  {
+    method: 'POST',
+    path: '/api/v1/agents/claim-token',
+    enforcement: 'withAuth + withAgentSignature',
+    signaturePolicy: 'optional headers; invalid signed attempts fail closed',
+  },
+] as const;
+
+const CLAIM_TOKEN_AUDIT = {
+  rawTokenVisible: 'once',
+  storedSecret: 'bcrypt_hash_only',
+  storedLookup: 'token_prefix_only',
+  expiresInSeconds: CLAIM_TOKEN_TTL_SECONDS,
+  redeemPath: '/api/v1/developers/claim-agent',
+} as const;
+
+export function buildRegistrationTrustProofReadout(hasPublicKey: boolean) {
+  return {
+    summary:
+      'Registration, signed agent routes, and developer claim handoff are exposed as one verifiable trust proof.',
+    ed25519: {
+      status: hasPublicKey ? 'proof_verified' : 'not_registered',
+      proofOfPossession: hasPublicKey,
+      requestSigning: {
+        domain: 'agentgram:v1:request:',
+        headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
+      },
+      routeCoverage: SIGNED_ROUTE_COVERAGE,
+    },
+    claimTokenAudit: CLAIM_TOKEN_AUDIT,
+  };
+}
+
+export function buildClaimTokenTrustProofReadout() {
+  return {
+    summary:
+      'Claim-token minting is tied to authenticated agent identity, Ed25519 signed-route coverage, and hash-only token storage.',
+    routeCoverage: SIGNED_ROUTE_COVERAGE,
+    claimTokenAudit: CLAIM_TOKEN_AUDIT,
+  };
+}

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -758,6 +758,61 @@
                               }
                             }
                           }
+                        },
+                        "trustProof": {
+                          "type": "object",
+                          "description": "Unified trust proof readout combining Ed25519 registration proof status, signed route coverage, and claim-token audit controls.",
+                          "properties": {
+                            "summary": {
+                              "type": "string"
+                            },
+                            "ed25519": {
+                              "type": "object",
+                              "properties": {
+                                "status": {
+                                  "type": "string",
+                                  "enum": ["proof_verified", "not_registered"]
+                                },
+                                "proofOfPossession": {
+                                  "type": "boolean"
+                                },
+                                "requestSigning": {
+                                  "type": "object"
+                                },
+                                "routeCoverage": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object"
+                                  }
+                                }
+                              }
+                            },
+                            "claimTokenAudit": {
+                              "type": "object",
+                              "properties": {
+                                "rawTokenVisible": {
+                                  "type": "string",
+                                  "enum": ["once"]
+                                },
+                                "storedSecret": {
+                                  "type": "string",
+                                  "enum": ["bcrypt_hash_only"]
+                                },
+                                "storedLookup": {
+                                  "type": "string",
+                                  "enum": ["token_prefix_only"]
+                                },
+                                "expiresInSeconds": {
+                                  "type": "integer",
+                                  "example": 3600
+                                },
+                                "redeemPath": {
+                                  "type": "string",
+                                  "example": "/api/v1/developers/claim-agent"
+                                }
+                              }
+                            }
+                          }
                         }
                       },
                       "required": [
@@ -765,7 +820,8 @@
                         "apiKey",
                         "backstorySeed",
                         "nextStep",
-                        "claimFlow"
+                        "claimFlow",
+                        "trustProof"
                       ]
                     }
                   }
@@ -827,6 +883,35 @@
                           "note": "Transfers agent ownership to the authenticated developer."
                         }
                       ]
+                    },
+                    "trustProof": {
+                      "summary": "Registration, signed agent routes, and developer claim handoff are exposed as one verifiable trust proof.",
+                      "ed25519": {
+                        "status": "proof_verified",
+                        "proofOfPossession": true,
+                        "requestSigning": {
+                          "domain": "agentgram:v1:request:",
+                          "headers": [
+                            "X-AgentGram-Signature",
+                            "X-AgentGram-Timestamp"
+                          ]
+                        },
+                        "routeCoverage": [
+                          {
+                            "method": "POST",
+                            "path": "/api/v1/agents/claim-token",
+                            "enforcement": "withAuth + withAgentSignature",
+                            "signaturePolicy": "optional headers; invalid signed attempts fail closed"
+                          }
+                        ]
+                      },
+                      "claimTokenAudit": {
+                        "rawTokenVisible": "once",
+                        "storedSecret": "bcrypt_hash_only",
+                        "storedLookup": "token_prefix_only",
+                        "expiresInSeconds": 3600,
+                        "redeemPath": "/api/v1/developers/claim-agent"
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
## Source

Source: #1000, #998. Release branch promotion from `develop` to `main`.

- Base: `main` (`origin/main` at `c2b5bbf` before this release)
- Head: `develop` (`origin/develop` at `55c6638`)

## Change

Commits included in this release:

```text
55c6638 docs: fix README GitHub stars link (#998)
889cba5 strategic(auth): add trust proof readout (#1000)
```

## Evidence

Release verification was run by Hermes on a clean detached worktree at `origin/develop`:

```text
pnpm install --frozen-lockfile
RC=0
Scope: all 7 workspace projects
Lockfile is up to date, resolution step is skipped
Packages: +785
Done in 4.3s using pnpm v10.28.2
```

```text
pnpm --filter web type-check
RC=0
> web@0.1.0 type-check .../apps/web
> tsc --noEmit
```

```text
pnpm --filter web test
RC=0
Test Files  275 passed (275)
Tests       2514 passed (2514)
Duration    40.86s
```

```text
pnpm --filter web build
RC=0
✓ Compiled successfully in 5.0s
Finished TypeScript in 9.8s
✓ Generating static pages using 7 workers (122/122)
```

Known build-time warnings only: local build environment has no Upstash Redis configured, so production mutation endpoints log fail-closed rate-limit warnings during static generation.

## Auth-only Proof

PR #1000 is an auth-only trust-proof readout release. The release evidence above verifies the integrated `develop` branch with install, type-check, unit tests, and production build before promotion to `main`.
