### PR TITLE
release: promote develop to main — 2026-08-05

### DIFF
--- a/apps/web/__tests__/api/ax-score-mcp-registry-audit.test.ts
+++ b/apps/web/__tests__/api/ax-score-mcp-registry-audit.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetDeveloperPlan = vi.fn();
+const mockSweepMcpRegistryCoverage = vi.fn();
+
+vi.mock('@agentgram/auth', () => ({
+  withRateLimit: (_config: unknown, handler: unknown) => handler,
+}));
+
+vi.mock('@/lib/auth/developer', () => ({
+  withDeveloperAuth: (handler: unknown) => handler,
+}));
+
+vi.mock('@/lib/ax-score/usage', () => ({
+  getDeveloperPlan: mockGetDeveloperPlan,
+}));
+
+vi.mock('@/lib/ax-score/mcp-registry-audit', () => ({
+  sweepMcpRegistryCoverage: mockSweepMcpRegistryCoverage,
+}));
+
+function makeRequest(
+  body: Record<string, unknown> = {},
+  headers: Record<string, string> = { 'x-developer-id': 'dev-1' }
+) {
+  return new Request('http://localhost/api/v1/ax-score/mcp-registry/audit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  }) as unknown as import('next/server').NextRequest;
+}
+
+describe('POST /api/v1/ax-score/mcp-registry/audit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDeveloperPlan.mockResolvedValue('team');
+    mockSweepMcpRegistryCoverage.mockResolvedValue({
+      summary: {
+        totalEntries: 2,
+        uniqueServerVersions: 2,
+        uniqueServerNames: 1,
+        remoteTransportEntries: 2,
+        remoteTransportCoveragePct: 100,
+        latestMarkedNames: 1,
+      },
+      pageChain: [
+        {
+          index: 0,
+          cursor: null,
+          nextCursor: null,
+          count: 2,
+          digest: 'page-digest',
+        },
+      ],
+      anomalies: {
+        duplicateServerVersions: [],
+        missingLatestMarkers: [],
+        missingRemoteTransports: [],
+        cursorLoops: [],
+        emptyPagesWithCursor: [],
+        truncated: false,
+      },
+      receipt: {
+        kind: 'agentgram.ax-score.mcp-registry.coverage-receipt',
+        registryEndpoint: 'https://registry.modelcontextprotocol.io/v0/servers',
+        generatedAt: '2026-08-04T00:00:00.000Z',
+        digestAlgorithm: 'sha256',
+        coverageDigest: 'coverage-digest',
+        pageChainDigest: 'page-chain-digest',
+        pageCount: 1,
+        serverVersionCount: 2,
+        uniqueServerVersionCount: 2,
+        anomalyCount: 0,
+        x402: {
+          status: 'ready',
+          paymentPurpose: 'mcp-registry-coverage-audit-report',
+          recommendedPriceUsd: '49.00',
+          deliverable: 'Full nextCursor sweep digest.',
+        },
+        signature: {
+          status: 'unsigned',
+          signingAlgorithm: 'ed25519',
+          payloadDigest: 'payload-digest',
+        },
+      },
+    });
+  });
+
+  it('requires an authenticated developer id', async () => {
+    const { POST } = await import(
+      '@/app/api/v1/ax-score/mcp-registry/audit/route'
+    );
+
+    const response = await POST(makeRequest({}, {}));
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.error.code).toBe('UNAUTHORIZED');
+    expect(mockSweepMcpRegistryCoverage).not.toHaveBeenCalled();
+  });
+
+  it('gates the paid coverage receipt package to billing-report plans', async () => {
+    mockGetDeveloperPlan.mockResolvedValueOnce('starter');
+    const { POST } = await import(
+      '@/app/api/v1/ax-score/mcp-registry/audit/route'
+    );
+
+    const response = await POST(makeRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(402);
+    expect(json.error.code).toBe('AX_PRO_REQUIRED');
+    expect(json.error.message).toContain('Pro, Team, and Enterprise');
+    expect(mockSweepMcpRegistryCoverage).not.toHaveBeenCalled();
+  });
+
+  it('returns an x402-ready registry coverage audit package', async () => {
+    const { POST } = await import(
+      '@/app/api/v1/ax-score/mcp-registry/audit/route'
+    );
+
+    const response = await POST(makeRequest({ limit: 50, maxPages: 3 }));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockSweepMcpRegistryCoverage).toHaveBeenCalledWith({
+      limit: 50,
+      maxPages: 3,
+      cursor: null,
+    });
+    expect(json.data).toMatchObject({
+      developerId: 'dev-1',
+      plan: 'team',
+      reportType: 'mcp-registry-coverage-audit',
+      payment: {
+        status: 'ready',
+        paymentPurpose: 'mcp-registry-coverage-audit-report',
+      },
+      audit: {
+        receipt: {
+          kind: 'agentgram.ax-score.mcp-registry.coverage-receipt',
+          signature: {
+            signingAlgorithm: 'ed25519',
+          },
+        },
+      },
+    });
+  });
+});

--- a/apps/web/__tests__/api/reputation-export.test.ts
+++ b/apps/web/__tests__/api/reputation-export.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  generateAgentKeypair,
+  signRequest,
+  SIGNATURE_HEADER,
+  TIMESTAMP_HEADER,
+} from '@agentgram/auth';
+
+const mockAgentSingle = vi.fn();
+const mockAgentEq = vi.fn();
+const mockAgentSelect = vi.fn();
+const mockTrustEventsOrder = vi.fn();
+const mockTrustEventsEq = vi.fn();
+const mockTrustEventsSelect = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@agentgram/db', () => ({
+  getSupabaseServiceClient: () => ({ from: mockFrom }),
+}));
+
+vi.mock('@agentgram/auth', async () => {
+  const actual = await vi.importActual<typeof import('@agentgram/auth')>(
+    '@agentgram/auth'
+  );
+
+  return {
+    ...actual,
+    withAuth: (handler: unknown) => handler,
+  };
+});
+
+const routePath = '/api/v1/agents/me/reputation-export';
+
+async function makeSignedRequest() {
+  const { publicKey, secretKey } = await generateAgentKeypair();
+  const timestamp = String(Date.now());
+  const signature = await signRequest(secretKey, {
+    method: 'GET',
+    path: routePath,
+    timestamp,
+    body: '',
+  });
+
+  vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'http://supabase.local');
+  vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-key');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => Response.json([{ public_key: publicKey }]))
+  );
+
+  return new Request(`http://localhost${routePath}`, {
+    method: 'GET',
+    headers: {
+      'x-agent-id': 'agent-1',
+      [SIGNATURE_HEADER]: signature,
+      [TIMESTAMP_HEADER]: timestamp,
+    },
+  }) as unknown as import('next/server').NextRequest;
+}
+
+function makeUnsignedRequest() {
+  return new Request(`http://localhost${routePath}`, {
+    method: 'GET',
+    headers: { 'x-agent-id': 'agent-1' },
+  }) as unknown as import('next/server').NextRequest;
+}
+
+describe('GET /api/v1/agents/me/reputation-export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+
+    mockAgentSingle.mockResolvedValue({
+      data: {
+        id: 'agent-1',
+        name: 'sage-bot',
+        display_name: 'Sage Bot',
+        public_key: 'registered-public-key',
+        verification_state: 'verified',
+        status: 'active',
+        trust_score: 0.73,
+        axp: 42,
+        updated_at: '2026-08-03T00:00:00.000Z',
+      },
+      error: null,
+    });
+    mockAgentEq.mockReturnValue({ single: mockAgentSingle });
+    mockAgentSelect.mockReturnValue({ eq: mockAgentEq });
+
+    mockTrustEventsOrder.mockResolvedValue({
+      data: [
+        {
+          id: 'event-1',
+          delta: 0.2,
+          reason: 'operator_verified',
+          reference_id: '11111111-1111-1111-1111-111111111111',
+          created_at: '2026-08-01T00:00:00.000Z',
+        },
+        {
+          id: 'event-2',
+          delta: 0.03,
+          reason: 'external_registry_receipt',
+          reference_id: '22222222-2222-2222-2222-222222222222',
+          created_at: '2026-08-02T00:00:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    mockTrustEventsEq.mockReturnValue({ order: mockTrustEventsOrder });
+    mockTrustEventsSelect.mockReturnValue({ eq: mockTrustEventsEq });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'agents') return { select: mockAgentSelect };
+      if (table === 'trust_events') return { select: mockTrustEventsSelect };
+      return {};
+    });
+  });
+
+  it('requires the Ed25519 signed verifier gate before exporting reputation evidence', async () => {
+    const { GET } = await import(
+      '@/app/api/v1/agents/me/reputation-export/route'
+    );
+
+    const response = await GET(makeUnsignedRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('SIGNATURE_REQUIRED');
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('preserves storage state and trust-event evidence as separate ERC-8004 export sections', async () => {
+    const { GET } = await import(
+      '@/app/api/v1/agents/me/reputation-export/route'
+    );
+
+    const response = await GET(await makeSignedRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.standard).toBe('ERC-8004');
+    expect(json.data.subject).toEqual(
+      expect.objectContaining({
+        agentId: 'agent-1',
+        name: 'sage-bot',
+        publicKey: 'registered-public-key',
+        verificationState: 'verified',
+      })
+    );
+    expect(json.data.signedVerifierGate).toEqual(
+      expect.objectContaining({
+        required: true,
+        verified: true,
+        headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
+      })
+    );
+    expect(json.data.storageState).toEqual(
+      expect.objectContaining({ trustScore: 0.73, axp: 42 })
+    );
+    expect(json.data.eventEvidence).toEqual(
+      expect.objectContaining({
+        sourceTable: 'trust_events',
+        retention: 'full_ledger',
+        eventCount: 2,
+        deltaSum: 0.23,
+      })
+    );
+    expect(json.data.eventEvidence.events).toHaveLength(2);
+    expect(json.data.storageEventReconciliation).toEqual(
+      expect.objectContaining({
+        baselineTrustScore: 0.5,
+        projectedTrustScoreFromEvents: 0.73,
+        storageEventDifference: 0,
+        preservesStorageEventDifference: true,
+      })
+    );
+  });
+});

--- a/apps/web/__tests__/lib/ax-score/mcp-registry-audit.test.ts
+++ b/apps/web/__tests__/lib/ax-score/mcp-registry-audit.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sweepMcpRegistryCoverage } from '@/lib/ax-score/mcp-registry-audit';
+
+function registryResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('sweepMcpRegistryCoverage', () => {
+  it('builds a full nextCursor page-chain digest and x402-ready receipt', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        registryResponse({
+          servers: [
+            {
+              server: {
+                name: 'acme/weather',
+                version: '1.0.0',
+                remotes: [{ type: 'streamable-http', url: 'https://weather.example/mcp' }],
+              },
+              _meta: {
+                'io.modelcontextprotocol.registry/official': {
+                  isLatest: false,
+                },
+              },
+            },
+          ],
+          metadata: { count: 1, nextCursor: 'acme/weather:1.0.0' },
+        })
+      )
+      .mockResolvedValueOnce(
+        registryResponse({
+          servers: [
+            {
+              server: {
+                name: 'acme/weather',
+                version: '1.1.0',
+                remotes: [{ type: 'streamable-http', url: 'https://weather.example/mcp' }],
+              },
+              _meta: {
+                'io.modelcontextprotocol.registry/official': {
+                  isLatest: true,
+                },
+              },
+            },
+          ],
+          metadata: { count: 1 },
+        })
+      );
+
+    const audit = await sweepMcpRegistryCoverage({
+      fetcher,
+      endpoint: 'https://registry.example/v0/servers',
+      limit: 1,
+      generatedAt: '2026-08-04T00:00:00.000Z',
+    });
+
+    expect(fetcher).toHaveBeenNthCalledWith(
+      1,
+      'https://registry.example/v0/servers?limit=1'
+    );
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      'https://registry.example/v0/servers?limit=1&cursor=acme%2Fweather%3A1.0.0'
+    );
+    expect(audit.summary).toMatchObject({
+      totalEntries: 2,
+      uniqueServerVersions: 2,
+      uniqueServerNames: 1,
+      remoteTransportEntries: 2,
+      remoteTransportCoveragePct: 100,
+      latestMarkedNames: 1,
+    });
+    expect(audit.pageChain).toHaveLength(2);
+    expect(audit.anomalies.duplicateServerVersions).toEqual([]);
+    expect(audit.anomalies.truncated).toBe(false);
+    expect(audit.receipt).toMatchObject({
+      kind: 'agentgram.ax-score.mcp-registry.coverage-receipt',
+      registryEndpoint: 'https://registry.example/v0/servers',
+      digestAlgorithm: 'sha256',
+      pageCount: 2,
+      serverVersionCount: 2,
+      uniqueServerVersionCount: 2,
+      anomalyCount: 0,
+      x402: {
+        status: 'ready',
+        paymentPurpose: 'mcp-registry-coverage-audit-report',
+      },
+      signature: {
+        status: 'unsigned',
+        signingAlgorithm: 'ed25519',
+      },
+    });
+    expect(audit.receipt.coverageDigest).toMatch(/^[a-f0-9]{64}$/);
+    expect(audit.receipt.signature.payloadDigest).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('reports duplicate, remote-coverage, latest-marker, and cursor anomalies', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        registryResponse({
+          servers: [
+            { server: { name: 'loop/server', version: '1.0.0', remotes: [] } },
+            { server: { name: 'loop/server', version: '1.0.0', remotes: [] } },
+          ],
+          metadata: { count: 2, nextCursor: 'cursor-a' },
+        })
+      )
+      .mockResolvedValueOnce(
+        registryResponse({
+          servers: [],
+          metadata: { count: 0, nextCursor: 'cursor-a' },
+        })
+      );
+
+    const audit = await sweepMcpRegistryCoverage({
+      fetcher,
+      endpoint: 'https://registry.example/v0/servers',
+      limit: 2,
+      generatedAt: '2026-08-04T00:00:00.000Z',
+    });
+
+    expect(audit.summary.remoteTransportCoveragePct).toBe(0);
+    expect(audit.anomalies.duplicateServerVersions).toEqual([
+      'loop/server@1.0.0',
+    ]);
+    expect(audit.anomalies.missingRemoteTransports).toEqual([
+      'loop/server@1.0.0',
+      'loop/server@1.0.0',
+    ]);
+    expect(audit.anomalies.missingLatestMarkers).toEqual(['loop/server']);
+    expect(audit.anomalies.emptyPagesWithCursor).toEqual(['cursor-a']);
+    expect(audit.anomalies.cursorLoops).toEqual(['cursor-a']);
+    expect(audit.receipt.anomalyCount).toBe(6);
+  });
+
+  it('marks a sweep as truncated when maxPages stops before registry exhaustion', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      registryResponse({
+        servers: [
+          {
+            server: {
+              name: 'paged/server',
+              version: '1.0.0',
+              remotes: [{ type: 'streamable-http', url: 'https://paged.example/mcp' }],
+            },
+            _meta: {
+              'io.modelcontextprotocol.registry/official': {
+                isLatest: true,
+              },
+            },
+          },
+        ],
+        metadata: { count: 1, nextCursor: 'next-page' },
+      })
+    );
+
+    const audit = await sweepMcpRegistryCoverage({
+      fetcher,
+      endpoint: 'https://registry.example/v0/servers',
+      maxPages: 1,
+      generatedAt: '2026-08-04T00:00:00.000Z',
+    });
+
+    expect(audit.pageChain).toHaveLength(1);
+    expect(audit.anomalies.truncated).toBe(true);
+    expect(audit.receipt.anomalyCount).toBe(1);
+  });
+});

--- a/apps/web/app/api/v1/agents/me/reputation-export/route.ts
+++ b/apps/web/app/api/v1/agents/me/reputation-export/route.ts
@@ -1,0 +1,168 @@
+import { NextRequest } from 'next/server';
+import {
+  SIGNATURE_HEADER,
+  TIMESTAMP_HEADER,
+  withAgentSignature,
+  withAuth,
+} from '@agentgram/auth';
+import { getSupabaseServiceClient } from '@agentgram/db';
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  ErrorResponses,
+  jsonResponse,
+} from '@agentgram/shared';
+
+const ERC_8004_REPUTATION_EXPORT_VERSION = 'agentgram.reputation.export.v1';
+const BASELINE_TRUST_SCORE = 0.5;
+
+type TrustEventRow = {
+  id: string;
+  delta: number | null;
+  reason: string | null;
+  reference_id: string | null;
+  created_at: string | null;
+};
+
+type AgentReputationRow = {
+  id: string;
+  name: string;
+  display_name: string | null;
+  public_key: string | null;
+  verification_state: string | null;
+  status: string | null;
+  trust_score: number | null;
+  axp: number | null;
+  updated_at: string | null;
+};
+
+function roundScore(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function clampTrustScore(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function hasSignedVerifierHeaders(req: NextRequest): boolean {
+  return (
+    req.headers.get(SIGNATURE_HEADER) !== null &&
+    req.headers.get(TIMESTAMP_HEADER) !== null
+  );
+}
+
+const handler = withAuth(
+  withAgentSignature(async function GET(req: NextRequest) {
+    try {
+      if (!hasSignedVerifierHeaders(req)) {
+        return jsonResponse(
+          createErrorResponse(
+            'SIGNATURE_REQUIRED',
+            'ERC-8004 reputation exports require an Ed25519 signed verifier request'
+          ),
+          401
+        );
+      }
+
+      const agentId = req.headers.get('x-agent-id');
+      if (!agentId) {
+        return jsonResponse(ErrorResponses.unauthorized('Agent ID not found'), 401);
+      }
+
+      const supabase = getSupabaseServiceClient();
+      const [agentResult, trustEventsResult] = await Promise.all([
+        supabase
+          .from('agents')
+          .select(
+            'id, name, display_name, public_key, verification_state, status, trust_score, axp, updated_at'
+          )
+          .eq('id', agentId)
+          .single(),
+        supabase
+          .from('trust_events')
+          .select('id, delta, reason, reference_id, created_at')
+          .eq('agent_id', agentId)
+          .order('created_at', { ascending: true }),
+      ]);
+
+      if (agentResult.error || !agentResult.data) {
+        return jsonResponse(ErrorResponses.notFound('Agent'), 404);
+      }
+
+      if (trustEventsResult.error) {
+        console.error('Reputation export trust event query error:', trustEventsResult.error);
+        return jsonResponse(
+          ErrorResponses.databaseError('Failed to load trust event evidence'),
+          500
+        );
+      }
+
+      const agent = agentResult.data as AgentReputationRow;
+      const events = (trustEventsResult.data ?? []) as TrustEventRow[];
+      const deltaSum = roundScore(
+        events.reduce((sum, event) => sum + (event.delta ?? 0), 0)
+      );
+      const storedTrustScore = roundScore(agent.trust_score ?? BASELINE_TRUST_SCORE);
+      const projectedTrustScoreFromEvents = roundScore(
+        clampTrustScore(BASELINE_TRUST_SCORE + deltaSum)
+      );
+      const storageEventDifference = roundScore(
+        storedTrustScore - projectedTrustScoreFromEvents
+      );
+
+      return jsonResponse(
+        createSuccessResponse({
+          standard: 'ERC-8004',
+          schemaVersion: ERC_8004_REPUTATION_EXPORT_VERSION,
+          generatedAt: new Date().toISOString(),
+          subject: {
+            agentId: agent.id,
+            name: agent.name,
+            displayName: agent.display_name,
+            publicKey: agent.public_key,
+            verificationState: agent.verification_state ?? 'unverified',
+            status: agent.status ?? 'unknown',
+          },
+          signedVerifierGate: {
+            required: true,
+            verified: true,
+            verifier: 'withAuth + withAgentSignature',
+            headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
+            canonicalRequestPath: new URL(req.url).pathname,
+          },
+          storageState: {
+            sourceTable: 'agents',
+            trustScore: storedTrustScore,
+            axp: agent.axp ?? 0,
+            updatedAt: agent.updated_at,
+          },
+          eventEvidence: {
+            sourceTable: 'trust_events',
+            retention: 'full_ledger',
+            eventCount: events.length,
+            deltaSum,
+            events: events.map((event) => ({
+              id: event.id,
+              delta: event.delta ?? 0,
+              reason: event.reason ?? 'unknown',
+              referenceId: event.reference_id,
+              createdAt: event.created_at,
+            })),
+          },
+          storageEventReconciliation: {
+            baselineTrustScore: BASELINE_TRUST_SCORE,
+            projectedTrustScoreFromEvents,
+            storedTrustScore,
+            storageEventDifference,
+            preservesStorageEventDifference: true,
+          },
+        })
+      );
+    } catch (error) {
+      console.error('Reputation export error:', error);
+      return jsonResponse(ErrorResponses.internalError(), 500);
+    }
+  })
+);
+
+export const GET = handler;

--- a/apps/web/app/api/v1/ax-score/mcp-registry/audit/route.ts
+++ b/apps/web/app/api/v1/ax-score/mcp-registry/audit/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest } from 'next/server';
+import { withRateLimit } from '@agentgram/auth';
+import { withDeveloperAuth } from '@/lib/auth/developer';
+import {
+  AX_BILLING_REPORT_PLANS,
+  AX_RATE_LIMITS,
+  ERROR_CODES,
+  ErrorResponses,
+  createErrorResponse,
+  createSuccessResponse,
+  jsonResponse,
+} from '@agentgram/shared';
+import { getDeveloperPlan } from '@/lib/ax-score/usage';
+import { sweepMcpRegistryCoverage } from '@/lib/ax-score/mcp-registry-audit';
+
+interface AuditRequestBody {
+  limit?: unknown;
+  maxPages?: unknown;
+  cursor?: unknown;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+    return undefined;
+  }
+
+  return value;
+}
+
+function isBillingReportPlan(plan: string): boolean {
+  return (AX_BILLING_REPORT_PLANS as readonly string[]).includes(plan);
+}
+
+/**
+ * POST /api/v1/ax-score/mcp-registry/audit
+ *
+ * Produce an x402-ready proof package for the official MCP Registry: a full
+ * nextCursor page-chain digest, coverage anomaly report, and Ed25519-signable
+ * receipt payload. Auth: Developer (Supabase session) — Pro/Team+ paid report.
+ */
+const handler = withDeveloperAuth(async function POST(req: NextRequest) {
+  try {
+    const developerId = req.headers.get('x-developer-id');
+    if (!developerId) {
+      return jsonResponse(ErrorResponses.unauthorized(), 401);
+    }
+
+    const plan = await getDeveloperPlan(developerId);
+    if (!isBillingReportPlan(plan)) {
+      return jsonResponse(
+        createErrorResponse(
+          ERROR_CODES.AX_PRO_REQUIRED,
+          'MCP Registry coverage audit receipts are available on Pro, Team, and Enterprise plans.'
+        ),
+        402
+      );
+    }
+
+    const body = (await req.json().catch(() => ({}))) as AuditRequestBody;
+    const limit = readPositiveInteger(body.limit);
+    const maxPages = readPositiveInteger(body.maxPages);
+    const cursor = typeof body.cursor === 'string' ? body.cursor : null;
+
+    const audit = await sweepMcpRegistryCoverage({
+      ...(limit ? { limit } : {}),
+      ...(maxPages ? { maxPages } : {}),
+      cursor,
+    });
+
+    return jsonResponse(
+      createSuccessResponse({
+        developerId,
+        plan,
+        reportType: 'mcp-registry-coverage-audit',
+        payment: audit.receipt.x402,
+        audit,
+      }),
+      200
+    );
+  } catch (error) {
+    console.error('MCP Registry coverage audit error:', error);
+    return jsonResponse(
+      ErrorResponses.internalError('Failed to produce MCP Registry coverage audit'),
+      500
+    );
+  }
+});
+
+export const POST = withRateLimit(
+  {
+    maxRequests: AX_RATE_LIMITS.REPORTS.limit,
+    windowMs: AX_RATE_LIMITS.REPORTS.windowMs,
+  },
+  handler
+);

--- a/apps/web/lib/agents/trust-proof-readout.ts
+++ b/apps/web/lib/agents/trust-proof-readout.ts
@@ -7,6 +7,12 @@ const SIGNED_ROUTE_COVERAGE = [
     enforcement: 'withAuth + withAgentSignature',
     signaturePolicy: 'optional headers; invalid signed attempts fail closed',
   },
+  {
+    method: 'GET',
+    path: '/api/v1/agents/me/reputation-export',
+    enforcement: 'withAuth + withAgentSignature + required verifier headers',
+    signaturePolicy: 'required headers; unsigned exports fail closed',
+  },
 ] as const;
 
 const CLAIM_TOKEN_AUDIT = {

--- a/apps/web/lib/ax-score/mcp-registry-audit.ts
+++ b/apps/web/lib/ax-score/mcp-registry-audit.ts
@@ -1,0 +1,333 @@
+import { createHash } from 'node:crypto';
+
+const MCP_REGISTRY_ENDPOINT = 'https://registry.modelcontextprotocol.io/v0/servers';
+const DEFAULT_PAGE_LIMIT = 100;
+const DEFAULT_MAX_PAGES = 100;
+
+export interface McpRegistrySweepOptions {
+  fetcher?: typeof fetch;
+  endpoint?: string;
+  limit?: number;
+  maxPages?: number;
+  cursor?: string | null;
+  generatedAt?: string;
+}
+
+interface McpRegistryServerDocument {
+  name?: unknown;
+  version?: unknown;
+  remotes?: unknown;
+  packages?: unknown;
+}
+
+interface McpRegistryEntry {
+  server?: McpRegistryServerDocument;
+  _meta?: {
+    'io.modelcontextprotocol.registry/official'?: {
+      isLatest?: unknown;
+      status?: unknown;
+      publishedAt?: unknown;
+      updatedAt?: unknown;
+    };
+  };
+}
+
+interface McpRegistryResponse {
+  servers?: McpRegistryEntry[];
+  metadata?: {
+    nextCursor?: unknown;
+    count?: unknown;
+  };
+}
+
+export interface McpRegistryPageDigest {
+  index: number;
+  cursor: string | null;
+  nextCursor: string | null;
+  count: number;
+  digest: string;
+}
+
+export interface McpRegistryCoverageAnomalies {
+  duplicateServerVersions: string[];
+  missingLatestMarkers: string[];
+  missingRemoteTransports: string[];
+  cursorLoops: string[];
+  emptyPagesWithCursor: string[];
+  truncated: boolean;
+}
+
+export interface McpRegistryCoverageReceipt {
+  kind: 'agentgram.ax-score.mcp-registry.coverage-receipt';
+  registryEndpoint: string;
+  generatedAt: string;
+  digestAlgorithm: 'sha256';
+  coverageDigest: string;
+  pageChainDigest: string;
+  pageCount: number;
+  serverVersionCount: number;
+  uniqueServerVersionCount: number;
+  anomalyCount: number;
+  x402: {
+    status: 'ready';
+    paymentPurpose: 'mcp-registry-coverage-audit-report';
+    recommendedPriceUsd: string;
+    deliverable: string;
+  };
+  signature: {
+    status: 'unsigned';
+    signingAlgorithm: 'ed25519';
+    payloadDigest: string;
+  };
+}
+
+export interface McpRegistryCoverageAudit {
+  summary: {
+    totalEntries: number;
+    uniqueServerVersions: number;
+    uniqueServerNames: number;
+    remoteTransportEntries: number;
+    remoteTransportCoveragePct: number;
+    latestMarkedNames: number;
+  };
+  pageChain: McpRegistryPageDigest[];
+  anomalies: McpRegistryCoverageAnomalies;
+  receipt: McpRegistryCoverageReceipt;
+}
+
+interface NormalizedServerVersion {
+  id: string;
+  name: string;
+  version: string;
+  isLatest: boolean;
+  hasRemoteTransport: boolean;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(',')}}`;
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(stableStringify(value)).digest('hex');
+}
+
+function getString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() ? value : fallback;
+}
+
+function hasRemoteTransport(server: McpRegistryServerDocument): boolean {
+  if (!Array.isArray(server.remotes)) return false;
+
+  return server.remotes.some((remote) => {
+    if (!remote || typeof remote !== 'object') return false;
+    const record = remote as Record<string, unknown>;
+    return typeof record.url === 'string' && record.url.startsWith('https://');
+  });
+}
+
+function normalizeServer(entry: McpRegistryEntry): NormalizedServerVersion {
+  const server = entry.server ?? {};
+  const name = getString(server.name, 'unknown-server');
+  const version = getString(server.version, 'unknown-version');
+  const official = entry._meta?.['io.modelcontextprotocol.registry/official'];
+
+  return {
+    id: `${name}@${version}`,
+    name,
+    version,
+    isLatest: official?.isLatest === true,
+    hasRemoteTransport: hasRemoteTransport(server),
+  };
+}
+
+function buildUrl(endpoint: string, cursor: string | null, limit: number): string {
+  const url = new URL(endpoint);
+  url.searchParams.set('limit', String(limit));
+  if (cursor) url.searchParams.set('cursor', cursor);
+  return url.toString();
+}
+
+function countAnomalies(anomalies: McpRegistryCoverageAnomalies): number {
+  return (
+    anomalies.duplicateServerVersions.length +
+    anomalies.missingLatestMarkers.length +
+    anomalies.missingRemoteTransports.length +
+    anomalies.cursorLoops.length +
+    anomalies.emptyPagesWithCursor.length +
+    (anomalies.truncated ? 1 : 0)
+  );
+}
+
+function buildReceipt(input: {
+  endpoint: string;
+  generatedAt: string;
+  pageChain: McpRegistryPageDigest[];
+  servers: NormalizedServerVersion[];
+  anomalies: McpRegistryCoverageAnomalies;
+}): McpRegistryCoverageReceipt {
+  const pageChainDigest = sha256(input.pageChain);
+  const coveragePayload = {
+    endpoint: input.endpoint,
+    pages: input.pageChain.map((page) => page.digest),
+    servers: input.servers.map((server) => server.id).sort(),
+    anomalies: input.anomalies,
+  };
+  const coverageDigest = sha256(coveragePayload);
+  const anomalyCount = countAnomalies(input.anomalies);
+  const signaturePayloadDigest = sha256({ coverageDigest, pageChainDigest });
+
+  return {
+    kind: 'agentgram.ax-score.mcp-registry.coverage-receipt',
+    registryEndpoint: input.endpoint,
+    generatedAt: input.generatedAt,
+    digestAlgorithm: 'sha256',
+    coverageDigest,
+    pageChainDigest,
+    pageCount: input.pageChain.length,
+    serverVersionCount: input.servers.length,
+    uniqueServerVersionCount: new Set(input.servers.map((server) => server.id)).size,
+    anomalyCount,
+    x402: {
+      status: 'ready',
+      paymentPurpose: 'mcp-registry-coverage-audit-report',
+      recommendedPriceUsd: '49.00',
+      deliverable: 'Full nextCursor sweep digest, coverage anomaly report, and Ed25519-signable receipt payload.',
+    },
+    signature: {
+      status: 'unsigned',
+      signingAlgorithm: 'ed25519',
+      payloadDigest: signaturePayloadDigest,
+    },
+  };
+}
+
+export async function sweepMcpRegistryCoverage(
+  options: McpRegistrySweepOptions = {}
+): Promise<McpRegistryCoverageAudit> {
+  const fetcher = options.fetcher ?? fetch;
+  const endpoint = options.endpoint ?? MCP_REGISTRY_ENDPOINT;
+  const limit = Math.max(1, Math.min(options.limit ?? DEFAULT_PAGE_LIMIT, 500));
+  const maxPages = Math.max(1, options.maxPages ?? DEFAULT_MAX_PAGES);
+  const generatedAt = options.generatedAt ?? new Date().toISOString();
+  const requestedCursors = new Set<string | null>();
+  const pageChain: McpRegistryPageDigest[] = [];
+  const servers: NormalizedServerVersion[] = [];
+  const cursorLoops: string[] = [];
+  const emptyPagesWithCursor: string[] = [];
+  let cursor = options.cursor ?? null;
+  let truncated = false;
+
+  for (let index = 0; index < maxPages; index += 1) {
+    if (requestedCursors.has(cursor)) {
+      cursorLoops.push(cursor ?? '<initial>');
+      break;
+    }
+    requestedCursors.add(cursor);
+
+    const response = await fetcher(buildUrl(endpoint, cursor, limit));
+    if (!response.ok) {
+      throw new Error(`MCP Registry fetch failed with status ${response.status}`);
+    }
+
+    const payload = (await response.json()) as McpRegistryResponse;
+    const entries = Array.isArray(payload.servers) ? payload.servers : [];
+    const normalizedPage = entries.map(normalizeServer);
+    const nextCursor =
+      typeof payload.metadata?.nextCursor === 'string' &&
+      payload.metadata.nextCursor.trim()
+        ? payload.metadata.nextCursor
+        : null;
+
+    if (normalizedPage.length === 0 && nextCursor) {
+      emptyPagesWithCursor.push(nextCursor);
+    }
+
+    pageChain.push({
+      index,
+      cursor,
+      nextCursor,
+      count: normalizedPage.length,
+      digest: sha256({ cursor, nextCursor, servers: normalizedPage }),
+    });
+    servers.push(...normalizedPage);
+
+    if (!nextCursor) {
+      cursor = null;
+      break;
+    }
+
+    cursor = nextCursor;
+    if (index === maxPages - 1) truncated = true;
+  }
+
+  const idCounts = new Map<string, number>();
+  const names = new Map<string, NormalizedServerVersion[]>();
+  for (const server of servers) {
+    idCounts.set(server.id, (idCounts.get(server.id) ?? 0) + 1);
+    names.set(server.name, [...(names.get(server.name) ?? []), server]);
+  }
+
+  const duplicateServerVersions = [...idCounts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([id]) => id)
+    .sort();
+  const missingLatestMarkers = [...names.entries()]
+    .filter(([, versions]) => !versions.some((version) => version.isLatest))
+    .map(([name]) => name)
+    .sort();
+  const missingRemoteTransports = servers
+    .filter((server) => !server.hasRemoteTransport)
+    .map((server) => server.id)
+    .sort();
+
+  const anomalies = {
+    duplicateServerVersions,
+    missingLatestMarkers,
+    missingRemoteTransports,
+    cursorLoops,
+    emptyPagesWithCursor,
+    truncated,
+  };
+  const remoteTransportEntries = servers.filter(
+    (server) => server.hasRemoteTransport
+  ).length;
+  const uniqueServerVersions = new Set(servers.map((server) => server.id)).size;
+  const uniqueServerNames = names.size;
+
+  return {
+    summary: {
+      totalEntries: servers.length,
+      uniqueServerVersions,
+      uniqueServerNames,
+      remoteTransportEntries,
+      remoteTransportCoveragePct:
+        servers.length === 0
+          ? 0
+          : Math.round((remoteTransportEntries / servers.length) * 10000) / 100,
+      latestMarkedNames: [...names.values()].filter((versions) =>
+        versions.some((version) => version.isLatest)
+      ).length,
+    },
+    pageChain,
+    anomalies,
+    receipt: buildReceipt({
+      endpoint,
+      generatedAt,
+      pageChain,
+      servers,
+      anomalies,
+    }),
+  };
+}

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -1126,6 +1126,41 @@ export type Database = {
           },
         ];
       };
+      trust_events: {
+        Row: {
+          agent_id: string;
+          created_at: string;
+          delta: number;
+          id: string;
+          reason: string;
+          reference_id: string | null;
+        };
+        Insert: {
+          agent_id: string;
+          created_at?: string;
+          delta: number;
+          id?: string;
+          reason: string;
+          reference_id?: string | null;
+        };
+        Update: {
+          agent_id?: string;
+          created_at?: string;
+          delta?: number;
+          id?: string;
+          reason?: string;
+          reference_id?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'trust_events_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
     };
     Views: {
       post_likes: {


### PR DESCRIPTION
## Source
Hermes kkami release-promote cron ca3cc60e24bb.
Ref: https://github.com/agentgram/agentgram

## Change
Promote the current `develop` branch to `main` through a guarded release PR.
This run detected `develop` ahead of `main` by 2 commit(s) at 2026-08-05 06:00 KST.

## Evidence
- diff: `git rev-list --count origin/main..origin/develop` => `2`
- test: release promotion script dry-run/smoke validation is available via `python3 scripts/agentgram_release_promote.py --dry-run --no-fetch`

## Auth-only Proof
N/A
