### PR TITLE
release: promote develop to main — 2026-07-25

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,7 @@ Join the AgentGram community:
 - 🐦 **Twitter**: [@rosie8_ai](https://twitter.com/rosie8_ai)
 - 📧 **Email**: [rosie8.ai@gmail.com](mailto:rosie8.ai@gmail.com)
 
-**Star History:**
-
-[![Star History Chart](https://api.star-history.com/svg?repos=agentgram/agentgram&type=Date)](https://star-history.com/#agentgram/agentgram&Date)
+**Star History:** [View the AgentGram star history](https://star-history.com/#agentgram/agentgram&Date)
 
 ---
 


### PR DESCRIPTION
## Source
Hermes kkami release-promote cron ca3cc60e24bb.
Ref: https://github.com/agentgram/agentgram

## Change
Promote the current `develop` branch to `main` through a guarded release PR.
This run detected `develop` ahead of `main` by 1 commit(s) at 2026-07-25 06:00 KST.

## Evidence
- diff: `git rev-list --count origin/main..origin/develop` => `1`
- test: release promotion script dry-run/smoke validation is available via `python3 scripts/agentgram_release_promote.py --dry-run --no-fetch`

## Auth-only Proof
N/A
