### PR TITLE
strategic(api): add reputation export gate

### DIFF
--- a/apps/web/__tests__/api/reputation-export.test.ts
+++ b/apps/web/__tests__/api/reputation-export.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  generateAgentKeypair,
+  signRequest,
+  SIGNATURE_HEADER,
+  TIMESTAMP_HEADER,
+} from '@agentgram/auth';
+
+const mockAgentSingle = vi.fn();
+const mockAgentEq = vi.fn();
+const mockAgentSelect = vi.fn();
+const mockTrustEventsOrder = vi.fn();
+const mockTrustEventsEq = vi.fn();
+const mockTrustEventsSelect = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@agentgram/db', () => ({
+  getSupabaseServiceClient: () => ({ from: mockFrom }),
+}));
+
+vi.mock('@agentgram/auth', async () => {
+  const actual = await vi.importActual<typeof import('@agentgram/auth')>(
+    '@agentgram/auth'
+  );
+
+  return {
+    ...actual,
+    withAuth: (handler: unknown) => handler,
+  };
+});
+
+const routePath = '/api/v1/agents/me/reputation-export';
+
+async function makeSignedRequest() {
+  const { publicKey, secretKey } = await generateAgentKeypair();
+  const timestamp = String(Date.now());
+  const signature = await signRequest(secretKey, {
+    method: 'GET',
+    path: routePath,
+    timestamp,
+    body: '',
+  });
+
+  vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'http://supabase.local');
+  vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-key');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => Response.json([{ public_key: publicKey }]))
+  );
+
+  return new Request(`http://localhost${routePath}`, {
+    method: 'GET',
+    headers: {
+      'x-agent-id': 'agent-1',
+      [SIGNATURE_HEADER]: signature,
+      [TIMESTAMP_HEADER]: timestamp,
+    },
+  }) as unknown as import('next/server').NextRequest;
+}
+
+function makeUnsignedRequest() {
+  return new Request(`http://localhost${routePath}`, {
+    method: 'GET',
+    headers: { 'x-agent-id': 'agent-1' },
+  }) as unknown as import('next/server').NextRequest;
+}
+
+describe('GET /api/v1/agents/me/reputation-export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+
+    mockAgentSingle.mockResolvedValue({
+      data: {
+        id: 'agent-1',
+        name: 'sage-bot',
+        display_name: 'Sage Bot',
+        public_key: 'registered-public-key',
+        verification_state: 'verified',
+        status: 'active',
+        trust_score: 0.73,
+        axp: 42,
+        updated_at: '2026-08-03T00:00:00.000Z',
+      },
+      error: null,
+    });
+    mockAgentEq.mockReturnValue({ single: mockAgentSingle });
+    mockAgentSelect.mockReturnValue({ eq: mockAgentEq });
+
+    mockTrustEventsOrder.mockResolvedValue({
+      data: [
+        {
+          id: 'event-1',
+          delta: 0.2,
+          reason: 'operator_verified',
+          reference_id: '11111111-1111-1111-1111-111111111111',
+          created_at: '2026-08-01T00:00:00.000Z',
+        },
+        {
+          id: 'event-2',
+          delta: 0.03,
+          reason: 'external_registry_receipt',
+          reference_id: '22222222-2222-2222-2222-222222222222',
+          created_at: '2026-08-02T00:00:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    mockTrustEventsEq.mockReturnValue({ order: mockTrustEventsOrder });
+    mockTrustEventsSelect.mockReturnValue({ eq: mockTrustEventsEq });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'agents') return { select: mockAgentSelect };
+      if (table === 'trust_events') return { select: mockTrustEventsSelect };
+      return {};
+    });
+  });
+
+  it('requires the Ed25519 signed verifier gate before exporting reputation evidence', async () => {
+    const { GET } = await import(
+      '@/app/api/v1/agents/me/reputation-export/route'
+    );
+
+    const response = await GET(makeUnsignedRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('SIGNATURE_REQUIRED');
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('preserves storage state and trust-event evidence as separate ERC-8004 export sections', async () => {
+    const { GET } = await import(
+      '@/app/api/v1/agents/me/reputation-export/route'
+    );
+
+    const response = await GET(await makeSignedRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.standard).toBe('ERC-8004');
+    expect(json.data.subject).toEqual(
+      expect.objectContaining({
+        agentId: 'agent-1',
+        name: 'sage-bot',
+        publicKey: 'registered-public-key',
+        verificationState: 'verified',
+      })
+    );
+    expect(json.data.signedVerifierGate).toEqual(
+      expect.objectContaining({
+        required: true,
+        verified: true,
+        headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
+      })
+    );
+    expect(json.data.storageState).toEqual(
+      expect.objectContaining({ trustScore: 0.73, axp: 42 })
+    );
+    expect(json.data.eventEvidence).toEqual(
+      expect.objectContaining({
+        sourceTable: 'trust_events',
+        retention: 'full_ledger',
+        eventCount: 2,
+        deltaSum: 0.23,
+      })
+    );
+    expect(json.data.eventEvidence.events).toHaveLength(2);
+    expect(json.data.storageEventReconciliation).toEqual(
+      expect.objectContaining({
+        baselineTrustScore: 0.5,
+        projectedTrustScoreFromEvents: 0.73,
+        storageEventDifference: 0,
+        preservesStorageEventDifference: true,
+      })
+    );
+  });
+});

--- a/apps/web/app/api/v1/agents/me/reputation-export/route.ts
+++ b/apps/web/app/api/v1/agents/me/reputation-export/route.ts
@@ -1,0 +1,168 @@
+import { NextRequest } from 'next/server';
+import {
+  SIGNATURE_HEADER,
+  TIMESTAMP_HEADER,
+  withAgentSignature,
+  withAuth,
+} from '@agentgram/auth';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  ErrorResponses,
+  jsonResponse,
+} from '@agentgram/shared';
+
+const ERC_8004_REPUTATION_EXPORT_VERSION = 'agentgram.reputation.export.v1';
+const BASELINE_TRUST_SCORE = 0.5;
+
+type TrustEventRow = {
+  id: string;
+  delta: number | null;
+  reason: string | null;
+  reference_id: string | null;
+  created_at: string | null;
+};
+
+type AgentReputationRow = {
+  id: string;
+  name: string;
+  display_name: string | null;
+  public_key: string | null;
+  verification_state: string | null;
+  status: string | null;
+  trust_score: number | null;
+  axp: number | null;
+  updated_at: string | null;
+};
+
+function roundScore(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function clampTrustScore(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function hasSignedVerifierHeaders(req: NextRequest): boolean {
+  return (
+    req.headers.get(SIGNATURE_HEADER) !== null &&
+    req.headers.get(TIMESTAMP_HEADER) !== null
+  );
+}
+
+const handler = withAuth(
+  withAgentSignature(async function GET(req: NextRequest) {
+    try {
+      if (!hasSignedVerifierHeaders(req)) {
+        return jsonResponse(
+          createErrorResponse(
+            'SIGNATURE_REQUIRED',
+            'ERC-8004 reputation exports require an Ed25519 signed verifier request'
+          ),
+          401
+        );
+      }
+
+      const agentId = req.headers.get('x-agent-id');
+      if (!agentId) {
+        return jsonResponse(ErrorResponses.unauthorized('Agent ID not found'), 401);
+      }
+
+      const supabase = getSupabaseServiceClient();
+      const [agentResult, trustEventsResult] = await Promise.all([
+        supabase
+          .from('agents')
+          .select(
+            'id, name, display_name, public_key, verification_state, status, trust_score, axp, updated_at'
+          )
+          .eq('id', agentId)
+          .single(),
+        supabase
+          .from('trust_events')
+          .select('id, delta, reason, reference_id, created_at')
+          .eq('agent_id', agentId)
+          .order('created_at', { ascending: true }),
+      ]);
+
+      if (agentResult.error || !agentResult.data) {
+        return jsonResponse(ErrorResponses.notFound('Agent'), 404);
+      }
+
+      if (trustEventsResult.error) {
+        console.error('Reputation export trust event query error:', trustEventsResult.error);
+        return jsonResponse(
+          ErrorResponses.databaseError('Failed to load trust event evidence'),
+          500
+        );
+      }
+
+      const agent = agentResult.data as AgentReputationRow;
+      const events = (trustEventsResult.data ?? []) as TrustEventRow[];
+      const deltaSum = roundScore(
+        events.reduce((sum, event) => sum + (event.delta ?? 0), 0)
+      );
+      const storedTrustScore = roundScore(agent.trust_score ?? BASELINE_TRUST_SCORE);
+      const projectedTrustScoreFromEvents = roundScore(
+        clampTrustScore(BASELINE_TRUST_SCORE + deltaSum)
+      );
+      const storageEventDifference = roundScore(
+        storedTrustScore - projectedTrustScoreFromEvents
+      );
+
+      return jsonResponse(
+        createSuccessResponse({
+          standard: 'ERC-8004',
+          schemaVersion: ERC_8004_REPUTATION_EXPORT_VERSION,
+          generatedAt: new Date().toISOString(),
+          subject: {
+            agentId: agent.id,
+            name: agent.name,
+            displayName: agent.display_name,
+            publicKey: agent.public_key,
+            verificationState: agent.verification_state ?? 'unverified',
+            status: agent.status ?? 'unknown',
+          },
+          signedVerifierGate: {
+            required: true,
+            verified: true,
+            verifier: 'withAuth + withAgentSignature',
+            headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
+            canonicalRequestPath: new URL(req.url).pathname,
+          },
+          storageState: {
+            sourceTable: 'agents',
+            trustScore: storedTrustScore,
+            axp: agent.axp ?? 0,
+            updatedAt: agent.updated_at,
+          },
+          eventEvidence: {
+            sourceTable: 'trust_events',
+            retention: 'full_ledger',
+            eventCount: events.length,
+            deltaSum,
+            events: events.map((event) => ({
+              id: event.id,
+              delta: event.delta ?? 0,
+              reason: event.reason ?? 'unknown',
+              referenceId: event.reference_id,
+              createdAt: event.created_at,
+            })),
+          },
+          storageEventReconciliation: {
+            baselineTrustScore: BASELINE_TRUST_SCORE,
+            projectedTrustScoreFromEvents,
+            storedTrustScore,
+            storageEventDifference,
+            preservesStorageEventDifference: true,
+          },
+        })
+      );
+    } catch (error) {
+      console.error('Reputation export error:', error);
+      return jsonResponse(ErrorResponses.internalError(), 500);
+    }
+  })
+);
+
+export const GET = handler;

--- a/apps/web/lib/agents/trust-proof-readout.ts
+++ b/apps/web/lib/agents/trust-proof-readout.ts
@@ -7,6 +7,12 @@ const SIGNED_ROUTE_COVERAGE = [
     enforcement: 'withAuth + withAgentSignature',
     signaturePolicy: 'optional headers; invalid signed attempts fail closed',
   },
+  {
+    method: 'GET',
+    path: '/api/v1/agents/me/reputation-export',
+    enforcement: 'withAuth + withAgentSignature + required verifier headers',
+    signaturePolicy: 'required headers; unsigned exports fail closed',
+  },
 ] as const;
 
 const CLAIM_TOKEN_AUDIT = {

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1126,6 +1126,41 @@ export type Database = {
           },
         ];
       };
+      trust_events: {
+        Row: {
+          agent_id: string;
+          created_at: string;
+          delta: number;
+          id: string;
+          reason: string;
+          reference_id: string | null;
+        };
+        Insert: {
+          agent_id: string;
+          created_at?: string;
+          delta: number;
+          id?: string;
+          reason: string;
+          reference_id?: string | null;
+        };
+        Update: {
+          agent_id?: string;
+          created_at?: string;
+          delta?: number;
+          id?: string;
+          reason?: string;
+          reference_id?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'trust_events_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
     };
     Views: {
       post_likes: {


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item 7a42be04fc.
Ref: https://github.com/agentgram/agentgram

## Change
Added a signed ERC-8004 reputation export endpoint for authenticated agents that requires Ed25519 verifier headers before returning evidence. The export keeps agents storage state, trust_events ledger evidence, and storage/event reconciliation in separate sections, and extends trust-proof route coverage plus typed trust_events access.

## Evidence
test: pnpm --dir apps/web test __tests__/api/reputation-export.test.ts __tests__/api/agents-register.test.ts __tests__/api/agents-claim-token.test.ts — 19 passed.
type-check/lint/build: pnpm type-check && pnpm lint && pnpm build — passed (lint completed with existing warnings only).
diff: 4 files changed, 390 insertions.

## Auth-only Proof
N/A