### PR TITLE
release: promote develop to main — 2026-08-17

### DIFF
--- a/apps/web/__tests__/api/a2a-agent-card-canonical-signature.test.ts
+++ b/apps/web/__tests__/api/a2a-agent-card-canonical-signature.test.ts
@@ -85,6 +85,46 @@ describe('A2A Agent Card canonical signature route', () => {
     expect(json.data.verdict.canonicalJson).toBeUndefined();
   });
 
+  it('accepts compact JWS material without leaking the protected header', async () => {
+    mockVerifyA2aAgentCardSignature.mockResolvedValueOnce({
+      ok: true,
+      canonicalJson: '{"name":"weather-agent"}',
+      payloadDigest: 'd'.repeat(64),
+      jwsProtectedHeader: {
+        alg: 'EdDSA',
+        kid: 'b'.repeat(64),
+        crit: ['agentgram-rfc8785'],
+        'agentgram-rfc8785': true,
+      },
+      evidence: mockBuildA2aAgentCardCanonicalSignatureEvidence(),
+    });
+    const { POST } = await import(
+      '@/app/api/v1/a2a/agent-card/canonical-signature/route'
+    );
+
+    const response = await POST(
+      makeRequest({
+        publicKey: 'b'.repeat(64),
+        jws: 'protected.payload.signature',
+        agentCard: { name: 'weather-agent' },
+      })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockVerifyA2aAgentCardSignature).toHaveBeenCalledWith({
+      publicKey: 'b'.repeat(64),
+      signature: undefined,
+      jws: 'protected.payload.signature',
+      agentCard: { name: 'weather-agent' },
+    });
+    expect(json.data.verdict).toMatchObject({
+      ok: true,
+      payloadDigest: 'd'.repeat(64),
+    });
+    expect(json.data.verdict.jwsProtectedHeader).toBeUndefined();
+  });
+
   it('fails closed when signature material is missing or invalid', async () => {
     mockVerifyA2aAgentCardSignature.mockResolvedValueOnce({
       ok: false,

--- a/apps/web/__tests__/auth/a2a-agent-card-signature.test.ts
+++ b/apps/web/__tests__/auth/a2a-agent-card-signature.test.ts
@@ -1,16 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import {
   A2A_AGENT_CARD_SIGNATURE_DOMAIN,
+  A2A_AGENT_CARD_JWS_ALGORITHM,
   RFC8785_AGENT_CARD_FIXTURE_CANONICAL_JSON,
   RFC8785_AGENT_CARD_FIXTURE_DIGEST,
   buildA2aAgentCardCanonicalSignatureEvidence,
   canonicalJson,
   generateAgentKeypair,
   signA2aAgentCard,
+  signA2aAgentCardJws,
   verifyA2aAgentCardSignature,
 } from '@agentgram/auth/src/ed25519';
 
 describe('A2A Agent Card canonical signature gate', () => {
+  function encodeJwsPart(value: string): string {
+    return Buffer.from(value, 'utf8').toString('base64url');
+  }
+
   it('publishes the RFC8785 canonicalization fixture used by the gate', () => {
     const evidence = buildA2aAgentCardCanonicalSignatureEvidence({
       generatedAt: '2026-08-05T00:00:00.000Z',
@@ -85,6 +91,129 @@ describe('A2A Agent Card canonical signature gate', () => {
     ).resolves.toMatchObject({
       ok: false,
       code: 'SIGNATURE_INVALID',
+    });
+  });
+
+  it('verifies compact JWS cards only when the protected header and RFC8785 payload are bound', async () => {
+    const { publicKey, secretKey } = await generateAgentKeypair();
+    const agentCard = {
+      name: 'weather-agent',
+      url: 'https://weather.example/.well-known/agent.json',
+      capabilities: { streaming: true, pushNotifications: false },
+      skills: [{ id: 'forecast', name: 'Forecast' }],
+    };
+    const jws = await signA2aAgentCardJws(secretKey, publicKey, agentCard);
+
+    const verdict = await verifyA2aAgentCardSignature({
+      publicKey,
+      agentCard: {
+        skills: [{ name: 'Forecast', id: 'forecast' }],
+        capabilities: { pushNotifications: false, streaming: true },
+        name: 'weather-agent',
+        url: 'https://weather.example/.well-known/agent.json',
+      },
+      jws,
+    });
+
+    expect(verdict.ok).toBe(true);
+    if (verdict.ok) {
+      expect(verdict.jwsProtectedHeader).toMatchObject({
+        alg: A2A_AGENT_CARD_JWS_ALGORITHM,
+        kid: publicKey,
+        crit: ['agentgram-rfc8785'],
+        'agentgram-rfc8785': true,
+      });
+      expect(verdict.payloadDigest).toMatch(/^[a-f0-9]{64}$/);
+    }
+  });
+
+  it('rejects algorithm confusion, unknown critical headers, kid mismatch, and detached-card substitution', async () => {
+    const { publicKey, secretKey } = await generateAgentKeypair();
+    const agentCard = { name: 'weather-agent', url: 'https://weather.example' };
+
+    await expect(
+      signA2aAgentCardJws(secretKey, publicKey, agentCard, { alg: 'none' })
+    ).rejects.toThrow('A2A Agent Card JWS alg must be EdDSA');
+
+    await expect(
+      signA2aAgentCardJws(secretKey, publicKey, agentCard, {
+        crit: ['agentgram-rfc8785', 'unknown-critical'],
+        'unknown-critical': true,
+      })
+    ).rejects.toThrow('Unsupported A2A Agent Card JWS critical header');
+
+    const algorithmConfusionJws = [
+      encodeJwsPart(JSON.stringify({ alg: 'none', kid: publicKey })),
+      encodeJwsPart(canonicalJson(agentCard)),
+      encodeJwsPart('unsigned'),
+    ].join('.');
+    await expect(
+      verifyA2aAgentCardSignature({
+        publicKey,
+        agentCard,
+        jws: algorithmConfusionJws,
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message:
+        'A2A Agent Card JWS protected header must allowlist EdDSA, public-key kid, and known critical headers',
+    });
+
+    const unknownCriticalHeaderJws = [
+      encodeJwsPart(
+        JSON.stringify({
+          alg: 'EdDSA',
+          kid: publicKey,
+          crit: ['unknown-critical'],
+          'unknown-critical': true,
+        })
+      ),
+      encodeJwsPart(canonicalJson(agentCard)),
+      encodeJwsPart('signature'),
+    ].join('.');
+    await expect(
+      verifyA2aAgentCardSignature({
+        publicKey,
+        agentCard,
+        jws: unknownCriticalHeaderJws,
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message:
+        'A2A Agent Card JWS protected header must allowlist EdDSA, public-key kid, and known critical headers',
+    });
+
+    const kidMismatchJws = await signA2aAgentCardJws(
+      secretKey,
+      'a'.repeat(64),
+      agentCard
+    );
+    await expect(
+      verifyA2aAgentCardSignature({ publicKey, agentCard, jws: kidMismatchJws })
+    ).resolves.toMatchObject({
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message: 'A2A Agent Card JWS kid must match the supplied public key',
+    });
+
+    const substitutedCardJws = await signA2aAgentCardJws(
+      secretKey,
+      publicKey,
+      agentCard
+    );
+    await expect(
+      verifyA2aAgentCardSignature({
+        publicKey,
+        jws: substitutedCardJws,
+        agentCard: { ...agentCard, url: 'https://evil.example' },
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message:
+        'A2A Agent Card JWS payload must equal the supplied RFC8785 canonical Agent Card',
     });
   });
 });

--- a/apps/web/app/api/v1/a2a/agent-card/canonical-signature/route.ts
+++ b/apps/web/app/api/v1/a2a/agent-card/canonical-signature/route.ts
@@ -16,6 +16,7 @@ interface AgentCardSignatureRequestBody {
   agentCard?: unknown;
   publicKey?: unknown;
   signature?: unknown;
+  jws?: unknown;
 }
 
 /**
@@ -60,6 +61,7 @@ const postHandler = async function POST(req: NextRequest) {
       agentCard: body.agentCard,
       publicKey: body.publicKey,
       signature: body.signature,
+      jws: body.jws,
     });
 
     if (!verdict.ok) {

--- a/packages/auth/src/ed25519.ts
+++ b/packages/auth/src/ed25519.ts
@@ -17,6 +17,9 @@ export const SIGNATURE_DOMAIN = 'agentgram:v1:';
 export const A2A_AGENT_CARD_SIGNATURE_DOMAIN =
   'agentgram:v1:a2a-agent-card:';
 
+export const A2A_AGENT_CARD_JWS_ALGORITHM = 'EdDSA';
+export const A2A_AGENT_CARD_JWS_CRITICAL_RFC8785 = 'agentgram-rfc8785';
+
 export const RFC8785_AGENT_CARD_FIXTURE_CANONICAL_JSON =
   '{"literals":[null,true,false],"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27],"string":"€$\\u000f\\nA\'B\\"\\\\\\"/"}';
 
@@ -29,6 +32,7 @@ export const SIGNATURE_FRESHNESS_WINDOW_MS = 5 * 60 * 1000;
 const PUBLIC_KEY_HEX_REGEX = /^[0-9a-f]{64}$/i;
 const SECRET_KEY_HEX_REGEX = /^[0-9a-f]{64}$/i;
 const SIGNATURE_HEX_REGEX = /^[0-9a-f]{128}$/i;
+const BASE64URL_REGEX = /^[A-Za-z0-9_-]+$/;
 
 export interface AgentKeypair {
   /** 32-byte Ed25519 public key, lowercase hex (64 chars). */
@@ -58,10 +62,23 @@ export interface A2aAgentCardCanonicalSignatureEvidence {
     status: 'fail-closed';
     signingAlgorithm: 'ed25519';
     signatureDomain: typeof A2A_AGENT_CARD_SIGNATURE_DOMAIN;
+    jws: {
+      algAllowlist: [typeof A2A_AGENT_CARD_JWS_ALGORITHM];
+      kidBinding: 'must-match-public-key';
+      criticalHeaderAllowlist: [typeof A2A_AGENT_CARD_JWS_CRITICAL_RFC8785];
+      payloadBinding: 'protected-payload-must-equal-rfc8785-agent-card';
+    };
     unsignedCardsAccepted: false;
-    requiredFields: ['agentCard', 'publicKey', 'signature'];
+    requiredFields: ['agentCard', 'publicKey', 'signature-or-jws'];
     failureModes: string[];
   };
+}
+
+export interface A2aAgentCardJwsProtectedHeader {
+  alg: typeof A2A_AGENT_CARD_JWS_ALGORITHM;
+  kid: string;
+  crit?: string[];
+  [A2A_AGENT_CARD_JWS_CRITICAL_RFC8785]?: true;
 }
 
 export type A2aAgentCardSignatureVerdict =
@@ -69,6 +86,7 @@ export type A2aAgentCardSignatureVerdict =
       ok: true;
       canonicalJson: string;
       payloadDigest: string;
+      jwsProtectedHeader?: A2aAgentCardJwsProtectedHeader;
       evidence: A2aAgentCardCanonicalSignatureEvidence;
     }
   | {
@@ -130,6 +148,83 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function base64UrlEncode(data: Uint8Array | string): string {
+  const buffer =
+    typeof data === 'string' ? Buffer.from(data, 'utf8') : Buffer.from(data);
+  return buffer
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function base64UrlDecodeToString(value: string): string | null {
+  if (!BASE64URL_REGEX.test(value)) {
+    return null;
+  }
+  try {
+    const padded = value.padEnd(value.length + ((4 - (value.length % 4)) % 4), '=');
+    return Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString(
+      'utf8'
+    );
+  } catch {
+    return null;
+  }
+}
+
+function base64UrlDecodeToBytes(value: string): Uint8Array | null {
+  if (!BASE64URL_REGEX.test(value)) {
+    return null;
+  }
+  try {
+    const padded = value.padEnd(value.length + ((4 - (value.length % 4)) % 4), '=');
+    return new Uint8Array(
+      Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+    );
+  } catch {
+    return null;
+  }
+}
+
+function parseA2aAgentCardJwsProtectedHeader(
+  encodedProtectedHeader: string
+): A2aAgentCardJwsProtectedHeader | null {
+  const decoded = base64UrlDecodeToString(encodedProtectedHeader);
+  if (decoded === null) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) {
+    return null;
+  }
+  if (
+    parsed.alg !== A2A_AGENT_CARD_JWS_ALGORITHM ||
+    typeof parsed.kid !== 'string' ||
+    !PUBLIC_KEY_HEX_REGEX.test(parsed.kid)
+  ) {
+    return null;
+  }
+  if (parsed.crit !== undefined) {
+    if (!Array.isArray(parsed.crit)) {
+      return null;
+    }
+    for (const criticalHeader of parsed.crit) {
+      if (criticalHeader !== A2A_AGENT_CARD_JWS_CRITICAL_RFC8785) {
+        return null;
+      }
+    }
+    if (parsed[A2A_AGENT_CARD_JWS_CRITICAL_RFC8785] !== true) {
+      return null;
+    }
+  }
+  return parsed as unknown as A2aAgentCardJwsProtectedHeader;
+}
+
 function buildA2aAgentCardMessage(agentCard: unknown): Uint8Array {
   return new TextEncoder().encode(
     A2A_AGENT_CARD_SIGNATURE_DOMAIN + canonicalJson(agentCard)
@@ -162,12 +257,22 @@ export function buildA2aAgentCardCanonicalSignatureEvidence(
       status: 'fail-closed',
       signingAlgorithm: 'ed25519',
       signatureDomain: A2A_AGENT_CARD_SIGNATURE_DOMAIN,
+      jws: {
+        algAllowlist: [A2A_AGENT_CARD_JWS_ALGORITHM],
+        kidBinding: 'must-match-public-key',
+        criticalHeaderAllowlist: [A2A_AGENT_CARD_JWS_CRITICAL_RFC8785],
+        payloadBinding: 'protected-payload-must-equal-rfc8785-agent-card',
+      },
       unsignedCardsAccepted: false,
-      requiredFields: ['agentCard', 'publicKey', 'signature'],
+      requiredFields: ['agentCard', 'publicKey', 'signature-or-jws'],
       failureModes: [
         'missing Agent Card payload',
         'missing or malformed Ed25519 public key',
-        'missing or malformed Ed25519 signature',
+        'missing or malformed Ed25519 signature or compact JWS',
+        'JWS protected header alg outside allowlist',
+        'JWS protected header kid mismatch',
+        'JWS unknown critical header',
+        'detached Agent Card substitution',
         'signature mismatch after RFC8785 canonicalization',
         'canonicalization fixture drift',
       ],
@@ -196,6 +301,52 @@ export async function signA2aAgentCard(
   return ed25519.etc.bytesToHex(signature);
 }
 
+export async function signA2aAgentCardJws(
+  secretKeyHex: string,
+  kid: string,
+  agentCard: unknown,
+  protectedHeader: Partial<A2aAgentCardJwsProtectedHeader> = {}
+): Promise<string> {
+  if (!SECRET_KEY_HEX_REGEX.test(secretKeyHex)) {
+    throw new Error('Secret key must be 64 hex characters');
+  }
+  if (!PUBLIC_KEY_HEX_REGEX.test(kid)) {
+    throw new Error('A2A Agent Card JWS kid must be a 64 character public key');
+  }
+  if (!isRecord(agentCard)) {
+    throw new Error('A2A Agent Card payload must be a JSON object');
+  }
+  if (
+    protectedHeader.alg !== undefined &&
+    protectedHeader.alg !== A2A_AGENT_CARD_JWS_ALGORITHM
+  ) {
+    throw new Error('A2A Agent Card JWS alg must be EdDSA');
+  }
+  const criticalHeaders = protectedHeader.crit ?? [
+    A2A_AGENT_CARD_JWS_CRITICAL_RFC8785,
+  ];
+  for (const criticalHeader of criticalHeaders) {
+    if (criticalHeader !== A2A_AGENT_CARD_JWS_CRITICAL_RFC8785) {
+      throw new Error('Unsupported A2A Agent Card JWS critical header');
+    }
+  }
+
+  const header: A2aAgentCardJwsProtectedHeader = {
+    alg: A2A_AGENT_CARD_JWS_ALGORITHM,
+    kid,
+    crit: criticalHeaders,
+    [A2A_AGENT_CARD_JWS_CRITICAL_RFC8785]: true,
+  };
+  const protectedPart = base64UrlEncode(JSON.stringify(header));
+  const payloadPart = base64UrlEncode(canonicalJson(agentCard));
+  const signingInput = `${protectedPart}.${payloadPart}`;
+  const signature = await ed25519.signAsync(
+    new TextEncoder().encode(signingInput),
+    ed25519.etc.hexToBytes(secretKeyHex)
+  );
+  return `${signingInput}.${base64UrlEncode(signature)}`;
+}
+
 /**
  * Verify an A2A Agent Card signature. This gate is intentionally fail-closed:
  * unsigned cards, malformed keys/signatures, fixture drift, and tampering all
@@ -204,6 +355,7 @@ export async function signA2aAgentCard(
 export async function verifyA2aAgentCardSignature(input: {
   publicKey?: unknown;
   signature?: unknown;
+  jws?: unknown;
   agentCard?: unknown;
 }): Promise<A2aAgentCardSignatureVerdict> {
   const evidence = buildA2aAgentCardCanonicalSignatureEvidence();
@@ -218,7 +370,6 @@ export async function verifyA2aAgentCardSignature(input: {
 
   if (
     typeof input.publicKey !== 'string' ||
-    typeof input.signature !== 'string' ||
     !isRecord(input.agentCard)
   ) {
     return {
@@ -232,13 +383,95 @@ export async function verifyA2aAgentCardSignature(input: {
 
   if (
     !PUBLIC_KEY_HEX_REGEX.test(input.publicKey) ||
-    !SIGNATURE_HEX_REGEX.test(input.signature)
+    (typeof input.signature !== 'string' && typeof input.jws !== 'string')
   ) {
     return {
       ok: false,
       code: 'SIGNATURE_INVALID',
       message:
-        'A2A Agent Card publicKey must be 64 hex characters and signature must be 128 hex characters',
+        'A2A Agent Card publicKey must be 64 hex characters and signature or compact JWS must be supplied',
+      evidence,
+    };
+  }
+
+  const canonicalPayload = canonicalJson(input.agentCard);
+
+  if (typeof input.jws === 'string') {
+    const parts = input.jws.split('.');
+    if (parts.length !== 3) {
+      return {
+        ok: false,
+        code: 'SIGNATURE_INVALID',
+        message: 'A2A Agent Card JWS must use compact protected.payload.signature form',
+        evidence,
+      };
+    }
+    const [protectedPart, payloadPart, signaturePart] = parts;
+    const header = parseA2aAgentCardJwsProtectedHeader(protectedPart);
+    if (header === null) {
+      return {
+        ok: false,
+        code: 'SIGNATURE_INVALID',
+        message:
+          'A2A Agent Card JWS protected header must allowlist EdDSA, public-key kid, and known critical headers',
+        evidence,
+      };
+    }
+    if (header.kid.toLowerCase() !== input.publicKey.toLowerCase()) {
+      return {
+        ok: false,
+        code: 'SIGNATURE_INVALID',
+        message: 'A2A Agent Card JWS kid must match the supplied public key',
+        evidence,
+      };
+    }
+    const jwsPayload = base64UrlDecodeToString(payloadPart);
+    if (jwsPayload !== canonicalPayload) {
+      return {
+        ok: false,
+        code: 'SIGNATURE_INVALID',
+        message:
+          'A2A Agent Card JWS payload must equal the supplied RFC8785 canonical Agent Card',
+        evidence,
+      };
+    }
+    const jwsSignature = base64UrlDecodeToBytes(signaturePart);
+    let validJws = false;
+    try {
+      validJws =
+        jwsSignature !== null &&
+        (await ed25519.verifyAsync(
+          jwsSignature,
+          new TextEncoder().encode(`${protectedPart}.${payloadPart}`),
+          ed25519.etc.hexToBytes(input.publicKey)
+        ));
+    } catch {
+      validJws = false;
+    }
+    if (!validJws) {
+      return {
+        ok: false,
+        code: 'SIGNATURE_INVALID',
+        message:
+          'A2A Agent Card JWS signature does not match the protected header and canonical payload',
+        evidence,
+      };
+    }
+    return {
+      ok: true,
+      canonicalJson: canonicalPayload,
+      payloadDigest: await sha256Hex(canonicalPayload),
+      jwsProtectedHeader: header,
+      evidence,
+    };
+  }
+
+  if (typeof input.signature !== 'string' || !SIGNATURE_HEX_REGEX.test(input.signature)) {
+    return {
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message:
+        'A2A Agent Card signature must be 128 hex characters when compact JWS is not supplied',
       evidence,
     };
   }
@@ -264,7 +497,6 @@ export async function verifyA2aAgentCardSignature(input: {
     };
   }
 
-  const canonicalPayload = canonicalJson(input.agentCard);
   return {
     ok: true,
     canonicalJson: canonicalPayload,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,6 +1,8 @@
 export { generateApiKey } from './keypair';
 export {
   A2A_AGENT_CARD_SIGNATURE_DOMAIN,
+  A2A_AGENT_CARD_JWS_ALGORITHM,
+  A2A_AGENT_CARD_JWS_CRITICAL_RFC8785,
   RFC8785_AGENT_CARD_FIXTURE_CANONICAL_JSON,
   RFC8785_AGENT_CARD_FIXTURE_DIGEST,
   SIGNATURE_DOMAIN,
@@ -9,6 +11,7 @@ export {
   canonicalJson,
   generateAgentKeypair,
   signA2aAgentCard,
+  signA2aAgentCardJws,
   signPayload,
   verifyA2aAgentCardSignature,
   verifySignature,
@@ -17,6 +20,7 @@ export {
 } from './ed25519';
 export type {
   A2aAgentCardCanonicalSignatureEvidence,
+  A2aAgentCardJwsProtectedHeader,
   A2aAgentCardSignatureVerdict,
   AgentKeypair,
   RegistrationProofPayload,


### PR DESCRIPTION
## Source
Hermes kkami release-promote cron ca3cc60e24bb.
Ref: https://github.com/agentgram/agentgram

## Change
Promote the current `develop` branch to `main` through a guarded release PR.
This run detected `develop` ahead of `main` by 1 commit(s) at 2026-08-17 06:00 KST.

## Evidence
- diff: `git rev-list --count origin/main..origin/develop` => `1`
- test: release promotion script dry-run/smoke validation is available via `python3 scripts/agentgram_release_promote.py --dry-run --no-fetch`

## Auth-only Proof
N/A
