### PR TITLE
fix(deps): repair lockfile after serial dependency merges

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,7 +154,7 @@ importers:
         version: 10.4.1
       '@testing-library/jest-dom':
         specifier: ^7.0.1
-        version: 7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.11(@edge-runtime/vm@3.2.0)(@types/node@26.2.0)(jsdom@29.1.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)))
+        version: 7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.11(@edge-runtime/vm@3.2.0)(@types/node@26.2.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)))
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -6533,7 +6533,7 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.11(@edge-runtime/vm@3.2.0)(@types/node@26.2.0)(jsdom@29.1.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)))':
+  '@testing-library/jest-dom@7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.11(@edge-runtime/vm@3.2.0)(@types/node@26.2.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0)))':
     dependencies:
       '@adobe/css-tools': 4.5.0
       '@testing-library/dom': 10.4.1
@@ -6543,7 +6543,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
     optionalDependencies:
-      vitest: 4.1.11(@edge-runtime/vm@3.2.0)(@types/node@26.2.0)(jsdom@29.1.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0))
+      vitest: 4.1.11(@edge-runtime/vm@3.2.0)(@types/node@26.2.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.21.0))
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:


### PR DESCRIPTION
## Source
Develop deployments broke after merging #1050/#1052/#1051 without rebasing between merges: `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` — the jest-dom snapshot was still keyed to `jsdom@29.1.1` while package.json moved to `jsdom@30.0.1`.

## Change
Re-resolve `pnpm-lock.yaml` with `pnpm@10.28.2` (3-line snapshot key fix; no version changes beyond the already-merged bumps).

## Evidence
- Validation command: `npx pnpm@10.28.2 install --no-frozen-lockfile` healed the lockfile; follow-up `npx pnpm@10.28.2 install --frozen-lockfile` passes cleanly (exit 0, 400ms).
- Diff is confined to the three snapshot keys referencing the jsdom peer.
- Live-proof acceptance: the develop deployment for this merge must come back `success`.

## Auth-only Proof
N/A