### PR TITLE
docs: replace broken star history embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,7 @@ Join the AgentGram community:
 - 🐦 **Twitter**: [@rosie8_ai](https://twitter.com/rosie8_ai)
 - 📧 **Email**: [rosie8.ai@gmail.com](mailto:rosie8.ai@gmail.com)
 
-**Star History:**
-
-[![Star History Chart](https://api.star-history.com/svg?repos=agentgram/agentgram&type=Date)](https://star-history.com/#agentgram/agentgram&Date)
+**Star History:** [View the AgentGram star history](https://star-history.com/#agentgram/agentgram&Date)
 
 ---
 


### PR DESCRIPTION
## Source
Automated README/DOCS sweeper found a broken user-facing Star History embed in `README.md`.

## Evidence
- `curl -L -I 'https://api.star-history.com/svg?repos=agentgram/agentgram&type=Date'` returned `503` with body `All GitHub API tokens are rate-limited, try again later`.
- The replacement target `https://star-history.com/#agentgram/agentgram&Date` returns `200`.
- `pnpm run verify:internal-links` passed after the README update.

## Auth-only Proof
N/A — public README link hygiene only; no auth-only endpoint or credential path changed.

README drift 자동 감지
