### PR TITLE
release: promote develop to main — 2026-08-11

### DIFF
--- a/apps/web/__tests__/api/a2a-agent-card-canonical-signature.test.ts
+++ b/apps/web/__tests__/api/a2a-agent-card-canonical-signature.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockVerifyA2aAgentCardSignature = vi.fn();
+const mockBuildA2aAgentCardCanonicalSignatureEvidence = vi.fn();
+
+vi.mock('@agentgram/auth', () => ({
+  withRateLimit: (_config: unknown, handler: unknown) => handler,
+  buildA2aAgentCardCanonicalSignatureEvidence:
+    mockBuildA2aAgentCardCanonicalSignatureEvidence,
+  verifyA2aAgentCardSignature: mockVerifyA2aAgentCardSignature,
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request(
+    'http://localhost/api/v1/a2a/agent-card/canonical-signature',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  ) as unknown as import('next/server').NextRequest;
+}
+
+describe('A2A Agent Card canonical signature route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildA2aAgentCardCanonicalSignatureEvidence.mockReturnValue({
+      kind: 'agentgram.a2a.agent-card.canonical-signature-gate',
+      generatedAt: '2026-08-05T00:00:00.000Z',
+      canonicalization: {
+        status: 'conformant',
+        standard: 'RFC8785',
+        fixture: { digest: 'fixture-digest' },
+      },
+      signature: {
+        status: 'fail-closed',
+        signingAlgorithm: 'ed25519',
+        unsignedCardsAccepted: false,
+      },
+    });
+  });
+
+  it('publishes public canonical-signature conformance evidence', async () => {
+    const { GET } = await import(
+      '@/app/api/v1/a2a/agent-card/canonical-signature/route'
+    );
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.reportType).toBe('a2a-agent-card-canonical-signature');
+    expect(json.data.evidence.signature).toMatchObject({
+      status: 'fail-closed',
+      unsignedCardsAccepted: false,
+    });
+  });
+
+  it('validates signed Agent Cards and returns payload digest evidence', async () => {
+    mockVerifyA2aAgentCardSignature.mockResolvedValueOnce({
+      ok: true,
+      canonicalJson: '{"name":"weather-agent"}',
+      payloadDigest: 'a'.repeat(64),
+      evidence: mockBuildA2aAgentCardCanonicalSignatureEvidence(),
+    });
+    const { POST } = await import(
+      '@/app/api/v1/a2a/agent-card/canonical-signature/route'
+    );
+
+    const response = await POST(
+      makeRequest({
+        publicKey: 'b'.repeat(64),
+        signature: 'c'.repeat(128),
+        agentCard: { name: 'weather-agent' },
+      })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data.verdict).toMatchObject({
+      ok: true,
+      payloadDigest: 'a'.repeat(64),
+    });
+    expect(json.data.verdict.canonicalJson).toBeUndefined();
+  });
+
+  it('fails closed when signature material is missing or invalid', async () => {
+    mockVerifyA2aAgentCardSignature.mockResolvedValueOnce({
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message: 'A2A Agent Card signatures require publicKey, signature, and agentCard',
+      evidence: mockBuildA2aAgentCardCanonicalSignatureEvidence(),
+    });
+    const { POST } = await import(
+      '@/app/api/v1/a2a/agent-card/canonical-signature/route'
+    );
+
+    const response = await POST(makeRequest({ agentCard: { name: 'unsigned' } }));
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.error.code).toBe('SIGNATURE_INVALID');
+    expect(json.error.details.evidence.signature.status).toBe('fail-closed');
+  });
+});

--- a/apps/web/__tests__/api/auth-coverage.test.ts
+++ b/apps/web/__tests__/api/auth-coverage.test.ts
@@ -20,6 +20,8 @@ type RouteExport = {
 };
 
 const PUBLIC_API_ROUTE_EXPORTS = new Set([
+  'a2a/agent-card/canonical-signature/route.ts#GET',
+  'a2a/agent-card/canonical-signature/route.ts#POST',
   'activity/live-stats/route.ts#GET',
   'agents/[agentId]/lorebook/preview/route.ts#GET',
   'agents/[agentId]/remixes/route.ts#GET',

--- a/apps/web/__tests__/auth/a2a-agent-card-signature.test.ts
+++ b/apps/web/__tests__/auth/a2a-agent-card-signature.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  A2A_AGENT_CARD_SIGNATURE_DOMAIN,
+  RFC8785_AGENT_CARD_FIXTURE_CANONICAL_JSON,
+  RFC8785_AGENT_CARD_FIXTURE_DIGEST,
+  buildA2aAgentCardCanonicalSignatureEvidence,
+  canonicalJson,
+  generateAgentKeypair,
+  signA2aAgentCard,
+  verifyA2aAgentCardSignature,
+} from '@agentgram/auth/src/ed25519';
+
+describe('A2A Agent Card canonical signature gate', () => {
+  it('publishes the RFC8785 canonicalization fixture used by the gate', () => {
+    const evidence = buildA2aAgentCardCanonicalSignatureEvidence({
+      generatedAt: '2026-08-05T00:00:00.000Z',
+    });
+
+    expect(evidence.kind).toBe(
+      'agentgram.a2a.agent-card.canonical-signature-gate'
+    );
+    expect(evidence.canonicalization.status).toBe('conformant');
+    expect(evidence.canonicalization.standard).toBe('RFC8785');
+    expect(evidence.canonicalization.fixture.canonicalJson).toBe(
+      RFC8785_AGENT_CARD_FIXTURE_CANONICAL_JSON
+    );
+    expect(evidence.canonicalization.fixture.digest).toBe(
+      RFC8785_AGENT_CARD_FIXTURE_DIGEST
+    );
+    expect(evidence.signature).toMatchObject({
+      status: 'fail-closed',
+      signingAlgorithm: 'ed25519',
+      signatureDomain: A2A_AGENT_CARD_SIGNATURE_DOMAIN,
+      unsignedCardsAccepted: false,
+    });
+  });
+
+  it('verifies a signed Agent Card independent of object key order', async () => {
+    const { publicKey, secretKey } = await generateAgentKeypair();
+    const card = {
+      url: 'https://weather.example/.well-known/agent.json',
+      name: 'weather-agent',
+      capabilities: { streaming: true, pushNotifications: false },
+      skills: [{ id: 'forecast', name: 'Forecast' }],
+    };
+    const signature = await signA2aAgentCard(secretKey, card);
+
+    const verdict = await verifyA2aAgentCardSignature({
+      publicKey,
+      signature,
+      agentCard: {
+        skills: [{ name: 'Forecast', id: 'forecast' }],
+        capabilities: { pushNotifications: false, streaming: true },
+        name: 'weather-agent',
+        url: 'https://weather.example/.well-known/agent.json',
+      },
+    });
+
+    expect(verdict.ok).toBe(true);
+    if (verdict.ok) {
+      expect(verdict.payloadDigest).toMatch(/^[a-f0-9]{64}$/);
+      expect(verdict.canonicalJson).toBe(canonicalJson(card));
+    }
+  });
+
+  it('fails closed for unsigned, malformed, or tampered Agent Cards', async () => {
+    const { publicKey, secretKey } = await generateAgentKeypair();
+    const agentCard = { name: 'weather-agent', url: 'https://weather.example' };
+    const signature = await signA2aAgentCard(secretKey, agentCard);
+
+    await expect(
+      verifyA2aAgentCardSignature({ publicKey, signature: '', agentCard })
+    ).resolves.toMatchObject({
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      evidence: { signature: { status: 'fail-closed' } },
+    });
+
+    await expect(
+      verifyA2aAgentCardSignature({
+        publicKey,
+        signature,
+        agentCard: { ...agentCard, url: 'https://evil.example' },
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+    });
+  });
+});

--- a/apps/web/app/api/v1/a2a/agent-card/canonical-signature/route.ts
+++ b/apps/web/app/api/v1/a2a/agent-card/canonical-signature/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest } from 'next/server';
+import { withRateLimit } from '@agentgram/auth';
+import {
+  buildA2aAgentCardCanonicalSignatureEvidence,
+  verifyA2aAgentCardSignature,
+} from '@agentgram/auth';
+import {
+  AX_RATE_LIMITS,
+  ErrorResponses,
+  createErrorResponse,
+  createSuccessResponse,
+  jsonResponse,
+} from '@agentgram/shared';
+
+interface AgentCardSignatureRequestBody {
+  agentCard?: unknown;
+  publicKey?: unknown;
+  signature?: unknown;
+}
+
+/**
+ * GET /api/v1/a2a/agent-card/canonical-signature
+ *
+ * Public evidence endpoint for the A2A Agent Card canonical-signature gate:
+ * it exposes the RFC8785 fixture and confirms unsigned or malformed cards are
+ * rejected rather than accepted optimistically.
+ * Auth: public (rate-limited) — publishes conformance evidence only, no
+ * account or developer state is read.
+ */
+export const GET = withRateLimit(
+  {
+    maxRequests: AX_RATE_LIMITS.SCAN.limit,
+    windowMs: AX_RATE_LIMITS.SCAN.windowMs,
+  },
+  async function GET() {
+    return jsonResponse(
+      createSuccessResponse({
+        reportType: 'a2a-agent-card-canonical-signature',
+        evidence: buildA2aAgentCardCanonicalSignatureEvidence(),
+      }),
+      200
+    );
+  }
+);
+
+/**
+ * POST /api/v1/a2a/agent-card/canonical-signature
+ *
+ * Verify a supplied A2A Agent Card against its Ed25519 signature over the
+ * RFC8785-style canonical JSON payload. The route deliberately omits raw
+ * canonicalJson from successful responses and returns fail-closed evidence on
+ * every negative verdict.
+ * Auth: public (rate-limited) — stateless verification of caller-supplied
+ * material, no account or developer state is read.
+ */
+const postHandler = async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as AgentCardSignatureRequestBody;
+    const verdict = await verifyA2aAgentCardSignature({
+      agentCard: body.agentCard,
+      publicKey: body.publicKey,
+      signature: body.signature,
+    });
+
+    if (!verdict.ok) {
+      return jsonResponse(
+        createErrorResponse(verdict.code, verdict.message, {
+          evidence: verdict.evidence,
+        }),
+        401
+      );
+    }
+
+    return jsonResponse(
+      createSuccessResponse({
+        reportType: 'a2a-agent-card-canonical-signature',
+        verdict: {
+          ok: true,
+          payloadDigest: verdict.payloadDigest,
+          evidence: verdict.evidence,
+        },
+      }),
+      200
+    );
+  } catch (error) {
+    console.error('A2A Agent Card canonical-signature gate error:', error);
+    return jsonResponse(
+      ErrorResponses.internalError(
+        'Failed to verify A2A Agent Card canonical signature'
+      ),
+      500
+    );
+  }
+};
+
+export const POST = withRateLimit(
+  {
+    maxRequests: AX_RATE_LIMITS.SCAN.limit,
+    windowMs: AX_RATE_LIMITS.SCAN.windowMs,
+  },
+  postHandler
+);

--- a/packages/auth/src/ed25519.ts
+++ b/packages/auth/src/ed25519.ts
@@ -13,6 +13,16 @@ import * as ed25519 from '@noble/ed25519';
 /** Domain prefix for payload signatures (registration proof-of-possession). */
 export const SIGNATURE_DOMAIN = 'agentgram:v1:';
 
+/** Domain prefix for A2A Agent Card canonical signatures. */
+export const A2A_AGENT_CARD_SIGNATURE_DOMAIN =
+  'agentgram:v1:a2a-agent-card:';
+
+export const RFC8785_AGENT_CARD_FIXTURE_CANONICAL_JSON =
+  '{"literals":[null,true,false],"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27],"string":"€$\\u000f\\nA\'B\\"\\\\\\"/"}';
+
+export const RFC8785_AGENT_CARD_FIXTURE_DIGEST =
+  '6d77565c0fe51d7346bd5debb08f2eebbe9bde01eade30b34e2011f360f91b0e';
+
 /** Maximum allowed clock skew between signer and server, in milliseconds. */
 export const SIGNATURE_FRESHNESS_WINDOW_MS = 5 * 60 * 1000;
 
@@ -30,6 +40,43 @@ export interface AgentKeypair {
 export type SignatureVerdict =
   | { ok: true }
   | { ok: false; code: 'SIGNATURE_EXPIRED' | 'SIGNATURE_INVALID'; message: string };
+
+export interface A2aAgentCardCanonicalSignatureEvidence {
+  kind: 'agentgram.a2a.agent-card.canonical-signature-gate';
+  generatedAt: string;
+  canonicalization: {
+    status: 'conformant' | 'failed';
+    standard: 'RFC8785';
+    fixture: {
+      name: 'rfc8785-json-canonicalization-number-string-order';
+      canonicalJson: string;
+      digestAlgorithm: 'sha256';
+      digest: string;
+    };
+  };
+  signature: {
+    status: 'fail-closed';
+    signingAlgorithm: 'ed25519';
+    signatureDomain: typeof A2A_AGENT_CARD_SIGNATURE_DOMAIN;
+    unsignedCardsAccepted: false;
+    requiredFields: ['agentCard', 'publicKey', 'signature'];
+    failureModes: string[];
+  };
+}
+
+export type A2aAgentCardSignatureVerdict =
+  | {
+      ok: true;
+      canonicalJson: string;
+      payloadDigest: string;
+      evidence: A2aAgentCardCanonicalSignatureEvidence;
+    }
+  | {
+      ok: false;
+      code: 'RFC8785_CONFORMANCE_FAILED' | 'SIGNATURE_INVALID';
+      message: string;
+      evidence: A2aAgentCardCanonicalSignatureEvidence;
+    };
 
 /**
  * Deterministic JSON serialization: object keys are sorted recursively so
@@ -63,6 +110,167 @@ export function canonicalJson(value: unknown): string {
     return `{${entries.join(',')}}`;
   }
   throw new Error(`Cannot canonicalize value of type ${kind}`);
+}
+
+const RFC8785_AGENT_CARD_FIXTURE = {
+  numbers: [Number('333333333.33333329'), 1e30, 4.5, 2e-3, 1e-27],
+  string: '€$\u000f\nA\'B"\\"/',
+  literals: [null, true, false],
+};
+
+async function sha256Hex(data: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(data)
+  );
+  return ed25519.etc.bytesToHex(new Uint8Array(digest));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function buildA2aAgentCardMessage(agentCard: unknown): Uint8Array {
+  return new TextEncoder().encode(
+    A2A_AGENT_CARD_SIGNATURE_DOMAIN + canonicalJson(agentCard)
+  );
+}
+
+export function buildA2aAgentCardCanonicalSignatureEvidence(
+  options: { generatedAt?: string } = {}
+): A2aAgentCardCanonicalSignatureEvidence {
+  const canonicalFixture = canonicalJson(RFC8785_AGENT_CARD_FIXTURE);
+  const isConformant =
+    canonicalFixture === RFC8785_AGENT_CARD_FIXTURE_CANONICAL_JSON;
+
+  return {
+    kind: 'agentgram.a2a.agent-card.canonical-signature-gate',
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    canonicalization: {
+      status: isConformant ? 'conformant' : 'failed',
+      standard: 'RFC8785',
+      fixture: {
+        name: 'rfc8785-json-canonicalization-number-string-order',
+        canonicalJson: canonicalFixture,
+        digestAlgorithm: 'sha256',
+        digest: isConformant
+          ? RFC8785_AGENT_CARD_FIXTURE_DIGEST
+          : 'fixture-conformance-failed',
+      },
+    },
+    signature: {
+      status: 'fail-closed',
+      signingAlgorithm: 'ed25519',
+      signatureDomain: A2A_AGENT_CARD_SIGNATURE_DOMAIN,
+      unsignedCardsAccepted: false,
+      requiredFields: ['agentCard', 'publicKey', 'signature'],
+      failureModes: [
+        'missing Agent Card payload',
+        'missing or malformed Ed25519 public key',
+        'missing or malformed Ed25519 signature',
+        'signature mismatch after RFC8785 canonicalization',
+        'canonicalization fixture drift',
+      ],
+    },
+  };
+}
+
+/**
+ * Sign an A2A Agent Card over RFC8785-style canonical JSON. Client-side helper
+ * (SDKs, tests); the public route verifies and fails closed.
+ */
+export async function signA2aAgentCard(
+  secretKeyHex: string,
+  agentCard: unknown
+): Promise<string> {
+  if (!SECRET_KEY_HEX_REGEX.test(secretKeyHex)) {
+    throw new Error('Secret key must be 64 hex characters');
+  }
+  if (!isRecord(agentCard)) {
+    throw new Error('A2A Agent Card payload must be a JSON object');
+  }
+  const signature = await ed25519.signAsync(
+    buildA2aAgentCardMessage(agentCard),
+    ed25519.etc.hexToBytes(secretKeyHex)
+  );
+  return ed25519.etc.bytesToHex(signature);
+}
+
+/**
+ * Verify an A2A Agent Card signature. This gate is intentionally fail-closed:
+ * unsigned cards, malformed keys/signatures, fixture drift, and tampering all
+ * return a structured negative verdict instead of falling back to trust.
+ */
+export async function verifyA2aAgentCardSignature(input: {
+  publicKey?: unknown;
+  signature?: unknown;
+  agentCard?: unknown;
+}): Promise<A2aAgentCardSignatureVerdict> {
+  const evidence = buildA2aAgentCardCanonicalSignatureEvidence();
+  if (evidence.canonicalization.status !== 'conformant') {
+    return {
+      ok: false,
+      code: 'RFC8785_CONFORMANCE_FAILED',
+      message: 'A2A Agent Card canonicalization fixture does not match RFC8785',
+      evidence,
+    };
+  }
+
+  if (
+    typeof input.publicKey !== 'string' ||
+    typeof input.signature !== 'string' ||
+    !isRecord(input.agentCard)
+  ) {
+    return {
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message:
+        'A2A Agent Card signatures require publicKey, signature, and agentCard',
+      evidence,
+    };
+  }
+
+  if (
+    !PUBLIC_KEY_HEX_REGEX.test(input.publicKey) ||
+    !SIGNATURE_HEX_REGEX.test(input.signature)
+  ) {
+    return {
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message:
+        'A2A Agent Card publicKey must be 64 hex characters and signature must be 128 hex characters',
+      evidence,
+    };
+  }
+
+  let valid = false;
+  try {
+    valid = await ed25519.verifyAsync(
+      ed25519.etc.hexToBytes(input.signature),
+      buildA2aAgentCardMessage(input.agentCard),
+      ed25519.etc.hexToBytes(input.publicKey)
+    );
+  } catch {
+    valid = false;
+  }
+
+  if (!valid) {
+    return {
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message:
+        'A2A Agent Card signature does not match the supplied public key and canonical payload',
+      evidence,
+    };
+  }
+
+  const canonicalPayload = canonicalJson(input.agentCard);
+  return {
+    ok: true,
+    canonicalJson: canonicalPayload,
+    payloadDigest: await sha256Hex(canonicalPayload),
+    evidence,
+  };
 }
 
 function encodeMessage(domain: string, payload: unknown): Uint8Array {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,15 +1,23 @@
 export { generateApiKey } from './keypair';
 export {
+  A2A_AGENT_CARD_SIGNATURE_DOMAIN,
+  RFC8785_AGENT_CARD_FIXTURE_CANONICAL_JSON,
+  RFC8785_AGENT_CARD_FIXTURE_DIGEST,
   SIGNATURE_DOMAIN,
   SIGNATURE_FRESHNESS_WINDOW_MS,
+  buildA2aAgentCardCanonicalSignatureEvidence,
   canonicalJson,
   generateAgentKeypair,
+  signA2aAgentCard,
   signPayload,
+  verifyA2aAgentCardSignature,
   verifySignature,
   buildRegistrationPayload,
   verifyRegistrationProof,
 } from './ed25519';
 export type {
+  A2aAgentCardCanonicalSignatureEvidence,
+  A2aAgentCardSignatureVerdict,
   AgentKeypair,
   RegistrationProofPayload,
   SignatureVerdict,


### PR DESCRIPTION
## Source
Hermes kkami release-promote cron ca3cc60e24bb.
Ref: https://github.com/agentgram/agentgram

## Change
Promote the current `develop` branch to `main` through a guarded release PR.
This run detected `develop` ahead of `main` by 1 commit(s) at 2026-08-11 06:00 KST.

## Evidence
- diff: `git rev-list --count origin/main..origin/develop` => `1`
- test: release promotion script dry-run/smoke validation is available via `python3 scripts/agentgram_release_promote.py --dry-run --no-fetch`

## Auth-only Proof
N/A
