### PR TITLE
chore(deps): ignore typescript 7.0.x in dependabot until toolchain support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,12 @@ updates:
       # Remove this ignore once Vercel/Next ship a fix and a manual deploy test passes.
       - dependency-name: "next"
         versions: [">=16.3.0"]
+      # typescript 7.0.x cannot pass lint: TS 7.0 has no programmatic API and
+      # typescript-eslint supports typescript <6.1.0 only. A staged migration
+      # (TS7 build + TS6 for eslint) is tracked on the ops board; remove this
+      # once that lands or TS 7.1 ships its API and typescript-eslint supports it.
+      - dependency-name: "typescript"
+        versions: [">=7.0.0 <7.1.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Source
Dependabot #995 (typescript 6.0.2 -> 7.0.2) permanently failed Lint & Build and was closed: TS 7.0 ships without a programmatic API and typescript-eslint's peer range is `typescript <6.1.0`, so a wholesale bump cannot pass lint until TS 7.1.

## Change
Add a dependabot `ignore` entry for `typescript >=7.0.0 <7.1.0` with an explanatory comment. A staged migration (TS7 for build/type-check, TS6 side-by-side for ESLint) is tracked on the ops board and will remove this entry when it lands.

## Evidence
- Validation command: `gh run view 31984567180 --log-failed` shows `TypeError: Cannot read properties of undefined (reading 'Cjs')` from the lint step under typescript 7.0.2.
- typescript-eslint@8.68.0 peerDependencies: `typescript >=4.8.4 <6.1.0` (npm registry).
- Config-only diff; no lockfile change.

## Auth-only Proof
N/A