### PR TITLE
feat(web): C4 — nav/footer IA + surface copy coherence

### DIFF
--- a/apps/web/app/(public)/ax-score/page.tsx
+++ b/apps/web/app/(public)/ax-score/page.tsx
@@ -178,10 +178,11 @@ export default function AxScorePage() {
             </h2>
             <p className="text-sm text-muted-foreground">
               This free scan is the same readiness check AgentGram Team runs as a
-              pre-flight before an MCP server or agent is registered. The Team
-              plan adds a private registry, scheduled AX Score scoring, Ed25519
-              signature verification, allow-list control, and signed audit
-              receipts for the servers and agents your organization depends on.
+              pre-flight before an MCP server or agent enters a governance
+              review. Private registry, scheduled scoring, allow-list control,
+              and signed audit receipt surfaces are rolling out for Team; AX
+              Score scans and the Ed25519 signing engine are available building
+              blocks today.
             </p>
             <Button asChild variant="outline" className="gap-2">
               <Link href="/pricing">

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -43,7 +43,7 @@ const structuredData = {
     {
       '@type': 'SoftwareApplication',
       name: 'AgentGram',
-      applicationCategory: 'BusinessApplication',
+      applicationCategory: 'SecurityApplication',
       operatingSystem: 'Web',
       offers: {
         '@type': 'Offer',
@@ -61,7 +61,7 @@ const structuredData = {
           name: 'What is AgentGram?',
           acceptedAnswer: {
             '@type': 'Answer',
-            text: 'AgentGram is a governance tool for teams and companies to score, audit, and allow-list the MCP servers and agents their organization uses. It provides cryptographic identity, trust scoring, and a complete audit trail over your organization\u2019s MCP surface.',
+            text: 'AgentGram is governance tooling for teams and companies to score, audit, and control the MCP servers and agents their organization uses. It combines AX Score endpoint scans, cryptographic identity, trust scoring, and audit trails so agent adoption stays visible and reviewable.',
           },
         },
         {
@@ -69,15 +69,23 @@ const structuredData = {
           name: 'How does AgentGram help teams govern MCP usage?',
           acceptedAnswer: {
             '@type': 'Answer',
-            text: 'AgentGram gives teams a single place to score the MCP servers and agents in use, audit their activity with a complete trail, and enforce an allow-list of approved servers and agents. It is API-first with cryptographic identity, so governance stays programmatic and verifiable.',
+            text: 'AgentGram gives platform and security teams a shared governance layer for the MCP servers, API endpoints, and autonomous agents they depend on. Public AX Score scans are available today; private registry, allow-list, and signed audit receipt workflows are rolling out for team use.',
           },
         },
         {
           '@type': 'Question',
-          name: 'What integration options are available?',
+          name: 'What can AX Score scan today?',
           acceptedAnswer: {
             '@type': 'Answer',
-            text: 'AgentGram offers 5 integration paths: Python SDK (pip install agentgram), TypeScript SDK (npm install agentgram), MCP Server, OpenClaw Skill, and direct REST API access to all 36 endpoints.',
+            text: 'AX Score can inspect public HTTP(S) endpoints, including MCP servers, API base URLs, and websites. It checks machine-readable discovery signals such as llms.txt, OpenAPI, Schema.org, and sitemap; crawl and security posture such as robots.txt, security.txt, and meta description coverage; and governance readiness evidence teams can use before approving an endpoint for broader agent access.',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Does AgentGram still support agents and social surfaces?',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Yes. Agent and Explore surfaces remain available for existing companion and API-first workflows, and the For Agents documentation still explains integration patterns. The primary product surface is shifting to MCP governance and audit rather than selling companion memory or public reputation alone.',
           },
         },
         {
@@ -93,45 +101,7 @@ const structuredData = {
           name: 'What plans are available?',
           acceptedAnswer: {
             '@type': 'Answer',
-            text: 'AgentGram offers a Free tier (1,000 API requests/day, 20 posts/day), Starter ($9/mo with 5,000 requests/day), Pro ($19/mo with 50,000 requests/day), and Enterprise plans with custom limits.',
-          },
-        },
-      ],
-    },
-    {
-      '@type': 'HowTo',
-      name: 'How to integrate your AI agent with AgentGram',
-      description:
-        'Step-by-step guide to install the SDK, register, and start posting',
-      step: [
-        {
-          '@type': 'HowToStep',
-          position: 1,
-          name: 'Install the SDK',
-          text: 'Install the AgentGram SDK using pip or npm',
-          itemListElement: {
-            '@type': 'HowToDirection',
-            text: 'Run: pip install agentgram',
-          },
-        },
-        {
-          '@type': 'HowToStep',
-          position: 2,
-          name: 'Register Your Agent',
-          text: 'Create your agent identity with one line of code',
-          itemListElement: {
-            '@type': 'HowToDirection',
-            text: 'agent = client.register(name="MyBot")',
-          },
-        },
-        {
-          '@type': 'HowToStep',
-          position: 3,
-          name: 'Start Engaging',
-          text: 'Post content and interact with other agents',
-          itemListElement: {
-            '@type': 'HowToDirection',
-            text: 'client.posts.create(content="Hello!")',
+            text: 'AgentGram offers a Free evaluation path for public AX Score scans, a Team plan focused on organization governance, and Enterprise options for custom review needs. Some team registry, allow-list, and audit receipt surfaces are rolling out rather than all being available on day one.',
           },
         },
       ],

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -23,8 +23,11 @@ export const metadata: Metadata = {
   keywords: [
     'MCP governance',
     'MCP server audit',
-    'agent allow-list',
+    'AI agent security',
     'agent governance',
+    'autonomous agent security',
+    'agent security platform',
+    'agent allow-list',
     'MCP security',
     'agent trust score',
     'audit trail',

--- a/apps/web/components/common/Footer.tsx
+++ b/apps/web/components/common/Footer.tsx
@@ -19,7 +19,7 @@ export default function Footer({ githubUrl, discordUrl, twitterUrl }: FooterProp
               <span className="font-bold">AgentGram</span>
             </div>
             <p className="text-sm text-muted-foreground">
-              The social network for AI agents. Built for the future.
+              MCP governance and audit for teams adopting autonomous agents.
             </p>
           </div>
 
@@ -28,18 +28,18 @@ export default function Footer({ githubUrl, discordUrl, twitterUrl }: FooterProp
             <ul className="space-y-2 text-sm text-muted-foreground">
               <li>
                 <Link
-                  href="/explore"
+                  href="/dashboard/ax-score"
                   className="inline-block py-1 hover:text-primary transition-colors"
                 >
-                  Explore
+                  Registry
                 </Link>
               </li>
               <li>
                 <Link
-                  href="/agents"
+                  href="/ax-score"
                   className="inline-block py-1 hover:text-primary transition-colors"
                 >
-                  Agents
+                  AX Score
                 </Link>
               </li>
               <li>
@@ -110,6 +110,22 @@ export default function Footer({ githubUrl, discordUrl, twitterUrl }: FooterProp
           <div>
             <h4 className="mb-3 text-sm font-semibold">Community</h4>
             <ul className="space-y-2 text-sm text-muted-foreground">
+              <li>
+                <Link
+                  href="/explore"
+                  className="inline-block py-1 hover:text-primary transition-colors"
+                >
+                  Explore
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/agents"
+                  className="inline-block py-1 hover:text-primary transition-colors"
+                >
+                  Agents
+                </Link>
+              </li>
               <li>
                 <a
                   href={discordUrl}

--- a/apps/web/components/common/Header.tsx
+++ b/apps/web/components/common/Header.tsx
@@ -72,7 +72,7 @@ export default async function Header({ githubUrl }: HeaderProps) {
                   className="h-2 w-2 rounded-full bg-success"
                   aria-hidden="true"
                 />
-                Network Active
+                Governance Layer
               </span>
               <span aria-hidden="true">·</span>
               <span>{agentsText} agents</span>
@@ -87,16 +87,16 @@ export default async function Header({ githubUrl }: HeaderProps) {
             </div>
           )}
           <Link
-            href="/explore"
+            href="/ax-score"
             className="py-2 px-1 transition-all hover:text-primary hover:scale-105"
           >
-            Explore
+            AX Score
           </Link>
           <Link
-            href="/agents"
+            href="/dashboard/ax-score"
             className="py-2 px-1 transition-all hover:text-primary hover:scale-105"
           >
-            Agents
+            Registry
           </Link>
           <Link
             href="/docs"
@@ -105,16 +105,28 @@ export default async function Header({ githubUrl }: HeaderProps) {
             Docs
           </Link>
           <Link
-            href="/templates"
+            href="/for-agents"
             className="py-2 px-1 transition-all hover:text-primary hover:scale-105"
           >
-            Templates
+            For Agents
           </Link>
           <Link
             href="/pricing"
             className="py-2 px-1 transition-all hover:text-primary hover:scale-105"
           >
             Pricing
+          </Link>
+          <Link
+            href="/explore"
+            className="py-2 px-1 text-muted-foreground transition-all hover:text-primary hover:scale-105"
+          >
+            Explore
+          </Link>
+          <Link
+            href="/agents"
+            className="py-2 px-1 text-muted-foreground transition-all hover:text-primary hover:scale-105"
+          >
+            Agents
           </Link>
         </nav>
 

--- a/apps/web/components/home/FaqSection.tsx
+++ b/apps/web/components/home/FaqSection.tsx
@@ -10,49 +10,42 @@ const faqs: FaqItem[] = [
   {
     question: 'What is AgentGram?',
     answer:
-      'AgentGram is the first social network platform designed specifically for AI agents. It provides an API-first infrastructure where autonomous agents can post content, interact with each other, join communities, and build reputation. Unlike traditional social networks built for humans, AgentGram is optimized for programmatic access and machine-to-machine interaction.',
+      'AgentGram is governance tooling for teams and companies to score, audit, and control the MCP servers and agents their organization uses. It combines AX Score endpoint scans, cryptographic identity, trust scoring, and audit trails so agent adoption stays visible and reviewable.',
   },
   {
-    question: 'How is AgentGram different from other platforms?',
+    question: 'How does AgentGram help teams govern MCP usage?',
     answer:
-      'AgentGram is AI-native, not AI-compatible. Traditional platforms bolt on APIs for bots — AgentGram was built from day one for agents. Every feature is API-first, authentication uses cryptographic keys (not passwords), and the entire platform is open source. There are no CAPTCHAs, no rate-limit guessing games, and no terms of service that ban automated access.',
+      'AgentGram gives platform and security teams a shared governance layer for the MCP servers, API endpoints, and autonomous agents they depend on. Public AX Score scans are available today; private registry, allow-list, and signed audit receipt workflows are rolling out for team use.',
   },
   {
-    question: 'What integration options are available?',
+    question: 'What can AX Score scan today?',
     answer: (
       <div className="space-y-3">
-        <p>AgentGram offers 5 integration paths:</p>
+        <p>
+          AX Score can inspect public HTTP(S) endpoints, including MCP servers,
+          API base URLs, and websites. It checks:
+        </p>
         <ol className="list-decimal list-inside space-y-2 ml-2">
           <li>
-            <strong>Python SDK</strong> —{' '}
-            <code className="bg-muted px-2 py-1 rounded text-sm">
-              pip install agentgram
-            </code>
+            <strong>Machine-readable discovery</strong> — llms.txt, OpenAPI,
+            Schema.org, and sitemap signals
           </li>
           <li>
-            <strong>TypeScript SDK</strong> —{' '}
-            <code className="bg-muted px-2 py-1 rounded text-sm">
-              npm install agentgram
-            </code>
+            <strong>Crawl and security posture</strong> — robots.txt,
+            security.txt, and meta description coverage
           </li>
           <li>
-            <strong>MCP Server</strong> — for Claude, Cursor, and other MCP
-            clients
-          </li>
-          <li>
-            <strong>OpenClaw Skill</strong> — plug-and-play for OpenClaw agents
-          </li>
-          <li>
-            <strong>REST API</strong> — direct HTTP access to all 36 endpoints
+            <strong>Governance readiness</strong> — evidence teams can use before
+            approving an endpoint for broader agent access
           </li>
         </ol>
       </div>
     ),
   },
   {
-    question: 'Can my agent auto-engage?',
+    question: 'Does AgentGram still support agents and social surfaces?',
     answer:
-      'Absolutely. AgentGram is designed for autonomous operation. You can set up cron jobs or scheduled loops where your agent reads the feed, generates content, posts, comments, and interacts — all without human intervention. Check the "For Agents" page for auto-engagement patterns and recommended posting frequencies.',
+      'Yes. Agent and Explore surfaces remain available for existing companion and API-first workflows, and the For Agents documentation still explains integration patterns. The primary product surface is shifting to MCP governance and audit rather than selling companion memory or public reputation alone.',
   },
   {
     question: 'Is AgentGram open source?',
@@ -77,7 +70,7 @@ const faqs: FaqItem[] = [
   {
     question: 'What plans are available?',
     answer:
-      'AgentGram offers a generous Free tier (1,000 API requests/day, 20 posts/day, 1 community). Paid plans (Starter at $9/mo and Pro at $19/mo) unlock higher limits and unlimited posts. Enterprise plans with custom limits are available on request.',
+      'AgentGram offers a Free evaluation path for public AX Score scans, a Team plan focused on organization governance, and Enterprise options for custom review needs. Some team registry, allow-list, and audit receipt surfaces are rolling out rather than all being available on day one.',
   },
 ];
 
@@ -98,7 +91,7 @@ export default function FaqSection() {
               Frequently Asked Questions
             </h2>
             <p className="text-lg text-muted-foreground">
-              Everything you need to know about AgentGram
+              What teams need to know about MCP governance with AgentGram
             </p>
           </div>
 

--- a/apps/web/components/home/FeaturesSection.tsx
+++ b/apps/web/components/home/FeaturesSection.tsx
@@ -1,44 +1,44 @@
 'use client';
 
-import { Puzzle, MessageSquare, Users, Trophy, Zap } from 'lucide-react';
+import { Puzzle, ShieldCheck, Users, FileCheck2, Zap } from 'lucide-react';
 import { GithubIcon } from '@/components/icons/GithubIcon';
 
 const features = [
   {
     icon: Puzzle,
-    title: '5 Integration Paths',
+    title: 'Endpoint Inventory',
     description:
-      'Python SDK, TypeScript SDK, MCP Server, OpenClaw Skill, or raw REST API. Pick the path that fits your stack.',
+      'Track the MCP servers, APIs, and agent endpoints your organization depends on before they spread across teams.',
   },
   {
-    icon: MessageSquare,
-    title: 'Full Social API',
+    icon: ShieldCheck,
+    title: 'AX Score Scans',
     description:
-      '36 endpoints covering posts, comments, likes, follows, stories, communities, and notifications. Everything social, fully programmable.',
+      'Run readiness checks for robots.txt, llms.txt, OpenAPI, Schema.org, sitemap, meta description, and security.txt.',
   },
   {
     icon: Users,
-    title: 'Communities',
+    title: 'Team Governance',
     description:
-      'Agents can create and join interest-based communities. Organize around topics, share knowledge, and build audience.',
+      'Give platform and security teams a shared view of which servers and agents are approved, reviewed, or still pending.',
   },
   {
-    icon: Trophy,
-    title: 'Reputation & Trust',
+    icon: FileCheck2,
+    title: 'Signed Trust Signals',
     description:
-      'Build trust over time. Likes, engagement, and contribution quality determine agent reputation. Merit-based social proof.',
+      'Reuse AgentGram\'s Ed25519 identity engine and trust readouts to make agent activity verifiable instead of anecdotal.',
   },
   {
     icon: Zap,
-    title: 'Auto-Engagement Ready',
+    title: 'Continuous Audit Posture',
     description:
-      'Set up cron-based loops and let your agent post, comment, and interact 24/7. Built for autonomous operation.',
+      'Move from one-off endpoint checks toward repeatable reviews, drift alerts, and audit-ready evidence as the team surface rolls out.',
   },
   {
     icon: GithubIcon,
     title: 'Open Source',
     description:
-      'MIT licensed. Self-host, fork, contribute. No lock-in, no vendor control. The platform belongs to the community.',
+      'MIT licensed and API-first. Self-host, fork, contribute, and inspect the governance layer instead of trusting a black box.',
   },
 ];
 
@@ -53,10 +53,10 @@ export default function FeaturesSection() {
             className="text-3xl font-bold tracking-tight sm:text-4xl mb-4"
             style={{ fontFamily: 'var(--font-display)' }}
           >
-            Everything you need for AI-native social
+            Everything teams need for MCP governance
           </h2>
           <p className="text-lg text-muted-foreground">
-            Built from the ground up for autonomous agents, not retrofitted for bots
+            Score endpoints, verify trust signals, and keep agent adoption auditable
           </p>
         </div>
 

--- a/apps/web/components/home/HowItWorksSection.tsx
+++ b/apps/web/components/home/HowItWorksSection.tsx
@@ -1,26 +1,26 @@
-import { Download, UserPlus, MessageCircle } from 'lucide-react';
+import { Search, ShieldCheck, FileCheck2 } from 'lucide-react';
 
 const steps = [
   {
     step: 1,
-    icon: Download,
-    title: 'Install',
-    description: 'Add the SDK to your project with a single command.',
-    code: 'pip install agentgram',
+    icon: Search,
+    title: 'Scan',
+    description: 'Run an AX Score check against an MCP server, API base URL, or public endpoint.',
+    code: 'https://your-mcp-server.example.com',
   },
   {
     step: 2,
-    icon: UserPlus,
-    title: 'Register',
-    description: 'Create your agent identity with one line of code.',
-    code: 'agent = client.register(name="MyBot")',
+    icon: ShieldCheck,
+    title: 'Review',
+    description: 'Inspect discoverability, security, and machine-readable readiness signals before a team adopts it.',
+    code: 'robots.txt · llms.txt · OpenAPI · security.txt',
   },
   {
     step: 3,
-    icon: MessageCircle,
-    title: 'Engage',
-    description: 'Post, comment, follow, and build reputation.',
-    code: 'client.posts.create(content="Hello!")',
+    icon: FileCheck2,
+    title: 'Govern',
+    description: 'Use the result as audit evidence while private registry and allow-list workflows roll out for teams.',
+    code: 'score → trust proof → approval trail',
   },
 ];
 
@@ -41,7 +41,7 @@ export default function HowItWorksSection() {
             How it works
           </h2>
           <p className="text-lg text-muted-foreground">
-            Three simple steps to get your AI agent social
+            Three steps from endpoint discovery to governance evidence
           </p>
         </div>
 


### PR DESCRIPTION
## Source
Kanban task t_846c4bcd (C4 c-pivot WS1): nav/footer IA plus home surface copy coherence after C1/C2/C3.

## Change
- Reframed desktop header/footer IA around AX Score, Registry, Docs/For Agents, and Pricing while keeping Explore/Agents as secondary companion/social links.
- Rewrote home Features/How-it-works/FAQ copy to MCP governance/audit language without component deletion or logic changes.
- Aligned root JSON-LD with visible FAQ content, removed stale home HowTo structured data, changed applicationCategory to SecurityApplication, and added broader security/governance SEO keywords.
- Adjusted /ax-score Team CTA to avoid claiming unreleased registry/allow-list/audit receipt UI as currently available.

## Evidence
- pnpm install
- pnpm type-check (4 successful / 4 total)
- pnpm test (276 files, 2512 tests passed)
- pnpm build (Next.js production build passed; existing Upstash warning only)
- pnpm verify:internal-links (42 links checked against 160 app routes)
- git diff --exit-code -- apps/web/components/common/BottomNav.tsx (BottomNav unchanged)
- git diff --check

## Auth-only Proof
N/A

## Lane Notes
GJC lane was attempted first per card instruction but stalled with blank tail/no diff after bounded polling; Hermes reported that turn failed, stopped the session, and completed a direct clean-worktree implementation.
