### PR TITLE
strategic(x): return durable receipt URLs

### DIFF
--- a/apps/web/__tests__/api/x-publish.test.ts
+++ b/apps/web/__tests__/api/x-publish.test.ts
@@ -10,6 +10,7 @@ const ORIGINAL_X_ACCESS_TOKEN = process.env.X_ACCESS_TOKEN;
 const ORIGINAL_X_ACCESS_TOKEN_SECRET = process.env.X_ACCESS_TOKEN_SECRET;
 const ORIGINAL_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const ORIGINAL_SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const ORIGINAL_APP_URL = process.env.NEXT_PUBLIC_APP_URL;
 
 type XPublishEnvName =
   | 'X_PUBLISH_SECRET'
@@ -19,7 +20,8 @@ type XPublishEnvName =
   | 'X_ACCESS_TOKEN'
   | 'X_ACCESS_TOKEN_SECRET'
   | 'NEXT_PUBLIC_SUPABASE_URL'
-  | 'SUPABASE_SERVICE_ROLE_KEY';
+  | 'SUPABASE_SERVICE_ROLE_KEY'
+  | 'NEXT_PUBLIC_APP_URL';
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn(),
@@ -36,11 +38,15 @@ function restoreEnv(name: XPublishEnvName, value: string | undefined) {
 }
 
 function mockReceiptInsert() {
-  const insert = vi.fn().mockResolvedValue({ error: null });
+  const single = vi
+    .fn()
+    .mockResolvedValue({ data: { id: '5f7e8c9a-6a2d-4462-a2f8-89e57573e1b4' }, error: null });
+  const select = vi.fn().mockReturnValue({ single });
+  const insert = vi.fn().mockReturnValue({ select });
   const from = vi.fn().mockReturnValue({ insert });
   createClientMock.mockReturnValue({ from } as never);
 
-  return { from, insert };
+  return { from, insert, select, single };
 }
 
 function makeRequest(body: unknown, authorization?: string) {
@@ -61,6 +67,7 @@ describe('POST /api/v1/distribution/x/publish', () => {
     restoreEnv('X_ACCESS_TOKEN_SECRET', ORIGINAL_X_ACCESS_TOKEN_SECRET);
     restoreEnv('NEXT_PUBLIC_SUPABASE_URL', ORIGINAL_SUPABASE_URL);
     restoreEnv('SUPABASE_SERVICE_ROLE_KEY', ORIGINAL_SUPABASE_SERVICE_ROLE_KEY);
+    restoreEnv('NEXT_PUBLIC_APP_URL', ORIGINAL_APP_URL);
     createClientMock.mockReset();
     vi.unstubAllGlobals();
   });
@@ -220,6 +227,7 @@ describe('POST /api/v1/distribution/x/publish', () => {
     process.env.X_BEARER_TOKEN = 'x-token';
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+    process.env.NEXT_PUBLIC_APP_URL = 'https://agentgram.co';
     const receiptDb = mockReceiptInsert();
     vi.stubGlobal(
       'fetch',
@@ -256,6 +264,9 @@ describe('POST /api/v1/distribution/x/publish', () => {
       persisted: true,
       table: 'post_distribution_receipts',
       channelStatus: 'sent',
+      receiptId: '5f7e8c9a-6a2d-4462-a2f8-89e57573e1b4',
+      receiptUrl:
+        'https://agentgram.co/posts/9a94f4e2-f27b-4b02-8405-b496904bea95#distribution-x-5f7e8c9a-6a2d-4462-a2f8-89e57573e1b4',
       externalId: '1800000000000000003',
       externalUrl: 'https://x.com/i/web/status/1800000000000000003',
     });
@@ -270,6 +281,8 @@ describe('POST /api/v1/distribution/x/publish', () => {
         retryable: false,
       })
     );
+    expect(receiptDb.select).toHaveBeenCalledWith('id');
+    expect(receiptDb.single).toHaveBeenCalled();
   });
 
   it('persists retryable error receipts when X returns a transient failure', async () => {

--- a/apps/web/lib/distribution/publish-receipts.ts
+++ b/apps/web/lib/distribution/publish-receipts.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { getBaseUrl } from '@/lib/env';
 import type { X_DISTRIBUTION_CHANNEL, X_POST_ENDPOINT } from '@/lib/distribution/x-publisher';
 
 export type XPublishChannelStatus = 'sent' | 'failed' | 'retryable_error';
@@ -22,6 +23,8 @@ export interface XPublishReceiptResult {
   persisted: boolean;
   table: 'post_distribution_receipts';
   channelStatus: XPublishChannelStatus;
+  receiptId?: string;
+  receiptUrl?: string;
   externalId?: string;
   externalUrl?: string;
   skippedReason?: string;
@@ -42,6 +45,22 @@ function getReceiptClient() {
   return createClient(supabaseUrl, serviceKey, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
+}
+
+function buildReceiptUrl(postId: string, receiptId: string): string {
+  return new URL(
+    `/posts/${encodeURIComponent(postId)}#distribution-x-${encodeURIComponent(receiptId)}`,
+    getBaseUrl()
+  ).toString();
+}
+
+function extractInsertedReceiptId(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const id = (value as { id?: unknown }).id;
+  return normalizePostId(id);
 }
 
 export function extractReceiptPostId(value: unknown): string | undefined {
@@ -71,20 +90,24 @@ export async function persistXPublishReceipt(
     };
   }
 
-  const { error } = await client.from('post_distribution_receipts').insert({
-    post_id: input.postId,
-    channel: input.channel,
-    channel_status: input.channelStatus,
-    external_id: input.externalId ?? null,
-    external_url: input.externalUrl ?? null,
-    endpoint: input.endpoint,
-    request_payload: input.requestPayload,
-    response_payload: input.responsePayload ?? null,
-    error_message: input.errorMessage ?? null,
-    error_status: input.errorStatus ?? null,
-    retryable: input.retryable,
-    verified_at: input.verifiedAt,
-  });
+  const { data, error } = await client
+    .from('post_distribution_receipts')
+    .insert({
+      post_id: input.postId,
+      channel: input.channel,
+      channel_status: input.channelStatus,
+      external_id: input.externalId ?? null,
+      external_url: input.externalUrl ?? null,
+      endpoint: input.endpoint,
+      request_payload: input.requestPayload,
+      response_payload: input.responsePayload ?? null,
+      error_message: input.errorMessage ?? null,
+      error_status: input.errorStatus ?? null,
+      retryable: input.retryable,
+      verified_at: input.verifiedAt,
+    })
+    .select('id')
+    .single();
 
   if (error) {
     return {
@@ -94,8 +117,11 @@ export async function persistXPublishReceipt(
     };
   }
 
+  const receiptId = extractInsertedReceiptId(data);
+
   return {
     ...resultBase,
     persisted: true,
+    ...(receiptId ? { receiptId, receiptUrl: buildReceiptUrl(input.postId, receiptId) } : {}),
   };
 }


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item a1014a0433.
Ref: https://github.com/agentgram/agentgram

## Change
Returned a persisted receipt id and durable AgentGram receipt URL from live X publish receipt writes. The publish receipt response now links the external tweet proof to the AgentGram post URL fragment for operator verification.

## Evidence
test: `pnpm --filter web test __tests__/api/x-publish.test.ts` → 7 passed.
type-check: `pnpm --filter web type-check` → exit 0.
build: `pnpm --filter web build` → exit 0 (with existing Upstash fail-closed warnings).
diff: 2 files changed, 56 insertions, 17 deletions.

## Auth-only Proof
N/A
