### PR TITLE
fix(billing): webhook self-dedup + propagate team plan to entitlements

### DIFF
--- a/apps/web/__tests__/api/billing-webhook.test.ts
+++ b/apps/web/__tests__/api/billing-webhook.test.ts
@@ -1,0 +1,174 @@
+import crypto from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const webhookInserts: Record<string, unknown>[] = [];
+const webhookProcessedIds: string[] = [];
+const developerUpdates: Record<string, unknown>[] = [];
+const existingWebhookRows: Array<{ id: string } | null> = [];
+let insertedRowCounter = 0;
+
+function createQuery(table: string) {
+  const query = {
+    insert(payload: Record<string, unknown>) {
+      if (table === 'webhook_events') webhookInserts.push(payload);
+      return query;
+    },
+    update(payload: Record<string, unknown>) {
+      if (table === 'developers') developerUpdates.push(payload);
+      return query;
+    },
+    select() {
+      return query;
+    },
+    eq(column: string, value: unknown) {
+      if (
+        table === 'webhook_events' &&
+        column === 'id' &&
+        typeof value === 'string'
+      ) {
+        webhookProcessedIds.push(value);
+      }
+      return query;
+    },
+    neq() {
+      return query;
+    },
+    not() {
+      return query;
+    },
+    limit() {
+      return query;
+    },
+    async single() {
+      insertedRowCounter += 1;
+      return { data: { id: `webhook-row-${insertedRowCounter}` }, error: null };
+    },
+    async maybeSingle() {
+      return { data: existingWebhookRows.shift() ?? null, error: null };
+    },
+    async or() {
+      return { error: null };
+    },
+  };
+
+  return query;
+}
+
+vi.mock('@agentgram/db', () => ({
+  getSupabaseServiceClient: () => ({
+    from: createQuery,
+  }),
+}));
+
+const invalidateAllPlanCaches = vi.fn();
+vi.mock('@agentgram/auth', () => ({
+  invalidateAllPlanCaches,
+}));
+
+function sign(rawBody: string) {
+  return crypto
+    .createHmac('sha256', process.env.LEMONSQUEEZY_WEBHOOK_SECRET ?? '')
+    .update(rawBody)
+    .digest('hex');
+}
+
+function subscriptionPayload(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    meta: {
+      event_name: 'subscription_created',
+      webhook_id: 'ls-webhook-1',
+      custom_data: { developer_id: 'developer-1' },
+    },
+    data: {
+      id: 'subscription-1',
+      type: 'subscriptions',
+      attributes: {
+        store_id: 123,
+        customer_id: 456,
+        order_id: 789,
+        product_id: 111,
+        variant_id: 222,
+        status: 'active',
+        user_email: 'buyer@example.com',
+        pause: null,
+        cancelled: false,
+        renews_at: '2026-08-21T00:00:00.000Z',
+        ends_at: null,
+        created_at: '2026-07-21T00:00:00.000Z',
+        updated_at: '2026-07-21T00:00:00.000Z',
+        urls: {
+          customer_portal: 'https://example.com/portal',
+          update_payment_method: 'https://example.com/payment',
+        },
+        ...overrides,
+      },
+    },
+  };
+}
+
+function requestFor(payload: unknown) {
+  const rawBody = JSON.stringify(payload);
+  return new NextRequest('http://localhost/api/v1/billing/webhook', {
+    method: 'POST',
+    body: rawBody,
+    headers: {
+      'X-Signature': sign(rawBody),
+    },
+  });
+}
+
+describe('billing webhook lifecycle', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    webhookInserts.length = 0;
+    webhookProcessedIds.length = 0;
+    developerUpdates.length = 0;
+    existingWebhookRows.length = 0;
+    insertedRowCounter = 0;
+    invalidateAllPlanCaches.mockClear();
+    process.env.LEMONSQUEEZY_WEBHOOK_SECRET = 'test-webhook-secret';
+    process.env.LEMONSQUEEZY_STORE_ID = '123';
+    process.env.LEMONSQUEEZY_TEAM_MONTHLY_VARIANT_ID = '222';
+  });
+
+  it('logs an unprocessed row, runs the handler, marks only that row processed, then dedups a duplicate delivery', async () => {
+    const { POST } = await import('../../app/api/v1/billing/webhook/route');
+    const payload = subscriptionPayload();
+
+    existingWebhookRows.push(null);
+    const first = await POST(requestFor(payload));
+
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({ received: true });
+    expect(webhookInserts).toHaveLength(1);
+    expect(webhookInserts[0]).toMatchObject({
+      event_name: 'subscription_created',
+      subscription_id: 'subscription-1',
+      developer_id: 'developer-1',
+      processed_at: null,
+    });
+    expect(developerUpdates).toHaveLength(1);
+    expect(developerUpdates[0]).toMatchObject({
+      payment_subscription_id: 'subscription-1',
+      payment_variant_id: '222',
+      plan: 'team',
+      subscription_status: 'active',
+    });
+    expect(webhookProcessedIds).toContain('webhook-row-1');
+    expect(invalidateAllPlanCaches).toHaveBeenCalledTimes(1);
+
+    existingWebhookRows.push({ id: 'webhook-row-1' });
+    const duplicate = await POST(requestFor(payload));
+
+    expect(duplicate.status).toBe(200);
+    expect(await duplicate.json()).toEqual({
+      received: true,
+      deduplicated: true,
+    });
+    expect(webhookInserts).toHaveLength(2);
+    expect(webhookInserts[1]).toMatchObject({ processed_at: null });
+    expect(developerUpdates).toHaveLength(1);
+    expect(webhookProcessedIds).not.toContain('webhook-row-2');
+  });
+});

--- a/apps/web/__tests__/lib/billing/lemonsqueezy.test.ts
+++ b/apps/web/__tests__/lib/billing/lemonsqueezy.test.ts
@@ -46,12 +46,12 @@ describe('lemonsqueezy variant mapping', () => {
     ).toBe('team');
   });
 
-  it('falls back to free for unknown or unset variants', async () => {
+  it('returns null for unknown or unset variants so webhooks preserve current plan', async () => {
     const { getPlanFromVariantId } = await import('@/lib/billing/lemonsqueezy');
 
-    expect(getPlanFromVariantId('nope')).toBe('free');
+    expect(getPlanFromVariantId('nope')).toBeNull();
     // Must not match when env is unset (undefined === undefined guard).
-    expect(getPlanFromVariantId('')).toBe('free');
+    expect(getPlanFromVariantId('')).toBeNull();
   });
 
   it('resolves Team variantIds from new env, then legacy env as fallback', async () => {
@@ -65,6 +65,14 @@ describe('lemonsqueezy variant mapping', () => {
     mod = await import('@/lib/billing/lemonsqueezy');
     // New team env takes precedence.
     expect(mod.PLANS.team.variantIds.monthly).toBe('team-monthly');
+  });
+
+  it('skips empty Team env and falls back to the first non-empty legacy env', async () => {
+    process.env.LEMONSQUEEZY_TEAM_MONTHLY_VARIANT_ID = '   ';
+    process.env.LEMONSQUEEZY_PRO_MONTHLY_VARIANT_ID = 'legacy-pro-monthly';
+    const { PLANS } = await import('@/lib/billing/lemonsqueezy');
+
+    expect(PLANS.team.variantIds.monthly).toBe('legacy-pro-monthly');
   });
 
   it('tolerates missing variant env without crashing', async () => {
@@ -107,8 +115,10 @@ describe('plan values stay in sync with the developers.plan DB constraint', () =
     process.env.LEMONSQUEEZY_PRO_MONTHLY_VARIANT_ID = 'legacy-pro';
     const { getPlanFromVariantId } = await import('@/lib/billing/lemonsqueezy');
 
-    for (const variant of ['team-monthly', 'legacy-starter', 'legacy-pro', 'unknown']) {
+    for (const variant of ['team-monthly', 'legacy-starter', 'legacy-pro']) {
       expect(ALLOWED_DB_PLANS).toContain(getPlanFromVariantId(variant));
     }
+
+    expect(getPlanFromVariantId('unknown')).toBeNull();
   });
 });

--- a/apps/web/__tests__/shared/constants.test.ts
+++ b/apps/web/__tests__/shared/constants.test.ts
@@ -9,6 +9,8 @@ import {
   PAGINATION,
   ERROR_CODES,
   AX_PLAN_LIMITS,
+  AX_BILLING_REPORT_PLANS,
+  PAID_OPERATOR_PLANS,
 } from '@agentgram/shared/src/constants';
 
 describe('RATE_LIMITS', () => {
@@ -94,5 +96,23 @@ describe('AX_PLAN_LIMITS', () => {
   it('pro plan enables alerts and competitors', () => {
     expect(AX_PLAN_LIMITS.pro.alerts).toBe(true);
     expect(AX_PLAN_LIMITS.pro.competitors).toBe(true);
+  });
+
+  it('team plan matches the advertised paid AX limits and reporting entitlements', () => {
+    expect(AX_PLAN_LIMITS.team.scansPerMonth).toBe(200);
+    expect(AX_PLAN_LIMITS.team.simulationsPerMonth).toBe(100);
+    expect(AX_PLAN_LIMITS.team.generationsPerMonth).toBe(50);
+    expect(AX_PLAN_LIMITS.team.alerts).toBe(true);
+    expect(AX_PLAN_LIMITS.team.monthlyReports).toBe(true);
+    expect(AX_BILLING_REPORT_PLANS).toContain('team');
+  });
+
+  it('paid operator plan registry includes team for dashboard gates', () => {
+    expect(PAID_OPERATOR_PLANS).toEqual([
+      'starter',
+      'pro',
+      'team',
+      'enterprise',
+    ]);
   });
 });

--- a/apps/web/app/api/v1/ax-score/cron/monthly-reports/route.ts
+++ b/apps/web/app/api/v1/ax-score/cron/monthly-reports/route.ts
@@ -6,6 +6,7 @@ import {
   createErrorResponse,
   ERROR_CODES,
   AX_PLAN_LIMITS,
+  AX_BILLING_REPORT_PLANS,
 } from '@agentgram/shared';
 import { getAxDbClient, type AxSiteRow } from '@/lib/ax-score/db';
 import { generateMonthlyReport } from '@/lib/ax-score/monthly-reports';
@@ -42,11 +43,11 @@ export async function POST(req: NextRequest) {
 
     const db = getAxDbClient();
 
-    // Get all developers with Pro or Enterprise plans
+    // Get all developers with Team, Pro, or Enterprise plans
     const { data: developers } = await db
       .from('developers')
       .select('id, plan')
-      .in('plan', ['pro', 'enterprise']);
+      .in('plan', AX_BILLING_REPORT_PLANS);
 
     if (!developers || developers.length === 0) {
       return jsonResponse(

--- a/apps/web/app/api/v1/ax-score/cron/weekly-alerts/route.ts
+++ b/apps/web/app/api/v1/ax-score/cron/weekly-alerts/route.ts
@@ -6,6 +6,7 @@ import {
   createErrorResponse,
   ERROR_CODES,
   AX_PLAN_LIMITS,
+  AX_BILLING_REPORT_PLANS,
 } from '@agentgram/shared';
 import { getAxDbClient } from '@/lib/ax-score/db';
 import { generateWeeklyAlerts } from '@/lib/ax-score/alerts';
@@ -36,11 +37,11 @@ export async function POST(req: NextRequest) {
 
     const db = getAxDbClient();
 
-    // Get all developers with Pro or Enterprise plans
+    // Get all developers with Team, Pro, or Enterprise plans
     const { data: developers } = await db
       .from('developers')
       .select('id, plan')
-      .in('plan', ['pro', 'enterprise']);
+      .in('plan', AX_BILLING_REPORT_PLANS);
 
     if (!developers || developers.length === 0) {
       return jsonResponse(

--- a/apps/web/app/api/v1/billing/webhook/route.ts
+++ b/apps/web/app/api/v1/billing/webhook/route.ts
@@ -5,10 +5,12 @@ import { invalidateAllPlanCaches } from '@agentgram/auth';
 import {
   getPlanFromVariantId,
   mapSubscriptionStatus,
+  type PlanType,
 } from '@/lib/billing/lemonsqueezy';
 
 interface WebhookMeta {
   event_name: string;
+  webhook_id?: string;
   custom_data?: { developer_id?: string };
 }
 
@@ -69,20 +71,36 @@ function validateStoreId(attrs: SubscriptionAttributes): boolean {
 async function logWebhookEvent(
   eventName: string,
   payload: WebhookPayload
-): Promise<void> {
+): Promise<string | null> {
   try {
-    await getSupabaseServiceClient()
+    const { data } = await getSupabaseServiceClient()
       .from('webhook_events')
       .insert({
         event_name: eventName,
         subscription_id: payload.data.id,
         developer_id: payload.meta.custom_data?.developer_id ?? null,
         payload: JSON.parse(JSON.stringify(payload)),
-      });
+        processed_at: null,
+      })
+      .select('id')
+      .single();
+
+    return data?.id ?? null;
   } catch {
     // Non-critical: log failure should not block webhook processing
     console.error('Failed to log webhook event:', eventName);
+    return null;
   }
+}
+
+function planPatchForVariant(variantId: string): { plan?: PlanType } {
+  const plan = getPlanFromVariantId(variantId);
+  if (plan) return { plan };
+
+  console.error(
+    `Unknown Lemon Squeezy variant_id ${variantId}; preserving current plan`
+  );
+  return {};
 }
 
 /**
@@ -160,17 +178,31 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ received: true });
   }
 
-  await logWebhookEvent(eventName, payload);
+  const loggedWebhookEventId = await logWebhookEvent(eventName, payload);
 
   // Idempotency check: skip already-processed webhook events
-  const { data: existing } = await getSupabaseServiceClient()
+  let existingEventQuery = getSupabaseServiceClient()
     .from('webhook_events')
     .select('id')
-    .eq('subscription_id', payload.data.id)
-    .eq('event_name', eventName)
     .not('processed_at', 'is', null)
-    .limit(1)
-    .maybeSingle();
+    .limit(1);
+
+  if (payload.meta.webhook_id) {
+    existingEventQuery = existingEventQuery.eq(
+      'payload->meta->>webhook_id',
+      payload.meta.webhook_id
+    );
+  } else {
+    existingEventQuery = existingEventQuery
+      .eq('subscription_id', payload.data.id)
+      .eq('event_name', eventName);
+  }
+
+  if (loggedWebhookEventId) {
+    existingEventQuery = existingEventQuery.neq('id', loggedWebhookEventId);
+  }
+
+  const { data: existing } = await existingEventQuery.maybeSingle();
 
   if (existing) {
     return NextResponse.json({ received: true, deduplicated: true });
@@ -206,13 +238,13 @@ export async function POST(req: NextRequest) {
         console.log(`Unhandled Lemon Squeezy event: ${eventName}`);
     }
 
-    // Mark webhook event as processed for idempotency
-    await getSupabaseServiceClient()
-      .from('webhook_events')
-      .update({ processed_at: new Date().toISOString() })
-      .eq('subscription_id', payload.data.id)
-      .eq('event_name', eventName)
-      .is('processed_at', null);
+    // Mark the current webhook event as processed for idempotency.
+    if (loggedWebhookEventId) {
+      await getSupabaseServiceClient()
+        .from('webhook_events')
+        .update({ processed_at: new Date().toISOString() })
+        .eq('id', loggedWebhookEventId);
+    }
 
     // Clear in-memory plan caches so plan-gate picks up changes immediately.
     // Redis-cached plans expire via TTL (60s) — acceptable for webhook latency.
@@ -240,7 +272,7 @@ async function handleSubscriptionCreated(payload: WebhookPayload) {
     return;
   }
 
-  const plan = getPlanFromVariantId(String(attrs.variant_id));
+  const planPatch = planPatchForVariant(String(attrs.variant_id));
 
   const result = await getSupabaseServiceClient()
     .from('developers')
@@ -249,7 +281,7 @@ async function handleSubscriptionCreated(payload: WebhookPayload) {
       payment_subscription_id: payload.data.id,
       payment_provider: 'lemonsqueezy',
       payment_variant_id: String(attrs.variant_id),
-      plan,
+      ...planPatch,
       subscription_status: mapSubscriptionStatus(attrs.status),
       current_period_end: attrs.renews_at,
       billing_last_event_at: attrs.updated_at,
@@ -263,12 +295,12 @@ async function handleSubscriptionCreated(payload: WebhookPayload) {
 
 async function handleSubscriptionUpdated(payload: WebhookPayload) {
   const attrs = payload.data.attributes;
-  const plan = getPlanFromVariantId(String(attrs.variant_id));
+  const planPatch = planPatchForVariant(String(attrs.variant_id));
 
   const result = await getSupabaseServiceClient()
     .from('developers')
     .update({
-      plan,
+      ...planPatch,
       payment_variant_id: String(attrs.variant_id),
       subscription_status: mapSubscriptionStatus(attrs.status),
       current_period_end: attrs.renews_at,

--- a/apps/web/components/dashboard/AgentDiaryForm.tsx
+++ b/apps/web/components/dashboard/AgentDiaryForm.tsx
@@ -10,7 +10,11 @@ import {
   ScrollText,
   Trash2,
 } from 'lucide-react';
-import { CONTENT_LIMITS, type AgentDiaryEntry } from '@agentgram/shared';
+import {
+  CONTENT_LIMITS,
+  PAID_OPERATOR_PLANS,
+  type AgentDiaryEntry,
+} from '@agentgram/shared';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -38,7 +42,7 @@ type SaveResponse = {
   };
 };
 
-const PAID_OPERATOR_PLANS = new Set(['starter', 'pro', 'enterprise']);
+const PAID_OPERATOR_PLAN_SET = new Set<string>(PAID_OPERATOR_PLANS);
 
 const LOCKED_GUIDED_PRESETS = [
   {
@@ -106,7 +110,7 @@ function FieldCount({ current, max }: { current: number; max: number }) {
 }
 
 function hasPaidOperatorPlan(plan?: string) {
-  return Boolean(plan && PAID_OPERATOR_PLANS.has(plan));
+  return Boolean(plan && PAID_OPERATOR_PLAN_SET.has(plan));
 }
 
 export function AgentDiaryForm({ settings }: AgentDiaryFormProps) {

--- a/apps/web/components/dashboard/AgentLorebookForm.tsx
+++ b/apps/web/components/dashboard/AgentLorebookForm.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import {
   CONTENT_LIMITS,
+  PAID_OPERATOR_PLANS,
   type AgentLorebook,
   type LorebookPersonEntry,
   type LorebookPlaceEntry,
@@ -117,7 +118,7 @@ function FieldCount({ current, max }: { current: number; max: number }) {
   );
 }
 
-const PAID_OPERATOR_PLANS = new Set(['starter', 'pro', 'enterprise']);
+const PAID_OPERATOR_PLAN_SET = new Set<string>(PAID_OPERATOR_PLANS);
 
 const LOCKED_CANON_TEMPLATES = [
   {
@@ -153,7 +154,7 @@ const LOCKED_CANON_TEMPLATES = [
 ] as const;
 
 function hasPaidOperatorPlan(plan?: string) {
-  return Boolean(plan && PAID_OPERATOR_PLANS.has(plan));
+  return Boolean(plan && PAID_OPERATOR_PLAN_SET.has(plan));
 }
 
 export function AgentLorebookForm({ settings }: AgentLorebookFormProps) {

--- a/apps/web/components/dashboard/AgentMemoryTrustForm.tsx
+++ b/apps/web/components/dashboard/AgentMemoryTrustForm.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { History, Loader2, Lock, RotateCcw, ShieldCheck } from 'lucide-react';
-import { CONTENT_LIMITS } from '@agentgram/shared';
+import { CONTENT_LIMITS, PAID_OPERATOR_PLANS } from '@agentgram/shared';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -100,10 +100,10 @@ function FieldCount({ current, max }: { current: number; max: number }) {
   );
 }
 
-const PAID_OPERATOR_PLANS = new Set(['starter', 'pro', 'enterprise']);
+const PAID_OPERATOR_PLAN_SET = new Set<string>(PAID_OPERATOR_PLANS);
 
 function hasPaidOperatorPlan(plan?: string) {
-  return Boolean(plan && PAID_OPERATOR_PLANS.has(plan));
+  return Boolean(plan && PAID_OPERATOR_PLAN_SET.has(plan));
 }
 
 export function AgentMemoryTrustForm({ settings }: AgentMemoryTrustFormProps) {

--- a/apps/web/components/dashboard/ProactiveControlsForm.tsx
+++ b/apps/web/components/dashboard/ProactiveControlsForm.tsx
@@ -9,6 +9,7 @@ import {
   MessageSquare,
   ShieldCheck,
 } from 'lucide-react';
+import { PAID_OPERATOR_PLANS } from '@agentgram/shared';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -70,10 +71,10 @@ function formatQuietHoursWindow(start: string, end: string): string {
   return `${start} → ${end} KST`;
 }
 
-const PAID_OPERATOR_PLANS = new Set(['starter', 'pro', 'enterprise']);
+const PAID_OPERATOR_PLAN_SET = new Set<string>(PAID_OPERATOR_PLANS);
 
 function hasPaidOperatorPlan(plan?: string) {
-  return Boolean(plan && PAID_OPERATOR_PLANS.has(plan));
+  return Boolean(plan && PAID_OPERATOR_PLAN_SET.has(plan));
 }
 
 export function ProactiveControlsForm({

--- a/apps/web/lib/billing/lemonsqueezy.ts
+++ b/apps/web/lib/billing/lemonsqueezy.ts
@@ -5,6 +5,14 @@ import {
 
 let _configured = false;
 
+function firstNonEmptyEnv(...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
 export function configureLemonSqueezy(): void {
   if (_configured) return;
 
@@ -53,14 +61,16 @@ export const PLANS = {
     name: 'Team',
     price: { monthly: 4900, annual: 47040 },
     variantIds: {
-      monthly:
-        process.env.LEMONSQUEEZY_TEAM_MONTHLY_VARIANT_ID ??
-        process.env.LEMONSQUEEZY_PRO_MONTHLY_VARIANT_ID ??
-        process.env.LEMONSQUEEZY_STARTER_MONTHLY_VARIANT_ID,
-      annual:
-        process.env.LEMONSQUEEZY_TEAM_ANNUAL_VARIANT_ID ??
-        process.env.LEMONSQUEEZY_PRO_ANNUAL_VARIANT_ID ??
-        process.env.LEMONSQUEEZY_STARTER_ANNUAL_VARIANT_ID,
+      monthly: firstNonEmptyEnv(
+        'LEMONSQUEEZY_TEAM_MONTHLY_VARIANT_ID',
+        'LEMONSQUEEZY_PRO_MONTHLY_VARIANT_ID',
+        'LEMONSQUEEZY_STARTER_MONTHLY_VARIANT_ID'
+      ),
+      annual: firstNonEmptyEnv(
+        'LEMONSQUEEZY_TEAM_ANNUAL_VARIANT_ID',
+        'LEMONSQUEEZY_PRO_ANNUAL_VARIANT_ID',
+        'LEMONSQUEEZY_STARTER_ANNUAL_VARIANT_ID'
+      ),
     },
     limits: {
       apiRequestsPerDay: 50000,
@@ -89,9 +99,10 @@ export type PlanType = keyof typeof PLANS;
  * New Team variants map to `team`. Legacy starter/pro variant IDs are still
  * recognized (webhook regression safety for any pre-existing subscription)
  * but are remapped to the `team` product — starter/pro are no longer sold.
- * Unknown or unset variants fall back to `free`.
+ * Unknown or unset variants return null so webhook handlers can preserve the
+ * current plan instead of silently downgrading paid customers to Free.
  */
-export function getPlanFromVariantId(variantId: string): PlanType {
+export function getPlanFromVariantId(variantId: string): PlanType | null {
   const teamVariantIds = [
     process.env.LEMONSQUEEZY_TEAM_MONTHLY_VARIANT_ID,
     process.env.LEMONSQUEEZY_TEAM_ANNUAL_VARIANT_ID,
@@ -102,13 +113,15 @@ export function getPlanFromVariantId(variantId: string): PlanType {
     process.env.LEMONSQUEEZY_PRO_ANNUAL_VARIANT_ID,
   ];
 
-  if (teamVariantIds.some((id) => id && id === variantId)) return 'team';
-  return 'free';
+  if (teamVariantIds.some((id) => id?.trim() && id.trim() === variantId)) {
+    return 'team';
+  }
+  return null;
 }
 
 export function getPlanFromSubscription(
   attributes: Subscription['data']['attributes']
-): PlanType {
+): PlanType | null {
   const variantId = String(attributes.variant_id);
   return getPlanFromVariantId(variantId);
 }

--- a/packages/auth/src/plan-gate.ts
+++ b/packages/auth/src/plan-gate.ts
@@ -3,7 +3,7 @@ import { redis } from './ratelimit';
 /**
  * Plan hierarchy — higher index = more privileged.
  */
-const PLAN_HIERARCHY = ['free', 'starter', 'pro', 'enterprise'] as const;
+const PLAN_HIERARCHY = ['free', 'starter', 'pro', 'team', 'enterprise'] as const;
 export type PlanName = (typeof PLAN_HIERARCHY)[number];
 
 /**

--- a/packages/auth/src/plan-limits.ts
+++ b/packages/auth/src/plan-limits.ts
@@ -8,6 +8,7 @@ const DAILY_POST_LIMITS: Record<PlanName, number> = {
   free: 20,
   starter: -1,
   pro: -1,
+  team: -1,
   enterprise: -1,
 };
 

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1015,7 +1015,7 @@ export type Database = {
           event_name: string;
           id: string;
           payload: Json;
-          processed_at: string;
+          processed_at: string | null;
           subscription_id: string | null;
         };
         Insert: {
@@ -1024,7 +1024,7 @@ export type Database = {
           event_name: string;
           id?: string;
           payload?: Json;
-          processed_at?: string;
+          processed_at?: string | null;
           subscription_id?: string | null;
         };
         Update: {
@@ -1033,7 +1033,7 @@ export type Database = {
           event_name?: string;
           id?: string;
           payload?: Json;
-          processed_at?: string;
+          processed_at?: string | null;
           subscription_id?: string | null;
         };
         Relationships: [

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -221,9 +221,13 @@ export const AX_RATE_LIMITS = {
 } as const;
 
 // AX Score Platform — Plan Limits (-1 = unlimited)
+export const PAID_OPERATOR_PLANS = ['starter', 'pro', 'team', 'enterprise'] as const;
+export const AX_BILLING_REPORT_PLANS = ['pro', 'team', 'enterprise'] as const;
+
 export const AX_PLAN_LIMITS = {
   free: { scansPerMonth: 3, simulationsPerMonth: 0, generationsPerMonth: 0, alerts: false, competitors: false, monthlyReports: false },
   starter: { scansPerMonth: 25, simulationsPerMonth: 10, generationsPerMonth: 5, alerts: false, competitors: false, monthlyReports: false },
   pro: { scansPerMonth: 200, simulationsPerMonth: 100, generationsPerMonth: 50, alerts: true, competitors: true, monthlyReports: true },
+  team: { scansPerMonth: 200, simulationsPerMonth: 100, generationsPerMonth: 50, alerts: true, competitors: true, monthlyReports: true },
   enterprise: { scansPerMonth: -1, simulationsPerMonth: -1, generationsPerMonth: -1, alerts: true, competitors: true, monthlyReports: true },
 } as const;

--- a/packages/shared/src/types/billing.ts
+++ b/packages/shared/src/types/billing.ts
@@ -1,4 +1,4 @@
-export type PlanType = 'free' | 'starter' | 'pro' | 'enterprise';
+export type PlanType = 'free' | 'starter' | 'pro' | 'team' | 'enterprise';
 
 export type SubscriptionStatus =
   | 'none'
@@ -28,7 +28,7 @@ export interface PlanDefinition {
 }
 
 export interface CheckoutRequest {
-  plan: 'starter' | 'pro';
+  plan: 'team';
   billingPeriod: BillingPeriod;
 }
 
@@ -46,6 +46,6 @@ export interface WebhookEvent {
   subscription_id: string | null;
   developer_id: string | null;
   payload: Record<string, unknown>;
-  processed_at: string;
+  processed_at: string | null;
   created_at: string;
 }

--- a/supabase/migrations/20260721071000_fix_webhook_events_processed_at.sql
+++ b/supabase/migrations/20260721071000_fix_webhook_events_processed_at.sql
@@ -1,0 +1,6 @@
+-- Allow billing webhooks to be logged before they are processed.
+-- The original table defaulted processed_at to now(), which made a freshly
+-- inserted audit row look already processed to the idempotency check.
+ALTER TABLE webhook_events
+  ALTER COLUMN processed_at DROP NOT NULL,
+  ALTER COLUMN processed_at DROP DEFAULT;


### PR DESCRIPTION
## Source
Kanban task t_767eeecf: P0 billing integrity hotfix for Lemon Squeezy webhook self-dedup and Team entitlement propagation.

## Change
This PR restores paid billing correctness so Lemon Squeezy subscription webhooks update developer plans instead of deduplicating themselves, Team customers receive paid operator/AX entitlements, empty variant env vars fall back safely, and unknown variants preserve the current customer plan instead of silently downgrading to Free.

## Summary
- Fix webhook_events lifecycle so a newly inserted audit row starts unprocessed, the handler runs, and only the current row is marked processed after success.
- Deduplicate by Lemon Squeezy webhook_id when present, otherwise by subscription/event while excluding the newly inserted row.
- Preserve the current developer plan on unknown Lemon Squeezy variants instead of silently downgrading to Free.
- Add Team to shared billing/auth/AX/dashboard entitlement registries and tests.

## Evidence
- pnpm type-check
- pnpm test
- pnpm build
- pnpm lint (0 errors; existing warnings only)

## Bug checklist
- 1a: forward-only migration drops webhook_events.processed_at NOT NULL and DEFAULT.
- 1b: inserts processed_at: null and marks by inserted row id only after success.
- 1c: dedups by LS webhook_id when available; fallback excludes current row.
- 1d: signed webhook lifecycle regression test covers receive -> handler -> processed mark -> duplicate dedup.
- 2: Team propagated to PlanType, plan hierarchy, AX limits/report cron, and dashboard paid plan registry.
- 3: variant env fallback trims and skips empty strings.
- 4: unknown variants preserve current plan and log an error.

## Auth-only Proof
N/A