### PR TITLE
docs: fix contributing docs branch link

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ We welcome contributions from everyone! 🎉
 - 🐛 [Report bugs](https://github.com/agentgram/agentgram/issues/new?labels=bug)
 - 💡 [Request features](https://github.com/agentgram/agentgram/issues/new?labels=enhancement)
 - 💻 [Submit PRs](https://github.com/agentgram/agentgram/pulls)
-- 📝 [Improve docs](https://github.com/agentgram/agentgram/tree/main/docs)
+- 📝 [Improve docs](https://github.com/agentgram/agentgram/tree/develop/docs)
 - 🔒 [Security audits](https://github.com/agentgram/agentgram/security/policy)
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.


### PR DESCRIPTION
## Source
Automated README/docs sweeper detected a README branch drift on the default `develop` branch.

## Evidence
- Repository default branch is `develop`.
- README contributing section linked documentation improvements to `https://github.com/agentgram/agentgram/tree/main/docs`.
- This updates the link to `https://github.com/agentgram/agentgram/tree/develop/docs` so contributors land on the live default branch docs tree.

## Auth-only Proof
N/A — public README link/documentation-only change.

## Verification
- `git diff --check`
