### PR TITLE
strategic(reputation): add provenance bundle signed export

### DIFF
--- a/apps/web/__tests__/api/reputation-export.test.ts
+++ b/apps/web/__tests__/api/reputation-export.test.ts
@@ -1,5 +1,7 @@
+import { createHash } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  canonicalJson,
   generateAgentKeypair,
   signRequest,
   SIGNATURE_HEADER,
@@ -30,6 +32,10 @@ vi.mock('@agentgram/auth', async () => {
 });
 
 const routePath = '/api/v1/agents/me/reputation-export';
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
 
 async function makeSignedRequest() {
   const { publicKey, secretKey } = await generateAgentKeypair();
@@ -176,6 +182,62 @@ describe('GET /api/v1/agents/me/reputation-export', () => {
         storageEventDifference: 0,
         preservesStorageEventDifference: true,
       })
+    );
+  });
+
+  it('adds a reproducible provenance bundle with digest, policy, tier, and canonical fixture', async () => {
+    const { GET } = await import(
+      '@/app/api/v1/agents/me/reputation-export/route'
+    );
+
+    const response = await GET(await makeSignedRequest());
+    const json = await response.json();
+    const bundle = json.data.provenanceBundle;
+
+    expect(response.status).toBe(200);
+    expect(bundle).toEqual(
+      expect.objectContaining({
+        kind: 'agentgram.reputation.provenance.bundle.v1',
+        scoringPolicy: expect.objectContaining({
+          version: 'agentgram.trust-score.policy.v1',
+          baselineTrustScore: 0.5,
+        }),
+        validation: expect.objectContaining({
+          tier: 'ed25519-verifier-gated-full-ledger',
+          signingAlgorithm: 'ed25519',
+          signedVerifierRequestRequired: true,
+        }),
+        aggregation: expect.objectContaining({
+          eventCount: 2,
+          firstEventAt: '2026-08-01T00:00:00.000Z',
+          lastEventAt: '2026-08-02T00:00:00.000Z',
+        }),
+      })
+    );
+    expect(bundle.evidenceDigest.inputEvidenceDigest).toMatch(/^[a-f0-9]{64}$/);
+    expect(sha256Hex(bundle.auditorVerification.canonicalInputEvidence)).toBe(
+      bundle.evidenceDigest.inputEvidenceDigest
+    );
+    expect(bundle.signaturePayload).toEqual(
+      expect.objectContaining({
+        status: 'ed25519-signable',
+        subjectAgentId: 'agent-1',
+        inputEvidenceDigest: bundle.evidenceDigest.inputEvidenceDigest,
+        scoringPolicyVersion: 'agentgram.trust-score.policy.v1',
+        validationTier: 'ed25519-verifier-gated-full-ledger',
+        payloadDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+      })
+    );
+    expect(sha256Hex(bundle.auditorVerification.canonicalSignaturePayload)).toBe(
+      bundle.signaturePayload.payloadDigest
+    );
+
+    const canonicalInputs = JSON.parse(
+      bundle.auditorVerification.canonicalInputEvidence
+    );
+    expect(canonicalInputs.eventEvidence.events).toHaveLength(2);
+    expect(canonicalJson(canonicalInputs)).toBe(
+      bundle.auditorVerification.canonicalInputEvidence
     );
   });
 });

--- a/apps/web/app/api/v1/agents/me/reputation-export/route.ts
+++ b/apps/web/app/api/v1/agents/me/reputation-export/route.ts
@@ -1,5 +1,7 @@
+import { createHash } from 'node:crypto';
 import { NextRequest } from 'next/server';
 import {
+  canonicalJson,
   SIGNATURE_HEADER,
   TIMESTAMP_HEADER,
   withAgentSignature,
@@ -14,6 +16,12 @@ import {
 } from '@agentgram/shared';
 
 const ERC_8004_REPUTATION_EXPORT_VERSION = 'agentgram.reputation.export.v1';
+const REPUTATION_PROVENANCE_BUNDLE_VERSION =
+  'agentgram.reputation.provenance.bundle.v1';
+const REPUTATION_PROVENANCE_SIGNATURE_DOMAIN =
+  'agentgram:v1:reputation-provenance:';
+const SCORING_POLICY_VERSION = 'agentgram.trust-score.policy.v1';
+const VALIDATION_TIER = 'ed25519-verifier-gated-full-ledger';
 const BASELINE_TRUST_SCORE = 0.5;
 
 type TrustEventRow = {
@@ -42,6 +50,10 @@ function roundScore(value: number): number {
 
 function clampTrustScore(value: number): number {
   return Math.min(1, Math.max(0, value));
+}
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
 }
 
 function hasSignedVerifierHeaders(req: NextRequest): boolean {
@@ -110,51 +122,117 @@ const handler = withAuth(
         storedTrustScore - projectedTrustScoreFromEvents
       );
 
+      const generatedAt = new Date().toISOString();
+      const eventRows = events.map((event) => ({
+        id: event.id,
+        delta: event.delta ?? 0,
+        reason: event.reason ?? 'unknown',
+        referenceId: event.reference_id,
+        createdAt: event.created_at,
+      }));
+      const subject = {
+        agentId: agent.id,
+        name: agent.name,
+        displayName: agent.display_name,
+        publicKey: agent.public_key,
+        verificationState: agent.verification_state ?? 'unverified',
+        status: agent.status ?? 'unknown',
+      };
+      const signedVerifierGate = {
+        required: true,
+        verified: true,
+        verifier: 'withAuth + withAgentSignature',
+        headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
+        canonicalRequestPath: new URL(req.url).pathname,
+      };
+      const storageState = {
+        sourceTable: 'agents',
+        trustScore: storedTrustScore,
+        axp: agent.axp ?? 0,
+        updatedAt: agent.updated_at,
+      };
+      const eventEvidence = {
+        sourceTable: 'trust_events',
+        retention: 'full_ledger',
+        eventCount: events.length,
+        deltaSum,
+        events: eventRows,
+      };
+      const storageEventReconciliation = {
+        baselineTrustScore: BASELINE_TRUST_SCORE,
+        projectedTrustScoreFromEvents,
+        storedTrustScore,
+        storageEventDifference,
+        preservesStorageEventDifference: true,
+      };
+      const provenanceInputs = {
+        subject,
+        signedVerifierGate,
+        storageState,
+        eventEvidence,
+        storageEventReconciliation,
+      };
+      const canonicalInputEvidence = canonicalJson(provenanceInputs);
+      const inputEvidenceDigest = sha256Hex(canonicalInputEvidence);
+      const signaturePayload = {
+        kind: REPUTATION_PROVENANCE_BUNDLE_VERSION,
+        subjectAgentId: agent.id,
+        inputEvidenceDigest,
+        scoringPolicyVersion: SCORING_POLICY_VERSION,
+        validationTier: VALIDATION_TIER,
+        aggregatedAt: generatedAt,
+      };
+      const canonicalSignaturePayload = canonicalJson(signaturePayload);
+
       return jsonResponse(
         createSuccessResponse({
           standard: 'ERC-8004',
           schemaVersion: ERC_8004_REPUTATION_EXPORT_VERSION,
-          generatedAt: new Date().toISOString(),
-          subject: {
-            agentId: agent.id,
-            name: agent.name,
-            displayName: agent.display_name,
-            publicKey: agent.public_key,
-            verificationState: agent.verification_state ?? 'unverified',
-            status: agent.status ?? 'unknown',
-          },
-          signedVerifierGate: {
-            required: true,
-            verified: true,
-            verifier: 'withAuth + withAgentSignature',
-            headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
-            canonicalRequestPath: new URL(req.url).pathname,
-          },
-          storageState: {
-            sourceTable: 'agents',
-            trustScore: storedTrustScore,
-            axp: agent.axp ?? 0,
-            updatedAt: agent.updated_at,
-          },
-          eventEvidence: {
-            sourceTable: 'trust_events',
-            retention: 'full_ledger',
-            eventCount: events.length,
-            deltaSum,
-            events: events.map((event) => ({
-              id: event.id,
-              delta: event.delta ?? 0,
-              reason: event.reason ?? 'unknown',
-              referenceId: event.reference_id,
-              createdAt: event.created_at,
-            })),
-          },
-          storageEventReconciliation: {
-            baselineTrustScore: BASELINE_TRUST_SCORE,
-            projectedTrustScoreFromEvents,
-            storedTrustScore,
-            storageEventDifference,
-            preservesStorageEventDifference: true,
+          generatedAt,
+          subject,
+          signedVerifierGate,
+          storageState,
+          eventEvidence,
+          storageEventReconciliation,
+          provenanceBundle: {
+            kind: REPUTATION_PROVENANCE_BUNDLE_VERSION,
+            generatedAt,
+            scoringPolicy: {
+              version: SCORING_POLICY_VERSION,
+              baselineTrustScore: BASELINE_TRUST_SCORE,
+              formula:
+                'clamp(baselineTrustScore + sum(trust_events.delta), 0, 1)',
+              storageEventDifferencePreserved: true,
+            },
+            validation: {
+              tier: VALIDATION_TIER,
+              signingAlgorithm: 'ed25519',
+              signatureDomain: REPUTATION_PROVENANCE_SIGNATURE_DOMAIN,
+              signedVerifierRequestRequired: true,
+            },
+            aggregation: {
+              aggregatedAt: generatedAt,
+              eventCount: events.length,
+              firstEventAt: eventRows[0]?.createdAt ?? null,
+              lastEventAt: eventRows[eventRows.length - 1]?.createdAt ?? null,
+            },
+            evidenceDigest: {
+              digestAlgorithm: 'sha256',
+              inputEvidenceDigest,
+            },
+            signaturePayload: {
+              ...signaturePayload,
+              digestAlgorithm: 'sha256',
+              payloadDigest: sha256Hex(canonicalSignaturePayload),
+              status: 'ed25519-signable',
+            },
+            auditorVerification: {
+              canonicalJsonStandard: 'sorted-key-json',
+              canonicalInputEvidence,
+              canonicalSignaturePayload,
+              verificationCommand:
+                'canonicalize provenance inputs, sha256 them, then Ed25519-sign the signaturePayload with the agent key',
+            },
           },
         })
       );


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item f87161d7f5.
Ref: https://github.com/agentgram/agentgram

## Change
Extended the signed verifier-gated reputation export with a reproducible provenance bundle: canonical input-evidence JSON, SHA-256 evidence digest, scoring-policy version, validation tier, aggregation timestamps, and an Ed25519-signable signature payload digest.
Added route tests proving auditors can recompute the canonical evidence digest and signature payload digest from the exported fixture.

## Evidence
Tests/type-check/lint run locally:
- test: `pnpm --filter web exec vitest run __tests__/api/reputation-export.test.ts` → 1 file passed, 3 tests passed.
- type-check: `pnpm --filter web type-check` → exit 0.
- lint: `pnpm --filter web lint` → exit 0 with existing warnings only (0 errors, 35 warnings).
- diff: 2 files changed, 181 insertions(+), 41 deletions(-).

## Auth-only Proof
N/A
