### PR TITLE
fix(infra): skip PR artifact guard for dependabot

### DIFF
--- a/.github/workflows/pr-artifact-pack.yml
+++ b/.github/workflows/pr-artifact-pack.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   validate-pr-artifact-pack:
     name: Validate PR verification artifact pack
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog infra item c5905b5fd5.
Ref: https://github.com/agentgram/agentgram

## Change
Skip the PR Artifact Pack Guard job when the workflow actor is `dependabot[bot]`, so Dependabot dependency PRs are not blocked by the human-authored verification artifact pack requirement.

## Evidence
- test: `node --test scripts/__tests__/validate-pr-body.test.mjs` passed (15/15).
- diff/ad-hoc check: workflow contains the job-level `github.actor != 'dependabot[bot]'` condition.
- type-check: `pnpm type-check` passed.

## Auth-only Proof
N/A
