### PR TITLE
strategic(a2a): A2A interface binding attestation gate

### DIFF
--- a/apps/web/__tests__/api/a2a-agent-card-interface-binding-attestation.test.ts
+++ b/apps/web/__tests__/api/a2a-agent-card-interface-binding-attestation.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockVerifyA2aAgentCardSignature = vi.fn();
+const mockBuildA2aInterfaceBindingAttestation = vi.fn();
+
+vi.mock('@agentgram/auth', () => ({
+  withRateLimit: (_config: unknown, handler: unknown) => handler,
+  verifyA2aAgentCardSignature: mockVerifyA2aAgentCardSignature,
+}));
+
+vi.mock('@/lib/a2a/interface-binding-attestation', () => ({
+  buildA2aInterfaceBindingAttestation: mockBuildA2aInterfaceBindingAttestation,
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request(
+    'http://localhost/api/v1/a2a/agent-card/interface-binding-attestation',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  ) as unknown as import('next/server').NextRequest;
+}
+
+describe('A2A Agent Card interface-binding attestation route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildA2aInterfaceBindingAttestation.mockResolvedValue({
+      kind: 'agentgram.a2a.interface-binding-attestation',
+      generatedAt: '2026-08-10T00:00:00.000Z',
+      summary: {
+        interfaceCount: 1,
+        reachableInterfaces: 1,
+        mismatchedBindings: 0,
+        axPenaltyApplied: false,
+      },
+      interfaceProbes: [
+        {
+          id: 'json-rpc',
+          url: 'https://agent.example/a2a',
+          transport: 'jsonrpc',
+          version: '1.0.0',
+          securityScheme: 'bearer',
+          probeStatus: 'reachable',
+          httpStatus: 200,
+          schemeMatchesUrl: true,
+          evidence: 'interface probe returned HTTP 200',
+        },
+      ],
+      receipt: {
+        kind: 'agentgram.a2a.interface-binding-attestation-receipt',
+        digestAlgorithm: 'sha256',
+        signatureVerification: {
+          status: 'verified',
+          signingAlgorithm: 'ed25519',
+          payloadDigest: 'a'.repeat(64),
+        },
+        signature: {
+          status: 'unsigned',
+          signingAlgorithm: 'ed25519',
+          payloadDigest: 'b'.repeat(64),
+        },
+      },
+    });
+  });
+
+  it('rejects unsigned Agent Cards before probing interfaces', async () => {
+    mockVerifyA2aAgentCardSignature.mockResolvedValueOnce({
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message: 'A2A Agent Card signatures require publicKey, signature, and agentCard',
+      evidence: { signature: { status: 'fail-closed' } },
+    });
+    const { POST } = await import(
+      '@/app/api/v1/a2a/agent-card/interface-binding-attestation/route'
+    );
+
+    const response = await POST(makeRequest({ agentCard: { name: 'unsigned' } }));
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.error.code).toBe('SIGNATURE_INVALID');
+    expect(json.error.details.evidence.signature.status).toBe('fail-closed');
+    expect(mockBuildA2aInterfaceBindingAttestation).not.toHaveBeenCalled();
+  });
+
+  it('returns a signed-card interface attestation report with probe evidence', async () => {
+    const agentCard = {
+      name: 'weather-agent',
+      interfaces: [
+        {
+          id: 'json-rpc',
+          url: 'https://agent.example/a2a',
+          transport: 'jsonrpc',
+          version: '1.0.0',
+          securityScheme: 'bearer',
+        },
+      ],
+    };
+    const previousAgentCard = {
+      ...agentCard,
+      interfaces: [{ ...agentCard.interfaces[0], version: '0.9.0' }],
+    };
+    mockVerifyA2aAgentCardSignature.mockResolvedValueOnce({
+      ok: true,
+      canonicalJson: '{"name":"weather-agent"}',
+      payloadDigest: 'a'.repeat(64),
+      evidence: { signature: { status: 'fail-closed' } },
+    });
+    const { POST } = await import(
+      '@/app/api/v1/a2a/agent-card/interface-binding-attestation/route'
+    );
+
+    const response = await POST(
+      makeRequest({
+        publicKey: 'c'.repeat(64),
+        signature: 'd'.repeat(128),
+        agentCard,
+        previousAgentCard,
+      })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockBuildA2aInterfaceBindingAttestation).toHaveBeenCalledWith({
+      agentCard,
+      previousAgentCard,
+      signatureVerified: true,
+      signaturePayloadDigest: 'a'.repeat(64),
+    });
+    expect(json.data).toMatchObject({
+      reportType: 'a2a-interface-binding-attestation',
+      verdict: {
+        ok: true,
+        payloadDigest: 'a'.repeat(64),
+      },
+      attestation: {
+        summary: {
+          interfaceCount: 1,
+          reachableInterfaces: 1,
+          axPenaltyApplied: false,
+        },
+        receipt: {
+          signatureVerification: {
+            status: 'verified',
+            signingAlgorithm: 'ed25519',
+          },
+        },
+      },
+    });
+  });
+});

--- a/apps/web/__tests__/api/auth-coverage.test.ts
+++ b/apps/web/__tests__/api/auth-coverage.test.ts
@@ -22,6 +22,7 @@ type RouteExport = {
 const PUBLIC_API_ROUTE_EXPORTS = new Set([
   'a2a/agent-card/canonical-signature/route.ts#GET',
   'a2a/agent-card/canonical-signature/route.ts#POST',
+  'a2a/agent-card/interface-binding-attestation/route.ts#POST',
   'activity/live-stats/route.ts#GET',
   'agents/[agentId]/lorebook/preview/route.ts#GET',
   'agents/[agentId]/remixes/route.ts#GET',

--- a/apps/web/__tests__/lib/a2a-interface-binding-attestation.test.ts
+++ b/apps/web/__tests__/lib/a2a-interface-binding-attestation.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildA2aInterfaceBindingAttestation } from '@/lib/a2a/interface-binding-attestation';
+
+describe('A2A interface binding attestation', () => {
+  it('probes signed interface bindings and records card-diff evidence', async () => {
+    const fetcher = vi.fn(async () => new Response(null, { status: 204 }));
+
+    const report = await buildA2aInterfaceBindingAttestation({
+      generatedAt: '2026-08-10T00:00:00.000Z',
+      signatureVerified: true,
+      signaturePayloadDigest: 'a'.repeat(64),
+      previousAgentCard: {
+        interfaces: [
+          {
+            id: 'json-rpc',
+            url: 'https://agent.example/a2a/v0',
+            transport: 'jsonrpc',
+            version: '0.9.0',
+            securityScheme: 'bearer',
+          },
+        ],
+      },
+      agentCard: {
+        name: 'weather-agent',
+        interfaces: [
+          {
+            id: 'json-rpc',
+            url: 'https://agent.example/a2a/v1',
+            transport: 'jsonrpc',
+            version: '1.0.0',
+            securityScheme: 'bearer',
+          },
+        ],
+      },
+      fetcher,
+    });
+
+    expect(fetcher).toHaveBeenCalledWith('https://agent.example/a2a/v1', {
+      method: 'HEAD',
+    });
+    expect(report.summary).toMatchObject({
+      interfaceCount: 1,
+      reachableInterfaces: 1,
+      axPenaltyApplied: false,
+    });
+    expect(report.interfaceProbes[0]).toMatchObject({
+      id: 'json-rpc',
+      probeStatus: 'reachable',
+      httpStatus: 204,
+      schemeMatchesUrl: true,
+    });
+    expect(report.cardDiff.status).toBe('changed');
+    expect(report.cardDiff.changedBindings).toEqual([
+      'added json-rpc https://agent.example/a2a/v1|jsonrpc|1.0.0|bearer',
+      'removed json-rpc https://agent.example/a2a/v0|jsonrpc|0.9.0|bearer',
+    ]);
+    expect(report.receipt.signatureVerification).toMatchObject({
+      status: 'verified',
+      signingAlgorithm: 'ed25519',
+      payloadDigest: 'a'.repeat(64),
+    });
+    expect(report.receipt.signature.payloadDigest).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('penalizes missing declarations, unreachable URLs, and security mismatches', async () => {
+    const fetcher = vi.fn(async () => new Response(null, { status: 503 }));
+
+    const report = await buildA2aInterfaceBindingAttestation({
+      generatedAt: '2026-08-10T00:00:00.000Z',
+      signatureVerified: false,
+      agentCard: {
+        interfaces: [
+          {
+            id: 'sse',
+            url: 'http://agent.example/a2a',
+            transport: 'sse',
+            version: '1.0.0',
+            securityScheme: 'bearer',
+          },
+          {
+            id: 'broken',
+            url: 'not a url',
+            transport: 'jsonrpc',
+            version: '1.0.0',
+            securityScheme: 'bearer',
+          },
+        ],
+      },
+      fetcher,
+    });
+
+    expect(report.axEvidence.status).toBe('penalized');
+    expect(report.anomalies).toMatchObject({
+      invalidInterfaceUrls: ['broken'],
+      unreachableInterfaces: ['sse'],
+      securitySchemeMismatches: ['broken', 'sse'],
+      unsignedOrUnverifiedCard: true,
+    });
+    expect(report.axEvidence.penaltyReasons).toEqual(
+      expect.arrayContaining([
+        'broken has an invalid URL',
+        'sse is unreachable',
+        'sse has an HTTPS/security-scheme mismatch',
+        'Agent Card signature was not verified',
+      ])
+    );
+  });
+});

--- a/apps/web/app/api/v1/a2a/agent-card/interface-binding-attestation/route.ts
+++ b/apps/web/app/api/v1/a2a/agent-card/interface-binding-attestation/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest } from 'next/server';
+import { withRateLimit } from '@agentgram/auth';
+import { verifyA2aAgentCardSignature } from '@agentgram/auth';
+import {
+  AX_RATE_LIMITS,
+  ErrorResponses,
+  createErrorResponse,
+  createSuccessResponse,
+  jsonResponse,
+} from '@agentgram/shared';
+import { buildA2aInterfaceBindingAttestation } from '@/lib/a2a/interface-binding-attestation';
+
+interface InterfaceBindingAttestationRequestBody {
+  agentCard?: unknown;
+  previousAgentCard?: unknown;
+  publicKey?: unknown;
+  signature?: unknown;
+}
+
+/**
+ * POST /api/v1/a2a/agent-card/interface-binding-attestation
+ *
+ * Verify the submitted Agent Card signature, probe each declared interface at
+ * URL/transport/version/security-scheme granularity, and return an
+ * Ed25519-signable attestation receipt that AX Score/discovery clients can
+ * penalize when interfaces are unreachable or security bindings drift.
+ * Auth: public (rate-limited) — stateless verification of caller-supplied
+ * material, no account or developer state is read.
+ */
+const postHandler = async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as InterfaceBindingAttestationRequestBody;
+    const verdict = await verifyA2aAgentCardSignature({
+      agentCard: body.agentCard,
+      publicKey: body.publicKey,
+      signature: body.signature,
+    });
+
+    if (!verdict.ok) {
+      return jsonResponse(
+        createErrorResponse(verdict.code, verdict.message, {
+          evidence: verdict.evidence,
+        }),
+        401
+      );
+    }
+
+    const attestation = await buildA2aInterfaceBindingAttestation({
+      agentCard: body.agentCard,
+      previousAgentCard: body.previousAgentCard,
+      signatureVerified: true,
+      signaturePayloadDigest: verdict.payloadDigest,
+    });
+
+    return jsonResponse(
+      createSuccessResponse({
+        reportType: 'a2a-interface-binding-attestation',
+        verdict: {
+          ok: true,
+          payloadDigest: verdict.payloadDigest,
+          evidence: verdict.evidence,
+        },
+        attestation,
+      }),
+      200
+    );
+  } catch (error) {
+    console.error('A2A Agent Card interface-binding attestation error:', error);
+    return jsonResponse(
+      ErrorResponses.internalError(
+        'Failed to produce A2A Agent Card interface-binding attestation'
+      ),
+      500
+    );
+  }
+};
+
+export const POST = withRateLimit(
+  {
+    maxRequests: AX_RATE_LIMITS.SCAN.limit,
+    windowMs: AX_RATE_LIMITS.SCAN.windowMs,
+  },
+  postHandler
+);

--- a/apps/web/lib/a2a/interface-binding-attestation.ts
+++ b/apps/web/lib/a2a/interface-binding-attestation.ts
@@ -1,0 +1,364 @@
+import { createHash } from 'node:crypto';
+
+export type A2aInterfaceProbeStatus =
+  | 'reachable'
+  | 'unreachable'
+  | 'invalid-url';
+
+export interface A2aInterfaceBindingInput {
+  agentCard: unknown;
+  previousAgentCard?: unknown;
+  signatureVerified: boolean;
+  signaturePayloadDigest?: string;
+  fetcher?: typeof fetch;
+  generatedAt?: string;
+}
+
+export interface A2aInterfaceBindingProbe {
+  id: string;
+  url: string;
+  transport: string;
+  version: string;
+  securityScheme: string;
+  probeStatus: A2aInterfaceProbeStatus;
+  httpStatus: number | null;
+  schemeMatchesUrl: boolean;
+  evidence: string;
+}
+
+export interface A2aInterfaceBindingAttestationReport {
+  kind: 'agentgram.a2a.interface-binding-attestation';
+  generatedAt: string;
+  summary: {
+    interfaceCount: number;
+    reachableInterfaces: number;
+    mismatchedBindings: number;
+    axPenaltyApplied: boolean;
+  };
+  interfaceProbes: A2aInterfaceBindingProbe[];
+  cardDiff: {
+    status: 'baseline' | 'unchanged' | 'changed';
+    changedBindings: string[];
+    previousDigest: string | null;
+    currentDigest: string;
+  };
+  anomalies: {
+    missingInterfaceDeclarations: boolean;
+    invalidInterfaceUrls: string[];
+    unreachableInterfaces: string[];
+    securitySchemeMismatches: string[];
+    unsignedOrUnverifiedCard: boolean;
+  };
+  axEvidence: {
+    status: 'pass' | 'penalized';
+    penaltyReasons: string[];
+  };
+  receipt: {
+    kind: 'agentgram.a2a.interface-binding-attestation-receipt';
+    digestAlgorithm: 'sha256';
+    interfaceBindingDigest: string;
+    cardDiffDigest: string;
+    signatureVerification: {
+      status: 'verified' | 'failed';
+      signingAlgorithm: 'ed25519';
+      payloadDigest: string | null;
+    };
+    signature: {
+      status: 'unsigned';
+      signingAlgorithm: 'ed25519';
+      payloadDigest: string;
+    };
+  };
+}
+
+interface NormalizedInterfaceBinding {
+  id: string;
+  url: string;
+  transport: string;
+  version: string;
+  securityScheme: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .filter((key) => record[key] !== undefined)
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(',')}}`;
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(stableStringify(value)).digest('hex');
+}
+
+function readString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function readSecurityScheme(value: unknown): string {
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  if (isRecord(value)) {
+    return readString(value.scheme ?? value.type ?? value.name, 'unspecified');
+  }
+  if (Array.isArray(value) && value.length > 0) {
+    return readSecurityScheme(value[0]);
+  }
+  return 'unspecified';
+}
+
+function inferTransport(url: string, explicitTransport: unknown): string {
+  const transport = readString(explicitTransport, '');
+  if (transport) return transport;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol.replace(':', '') || 'unspecified';
+  } catch {
+    return 'unspecified';
+  }
+}
+
+function normalizeInterface(
+  binding: Record<string, unknown>,
+  index: number
+): NormalizedInterfaceBinding | null {
+  const url = readString(
+    binding.url ?? binding.endpoint ?? binding.href ?? binding.serviceEndpoint,
+    ''
+  );
+  if (!url) return null;
+
+  return {
+    id: readString(binding.id ?? binding.name, `interface-${index + 1}`),
+    url,
+    transport: inferTransport(url, binding.transport ?? binding.protocol),
+    version: readString(
+      binding.version ?? binding.protocolVersion ?? binding.apiVersion,
+      'unspecified'
+    ),
+    securityScheme: readSecurityScheme(
+      binding.securityScheme ?? binding.securitySchemes ?? binding.security
+    ),
+  };
+}
+
+function normalizeInterfaces(agentCard: unknown): NormalizedInterfaceBinding[] {
+  if (!isRecord(agentCard)) return [];
+
+  const declared = agentCard.interfaces ?? agentCard.agentInterfaces;
+  if (Array.isArray(declared)) {
+    return declared
+      .map((binding, index) =>
+        isRecord(binding) ? normalizeInterface(binding, index) : null
+      )
+      .filter((binding): binding is NormalizedInterfaceBinding => binding !== null);
+  }
+
+  const fallback = normalizeInterface(agentCard, 0);
+  return fallback ? [fallback] : [];
+}
+
+function bindingKey(binding: NormalizedInterfaceBinding): string {
+  return [
+    binding.url,
+    binding.transport,
+    binding.version,
+    binding.securityScheme,
+  ].join('|');
+}
+
+function compareBindings(
+  previous: NormalizedInterfaceBinding[],
+  current: NormalizedInterfaceBinding[]
+): string[] {
+  if (previous.length === 0) return [];
+  const previousKeys = new Set(previous.map(bindingKey));
+  const currentKeys = new Set(current.map(bindingKey));
+  return [
+    ...current
+      .filter((binding) => !previousKeys.has(bindingKey(binding)))
+      .map((binding) => `added ${binding.id} ${bindingKey(binding)}`),
+    ...previous
+      .filter((binding) => !currentKeys.has(bindingKey(binding)))
+      .map((binding) => `removed ${binding.id} ${bindingKey(binding)}`),
+  ].sort();
+}
+
+function schemeMatchesUrl(binding: NormalizedInterfaceBinding): boolean {
+  try {
+    const parsed = new URL(binding.url);
+    if (parsed.protocol !== 'https:') return false;
+  } catch {
+    return false;
+  }
+
+  return binding.securityScheme !== 'unspecified' && binding.securityScheme !== 'none';
+}
+
+async function probeInterface(
+  binding: NormalizedInterfaceBinding,
+  fetcher: typeof fetch
+): Promise<A2aInterfaceBindingProbe> {
+  let parsed: URL;
+  try {
+    parsed = new URL(binding.url);
+  } catch {
+    return {
+      ...binding,
+      probeStatus: 'invalid-url',
+      httpStatus: null,
+      schemeMatchesUrl: false,
+      evidence: 'interface URL is not parseable',
+    };
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return {
+      ...binding,
+      probeStatus: 'invalid-url',
+      httpStatus: null,
+      schemeMatchesUrl: false,
+      evidence: 'interface URL must use http or https for reachability probing',
+    };
+  }
+
+  let status: number | null = null;
+  try {
+    let response = await fetcher(binding.url, { method: 'HEAD' });
+    if (response.status === 405) {
+      response = await fetcher(binding.url, { method: 'GET' });
+    }
+    status = response.status;
+  } catch {
+    status = null;
+  }
+
+  const reachable = status !== null && status >= 200 && status < 400;
+  return {
+    ...binding,
+    probeStatus: reachable ? 'reachable' : 'unreachable',
+    httpStatus: status,
+    schemeMatchesUrl: schemeMatchesUrl(binding),
+    evidence: reachable
+      ? `interface probe returned HTTP ${status}`
+      : status === null
+        ? 'interface probe failed before an HTTP response'
+        : `interface probe returned HTTP ${status}`,
+  };
+}
+
+export async function buildA2aInterfaceBindingAttestation(
+  input: A2aInterfaceBindingInput
+): Promise<A2aInterfaceBindingAttestationReport> {
+  const fetcher = input.fetcher ?? fetch;
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  const currentBindings = normalizeInterfaces(input.agentCard);
+  const previousBindings = normalizeInterfaces(input.previousAgentCard);
+  const interfaceProbes = await Promise.all(
+    currentBindings.map((binding) => probeInterface(binding, fetcher))
+  );
+  const changedBindings = compareBindings(previousBindings, currentBindings);
+  const invalidInterfaceUrls = interfaceProbes
+    .filter((probe) => probe.probeStatus === 'invalid-url')
+    .map((probe) => probe.id)
+    .sort();
+  const unreachableInterfaces = interfaceProbes
+    .filter((probe) => probe.probeStatus === 'unreachable')
+    .map((probe) => probe.id)
+    .sort();
+  const securitySchemeMismatches = interfaceProbes
+    .filter((probe) => !probe.schemeMatchesUrl)
+    .map((probe) => probe.id)
+    .sort();
+  const missingInterfaceDeclarations = currentBindings.length === 0;
+  const unsignedOrUnverifiedCard = !input.signatureVerified;
+  const anomalies = {
+    missingInterfaceDeclarations,
+    invalidInterfaceUrls,
+    unreachableInterfaces,
+    securitySchemeMismatches,
+    unsignedOrUnverifiedCard,
+  };
+  const penaltyReasons = [
+    ...(missingInterfaceDeclarations ? ['missing interface declarations'] : []),
+    ...invalidInterfaceUrls.map((id) => `${id} has an invalid URL`),
+    ...unreachableInterfaces.map((id) => `${id} is unreachable`),
+    ...securitySchemeMismatches.map(
+      (id) => `${id} has an HTTPS/security-scheme mismatch`
+    ),
+    ...(unsignedOrUnverifiedCard ? ['Agent Card signature was not verified'] : []),
+  ];
+  const currentDigest = sha256(currentBindings);
+  const previousDigest = previousBindings.length > 0 ? sha256(previousBindings) : null;
+  const cardDiff = {
+    status:
+      previousBindings.length === 0
+        ? 'baseline'
+        : changedBindings.length > 0
+          ? 'changed'
+          : 'unchanged',
+    changedBindings,
+    previousDigest,
+    currentDigest,
+  } as const;
+  const interfaceBindingDigest = sha256({ interfaceProbes, anomalies });
+  const cardDiffDigest = sha256(cardDiff);
+  const signaturePayloadDigest = input.signaturePayloadDigest ?? null;
+  const receiptPayloadDigest = sha256({
+    interfaceBindingDigest,
+    cardDiffDigest,
+    signaturePayloadDigest,
+    generatedAt,
+  });
+
+  return {
+    kind: 'agentgram.a2a.interface-binding-attestation',
+    generatedAt,
+    summary: {
+      interfaceCount: currentBindings.length,
+      reachableInterfaces: interfaceProbes.filter(
+        (probe) => probe.probeStatus === 'reachable'
+      ).length,
+      mismatchedBindings:
+        invalidInterfaceUrls.length +
+        unreachableInterfaces.length +
+        securitySchemeMismatches.length,
+      axPenaltyApplied: penaltyReasons.length > 0,
+    },
+    interfaceProbes,
+    cardDiff,
+    anomalies,
+    axEvidence: {
+      status: penaltyReasons.length > 0 ? 'penalized' : 'pass',
+      penaltyReasons,
+    },
+    receipt: {
+      kind: 'agentgram.a2a.interface-binding-attestation-receipt',
+      digestAlgorithm: 'sha256',
+      interfaceBindingDigest,
+      cardDiffDigest,
+      signatureVerification: {
+        status: input.signatureVerified ? 'verified' : 'failed',
+        signingAlgorithm: 'ed25519',
+        payloadDigest: signaturePayloadDigest,
+      },
+      signature: {
+        status: 'unsigned',
+        signingAlgorithm: 'ed25519',
+        payloadDigest: receiptPayloadDigest,
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item a314ad7f24.
Ref: https://github.com/agentgram/agentgram

## Change
Adds a public A2A Agent Card interface-binding attestation endpoint that verifies the card signature before probing each declared URL/transport/version/security-scheme tuple. The attestation reports reachability, card-diff evidence, AX penalty reasons, and an Ed25519-signable receipt digest for external discovery clients.

## Evidence
test: pnpm --filter web exec vitest run __tests__/lib/a2a-interface-binding-attestation.test.ts __tests__/api/a2a-agent-card-interface-binding-attestation.test.ts __tests__/api/auth-coverage.test.ts — 3 files / 5 tests passed.
type-check: pnpm --filter web type-check — passed.
lint: pnpm exec eslint lib/a2a/interface-binding-attestation.ts app/api/v1/a2a/agent-card/interface-binding-attestation/route.ts __tests__/lib/a2a-interface-binding-attestation.test.ts __tests__/api/a2a-agent-card-interface-binding-attestation.test.ts __tests__/api/auth-coverage.test.ts — passed.
build: pnpm --filter web build — passed, including /api/v1/a2a/agent-card/interface-binding-attestation route.
diff: 5 files changed, 711 insertions.

## Auth-only Proof
N/A