### PR TITLE
strategic(ax-score): add registry lifecycle chronology receipt

### DIFF
--- a/apps/web/__tests__/api/ax-score-mcp-registry-audit.test.ts
+++ b/apps/web/__tests__/api/ax-score-mcp-registry-audit.test.ts
@@ -44,6 +44,8 @@ describe('POST /api/v1/ax-score/mcp-registry/audit', () => {
         latestMarkedNames: 1,
         schemaCompatibleEntries: 2,
         schemaCompatibilityPct: 100,
+        lifecycleChronologyEntries: 1,
+        lifecycleTimestampCoveragePct: 100,
       },
       pageChain: [
         {
@@ -54,6 +56,18 @@ describe('POST /api/v1/ax-score/mcp-registry/audit', () => {
           digest: 'page-digest',
         },
       ],
+      lifecycleChronology: [
+        {
+          id: 'acme/weather@1.0.0',
+          name: 'acme/weather',
+          version: '1.0.0',
+          status: 'active',
+          publishedAt: '2026-08-01T00:00:00.000Z',
+          updatedAt: '2026-08-04T00:00:00.000Z',
+          isLatest: true,
+          eventDigest: 'event-digest',
+        },
+      ],
       anomalies: {
         duplicateServerVersions: [],
         missingLatestMarkers: [],
@@ -61,6 +75,7 @@ describe('POST /api/v1/ax-score/mcp-registry/audit', () => {
         cursorLoops: [],
         emptyPagesWithCursor: [],
         schemaCompatibilityFailures: [],
+        lifecycleChronologyGaps: [],
         truncated: false,
       },
       receipt: {
@@ -163,8 +178,11 @@ describe('POST /api/v1/ax-score/mcp-registry/audit', () => {
         latestMarkedNames: 2,
         schemaCompatibleEntries: 1,
         schemaCompatibilityPct: 50,
+        lifecycleChronologyEntries: 0,
+        lifecycleTimestampCoveragePct: 0,
       },
       pageChain: [],
+      lifecycleChronology: [],
       anomalies: {
         duplicateServerVersions: [],
         missingLatestMarkers: [],
@@ -174,6 +192,7 @@ describe('POST /api/v1/ax-score/mcp-registry/audit', () => {
         schemaCompatibilityFailures: [
           'bad/server@0.1.0: missing MCP launch surface (https remote or package)',
         ],
+        lifecycleChronologyGaps: [],
         truncated: false,
       },
       receipt: {
@@ -221,6 +240,96 @@ describe('POST /api/v1/ax-score/mcp-registry/audit', () => {
       payment: {
         status: 'ready',
         paymentPurpose: 'mcp-schema-compatibility-audit-report',
+      },
+    });
+  });
+
+  it('passes through the paid MCP registry lifecycle chronology report type', async () => {
+    mockSweepMcpRegistryCoverage.mockResolvedValueOnce({
+      summary: {
+        totalEntries: 1,
+        uniqueServerVersions: 1,
+        uniqueServerNames: 1,
+        remoteTransportEntries: 1,
+        remoteTransportCoveragePct: 100,
+        latestMarkedNames: 1,
+        schemaCompatibleEntries: 1,
+        schemaCompatibilityPct: 100,
+        lifecycleChronologyEntries: 1,
+        lifecycleTimestampCoveragePct: 100,
+      },
+      pageChain: [],
+      lifecycleChronology: [
+        {
+          id: 'chrono/server@1.0.0',
+          name: 'chrono/server',
+          version: '1.0.0',
+          status: 'active',
+          publishedAt: '2026-08-01T00:00:00.000Z',
+          updatedAt: '2026-08-04T00:00:00.000Z',
+          isLatest: true,
+          eventDigest: 'event-digest',
+        },
+      ],
+      anomalies: {
+        duplicateServerVersions: [],
+        missingLatestMarkers: [],
+        missingRemoteTransports: [],
+        cursorLoops: [],
+        emptyPagesWithCursor: [],
+        schemaCompatibilityFailures: [],
+        lifecycleChronologyGaps: [],
+        truncated: false,
+      },
+      receipt: {
+        kind: 'agentgram.ax-score.mcp-registry.lifecycle-chronology-receipt',
+        registryEndpoint: 'https://registry.modelcontextprotocol.io/v0/servers',
+        generatedAt: '2026-08-04T00:00:00.000Z',
+        digestAlgorithm: 'sha256',
+        coverageDigest: 'coverage-digest',
+        pageChainDigest: 'page-chain-digest',
+        pageCount: 1,
+        serverVersionCount: 1,
+        uniqueServerVersionCount: 1,
+        anomalyCount: 0,
+        x402: {
+          status: 'ready',
+          paymentPurpose: 'mcp-registry-lifecycle-chronology-audit-report',
+          recommendedPriceUsd: '99.00',
+          deliverable: 'MCP Registry lifecycle chronology findings.',
+        },
+        signature: {
+          status: 'unsigned',
+          signingAlgorithm: 'ed25519',
+          payloadDigest: 'payload-digest',
+        },
+      },
+    });
+    const { POST } = await import(
+      '@/app/api/v1/ax-score/mcp-registry/audit/route'
+    );
+
+    const response = await POST(
+      makeRequest({
+        reportType: 'mcp-registry-lifecycle-chronology-audit',
+        limit: 10,
+      })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockSweepMcpRegistryCoverage).toHaveBeenCalledWith({
+      limit: 10,
+      cursor: null,
+      reportType: 'mcp-registry-lifecycle-chronology-audit',
+    });
+    expect(json.data).toMatchObject({
+      plan: 'team',
+      reportType: 'mcp-registry-lifecycle-chronology-audit',
+      payment: {
+        status: 'ready',
+        paymentPurpose: 'mcp-registry-lifecycle-chronology-audit-report',
+        recommendedPriceUsd: '99.00',
       },
     });
   });

--- a/apps/web/__tests__/lib/ax-score/mcp-registry-audit.test.ts
+++ b/apps/web/__tests__/lib/ax-score/mcp-registry-audit.test.ts
@@ -155,6 +155,85 @@ describe('sweepMcpRegistryCoverage', () => {
     });
   });
 
+  it('produces a paid lifecycle chronology receipt with timestamp gap evidence', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      registryResponse({
+        servers: [
+          {
+            server: {
+              name: 'chrono/server',
+              version: '1.0.0',
+              remotes: [{ type: 'streamable-http', url: 'https://chrono.example/mcp' }],
+            },
+            _meta: {
+              'io.modelcontextprotocol.registry/official': {
+                status: 'active',
+                publishedAt: '2026-08-01T00:00:00.000Z',
+                updatedAt: '2026-08-03T00:00:00.000Z',
+                isLatest: true,
+              },
+            },
+          },
+          {
+            server: {
+              name: 'chrono/server',
+              version: '0.9.0',
+              remotes: [{ type: 'streamable-http', url: 'https://chrono.example/mcp' }],
+            },
+            _meta: {
+              'io.modelcontextprotocol.registry/official': {
+                publishedAt: '2026-07-01T00:00:00.000Z',
+                isLatest: false,
+              },
+            },
+          },
+        ],
+        metadata: { count: 2 },
+      })
+    );
+
+    const audit = await sweepMcpRegistryCoverage({
+      fetcher,
+      endpoint: 'https://registry.example/v0/servers',
+      reportType: 'mcp-registry-lifecycle-chronology-audit',
+      generatedAt: '2026-08-04T00:00:00.000Z',
+    });
+
+    expect(audit.summary.lifecycleChronologyEntries).toBe(2);
+    expect(audit.summary.lifecycleTimestampCoveragePct).toBe(50);
+    expect([
+      audit.lifecycleChronology[0].id,
+      audit.lifecycleChronology[1].id,
+    ]).toEqual([
+      'chrono/server@0.9.0',
+      'chrono/server@1.0.0',
+    ]);
+    expect(audit.lifecycleChronology[0]).toMatchObject({
+      status: null,
+      publishedAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: null,
+      isLatest: false,
+    });
+    expect(audit.lifecycleChronology[0].eventDigest).toMatch(/^[a-f0-9]{64}$/);
+    expect(audit.anomalies.lifecycleChronologyGaps).toEqual([
+      'chrono/server@0.9.0: missing lifecycle status',
+      'chrono/server@0.9.0: missing updatedAt',
+    ]);
+    expect(audit.receipt).toMatchObject({
+      kind: 'agentgram.ax-score.mcp-registry.lifecycle-chronology-receipt',
+      anomalyCount: 2,
+      x402: {
+        status: 'ready',
+        paymentPurpose: 'mcp-registry-lifecycle-chronology-audit-report',
+        recommendedPriceUsd: '99.00',
+      },
+      signature: {
+        status: 'unsigned',
+        signingAlgorithm: 'ed25519',
+      },
+    });
+  });
+
   it('reports duplicate, remote-coverage, latest-marker, and cursor anomalies', async () => {
     const fetcher = vi
       .fn<typeof fetch>()

--- a/apps/web/app/api/v1/ax-score/mcp-registry/audit/route.ts
+++ b/apps/web/app/api/v1/ax-score/mcp-registry/audit/route.ts
@@ -26,6 +26,7 @@ interface AuditRequestBody {
 const MCP_REGISTRY_AUDIT_REPORT_TYPES = [
   'mcp-registry-coverage-audit',
   'mcp-schema-compatibility-audit',
+  'mcp-registry-lifecycle-chronology-audit',
 ] as const;
 
 function readPositiveInteger(value: unknown): number | undefined {
@@ -51,8 +52,9 @@ function readReportType(value: unknown): McpRegistryAuditReportType {
  * POST /api/v1/ax-score/mcp-registry/audit
  *
  * Produce an x402-ready proof package for the official MCP Registry: a full
- * nextCursor page-chain digest, coverage anomaly report, and Ed25519-signable
- * receipt payload. Auth: Developer (Supabase session) — Pro/Team+ paid report.
+ * nextCursor page-chain digest, coverage/chronology anomaly report, and
+ * Ed25519-signable receipt payload. Auth: Developer (Supabase session) —
+ * Pro/Team+ paid report.
  */
 const handler = withDeveloperAuth(async function POST(req: NextRequest) {
   try {

--- a/apps/web/lib/ax-score/mcp-registry-audit.ts
+++ b/apps/web/lib/ax-score/mcp-registry-audit.ts
@@ -6,7 +6,8 @@ const DEFAULT_MAX_PAGES = 100;
 
 export type McpRegistryAuditReportType =
   | 'mcp-registry-coverage-audit'
-  | 'mcp-schema-compatibility-audit';
+  | 'mcp-schema-compatibility-audit'
+  | 'mcp-registry-lifecycle-chronology-audit';
 
 export interface McpRegistrySweepOptions {
   fetcher?: typeof fetch;
@@ -60,13 +61,15 @@ export interface McpRegistryCoverageAnomalies {
   cursorLoops: string[];
   emptyPagesWithCursor: string[];
   schemaCompatibilityFailures: string[];
+  lifecycleChronologyGaps: string[];
   truncated: boolean;
 }
 
 export interface McpRegistryCoverageReceipt {
   kind:
     | 'agentgram.ax-score.mcp-registry.coverage-receipt'
-    | 'agentgram.ax-score.mcp-registry.schema-compatibility-receipt';
+    | 'agentgram.ax-score.mcp-registry.schema-compatibility-receipt'
+    | 'agentgram.ax-score.mcp-registry.lifecycle-chronology-receipt';
   registryEndpoint: string;
   generatedAt: string;
   digestAlgorithm: 'sha256';
@@ -80,7 +83,8 @@ export interface McpRegistryCoverageReceipt {
     status: 'ready';
     paymentPurpose:
       | 'mcp-registry-coverage-audit-report'
-      | 'mcp-schema-compatibility-audit-report';
+      | 'mcp-schema-compatibility-audit-report'
+      | 'mcp-registry-lifecycle-chronology-audit-report';
     recommendedPriceUsd: string;
     deliverable: string;
   };
@@ -101,10 +105,24 @@ export interface McpRegistryCoverageAudit {
     latestMarkedNames: number;
     schemaCompatibleEntries: number;
     schemaCompatibilityPct: number;
+    lifecycleChronologyEntries: number;
+    lifecycleTimestampCoveragePct: number;
   };
   pageChain: McpRegistryPageDigest[];
+  lifecycleChronology: McpRegistryLifecycleChronologyEntry[];
   anomalies: McpRegistryCoverageAnomalies;
   receipt: McpRegistryCoverageReceipt;
+}
+
+export interface McpRegistryLifecycleChronologyEntry {
+  id: string;
+  name: string;
+  version: string;
+  status: string | null;
+  publishedAt: string | null;
+  updatedAt: string | null;
+  isLatest: boolean;
+  eventDigest: string;
 }
 
 interface NormalizedServerVersion {
@@ -112,6 +130,9 @@ interface NormalizedServerVersion {
   name: string;
   version: string;
   isLatest: boolean;
+  status: string | null;
+  publishedAt: string | null;
+  updatedAt: string | null;
   hasRemoteTransport: boolean;
   schemaCompatible: boolean;
   schemaCompatibilityErrors: string[];
@@ -139,6 +160,10 @@ function sha256(value: unknown): string {
 
 function getString(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.trim() ? value : fallback;
+}
+
+function getOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
 }
 
 function hasRemoteTransport(server: McpRegistryServerDocument): boolean {
@@ -196,10 +221,40 @@ function normalizeServer(entry: McpRegistryEntry): NormalizedServerVersion {
     name,
     version,
     isLatest: official?.isLatest === true,
+    status: getOptionalString(official?.status),
+    publishedAt: getOptionalString(official?.publishedAt),
+    updatedAt: getOptionalString(official?.updatedAt),
     hasRemoteTransport: hasRemote,
     schemaCompatible: schemaCompatibilityErrors.length === 0,
     schemaCompatibilityErrors,
   };
+}
+
+function buildLifecycleChronology(
+  servers: NormalizedServerVersion[]
+): McpRegistryLifecycleChronologyEntry[] {
+  return servers
+    .map((server) => ({
+      id: server.id,
+      name: server.name,
+      version: server.version,
+      status: server.status,
+      publishedAt: server.publishedAt,
+      updatedAt: server.updatedAt,
+      isLatest: server.isLatest,
+      eventDigest: sha256({
+        id: server.id,
+        status: server.status,
+        publishedAt: server.publishedAt,
+        updatedAt: server.updatedAt,
+        isLatest: server.isLatest,
+      }),
+    }))
+    .sort((a, b) => {
+      const aTime = a.updatedAt ?? a.publishedAt ?? '';
+      const bTime = b.updatedAt ?? b.publishedAt ?? '';
+      return aTime.localeCompare(bTime) || a.id.localeCompare(b.id);
+    });
 }
 
 function buildUrl(endpoint: string, cursor: string | null, limit: number): string {
@@ -217,6 +272,7 @@ function countAnomalies(anomalies: McpRegistryCoverageAnomalies): number {
     anomalies.cursorLoops.length +
     anomalies.emptyPagesWithCursor.length +
     anomalies.schemaCompatibilityFailures.length +
+    anomalies.lifecycleChronologyGaps.length +
     (anomalies.truncated ? 1 : 0)
   );
 }
@@ -249,11 +305,15 @@ function buildReceipt(input: {
   const signaturePayloadDigest = sha256({ coverageDigest, pageChainDigest });
   const isSchemaCompatibilityReport =
     input.reportType === 'mcp-schema-compatibility-audit';
+  const isLifecycleChronologyReport =
+    input.reportType === 'mcp-registry-lifecycle-chronology-audit';
 
   return {
-    kind: isSchemaCompatibilityReport
-      ? 'agentgram.ax-score.mcp-registry.schema-compatibility-receipt'
-      : 'agentgram.ax-score.mcp-registry.coverage-receipt',
+    kind: isLifecycleChronologyReport
+      ? 'agentgram.ax-score.mcp-registry.lifecycle-chronology-receipt'
+      : isSchemaCompatibilityReport
+        ? 'agentgram.ax-score.mcp-registry.schema-compatibility-receipt'
+        : 'agentgram.ax-score.mcp-registry.coverage-receipt',
     registryEndpoint: input.endpoint,
     generatedAt: input.generatedAt,
     digestAlgorithm: 'sha256',
@@ -265,13 +325,21 @@ function buildReceipt(input: {
     anomalyCount,
     x402: {
       status: 'ready',
-      paymentPurpose: isSchemaCompatibilityReport
-        ? 'mcp-schema-compatibility-audit-report'
-        : 'mcp-registry-coverage-audit-report',
-      recommendedPriceUsd: isSchemaCompatibilityReport ? '79.00' : '49.00',
-      deliverable: isSchemaCompatibilityReport
-        ? 'MCP Registry schema compatibility findings, launch-surface gate results, and Ed25519-signable receipt payload.'
-        : 'Full nextCursor sweep digest, coverage anomaly report, and Ed25519-signable receipt payload.',
+      paymentPurpose: isLifecycleChronologyReport
+        ? 'mcp-registry-lifecycle-chronology-audit-report'
+        : isSchemaCompatibilityReport
+          ? 'mcp-schema-compatibility-audit-report'
+          : 'mcp-registry-coverage-audit-report',
+      recommendedPriceUsd: isLifecycleChronologyReport
+        ? '99.00'
+        : isSchemaCompatibilityReport
+          ? '79.00'
+          : '49.00',
+      deliverable: isLifecycleChronologyReport
+        ? 'MCP Registry server-version lifecycle chronology, timestamp gap analysis, and Ed25519-signable receipt payload.'
+        : isSchemaCompatibilityReport
+          ? 'MCP Registry schema compatibility findings, launch-surface gate results, and Ed25519-signable receipt payload.'
+          : 'Full nextCursor sweep digest, coverage anomaly report, and Ed25519-signable receipt payload.',
     },
     signature: {
       status: 'unsigned',
@@ -364,6 +432,19 @@ export async function sweepMcpRegistryCoverage(
     .filter((server) => !server.schemaCompatible)
     .map((server) => `${server.id}: ${server.schemaCompatibilityErrors.join('; ')}`)
     .sort();
+  const lifecycleChronology = buildLifecycleChronology(servers);
+  const lifecycleChronologyGaps =
+    reportType === 'mcp-registry-lifecycle-chronology-audit'
+      ? servers
+          .flatMap((server) => {
+            const gaps: string[] = [];
+            if (!server.status) gaps.push('missing lifecycle status');
+            if (!server.publishedAt) gaps.push('missing publishedAt');
+            if (!server.updatedAt) gaps.push('missing updatedAt');
+            return gaps.map((gap) => `${server.id}: ${gap}`);
+          })
+          .sort()
+      : [];
 
   const anomalies = {
     duplicateServerVersions,
@@ -372,6 +453,7 @@ export async function sweepMcpRegistryCoverage(
     cursorLoops,
     emptyPagesWithCursor,
     schemaCompatibilityFailures,
+    lifecycleChronologyGaps,
     truncated,
   };
   const remoteTransportEntries = servers.filter(
@@ -381,6 +463,9 @@ export async function sweepMcpRegistryCoverage(
   const uniqueServerNames = names.size;
   const schemaCompatibleEntries = servers.filter(
     (server) => server.schemaCompatible
+  ).length;
+  const lifecycleTimestampEntries = servers.filter(
+    (server) => server.publishedAt && server.updatedAt
   ).length;
 
   return {
@@ -401,8 +486,14 @@ export async function sweepMcpRegistryCoverage(
         servers.length === 0
           ? 0
           : Math.round((schemaCompatibleEntries / servers.length) * 10000) / 100,
+      lifecycleChronologyEntries: lifecycleChronology.length,
+      lifecycleTimestampCoveragePct:
+        servers.length === 0
+          ? 0
+          : Math.round((lifecycleTimestampEntries / servers.length) * 10000) / 100,
     },
     pageChain,
+    lifecycleChronology,
     anomalies,
     receipt: buildReceipt({
       endpoint,


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog strategic item ed4d31746b.
Ref: https://github.com/agentgram/agentgram

## Change
Added the paid MCP Registry lifecycle chronology audit report type to the AX Score registry receipt endpoint. The sweep now returns sortable lifecycle event digests, timestamp coverage, lifecycle gap anomalies, and an x402-ready Ed25519-signable receipt.

## Evidence
pnpm --filter web exec vitest run __tests__/lib/ax-score/mcp-registry-audit.test.ts __tests__/api/ax-score-mcp-registry-audit.test.ts — 2 test files passed, 10 tests passed.
pnpm --filter web type-check — passed.
pnpm --filter web lint — passed with existing warnings only.
Diff: 4 files changed, 296 insertions(+), 15 deletions(-).

## Auth-only Proof
N/A