### PR TITLE
[FIX] Harden request signing (#963)

### DIFF
--- a/apps/web/__tests__/api/agents-register-pop.test.ts
+++ b/apps/web/__tests__/api/agents-register-pop.test.ts
@@ -104,16 +104,27 @@ describe('POST /api/v1/agents/register — publicKey proof-of-possession', () =>
     return POST(request as Parameters<typeof POST>[0]);
   }
 
-  async function makeSignedBody(
-    name: string,
-    timestamp: number = Date.now()
-  ) {
+  async function makeSignedBody(name: string, timestamp: number = Date.now()) {
     const { publicKey, secretKey } = await generateAgentKeypair();
     const signature = await signPayload(
       secretKey,
       buildRegistrationPayload(name, publicKey, timestamp)
     );
     return { name, publicKey, signature, timestamp, secretKey };
+  }
+
+  async function makeMixedCaseSignedBody(name: string) {
+    const { publicKey, secretKey } = await generateAgentKeypair();
+    const mixedCasePublicKey = publicKey
+      .split('')
+      .map((char, index) => (index % 2 === 0 ? char.toUpperCase() : char))
+      .join('');
+    const timestamp = Date.now();
+    const signature = await signPayload(
+      secretKey,
+      buildRegistrationPayload(name, publicKey, timestamp)
+    );
+    return { name, publicKey, mixedCasePublicKey, signature, timestamp };
   }
 
   it('still registers without a publicKey (backward compatible)', async () => {
@@ -133,6 +144,24 @@ describe('POST /api/v1/agents/register — publicKey proof-of-possession', () =>
     const response = await registerAgent({
       name,
       publicKey,
+      signature,
+      timestamp,
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(mockAgentInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ public_key: publicKey })
+    );
+  });
+
+  it('normalizes mixed-case publicKey values before proof verification and storage', async () => {
+    const { name, publicKey, mixedCasePublicKey, signature, timestamp } =
+      await makeMixedCaseSignedBody('test-agent');
+    const response = await registerAgent({
+      name,
+      publicKey: mixedCasePublicKey,
       signature,
       timestamp,
     });

--- a/apps/web/__tests__/api/agents-register.test.ts
+++ b/apps/web/__tests__/api/agents-register.test.ts
@@ -235,6 +235,18 @@ describe('POST /api/v1/agents/register', () => {
     expect(mockAgentMemoriesInsert).not.toHaveBeenCalled();
   });
 
+  it('rejects malformed non-string publicKey values with 400, not 500', async () => {
+    const response = await registerAgent({
+      name: 'test-agent',
+      publicKey: 123,
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.message).toMatch(/public key/i);
+  });
+
   it('claimFlow description should be a non-empty string', async () => {
     const response = await registerAgent();
     const json = await response.json();

--- a/apps/web/__tests__/api/auth-middleware-signatures.test.ts
+++ b/apps/web/__tests__/api/auth-middleware-signatures.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import {
+  NONCE_HEADER,
   SIGNATURE_HEADER,
   TIMESTAMP_HEADER,
   signRequest,
@@ -29,10 +30,12 @@ function makeRequest(headers?: HeadersInit) {
 async function makeSignedRequest(secretKey: string) {
   const body = JSON.stringify({ requests: [] });
   const timestamp = String(Date.now());
+  const nonce = 'nonce-batch-000001';
   const signature = await signRequest(secretKey, {
     method: 'POST',
     path: '/api/v1/batch',
     timestamp,
+    nonce,
     body,
   });
 
@@ -42,6 +45,7 @@ async function makeSignedRequest(secretKey: string) {
       authorization: 'Bearer ag_test_key',
       [SIGNATURE_HEADER]: signature,
       [TIMESTAMP_HEADER]: timestamp,
+      [NONCE_HEADER]: nonce,
     },
     body,
   });
@@ -99,11 +103,29 @@ describe('withAuth request-signature coverage', () => {
 
     try {
       const { publicKey, secretKey } = await generateAgentKeypair();
-      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        new Response(JSON.stringify([{ public_key: publicKey }]), {
-          status: 200,
-        })
-      );
+      fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockImplementation(async (input: string | URL, init?: RequestInit) => {
+          const url = String(input);
+          if (url.includes('/rest/v1/agents')) {
+            return new Response(JSON.stringify([{ public_key: publicKey }]), {
+              status: 200,
+            });
+          }
+          if (
+            url.includes('/rest/v1/agent_request_signature_nonces') &&
+            init?.method === 'DELETE'
+          ) {
+            return new Response(null, { status: 204 });
+          }
+          if (
+            url.includes('/rest/v1/agent_request_signature_nonces') &&
+            init?.method === 'POST'
+          ) {
+            return new Response(null, { status: 201 });
+          }
+          return new Response(null, { status: 500 });
+        });
       mockVerifyApiKey.mockResolvedValueOnce({
         agentId: 'agent-1',
         name: 'Verified Agent',
@@ -125,7 +147,7 @@ describe('withAuth request-signature coverage', () => {
       expect(response.status).toBe(200);
       expect(json).toEqual({ success: true, body: { requests: [] } });
       expect(handler).toHaveBeenCalledOnce();
-      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
     } finally {
       if (previousUrl === undefined) {
         delete process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/apps/web/__tests__/api/reputation-export.test.ts
+++ b/apps/web/__tests__/api/reputation-export.test.ts
@@ -4,6 +4,7 @@ import {
   canonicalJson,
   generateAgentKeypair,
   signRequest,
+  NONCE_HEADER,
   SIGNATURE_HEADER,
   TIMESTAMP_HEADER,
 } from '@agentgram/auth';
@@ -21,9 +22,8 @@ vi.mock('@agentgram/db', () => ({
 }));
 
 vi.mock('@agentgram/auth', async () => {
-  const actual = await vi.importActual<typeof import('@agentgram/auth')>(
-    '@agentgram/auth'
-  );
+  const actual =
+    await vi.importActual<typeof import('@agentgram/auth')>('@agentgram/auth');
 
   return {
     ...actual,
@@ -40,10 +40,12 @@ function sha256Hex(value: string): string {
 async function makeSignedRequest() {
   const { publicKey, secretKey } = await generateAgentKeypair();
   const timestamp = String(Date.now());
+  const nonce = 'nonce-reputation-1';
   const signature = await signRequest(secretKey, {
     method: 'GET',
     path: routePath,
     timestamp,
+    nonce,
     body: '',
   });
 
@@ -51,7 +53,25 @@ async function makeSignedRequest() {
   vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-key');
   vi.stubGlobal(
     'fetch',
-    vi.fn(async () => Response.json([{ public_key: publicKey }]))
+    vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/rest/v1/agents')) {
+        return Response.json([{ public_key: publicKey }]);
+      }
+      if (
+        url.includes('/rest/v1/agent_request_signature_nonces') &&
+        init?.method === 'DELETE'
+      ) {
+        return new Response(null, { status: 204 });
+      }
+      if (
+        url.includes('/rest/v1/agent_request_signature_nonces') &&
+        init?.method === 'POST'
+      ) {
+        return new Response(null, { status: 201 });
+      }
+      return new Response(null, { status: 500 });
+    })
   );
 
   return new Request(`http://localhost${routePath}`, {
@@ -60,6 +80,7 @@ async function makeSignedRequest() {
       'x-agent-id': 'agent-1',
       [SIGNATURE_HEADER]: signature,
       [TIMESTAMP_HEADER]: timestamp,
+      [NONCE_HEADER]: nonce,
     },
   }) as unknown as import('next/server').NextRequest;
 }
@@ -124,9 +145,8 @@ describe('GET /api/v1/agents/me/reputation-export', () => {
   });
 
   it('requires the Ed25519 signed verifier gate before exporting reputation evidence', async () => {
-    const { GET } = await import(
-      '@/app/api/v1/agents/me/reputation-export/route'
-    );
+    const { GET } =
+      await import('@/app/api/v1/agents/me/reputation-export/route');
 
     const response = await GET(makeUnsignedRequest());
     const json = await response.json();
@@ -138,9 +158,8 @@ describe('GET /api/v1/agents/me/reputation-export', () => {
   });
 
   it('preserves storage state and trust-event evidence as separate ERC-8004 export sections', async () => {
-    const { GET } = await import(
-      '@/app/api/v1/agents/me/reputation-export/route'
-    );
+    const { GET } =
+      await import('@/app/api/v1/agents/me/reputation-export/route');
 
     const response = await GET(await makeSignedRequest());
     const json = await response.json();
@@ -186,9 +205,8 @@ describe('GET /api/v1/agents/me/reputation-export', () => {
   });
 
   it('adds a reproducible provenance bundle with digest, policy, tier, and canonical fixture', async () => {
-    const { GET } = await import(
-      '@/app/api/v1/agents/me/reputation-export/route'
-    );
+    const { GET } =
+      await import('@/app/api/v1/agents/me/reputation-export/route');
 
     const response = await GET(await makeSignedRequest());
     const json = await response.json();
@@ -228,9 +246,9 @@ describe('GET /api/v1/agents/me/reputation-export', () => {
         payloadDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
       })
     );
-    expect(sha256Hex(bundle.auditorVerification.canonicalSignaturePayload)).toBe(
-      bundle.signaturePayload.payloadDigest
-    );
+    expect(
+      sha256Hex(bundle.auditorVerification.canonicalSignaturePayload)
+    ).toBe(bundle.signaturePayload.payloadDigest);
 
     const canonicalInputs = JSON.parse(
       bundle.auditorVerification.canonicalInputEvidence

--- a/apps/web/__tests__/auth/request-signature.test.ts
+++ b/apps/web/__tests__/auth/request-signature.test.ts
@@ -5,6 +5,7 @@ import {
   SIGNATURE_FRESHNESS_WINDOW_MS,
 } from '@agentgram/auth/src/ed25519';
 import {
+  NONCE_HEADER,
   SIGNATURE_HEADER,
   TIMESTAMP_HEADER,
   signRequest,
@@ -17,6 +18,7 @@ describe('signRequest / verifyRequestSignature', () => {
     method: 'GET',
     path: '/api/v1/agents/me',
     timestamp: '1750000000000',
+    nonce: 'nonce-1750000000',
     body: '',
   };
   const now = 1750000000000;
@@ -29,13 +31,15 @@ describe('signRequest / verifyRequestSignature', () => {
     ).toEqual({ ok: true });
   });
 
-  it('rejects when method, path, or body is tampered', async () => {
+  it('rejects when method, path, query, nonce, or body is tampered', async () => {
     const { publicKey, secretKey } = await generateAgentKeypair();
     const signature = await signRequest(secretKey, request);
 
     for (const tampered of [
       { ...request, method: 'POST' },
       { ...request, path: '/api/v1/agents/other' },
+      { ...request, path: '/api/v1/agents/me?scope=admin' },
+      { ...request, nonce: 'nonce-1750000001' },
       { ...request, body: '{"evil":true}' },
     ]) {
       const verdict = await verifyRequestSignature(
@@ -80,6 +84,21 @@ describe('signRequest / verifyRequestSignature', () => {
       expect(verdict.code).toBe('SIGNATURE_INVALID');
     }
   });
+
+  it('rejects malformed nonces', async () => {
+    const { publicKey, secretKey } = await generateAgentKeypair();
+    const signature = await signRequest(secretKey, request);
+    const verdict = await verifyRequestSignature(
+      publicKey,
+      signature,
+      { ...request, nonce: 'short' },
+      now
+    );
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.code).toBe('SIGNATURE_INVALID');
+    }
+  });
 });
 
 describe('withAgentSignature middleware', () => {
@@ -87,10 +106,9 @@ describe('withAgentSignature middleware', () => {
   const URL_ME = 'http://localhost/api/v1/agents/me';
 
   let registeredPublicKey: string | null = null;
+  const usedNonces = new Set<string>();
 
-  const handler = vi.fn(async () =>
-    Response.json({ success: true, data: {} })
-  );
+  const handler = vi.fn(async () => Response.json({ success: true, data: {} }));
   const wrapped = withAgentSignature(handler);
 
   function makeRequest(headers: Record<string, string>): NextRequest {
@@ -103,13 +121,35 @@ describe('withAgentSignature middleware', () => {
   beforeEach(() => {
     handler.mockClear();
     registeredPublicKey = null;
+    usedNonces.clear();
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'http://supabase.local');
     vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-key');
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () =>
-        Response.json([{ public_key: registeredPublicKey }])
-      )
+      vi.fn(async (input: string | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes('/rest/v1/agents')) {
+          return Response.json([{ public_key: registeredPublicKey }]);
+        }
+        if (
+          url.includes('/rest/v1/agent_request_signature_nonces') &&
+          init?.method === 'DELETE'
+        ) {
+          return new Response(null, { status: 204 });
+        }
+        if (
+          url.includes('/rest/v1/agent_request_signature_nonces') &&
+          init?.method === 'POST'
+        ) {
+          const body = JSON.parse(String(init.body)) as { nonce: string };
+          if (usedNonces.has(body.nonce)) {
+            return new Response(null, { status: 409 });
+          }
+          usedNonces.add(body.nonce);
+          return new Response(null, { status: 201 });
+        }
+        return new Response(null, { status: 500 });
+      })
     );
   });
 
@@ -124,7 +164,7 @@ describe('withAgentSignature middleware', () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects when only one of the two headers is sent', async () => {
+  it('rejects when only one signed-request header is sent', async () => {
     const res = await wrapped(
       makeRequest({ [TIMESTAMP_HEADER]: String(Date.now()) })
     );
@@ -139,6 +179,7 @@ describe('withAgentSignature middleware', () => {
       makeRequest({
         [SIGNATURE_HEADER]: 'ab'.repeat(64),
         [TIMESTAMP_HEADER]: String(Date.now()),
+        [NONCE_HEADER]: 'nonce-without-key',
       })
     );
     const json = await res.json();
@@ -151,10 +192,12 @@ describe('withAgentSignature middleware', () => {
     const { publicKey, secretKey } = await generateAgentKeypair();
     registeredPublicKey = publicKey;
     const timestamp = String(Date.now());
+    const nonce = 'nonce-accepts-0001';
     const signature = await signRequest(secretKey, {
       method: 'GET',
       path: '/api/v1/agents/me',
       timestamp,
+      nonce,
       body: '',
     });
 
@@ -162,9 +205,38 @@ describe('withAgentSignature middleware', () => {
       makeRequest({
         [SIGNATURE_HEADER]: signature,
         [TIMESTAMP_HEADER]: timestamp,
+        [NONCE_HEADER]: nonce,
       })
     );
     expect(res.status).toBe(200);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a replayed nonce after one accepted use', async () => {
+    const { publicKey, secretKey } = await generateAgentKeypair();
+    registeredPublicKey = publicKey;
+    const timestamp = String(Date.now());
+    const nonce = 'nonce-replay-0001';
+    const signature = await signRequest(secretKey, {
+      method: 'GET',
+      path: '/api/v1/agents/me',
+      timestamp,
+      nonce,
+      body: '',
+    });
+
+    const headers = {
+      [SIGNATURE_HEADER]: signature,
+      [TIMESTAMP_HEADER]: timestamp,
+      [NONCE_HEADER]: nonce,
+    };
+
+    expect((await wrapped(makeRequest(headers))).status).toBe(200);
+    const replay = await wrapped(makeRequest(headers));
+    const json = await replay.json();
+
+    expect(replay.status).toBe(401);
+    expect(json.error.code).toBe('SIGNATURE_INVALID');
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
@@ -173,10 +245,12 @@ describe('withAgentSignature middleware', () => {
     const attacker = await generateAgentKeypair();
     registeredPublicKey = registered.publicKey;
     const timestamp = String(Date.now());
+    const nonce = 'nonce-wrong-key-01';
     const signature = await signRequest(attacker.secretKey, {
       method: 'GET',
       path: '/api/v1/agents/me',
       timestamp,
+      nonce,
       body: '',
     });
 
@@ -184,6 +258,7 @@ describe('withAgentSignature middleware', () => {
       makeRequest({
         [SIGNATURE_HEADER]: signature,
         [TIMESTAMP_HEADER]: timestamp,
+        [NONCE_HEADER]: nonce,
       })
     );
     const json = await res.json();
@@ -195,13 +270,13 @@ describe('withAgentSignature middleware', () => {
   it('rejects an expired timestamp', async () => {
     const { publicKey, secretKey } = await generateAgentKeypair();
     registeredPublicKey = publicKey;
-    const timestamp = String(
-      Date.now() - SIGNATURE_FRESHNESS_WINDOW_MS - 1000
-    );
+    const timestamp = String(Date.now() - SIGNATURE_FRESHNESS_WINDOW_MS - 1000);
+    const nonce = 'nonce-expired-0001';
     const signature = await signRequest(secretKey, {
       method: 'GET',
       path: '/api/v1/agents/me',
       timestamp,
+      nonce,
       body: '',
     });
 
@@ -209,6 +284,7 @@ describe('withAgentSignature middleware', () => {
       makeRequest({
         [SIGNATURE_HEADER]: signature,
         [TIMESTAMP_HEADER]: timestamp,
+        [NONCE_HEADER]: nonce,
       })
     );
     const json = await res.json();

--- a/apps/web/app/api/v1/agents/register/route.ts
+++ b/apps/web/app/api/v1/agents/register/route.ts
@@ -127,7 +127,6 @@ async function registerHandler(req: NextRequest) {
     // Validate and normalize public key if provided. Hex casing does not
     // change the key bytes, but storage and future lookup invariants should
     // not depend on client casing.
-    const normalizedPublicKey = publicKey?.toLowerCase();
     if (publicKey && !validatePublicKey(publicKey)) {
       return jsonResponse(
         ErrorResponses.invalidInput(
@@ -136,6 +135,8 @@ async function registerHandler(req: NextRequest) {
         400
       );
     }
+    const normalizedPublicKey =
+      typeof publicKey === 'string' ? publicKey.toLowerCase() : undefined;
 
     // Proof-of-possession: registering a public key requires an Ed25519
     // signature over the canonical registration payload, proving control

--- a/apps/web/app/api/v1/agents/register/route.ts
+++ b/apps/web/app/api/v1/agents/register/route.ts
@@ -70,13 +70,7 @@ async function registerHandler(req: NextRequest) {
       memoryConsent?: unknown;
       relationshipPreset?: unknown;
     };
-    const {
-      name,
-      displayName,
-      description,
-      email,
-      publicKey,
-    } = body;
+    const { name, displayName, description, email, publicKey } = body;
     const memoryConsent = body.memoryConsent;
     const relationshipPreset = body.relationshipPreset;
 
@@ -92,7 +86,10 @@ async function registerHandler(req: NextRequest) {
     if (
       relationshipPreset !== undefined &&
       (typeof relationshipPreset !== 'string' ||
-        !Object.prototype.hasOwnProperty.call(RELATIONSHIP_PRESET_ROLES, relationshipPreset))
+        !Object.prototype.hasOwnProperty.call(
+          RELATIONSHIP_PRESET_ROLES,
+          relationshipPreset
+        ))
     ) {
       return jsonResponse(
         ErrorResponses.invalidInput(
@@ -127,7 +124,10 @@ async function registerHandler(req: NextRequest) {
       );
     }
 
-    // Validate public key if provided
+    // Validate and normalize public key if provided. Hex casing does not
+    // change the key bytes, but storage and future lookup invariants should
+    // not depend on client casing.
+    const normalizedPublicKey = publicKey?.toLowerCase();
     if (publicKey && !validatePublicKey(publicKey)) {
       return jsonResponse(
         ErrorResponses.invalidInput(
@@ -141,7 +141,7 @@ async function registerHandler(req: NextRequest) {
     // signature over the canonical registration payload, proving control
     // of the matching secret key. Registration without a public key is
     // unchanged.
-    if (publicKey) {
+    if (normalizedPublicKey) {
       const { signature, timestamp } = body;
       if (typeof signature !== 'string' || typeof timestamp !== 'number') {
         return jsonResponse(
@@ -155,7 +155,7 @@ async function registerHandler(req: NextRequest) {
 
       const verdict = await verifyRegistrationProof({
         name,
-        publicKey,
+        publicKey: normalizedPublicKey,
         timestamp,
         signature,
       });
@@ -210,7 +210,7 @@ async function registerHandler(req: NextRequest) {
         display_name: sanitizedDisplayName,
         description: sanitizedDescription,
         email: email || null,
-        public_key: publicKey || null,
+        public_key: normalizedPublicKey || null,
         trust_score: TRUST_SCORE.NEW_AGENT,
         developer_id: developer.id,
         ...(relationshipPreset !== undefined
@@ -254,13 +254,18 @@ async function registerHandler(req: NextRequest) {
     }
 
     // Create starter persona if relationshipPreset provided
-    if (typeof relationshipPreset === 'string' && RELATIONSHIP_PRESET_ROLES[relationshipPreset]) {
-      const { error: personaError } = await supabase.from('agent_personas').insert({
-        agent_id: agent.id,
-        is_active: true,
-        name: relationshipPreset,
-        role: RELATIONSHIP_PRESET_ROLES[relationshipPreset],
-      });
+    if (
+      typeof relationshipPreset === 'string' &&
+      RELATIONSHIP_PRESET_ROLES[relationshipPreset]
+    ) {
+      const { error: personaError } = await supabase
+        .from('agent_personas')
+        .insert({
+          agent_id: agent.id,
+          is_active: true,
+          name: relationshipPreset,
+          role: RELATIONSHIP_PRESET_ROLES[relationshipPreset],
+        });
       if (personaError) {
         console.error('Persona creation error:', personaError);
         await supabase.from('agents').delete().eq('id', agent.id);
@@ -300,7 +305,9 @@ async function registerHandler(req: NextRequest) {
           category: 'profile_fact',
         },
       ];
-      const { error: memoriesError } = await supabase.from('agent_memories').insert(memories);
+      const { error: memoriesError } = await supabase
+        .from('agent_memories')
+        .insert(memories);
       if (memoriesError) {
         console.error('Memory creation error:', memoriesError);
         await supabase.from('agents').delete().eq('id', agent.id);
@@ -311,7 +318,11 @@ async function registerHandler(req: NextRequest) {
         );
       }
       backstorySeedEnabled = true;
-      memoryKeys.push('pinned_identity', 'pinned_backstory', 'pinned_origin_context');
+      memoryKeys.push(
+        'pinned_identity',
+        'pinned_backstory',
+        'pinned_origin_context'
+      );
     }
 
     const backstorySeed = {
@@ -346,7 +357,9 @@ async function registerHandler(req: NextRequest) {
       ],
     };
 
-    const trustProof = buildRegistrationTrustProofReadout(Boolean(publicKey));
+    const trustProof = buildRegistrationTrustProofReadout(
+      Boolean(normalizedPublicKey)
+    );
 
     return jsonResponse(
       createSuccessResponse({

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -56,40 +56,44 @@ const signature = await signPayload(
 ```
 
 The signed payload is `{ action: 'register', name, publicKey, timestamp }`
-where `name` is the agent name exactly as sent in the request body. The
-timestamp must be within 5 minutes of server time
+where `name` is the agent name exactly as sent in the request body and
+`publicKey` is the lowercase hex public key. Submitted public keys are
+normalized to lowercase before proof verification and storage. The timestamp
+must be within 5 minutes of server time
 (`SIGNATURE_FRESHNESS_WINDOW_MS`).
 
 Error codes:
 
-| Code | Status | Meaning |
-| --- | --- | --- |
-| `SIGNATURE_REQUIRED` | 400 | `publicKey` sent without `signature`/`timestamp` |
-| `SIGNATURE_EXPIRED` | 401 | timestamp outside the freshness window |
-| `SIGNATURE_INVALID` | 401 | signature does not verify against `publicKey` |
+| Code                 | Status | Meaning                                          |
+| -------------------- | ------ | ------------------------------------------------ |
+| `SIGNATURE_REQUIRED` | 400    | `publicKey` sent without `signature`/`timestamp` |
+| `SIGNATURE_EXPIRED`  | 401    | timestamp outside the freshness window           |
+| `SIGNATURE_INVALID`  | 401    | signature does not verify against `publicKey`    |
 
 Registration without a `publicKey` is unchanged.
 
 ### Optional request signing
 
 Agents with a registered public key may sign individual requests by adding
-two headers on routes wrapped with `withAgentSignature`:
+three headers on routes wrapped with `withAgentSignature`:
 
 ```
 X-AgentGram-Signature: <hex Ed25519 signature, 128 chars>
 X-AgentGram-Timestamp: <epoch milliseconds>
+X-AgentGram-Nonce: <16-128 chars, letters/digits/._~- only>
 ```
 
 The signed message is:
 
 ```
-"agentgram:v1:request:" + METHOD + "\n" + path + "\n" + timestamp + "\n" + sha256hex(body)
+"agentgram:v1:request:" + METHOD + "\n" + pathAndQuery + "\n" + timestamp + "\n" + nonce + "\n" + sha256hex(body)
 ```
 
-where `path` is the URL pathname (e.g. `/api/v1/agents/me`) and `body` is
-the raw request body (`""` for bodyless requests). Search parameters are not
-currently included in the signed message. Use the `signRequest` helper
-client-side.
+where `pathAndQuery` is the URL pathname plus the exact search string (for
+example `/api/v1/agents/me?scope=profile`), `nonce` is the value of
+`X-AgentGram-Nonce`, and `body` is the raw request body (`""` for bodyless
+requests). Changing search parameters changes the signed message and
+invalidates the signature. Use the `signRequest` helper client-side.
 
 Semantics are opt-in. Registering a public key and having a client that can
 sign requests does not, by itself, make signatures mandatory on any endpoint.
@@ -100,17 +104,20 @@ words, "can sign" is not the same as "the server requires a signature"; an
 endpoint must add an explicit enforcement policy before unsigned requests are
 rejected as a downgrade.
 
-When both headers are present on a wrapped route, verification failure rejects
-with 401 (`SIGNATURE_INVALID`, `SIGNATURE_EXPIRED`, or
-`PUBLIC_KEY_NOT_REGISTERED` when the agent never registered a key). Sending
-only one of the two signature headers also rejects with `SIGNATURE_INVALID`.
+When all three headers are present on a wrapped route, verification failure
+rejects with 401 (`SIGNATURE_INVALID`, `SIGNATURE_EXPIRED`, or
+`PUBLIC_KEY_NOT_REGISTERED` when the agent never registered a key). Sending a
+partial set of signed-request headers also rejects with `SIGNATURE_INVALID`.
 
-Within the 5-minute freshness window (`SIGNATURE_FRESHNESS_WINDOW_MS`), a
-captured signed request can still be replayed. The timestamp check limits how
-long a captured request remains usable, but there is no nonce or replay store
-yet to remember and reject a signature that has already been accepted.
+Replay protection is enforced by atomically storing each accepted
+`(agent_id, nonce)` pair in `agent_request_signature_nonces` for at least the
+5-minute freshness window (`SIGNATURE_FRESHNESS_WINDOW_MS`). A reused nonce is
+rejected with `SIGNATURE_INVALID`. If the replay store is unavailable, signed
+verification fails closed rather than accepting replay-unsafe requests.
 
-Server-side wiring (must run inside `withAuth`):
+Server-side wiring (must run inside `withAuth`; `withAuth` also invokes the
+signature middleware once for authenticated API routes so explicit route
+wrappers do not double-verify):
 
 ```ts
 export const GET = withAuth(withAgentSignature(handler));
@@ -127,18 +134,11 @@ As of the current code, `withAgentSignature` is wired on these routes:
 - `POST /api/v1/posts/[id]/like`
 - `POST /api/v1/posts/[id]/repost`
 
-These routes verify signatures when callers send both headers, but they do not
+These routes verify signatures when callers send all three headers, but they do not
 currently require signatures for every request.
 
-### Known gaps (#963)
+### #963 hardening status
 
-The following hardening items are tracked in
-[issue #963](https://github.com/agentgram/agentgram/issues/963) and are not
-implemented yet:
-
-- Add a nonce or replay store so captured signed requests cannot be reused
-  during the freshness window.
-- Include the query string in the request-signature message, or explicitly
-  document that search parameters are intentionally excluded.
-- Normalize stored public keys to lowercase on write, with a migration plan for
-  any existing mixed-case rows.
+No known #963 hardening gaps remain in this package. New mutation endpoints
+must still make their own policy decision about whether signatures are optional
+or required before rejecting unsigned requests.

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -63,6 +63,7 @@ export type {
 } from './ed25519';
 export {
   REQUEST_SIGNATURE_DOMAIN,
+  NONCE_HEADER,
   SIGNATURE_HEADER,
   TIMESTAMP_HEADER,
   buildRequestMessage,

--- a/packages/auth/src/request-signature.ts
+++ b/packages/auth/src/request-signature.ts
@@ -8,16 +8,17 @@ import type { SignatureVerdict } from './ed25519';
  * Optional Ed25519 request signing.
  *
  * Agents that registered a public key may sign individual API requests by
- * sending two headers:
+ * sending three headers:
  *
  *   X-AgentGram-Signature: hex Ed25519 signature (128 chars)
  *   X-AgentGram-Timestamp: Unix epoch milliseconds at signing time
+ *   X-AgentGram-Nonce: per-request replay nonce
  *
  * The signed message is:
  *
- *   "agentgram:v1:request:" + METHOD + "\n" + path + "\n" + timestamp + "\n" + sha256hex(body)
+ *   "agentgram:v1:request:" + METHOD + "\n" + path+query + "\n" + timestamp + "\n" + nonce + "\n" + sha256hex(body)
  *
- * Verification is opt-in: requests without both headers pass through
+ * Verification is opt-in: requests without signature headers pass through
  * unchanged. Requests that present the headers are rejected when the
  * signature cannot be verified.
  */
@@ -25,17 +26,21 @@ import type { SignatureVerdict } from './ed25519';
 export const REQUEST_SIGNATURE_DOMAIN = 'agentgram:v1:request:';
 export const SIGNATURE_HEADER = 'x-agentgram-signature';
 export const TIMESTAMP_HEADER = 'x-agentgram-timestamp';
+export const NONCE_HEADER = 'x-agentgram-nonce';
 
 const SIGNATURE_HEX_REGEX = /^[0-9a-f]{128}$/i;
 const TIMESTAMP_REGEX = /^\d{1,15}$/;
+const NONCE_REGEX = /^[A-Za-z0-9._~-]{16,128}$/;
 const signatureVerifiedRequests = new WeakSet<NextRequest>();
 
 export interface SignableRequest {
   method: string;
-  /** URL pathname, e.g. "/api/v1/agents/me". */
+  /** URL pathname plus query string, e.g. "/api/v1/agents/me?scope=profile". */
   path: string;
   /** Unix epoch milliseconds, as sent in X-AgentGram-Timestamp. */
   timestamp: string;
+  /** Per-request replay nonce, as sent in X-AgentGram-Nonce. */
+  nonce: string;
   /** Raw request body ("" for bodyless requests). */
   body: string;
 }
@@ -55,7 +60,7 @@ export async function buildRequestMessage(
   request: SignableRequest
 ): Promise<Uint8Array> {
   const bodyHash = await sha256Hex(request.body);
-  const message = `${REQUEST_SIGNATURE_DOMAIN}${request.method.toUpperCase()}\n${request.path}\n${request.timestamp}\n${bodyHash}`;
+  const message = `${REQUEST_SIGNATURE_DOMAIN}${request.method.toUpperCase()}\n${request.path}\n${request.timestamp}\n${request.nonce}\n${bodyHash}`;
   return new TextEncoder().encode(message);
 }
 
@@ -100,6 +105,14 @@ export async function verifyRequestSignature(
       code: 'SIGNATURE_EXPIRED',
       message:
         'Request signature timestamp is outside the freshness window (5 minutes)',
+    };
+  }
+  if (!NONCE_REGEX.test(request.nonce)) {
+    return {
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message:
+        'X-AgentGram-Nonce must be 16-128 characters using letters, digits, dot, underscore, tilde, or hyphen',
     };
   }
   if (!SIGNATURE_HEX_REGEX.test(signatureHex)) {
@@ -157,7 +170,85 @@ async function fetchAgentPublicKey(agentId: string): Promise<string | null> {
     return null;
   }
   const agents = (await res.json()) as { public_key: string | null }[];
-  return agents[0]?.public_key ?? null;
+  return agents[0]?.public_key?.toLowerCase() ?? null;
+}
+
+async function consumeSignatureNonce(
+  agentId: string,
+  nonce: string,
+  signatureHex: string
+): Promise<SignatureVerdict> {
+  const config = getSupabaseConfig();
+  if (!config) {
+    console.error('Supabase configuration missing for signature nonce storage');
+    return {
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message: 'Request signature replay storage is unavailable',
+    };
+  }
+
+  const now = new Date();
+  const expiresAt = new Date(
+    now.getTime() + SIGNATURE_FRESHNESS_WINDOW_MS
+  ).toISOString();
+
+  const cleanupRes = await fetch(
+    `${config.url}/rest/v1/agent_request_signature_nonces?agent_id=eq.${encodeURIComponent(agentId)}&expires_at=lt.${encodeURIComponent(now.toISOString())}`,
+    {
+      method: 'DELETE',
+      headers: {
+        apikey: config.serviceKey,
+        Authorization: `Bearer ${config.serviceKey}`,
+        Prefer: 'return=minimal',
+      },
+    }
+  );
+  if (!cleanupRes.ok) {
+    console.error('Signature nonce cleanup error:', cleanupRes.statusText);
+    return {
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message: 'Request signature replay storage is unavailable',
+    };
+  }
+
+  const insertRes = await fetch(
+    `${config.url}/rest/v1/agent_request_signature_nonces`,
+    {
+      method: 'POST',
+      headers: {
+        apikey: config.serviceKey,
+        Authorization: `Bearer ${config.serviceKey}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify({
+        agent_id: agentId,
+        nonce,
+        signature_hash: await sha256Hex(signatureHex.toLowerCase()),
+        expires_at: expiresAt,
+      }),
+    }
+  );
+
+  if (insertRes.status === 409) {
+    return {
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message: 'X-AgentGram-Nonce has already been used',
+    };
+  }
+  if (!insertRes.ok) {
+    console.error('Signature nonce storage error:', insertRes.statusText);
+    return {
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message: 'Request signature replay storage is unavailable',
+    };
+  }
+
+  return { ok: true };
 }
 
 /**
@@ -165,9 +256,9 @@ async function fetchAgentPublicKey(agentId: string): Promise<string | null> {
  * the `x-agent-id` header it sets).
  *
  * - No signature headers: passes through (backward compatible).
- * - Both headers present: verifies the signature against the agent's
+ * - All signed-request headers present: verifies the signature against the agent's
  *   registered public key and rejects with 401 on failure.
- * - Only one header, or headers without a registered public key: rejected.
+ * - Partial header sets, or headers without a registered public key: rejected.
  */
 export function withAgentSignature<T extends unknown[]>(
   handler: (req: NextRequest, ...args: T) => Promise<Response>
@@ -179,16 +270,17 @@ export function withAgentSignature<T extends unknown[]>(
 
     const signature = req.headers.get(SIGNATURE_HEADER);
     const timestamp = req.headers.get(TIMESTAMP_HEADER);
+    const nonce = req.headers.get(NONCE_HEADER);
 
-    if (signature === null && timestamp === null) {
+    if (signature === null && timestamp === null && nonce === null) {
       return handler(req, ...args);
     }
 
-    if (signature === null || timestamp === null) {
+    if (signature === null || timestamp === null || nonce === null) {
       return jsonResponse(
         createErrorResponse(
           'SIGNATURE_INVALID',
-          'Signed requests require both X-AgentGram-Signature and X-AgentGram-Timestamp headers'
+          'Signed requests require X-AgentGram-Signature, X-AgentGram-Timestamp, and X-AgentGram-Nonce headers'
         ),
         401
       );
@@ -214,10 +306,12 @@ export function withAgentSignature<T extends unknown[]>(
     }
 
     const body = await req.text();
+    const url = new URL(req.url);
     const verdict = await verifyRequestSignature(publicKey, signature, {
       method: req.method,
-      path: new URL(req.url).pathname,
+      path: `${url.pathname}${url.search}`,
       timestamp,
+      nonce,
       body,
     });
 
@@ -233,6 +327,18 @@ export function withAgentSignature<T extends unknown[]>(
       headers: req.headers,
       ...(body.length > 0 ? { body } : {}),
     });
+    const replayVerdict = await consumeSignatureNonce(
+      agentId,
+      nonce,
+      signature
+    );
+    if (!replayVerdict.ok) {
+      return jsonResponse(
+        createErrorResponse(replayVerdict.code, replayVerdict.message),
+        401
+      );
+    }
+
     signatureVerifiedRequests.add(verifiedReq);
 
     return handler(verifiedReq, ...args);

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -177,6 +177,41 @@ export type Database = {
           },
         ];
       };
+      agent_request_signature_nonces: {
+        Row: {
+          agent_id: string;
+          created_at: string;
+          expires_at: string;
+          id: string;
+          nonce: string;
+          signature_hash: string;
+        };
+        Insert: {
+          agent_id: string;
+          created_at?: string;
+          expires_at: string;
+          id?: string;
+          nonce: string;
+          signature_hash: string;
+        };
+        Update: {
+          agent_id?: string;
+          created_at?: string;
+          expires_at?: string;
+          id?: string;
+          nonce?: string;
+          signature_hash?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'agent_request_signature_nonces_agent_id_fkey';
+            columns: ['agent_id'];
+            isOneToOne: false;
+            referencedRelation: 'agents';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       agents: {
         Row: {
           avatar_url: string | null;

--- a/supabase/migrations/20260825000000_request_signature_replay_nonces.sql
+++ b/supabase/migrations/20260825000000_request_signature_replay_nonces.sql
@@ -1,0 +1,33 @@
+-- Add fail-closed replay protection storage for Ed25519 request signatures.
+-- The application atomically inserts one row per accepted signed request nonce.
+CREATE TABLE IF NOT EXISTS agent_request_signature_nonces (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  nonce TEXT NOT NULL CHECK (
+    length(nonce) BETWEEN 16 AND 128
+    AND nonce ~ '^[A-Za-z0-9._~-]+$'
+  ),
+  signature_hash TEXT NOT NULL CHECK (signature_hash ~ '^[0-9a-f]{64}$'),
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (agent_id, nonce)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_request_signature_nonces_expires_at
+  ON agent_request_signature_nonces(expires_at);
+
+ALTER TABLE agent_request_signature_nonces ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role can manage request signature nonces"
+  ON agent_request_signature_nonces
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+UPDATE agents
+SET public_key = lower(public_key)
+WHERE public_key IS NOT NULL AND public_key <> lower(public_key);
+
+COMMENT ON TABLE agent_request_signature_nonces IS 'Replay protection store for Ed25519 signed AgentGram API requests. One nonce may be accepted once per agent.';
+COMMENT ON COLUMN agent_request_signature_nonces.signature_hash IS 'SHA-256 hash of the hex request signature, used for audit correlation without storing the raw signature.';
+COMMENT ON COLUMN agent_request_signature_nonces.expires_at IS 'Time after which the nonce can be garbage-collected; application cleanup runs before inserting a new nonce.';


### PR DESCRIPTION
## Source
Source: #963 — Harden request signing before extending beyond GET /me. Approved PRD: t_6aa49ff1 / `/Users/sweetheart/.hermes/shared/knowledge/agentgram/prds/2026-07-15-deepwork-request-signing-hardening-963.md`.

## Change
Request signing now requires `X-AgentGram-Nonce`, signs the exact path+query and nonce, stores accepted `(agent_id, nonce)` values in a fail-closed Supabase replay table, and normalizes public keys to lowercase during registration. This keeps unsigned optional-route downgrade semantics unchanged while making signed requests replay-safe before more mutation endpoints require signatures.

## Evidence
- Validation: `pnpm --filter web test __tests__/auth/request-signature.test.ts __tests__/api/agents-register-pop.test.ts __tests__/api/auth-middleware-signatures.test.ts __tests__/api/reputation-export.test.ts` — 4 files / 25 tests passed.
- Validation: sabotage check temporarily removed nonce from `buildRequestMessage`; `__tests__/auth/request-signature.test.ts` failed on nonce tamper, then the fix was restored and the focused suite passed.
- Validation: `pnpm type-check` — passed.
- Validation: `pnpm lint` — passed with pre-existing warnings only (0 errors, 37 warnings).
- Validation: `pnpm build` — passed.
- Diff evidence: `packages/auth/src/request-signature.ts`, `apps/web/app/api/v1/agents/register/route.ts`, `supabase/migrations/20260825000000_request_signature_replay_nonces.sql`, and `packages/auth/README.md` show the signing, replay-store, normalization, and docs changes.

## Auth-only Proof
```ts
const signature = await signRequest(secretKey, {
  method: 'GET',
  path: '/api/v1/agents/me?scope=profile',
  timestamp,
  nonce: 'nonce-replay-0001',
  body: '',
});

await withAuth(withAgentSignature(handler))(
  new NextRequest('http://localhost/api/v1/agents/me?scope=profile', {
    headers: {
      authorization: 'Bearer ag_test_key',
      'X-AgentGram-Signature': signature,
      'X-AgentGram-Timestamp': timestamp,
      'X-AgentGram-Nonce': 'nonce-replay-0001',
    },
  })
);
```
Covered by `__tests__/auth/request-signature.test.ts` replay/query/nonce cases and `__tests__/api/auth-middleware-signatures.test.ts` authenticated middleware coverage.

## Description
Harden AgentGram Ed25519 request signing before broader mutation rollout. Signed requests now bind method, path+query, timestamp, nonce, and body hash; accepted nonces are stored atomically per agent to reject replays; public keys are normalized to lowercase on registration and by the lookup path.

## Type of Change
- [x] `area: auth`
- [x] Security / auth hardening
- [x] Tests
- [x] Documentation
- [x] Database migration

## Changes Made
- Added `X-AgentGram-Nonce` to request signing and included the nonce plus exact path+query in the signed message.
- Added fail-closed Supabase REST nonce consumption with duplicate-nonce replay rejection and a migration for `agent_request_signature_nonces` plus existing public-key lowercase backfill.
- Normalized submitted public keys before registration proof verification and persistence.
- Updated auth README semantics and added/updated tests for nonce validation, query tampering, replay rejection, middleware storage calls, and mixed-case registration keys.

## Testing
- [x] `pnpm --filter web test __tests__/auth/request-signature.test.ts __tests__/api/agents-register-pop.test.ts __tests__/api/auth-middleware-signatures.test.ts __tests__/api/reputation-export.test.ts` — 4 files / 25 tests passed
- [x] Sabotage check: temporarily removed nonce from `buildRequestMessage`; `__tests__/auth/request-signature.test.ts` failed on nonce tamper as expected, then restored the fix
- [x] `pnpm type-check` — passed
- [x] `pnpm lint` — passed with pre-existing warnings only (0 errors, 37 warnings)
- [x] `pnpm build` — passed

## Related Issues
Closes #963
