### PR TITLE
release: promote develop to main — 2026-08-12

### DIFF
--- a/apps/web/__tests__/api/ax-score-mcp-registry-audit.test.ts
+++ b/apps/web/__tests__/api/ax-score-mcp-registry-audit.test.ts
@@ -42,6 +42,8 @@ describe('POST /api/v1/ax-score/mcp-registry/audit', () => {
         remoteTransportEntries: 2,
         remoteTransportCoveragePct: 100,
         latestMarkedNames: 1,
+        schemaCompatibleEntries: 2,
+        schemaCompatibilityPct: 100,
       },
       pageChain: [
         {
@@ -58,6 +60,7 @@ describe('POST /api/v1/ax-score/mcp-registry/audit', () => {
         missingRemoteTransports: [],
         cursorLoops: [],
         emptyPagesWithCursor: [],
+        schemaCompatibilityFailures: [],
         truncated: false,
       },
       receipt: {
@@ -128,6 +131,7 @@ describe('POST /api/v1/ax-score/mcp-registry/audit', () => {
       limit: 50,
       maxPages: 3,
       cursor: null,
+      reportType: 'mcp-registry-coverage-audit',
     });
     expect(json.data).toMatchObject({
       developerId: 'dev-1',
@@ -144,6 +148,79 @@ describe('POST /api/v1/ax-score/mcp-registry/audit', () => {
             signingAlgorithm: 'ed25519',
           },
         },
+      },
+    });
+  });
+
+  it('passes through the paid MCP schema compatibility audit report type', async () => {
+    mockSweepMcpRegistryCoverage.mockResolvedValueOnce({
+      summary: {
+        totalEntries: 2,
+        uniqueServerVersions: 2,
+        uniqueServerNames: 2,
+        remoteTransportEntries: 1,
+        remoteTransportCoveragePct: 50,
+        latestMarkedNames: 2,
+        schemaCompatibleEntries: 1,
+        schemaCompatibilityPct: 50,
+      },
+      pageChain: [],
+      anomalies: {
+        duplicateServerVersions: [],
+        missingLatestMarkers: [],
+        missingRemoteTransports: ['bad/server@0.1.0'],
+        cursorLoops: [],
+        emptyPagesWithCursor: [],
+        schemaCompatibilityFailures: [
+          'bad/server@0.1.0: missing MCP launch surface (https remote or package)',
+        ],
+        truncated: false,
+      },
+      receipt: {
+        kind: 'agentgram.ax-score.mcp-registry.schema-compatibility-receipt',
+        registryEndpoint: 'https://registry.modelcontextprotocol.io/v0/servers',
+        generatedAt: '2026-08-04T00:00:00.000Z',
+        digestAlgorithm: 'sha256',
+        coverageDigest: 'coverage-digest',
+        pageChainDigest: 'page-chain-digest',
+        pageCount: 1,
+        serverVersionCount: 2,
+        uniqueServerVersionCount: 2,
+        anomalyCount: 1,
+        x402: {
+          status: 'ready',
+          paymentPurpose: 'mcp-schema-compatibility-audit-report',
+          recommendedPriceUsd: '79.00',
+          deliverable: 'MCP Registry schema compatibility findings.',
+        },
+        signature: {
+          status: 'unsigned',
+          signingAlgorithm: 'ed25519',
+          payloadDigest: 'payload-digest',
+        },
+      },
+    });
+    const { POST } = await import(
+      '@/app/api/v1/ax-score/mcp-registry/audit/route'
+    );
+
+    const response = await POST(
+      makeRequest({ reportType: 'mcp-schema-compatibility-audit', limit: 25 })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockSweepMcpRegistryCoverage).toHaveBeenCalledWith({
+      limit: 25,
+      cursor: null,
+      reportType: 'mcp-schema-compatibility-audit',
+    });
+    expect(json.data).toMatchObject({
+      plan: 'team',
+      reportType: 'mcp-schema-compatibility-audit',
+      payment: {
+        status: 'ready',
+        paymentPurpose: 'mcp-schema-compatibility-audit-report',
       },
     });
   });

--- a/apps/web/__tests__/api/reputation-export.test.ts
+++ b/apps/web/__tests__/api/reputation-export.test.ts
@@ -1,5 +1,7 @@
+import { createHash } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  canonicalJson,
   generateAgentKeypair,
   signRequest,
   SIGNATURE_HEADER,
@@ -30,6 +32,10 @@ vi.mock('@agentgram/auth', async () => {
 });
 
 const routePath = '/api/v1/agents/me/reputation-export';
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
 
 async function makeSignedRequest() {
   const { publicKey, secretKey } = await generateAgentKeypair();
@@ -176,6 +182,62 @@ describe('GET /api/v1/agents/me/reputation-export', () => {
         storageEventDifference: 0,
         preservesStorageEventDifference: true,
       })
+    );
+  });
+
+  it('adds a reproducible provenance bundle with digest, policy, tier, and canonical fixture', async () => {
+    const { GET } = await import(
+      '@/app/api/v1/agents/me/reputation-export/route'
+    );
+
+    const response = await GET(await makeSignedRequest());
+    const json = await response.json();
+    const bundle = json.data.provenanceBundle;
+
+    expect(response.status).toBe(200);
+    expect(bundle).toEqual(
+      expect.objectContaining({
+        kind: 'agentgram.reputation.provenance.bundle.v1',
+        scoringPolicy: expect.objectContaining({
+          version: 'agentgram.trust-score.policy.v1',
+          baselineTrustScore: 0.5,
+        }),
+        validation: expect.objectContaining({
+          tier: 'ed25519-verifier-gated-full-ledger',
+          signingAlgorithm: 'ed25519',
+          signedVerifierRequestRequired: true,
+        }),
+        aggregation: expect.objectContaining({
+          eventCount: 2,
+          firstEventAt: '2026-08-01T00:00:00.000Z',
+          lastEventAt: '2026-08-02T00:00:00.000Z',
+        }),
+      })
+    );
+    expect(bundle.evidenceDigest.inputEvidenceDigest).toMatch(/^[a-f0-9]{64}$/);
+    expect(sha256Hex(bundle.auditorVerification.canonicalInputEvidence)).toBe(
+      bundle.evidenceDigest.inputEvidenceDigest
+    );
+    expect(bundle.signaturePayload).toEqual(
+      expect.objectContaining({
+        status: 'ed25519-signable',
+        subjectAgentId: 'agent-1',
+        inputEvidenceDigest: bundle.evidenceDigest.inputEvidenceDigest,
+        scoringPolicyVersion: 'agentgram.trust-score.policy.v1',
+        validationTier: 'ed25519-verifier-gated-full-ledger',
+        payloadDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+      })
+    );
+    expect(sha256Hex(bundle.auditorVerification.canonicalSignaturePayload)).toBe(
+      bundle.signaturePayload.payloadDigest
+    );
+
+    const canonicalInputs = JSON.parse(
+      bundle.auditorVerification.canonicalInputEvidence
+    );
+    expect(canonicalInputs.eventEvidence.events).toHaveLength(2);
+    expect(canonicalJson(canonicalInputs)).toBe(
+      bundle.auditorVerification.canonicalInputEvidence
     );
   });
 });

--- a/apps/web/__tests__/lib/ax-score/mcp-registry-audit.test.ts
+++ b/apps/web/__tests__/lib/ax-score/mcp-registry-audit.test.ts
@@ -73,6 +73,8 @@ describe('sweepMcpRegistryCoverage', () => {
       remoteTransportEntries: 2,
       remoteTransportCoveragePct: 100,
       latestMarkedNames: 1,
+      schemaCompatibleEntries: 2,
+      schemaCompatibilityPct: 100,
     });
     expect(audit.pageChain).toHaveLength(2);
     expect(audit.anomalies.duplicateServerVersions).toEqual([]);
@@ -96,6 +98,61 @@ describe('sweepMcpRegistryCoverage', () => {
     });
     expect(audit.receipt.coverageDigest).toMatch(/^[a-f0-9]{64}$/);
     expect(audit.receipt.signature.payloadDigest).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('produces a paid schema compatibility receipt and flags incompatible registry entries', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      registryResponse({
+        servers: [
+          {
+            server: {
+              name: 'valid/server',
+              version: '1.0.0',
+              remotes: [{ type: 'streamable-http', url: 'https://valid.example/mcp' }],
+            },
+            _meta: {
+              'io.modelcontextprotocol.registry/official': {
+                isLatest: true,
+              },
+            },
+          },
+          {
+            server: {
+              name: 'missing/launch-surface',
+              version: '0.1.0',
+              remotes: [{ type: 'streamable-http', url: 'http://insecure.example/mcp' }],
+            },
+            _meta: {
+              'io.modelcontextprotocol.registry/official': {
+                isLatest: true,
+              },
+            },
+          },
+        ],
+        metadata: { count: 2 },
+      })
+    );
+
+    const audit = await sweepMcpRegistryCoverage({
+      fetcher,
+      endpoint: 'https://registry.example/v0/servers',
+      reportType: 'mcp-schema-compatibility-audit',
+      generatedAt: '2026-08-04T00:00:00.000Z',
+    });
+
+    expect(audit.summary.schemaCompatibleEntries).toBe(1);
+    expect(audit.summary.schemaCompatibilityPct).toBe(50);
+    expect(audit.anomalies.schemaCompatibilityFailures).toEqual([
+      'missing/launch-surface@0.1.0: missing MCP launch surface (https remote or package)',
+    ]);
+    expect(audit.receipt).toMatchObject({
+      kind: 'agentgram.ax-score.mcp-registry.schema-compatibility-receipt',
+      x402: {
+        status: 'ready',
+        paymentPurpose: 'mcp-schema-compatibility-audit-report',
+        recommendedPriceUsd: '79.00',
+      },
+    });
   });
 
   it('reports duplicate, remote-coverage, latest-marker, and cursor anomalies', async () => {
@@ -135,7 +192,11 @@ describe('sweepMcpRegistryCoverage', () => {
     expect(audit.anomalies.missingLatestMarkers).toEqual(['loop/server']);
     expect(audit.anomalies.emptyPagesWithCursor).toEqual(['cursor-a']);
     expect(audit.anomalies.cursorLoops).toEqual(['cursor-a']);
-    expect(audit.receipt.anomalyCount).toBe(6);
+    expect(audit.anomalies.schemaCompatibilityFailures).toEqual([
+      'loop/server@1.0.0: missing MCP launch surface (https remote or package)',
+      'loop/server@1.0.0: missing MCP launch surface (https remote or package)',
+    ]);
+    expect(audit.receipt.anomalyCount).toBe(8);
   });
 
   it('marks a sweep as truncated when maxPages stops before registry exhaustion', async () => {

--- a/apps/web/app/api/v1/agents/me/reputation-export/route.ts
+++ b/apps/web/app/api/v1/agents/me/reputation-export/route.ts
@@ -1,5 +1,7 @@
+import { createHash } from 'node:crypto';
 import { NextRequest } from 'next/server';
 import {
+  canonicalJson,
   SIGNATURE_HEADER,
   TIMESTAMP_HEADER,
   withAgentSignature,
@@ -14,6 +16,12 @@ import {
 } from '@agentgram/shared';
 
 const ERC_8004_REPUTATION_EXPORT_VERSION = 'agentgram.reputation.export.v1';
+const REPUTATION_PROVENANCE_BUNDLE_VERSION =
+  'agentgram.reputation.provenance.bundle.v1';
+const REPUTATION_PROVENANCE_SIGNATURE_DOMAIN =
+  'agentgram:v1:reputation-provenance:';
+const SCORING_POLICY_VERSION = 'agentgram.trust-score.policy.v1';
+const VALIDATION_TIER = 'ed25519-verifier-gated-full-ledger';
 const BASELINE_TRUST_SCORE = 0.5;
 
 type TrustEventRow = {
@@ -42,6 +50,10 @@ function roundScore(value: number): number {
 
 function clampTrustScore(value: number): number {
   return Math.min(1, Math.max(0, value));
+}
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
 }
 
 function hasSignedVerifierHeaders(req: NextRequest): boolean {
@@ -110,51 +122,117 @@ const handler = withAuth(
         storedTrustScore - projectedTrustScoreFromEvents
       );
 
+      const generatedAt = new Date().toISOString();
+      const eventRows = events.map((event) => ({
+        id: event.id,
+        delta: event.delta ?? 0,
+        reason: event.reason ?? 'unknown',
+        referenceId: event.reference_id,
+        createdAt: event.created_at,
+      }));
+      const subject = {
+        agentId: agent.id,
+        name: agent.name,
+        displayName: agent.display_name,
+        publicKey: agent.public_key,
+        verificationState: agent.verification_state ?? 'unverified',
+        status: agent.status ?? 'unknown',
+      };
+      const signedVerifierGate = {
+        required: true,
+        verified: true,
+        verifier: 'withAuth + withAgentSignature',
+        headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
+        canonicalRequestPath: new URL(req.url).pathname,
+      };
+      const storageState = {
+        sourceTable: 'agents',
+        trustScore: storedTrustScore,
+        axp: agent.axp ?? 0,
+        updatedAt: agent.updated_at,
+      };
+      const eventEvidence = {
+        sourceTable: 'trust_events',
+        retention: 'full_ledger',
+        eventCount: events.length,
+        deltaSum,
+        events: eventRows,
+      };
+      const storageEventReconciliation = {
+        baselineTrustScore: BASELINE_TRUST_SCORE,
+        projectedTrustScoreFromEvents,
+        storedTrustScore,
+        storageEventDifference,
+        preservesStorageEventDifference: true,
+      };
+      const provenanceInputs = {
+        subject,
+        signedVerifierGate,
+        storageState,
+        eventEvidence,
+        storageEventReconciliation,
+      };
+      const canonicalInputEvidence = canonicalJson(provenanceInputs);
+      const inputEvidenceDigest = sha256Hex(canonicalInputEvidence);
+      const signaturePayload = {
+        kind: REPUTATION_PROVENANCE_BUNDLE_VERSION,
+        subjectAgentId: agent.id,
+        inputEvidenceDigest,
+        scoringPolicyVersion: SCORING_POLICY_VERSION,
+        validationTier: VALIDATION_TIER,
+        aggregatedAt: generatedAt,
+      };
+      const canonicalSignaturePayload = canonicalJson(signaturePayload);
+
       return jsonResponse(
         createSuccessResponse({
           standard: 'ERC-8004',
           schemaVersion: ERC_8004_REPUTATION_EXPORT_VERSION,
-          generatedAt: new Date().toISOString(),
-          subject: {
-            agentId: agent.id,
-            name: agent.name,
-            displayName: agent.display_name,
-            publicKey: agent.public_key,
-            verificationState: agent.verification_state ?? 'unverified',
-            status: agent.status ?? 'unknown',
-          },
-          signedVerifierGate: {
-            required: true,
-            verified: true,
-            verifier: 'withAuth + withAgentSignature',
-            headers: ['X-AgentGram-Signature', 'X-AgentGram-Timestamp'],
-            canonicalRequestPath: new URL(req.url).pathname,
-          },
-          storageState: {
-            sourceTable: 'agents',
-            trustScore: storedTrustScore,
-            axp: agent.axp ?? 0,
-            updatedAt: agent.updated_at,
-          },
-          eventEvidence: {
-            sourceTable: 'trust_events',
-            retention: 'full_ledger',
-            eventCount: events.length,
-            deltaSum,
-            events: events.map((event) => ({
-              id: event.id,
-              delta: event.delta ?? 0,
-              reason: event.reason ?? 'unknown',
-              referenceId: event.reference_id,
-              createdAt: event.created_at,
-            })),
-          },
-          storageEventReconciliation: {
-            baselineTrustScore: BASELINE_TRUST_SCORE,
-            projectedTrustScoreFromEvents,
-            storedTrustScore,
-            storageEventDifference,
-            preservesStorageEventDifference: true,
+          generatedAt,
+          subject,
+          signedVerifierGate,
+          storageState,
+          eventEvidence,
+          storageEventReconciliation,
+          provenanceBundle: {
+            kind: REPUTATION_PROVENANCE_BUNDLE_VERSION,
+            generatedAt,
+            scoringPolicy: {
+              version: SCORING_POLICY_VERSION,
+              baselineTrustScore: BASELINE_TRUST_SCORE,
+              formula:
+                'clamp(baselineTrustScore + sum(trust_events.delta), 0, 1)',
+              storageEventDifferencePreserved: true,
+            },
+            validation: {
+              tier: VALIDATION_TIER,
+              signingAlgorithm: 'ed25519',
+              signatureDomain: REPUTATION_PROVENANCE_SIGNATURE_DOMAIN,
+              signedVerifierRequestRequired: true,
+            },
+            aggregation: {
+              aggregatedAt: generatedAt,
+              eventCount: events.length,
+              firstEventAt: eventRows[0]?.createdAt ?? null,
+              lastEventAt: eventRows[eventRows.length - 1]?.createdAt ?? null,
+            },
+            evidenceDigest: {
+              digestAlgorithm: 'sha256',
+              inputEvidenceDigest,
+            },
+            signaturePayload: {
+              ...signaturePayload,
+              digestAlgorithm: 'sha256',
+              payloadDigest: sha256Hex(canonicalSignaturePayload),
+              status: 'ed25519-signable',
+            },
+            auditorVerification: {
+              canonicalJsonStandard: 'sorted-key-json',
+              canonicalInputEvidence,
+              canonicalSignaturePayload,
+              verificationCommand:
+                'canonicalize provenance inputs, sha256 them, then Ed25519-sign the signaturePayload with the agent key',
+            },
           },
         })
       );

--- a/apps/web/app/api/v1/ax-score/mcp-registry/audit/route.ts
+++ b/apps/web/app/api/v1/ax-score/mcp-registry/audit/route.ts
@@ -11,13 +11,22 @@ import {
   jsonResponse,
 } from '@agentgram/shared';
 import { getDeveloperPlan } from '@/lib/ax-score/usage';
-import { sweepMcpRegistryCoverage } from '@/lib/ax-score/mcp-registry-audit';
+import {
+  type McpRegistryAuditReportType,
+  sweepMcpRegistryCoverage,
+} from '@/lib/ax-score/mcp-registry-audit';
 
 interface AuditRequestBody {
   limit?: unknown;
   maxPages?: unknown;
   cursor?: unknown;
+  reportType?: unknown;
 }
+
+const MCP_REGISTRY_AUDIT_REPORT_TYPES = [
+  'mcp-registry-coverage-audit',
+  'mcp-schema-compatibility-audit',
+] as const;
 
 function readPositiveInteger(value: unknown): number | undefined {
   if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
@@ -29,6 +38,13 @@ function readPositiveInteger(value: unknown): number | undefined {
 
 function isBillingReportPlan(plan: string): boolean {
   return (AX_BILLING_REPORT_PLANS as readonly string[]).includes(plan);
+}
+
+function readReportType(value: unknown): McpRegistryAuditReportType {
+  return typeof value === 'string' &&
+    (MCP_REGISTRY_AUDIT_REPORT_TYPES as readonly string[]).includes(value)
+    ? (value as McpRegistryAuditReportType)
+    : 'mcp-registry-coverage-audit';
 }
 
 /**
@@ -60,18 +76,20 @@ const handler = withDeveloperAuth(async function POST(req: NextRequest) {
     const limit = readPositiveInteger(body.limit);
     const maxPages = readPositiveInteger(body.maxPages);
     const cursor = typeof body.cursor === 'string' ? body.cursor : null;
+    const reportType = readReportType(body.reportType);
 
     const audit = await sweepMcpRegistryCoverage({
       ...(limit ? { limit } : {}),
       ...(maxPages ? { maxPages } : {}),
       cursor,
+      reportType,
     });
 
     return jsonResponse(
       createSuccessResponse({
         developerId,
         plan,
-        reportType: 'mcp-registry-coverage-audit',
+        reportType,
         payment: audit.receipt.x402,
         audit,
       }),

--- a/apps/web/lib/ax-score/mcp-registry-audit.ts
+++ b/apps/web/lib/ax-score/mcp-registry-audit.ts
@@ -4,6 +4,10 @@ const MCP_REGISTRY_ENDPOINT = 'https://registry.modelcontextprotocol.io/v0/serve
 const DEFAULT_PAGE_LIMIT = 100;
 const DEFAULT_MAX_PAGES = 100;
 
+export type McpRegistryAuditReportType =
+  | 'mcp-registry-coverage-audit'
+  | 'mcp-schema-compatibility-audit';
+
 export interface McpRegistrySweepOptions {
   fetcher?: typeof fetch;
   endpoint?: string;
@@ -11,6 +15,7 @@ export interface McpRegistrySweepOptions {
   maxPages?: number;
   cursor?: string | null;
   generatedAt?: string;
+  reportType?: McpRegistryAuditReportType;
 }
 
 interface McpRegistryServerDocument {
@@ -54,11 +59,14 @@ export interface McpRegistryCoverageAnomalies {
   missingRemoteTransports: string[];
   cursorLoops: string[];
   emptyPagesWithCursor: string[];
+  schemaCompatibilityFailures: string[];
   truncated: boolean;
 }
 
 export interface McpRegistryCoverageReceipt {
-  kind: 'agentgram.ax-score.mcp-registry.coverage-receipt';
+  kind:
+    | 'agentgram.ax-score.mcp-registry.coverage-receipt'
+    | 'agentgram.ax-score.mcp-registry.schema-compatibility-receipt';
   registryEndpoint: string;
   generatedAt: string;
   digestAlgorithm: 'sha256';
@@ -70,7 +78,9 @@ export interface McpRegistryCoverageReceipt {
   anomalyCount: number;
   x402: {
     status: 'ready';
-    paymentPurpose: 'mcp-registry-coverage-audit-report';
+    paymentPurpose:
+      | 'mcp-registry-coverage-audit-report'
+      | 'mcp-schema-compatibility-audit-report';
     recommendedPriceUsd: string;
     deliverable: string;
   };
@@ -89,6 +99,8 @@ export interface McpRegistryCoverageAudit {
     remoteTransportEntries: number;
     remoteTransportCoveragePct: number;
     latestMarkedNames: number;
+    schemaCompatibleEntries: number;
+    schemaCompatibilityPct: number;
   };
   pageChain: McpRegistryPageDigest[];
   anomalies: McpRegistryCoverageAnomalies;
@@ -101,6 +113,8 @@ interface NormalizedServerVersion {
   version: string;
   isLatest: boolean;
   hasRemoteTransport: boolean;
+  schemaCompatible: boolean;
+  schemaCompatibilityErrors: string[];
 }
 
 function stableStringify(value: unknown): string {
@@ -137,18 +151,54 @@ function hasRemoteTransport(server: McpRegistryServerDocument): boolean {
   });
 }
 
+function hasPackageLaunchSurface(server: McpRegistryServerDocument): boolean {
+  if (!Array.isArray(server.packages)) return false;
+
+  return server.packages.some((pkg) => {
+    if (!pkg || typeof pkg !== 'object') return false;
+    const record = pkg as Record<string, unknown>;
+    return (
+      typeof record.name === 'string' &&
+      record.name.trim().length > 0 &&
+      typeof record.version === 'string' &&
+      record.version.trim().length > 0
+    );
+  });
+}
+
+function getSchemaCompatibilityErrors(
+  server: McpRegistryServerDocument,
+  hasRemote: boolean
+): string[] {
+  const errors: string[] = [];
+  if (typeof server.name !== 'string' || !server.name.trim()) {
+    errors.push('missing server.name');
+  }
+  if (typeof server.version !== 'string' || !server.version.trim()) {
+    errors.push('missing server.version');
+  }
+  if (!hasRemote && !hasPackageLaunchSurface(server)) {
+    errors.push('missing MCP launch surface (https remote or package)');
+  }
+  return errors;
+}
+
 function normalizeServer(entry: McpRegistryEntry): NormalizedServerVersion {
   const server = entry.server ?? {};
   const name = getString(server.name, 'unknown-server');
   const version = getString(server.version, 'unknown-version');
   const official = entry._meta?.['io.modelcontextprotocol.registry/official'];
+  const hasRemote = hasRemoteTransport(server);
+  const schemaCompatibilityErrors = getSchemaCompatibilityErrors(server, hasRemote);
 
   return {
     id: `${name}@${version}`,
     name,
     version,
     isLatest: official?.isLatest === true,
-    hasRemoteTransport: hasRemoteTransport(server),
+    hasRemoteTransport: hasRemote,
+    schemaCompatible: schemaCompatibilityErrors.length === 0,
+    schemaCompatibilityErrors,
   };
 }
 
@@ -166,6 +216,7 @@ function countAnomalies(anomalies: McpRegistryCoverageAnomalies): number {
     anomalies.missingRemoteTransports.length +
     anomalies.cursorLoops.length +
     anomalies.emptyPagesWithCursor.length +
+    anomalies.schemaCompatibilityFailures.length +
     (anomalies.truncated ? 1 : 0)
   );
 }
@@ -176,20 +227,33 @@ function buildReceipt(input: {
   pageChain: McpRegistryPageDigest[];
   servers: NormalizedServerVersion[];
   anomalies: McpRegistryCoverageAnomalies;
+  reportType: McpRegistryAuditReportType;
 }): McpRegistryCoverageReceipt {
   const pageChainDigest = sha256(input.pageChain);
   const coveragePayload = {
     endpoint: input.endpoint,
+    reportType: input.reportType,
     pages: input.pageChain.map((page) => page.digest),
     servers: input.servers.map((server) => server.id).sort(),
+    schemaCompatibility: input.servers
+      .map((server) => ({
+        id: server.id,
+        compatible: server.schemaCompatible,
+        errors: server.schemaCompatibilityErrors,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
     anomalies: input.anomalies,
   };
   const coverageDigest = sha256(coveragePayload);
   const anomalyCount = countAnomalies(input.anomalies);
   const signaturePayloadDigest = sha256({ coverageDigest, pageChainDigest });
+  const isSchemaCompatibilityReport =
+    input.reportType === 'mcp-schema-compatibility-audit';
 
   return {
-    kind: 'agentgram.ax-score.mcp-registry.coverage-receipt',
+    kind: isSchemaCompatibilityReport
+      ? 'agentgram.ax-score.mcp-registry.schema-compatibility-receipt'
+      : 'agentgram.ax-score.mcp-registry.coverage-receipt',
     registryEndpoint: input.endpoint,
     generatedAt: input.generatedAt,
     digestAlgorithm: 'sha256',
@@ -201,9 +265,13 @@ function buildReceipt(input: {
     anomalyCount,
     x402: {
       status: 'ready',
-      paymentPurpose: 'mcp-registry-coverage-audit-report',
-      recommendedPriceUsd: '49.00',
-      deliverable: 'Full nextCursor sweep digest, coverage anomaly report, and Ed25519-signable receipt payload.',
+      paymentPurpose: isSchemaCompatibilityReport
+        ? 'mcp-schema-compatibility-audit-report'
+        : 'mcp-registry-coverage-audit-report',
+      recommendedPriceUsd: isSchemaCompatibilityReport ? '79.00' : '49.00',
+      deliverable: isSchemaCompatibilityReport
+        ? 'MCP Registry schema compatibility findings, launch-surface gate results, and Ed25519-signable receipt payload.'
+        : 'Full nextCursor sweep digest, coverage anomaly report, and Ed25519-signable receipt payload.',
     },
     signature: {
       status: 'unsigned',
@@ -221,6 +289,7 @@ export async function sweepMcpRegistryCoverage(
   const limit = Math.max(1, Math.min(options.limit ?? DEFAULT_PAGE_LIMIT, 500));
   const maxPages = Math.max(1, options.maxPages ?? DEFAULT_MAX_PAGES);
   const generatedAt = options.generatedAt ?? new Date().toISOString();
+  const reportType = options.reportType ?? 'mcp-registry-coverage-audit';
   const requestedCursors = new Set<string | null>();
   const pageChain: McpRegistryPageDigest[] = [];
   const servers: NormalizedServerVersion[] = [];
@@ -291,6 +360,10 @@ export async function sweepMcpRegistryCoverage(
     .filter((server) => !server.hasRemoteTransport)
     .map((server) => server.id)
     .sort();
+  const schemaCompatibilityFailures = servers
+    .filter((server) => !server.schemaCompatible)
+    .map((server) => `${server.id}: ${server.schemaCompatibilityErrors.join('; ')}`)
+    .sort();
 
   const anomalies = {
     duplicateServerVersions,
@@ -298,6 +371,7 @@ export async function sweepMcpRegistryCoverage(
     missingRemoteTransports,
     cursorLoops,
     emptyPagesWithCursor,
+    schemaCompatibilityFailures,
     truncated,
   };
   const remoteTransportEntries = servers.filter(
@@ -305,6 +379,9 @@ export async function sweepMcpRegistryCoverage(
   ).length;
   const uniqueServerVersions = new Set(servers.map((server) => server.id)).size;
   const uniqueServerNames = names.size;
+  const schemaCompatibleEntries = servers.filter(
+    (server) => server.schemaCompatible
+  ).length;
 
   return {
     summary: {
@@ -319,6 +396,11 @@ export async function sweepMcpRegistryCoverage(
       latestMarkedNames: [...names.values()].filter((versions) =>
         versions.some((version) => version.isLatest)
       ).length,
+      schemaCompatibleEntries,
+      schemaCompatibilityPct:
+        servers.length === 0
+          ? 0
+          : Math.round((schemaCompatibleEntries / servers.length) * 10000) / 100,
     },
     pageChain,
     anomalies,
@@ -328,6 +410,7 @@ export async function sweepMcpRegistryCoverage(
       pageChain,
       servers,
       anomalies,
+      reportType,
     }),
   };
 }


### PR DESCRIPTION
## Source
Hermes kkami release-promote cron ca3cc60e24bb.
Ref: https://github.com/agentgram/agentgram

## Change
Promote the current `develop` branch to `main` through a guarded release PR.
This run detected `develop` ahead of `main` by 2 commit(s) at 2026-08-12 06:00 KST.

## Evidence
- diff: `git rev-list --count origin/main..origin/develop` => `2`
- test: release promotion script dry-run/smoke validation is available via `python3 scripts/agentgram_release_promote.py --dry-run --no-fetch`

## Auth-only Proof
N/A
