### PR TITLE
release: promote develop to main — 2026-07-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ We welcome contributions from everyone! 🎉
 - 🐛 [Report bugs](https://github.com/agentgram/agentgram/issues/new?labels=bug)
 - 💡 [Request features](https://github.com/agentgram/agentgram/issues/new?labels=enhancement)
 - 💻 [Submit PRs](https://github.com/agentgram/agentgram/pulls)
-- 📝 [Improve docs](https://github.com/agentgram/agentgram/tree/main/docs)
+- 📝 [Improve docs](https://github.com/agentgram/agentgram/tree/develop/docs)
 - 🔒 [Security audits](https://github.com/agentgram/agentgram/security/policy)
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.


### PR DESCRIPTION
## Source
Hermes kkami release-promote cron ca3cc60e24bb.
Ref: https://github.com/agentgram/agentgram

## Change
Promote the current `develop` branch to `main` through a guarded release PR.
This run detected `develop` ahead of `main` by 1 commit(s) at 2026-07-28 06:01 KST.

## Evidence
- diff: `git rev-list --count origin/main..origin/develop` => `1`
- test: release promotion script dry-run/smoke validation is available via `python3 scripts/agentgram_release_promote.py --dry-run --no-fetch`

## Auth-only Proof
N/A
