### PR TITLE
feat(web): C3 — ax-score page refresh for MCP governance pivot

### DIFF
--- a/apps/web/app/(public)/ax-score/page.tsx
+++ b/apps/web/app/(public)/ax-score/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Search, Loader2, ArrowRight, Lock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -104,12 +105,15 @@ export default function AxScorePage() {
             AX Score
           </h1>
           <p className="text-xl text-muted-foreground">
-            Will AI systems discover and recommend your site? Find out in
-            seconds.
+            Score, audit, and govern the MCP servers and agents your team
+            depends on.
           </p>
           <p className="text-sm text-muted-foreground">
-            Check your site&apos;s discoverability readiness signals — robots.txt,
-            llms.txt, OpenAPI, Schema.org, and more.
+            Run a free governance pre-flight on any MCP or API endpoint. AX Score
+            checks the readiness and discoverability signals AgentGram Team uses
+            to score and allow-list the servers your organization runs —
+            robots.txt, llms.txt, OpenAPI, Schema.org, sitemap, meta
+            description, and security.txt. No sign-up required.
           </p>
         </motion.div>
       </section>
@@ -123,7 +127,7 @@ export default function AxScorePage() {
         >
           <div className="flex gap-2">
             <Input
-              placeholder="https://example.com"
+              placeholder="https://your-mcp-server.example.com"
               value={url}
               onChange={(e) => setUrl(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && handleScan()}
@@ -152,7 +156,41 @@ export default function AxScorePage() {
               {error}
             </motion.p>
           )}
+          <p className="text-xs text-muted-foreground mt-3">
+            Point it at an MCP server endpoint, an API base URL, or any public
+            site — for example{' '}
+            <code className="text-foreground/80">
+              https://your-mcp-server.example.com
+            </code>{' '}
+            or{' '}
+            <code className="text-foreground/80">https://api.example.com</code>.
+            The public scan inspects the HTTP(S) endpoint you enter.
+          </p>
         </motion.div>
+      </section>
+
+      {/* Governance context / Team CTA */}
+      <section className="container pb-8 max-w-3xl mx-auto">
+        <Card className="border-primary/20 bg-primary/5">
+          <CardContent className="p-6 space-y-3 text-center">
+            <h2 className="text-lg font-semibold text-foreground">
+              From a public scan to organization-wide MCP governance
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              This free scan is the same readiness check AgentGram Team runs as a
+              pre-flight before an MCP server or agent is registered. The Team
+              plan adds a private registry, scheduled AX Score scoring, Ed25519
+              signature verification, allow-list control, and signed audit
+              receipts for the servers and agents your organization depends on.
+            </p>
+            <Button asChild variant="outline" className="gap-2">
+              <Link href="/pricing">
+                See AgentGram Team
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
       </section>
 
       {/* Results */}
@@ -193,7 +231,7 @@ export default function AxScorePage() {
             <Card>
               <CardHeader className="pb-3">
                 <CardTitle className="text-base">
-                  Discoverability Signals
+                  Endpoint readiness signals
                 </CardTitle>
               </CardHeader>
               <CardContent>
@@ -243,8 +281,8 @@ export default function AxScorePage() {
                     <Lock className="h-4 w-4 text-muted-foreground" />
                   </h3>
                   <p className="text-sm text-muted-foreground">
-                    See how an AI system would respond when asked about your
-                    site.
+                    See how an AI system would respond when asked about this
+                    endpoint.
                   </p>
                   <Button
                     onClick={handleSimulate}
@@ -269,7 +307,7 @@ export default function AxScorePage() {
                     <Lock className="h-4 w-4 text-muted-foreground" />
                   </h3>
                   <p className="text-sm text-muted-foreground">
-                    Auto-generate an llms.txt file tailored to your site.
+                    Auto-generate an llms.txt file tailored to this endpoint.
                   </p>
                   <Button
                     onClick={handleGenerate}


### PR DESCRIPTION
## Source
Source: t_31d874ba — C3 public `/ax-score` page refresh for the C-pivot WS1 MCP governance surface. Plan source: `/Users/sweetheart/.hermes/shared/knowledge/agentgram/plans/c-pivot-plan-20260721.md` lines 80-84.

## Change
- Refreshed the public `/ax-score` page from stale general AI discoverability copy to the C-plan MCP server and agent scoring/governance narrative.
- Kept the anonymous scan flow intact: the page still submits `useAxScan({ url })` and renders the same `ScanResponse` results.
- Added endpoint-oriented examples (`https://your-mcp-server.example.com`, API base URL) and a Team CTA to `/pricing` without adding backend/API/schema/WS2 MCP registry integration.

## Evidence
- Local validation commands passed:
  - `pnpm type-check` — PASS, 4/4 turbo tasks successful.
  - `pnpm test` — PASS, 276 test files / 2512 tests passed.
  - `pnpm build` — PASS, Next build compiled and generated 122/122 static pages; `/ax-score` listed as static output.
- Static `/ax-score` smoke validation passed against `apps/web/.next/server/app/ax-score.html` (42,663 bytes): verified updated hero copy, MCP endpoint placeholder, Team CTA, Scan button, and no `coming soon` / `soon supported` / `not yet` claims.
- Diff is copy/presentation-only in `apps/web/app/(public)/ax-score/page.tsx`; no `hooks/use-ax-score.ts`, `components/ax-score/*`, API, scanner, schema, or migration files changed.
- Note: live `next start` smoke is blocked by an existing app-wide dynamic-route slug conflict (`agentId` vs `id`), so HTTP serving returned 500 before page-specific validation. Build and generated static artifact validation are green.

## Auth-only Proof
N/A
