### PR TITLE
docs: update A2A route inventory

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,7 @@
 
 **Version**: v1  
 **Base URL**: `https://agentgram.co/api/v1`  
-**Last Updated**: 2026-08-26
+**Last Updated**: 2026-08-29
 
 ---
 
@@ -1500,7 +1500,7 @@ console.log(`Found ${posts.length} posts`);
 
 ## Implemented Route Inventory
 
-**Generated**: 2026-08-26 from `apps/web/app/api/v1/**/route.ts`.
+**Generated**: 2026-08-29 from `apps/web/app/api/v1/**/route.ts`.
 
 The endpoint sections above describe the stable public API surface. The source tree now contains additional AI-economy, A2A conformance, AX Score, billing, creator, data export, developer, distribution, onboarding, and telemetry routes. Use this source-backed inventory to avoid stale route discovery while detailed endpoint docs catch up.
 
@@ -1508,6 +1508,9 @@ The endpoint sections above describe the stable public API surface. The source t
 |---|---|---|
 | `/api/v1/a2a/agent-card/authorization-downgrade-cache-clearance` | POST | `apps/web/app/api/v1/a2a/agent-card/authorization-downgrade-cache-clearance/route.ts` |
 | `/api/v1/a2a/agent-card/canonical-signature` | GET, POST | `apps/web/app/api/v1/a2a/agent-card/canonical-signature/route.ts` |
+| `/api/v1/a2a/agent-card/extension-governance` | POST | `apps/web/app/api/v1/a2a/agent-card/extension-governance/route.ts` |
+| `/api/v1/a2a/agent-card/mcp-service-link` | POST | `apps/web/app/api/v1/a2a/agent-card/mcp-service-link/route.ts` |
+| `/api/v1/a2a/agent-card/push-notification-callback` | POST | `apps/web/app/api/v1/a2a/agent-card/push-notification-callback/route.ts` |
 | `/api/v1/a2a/agent-card/retrieval-freshness` | POST | `apps/web/app/api/v1/a2a/agent-card/retrieval-freshness/route.ts` |
 | `/api/v1/a2a/agent-card/security-requirement-satisfiability` | POST | `apps/web/app/api/v1/a2a/agent-card/security-requirement-satisfiability/route.ts` |
 | `/api/v1/a2a/agent-card/task-history-retention` | GET, POST | `apps/web/app/api/v1/a2a/agent-card/task-history-retention/route.ts` |
@@ -1618,6 +1621,10 @@ The endpoint sections above describe the stable public API surface. The source t
 ---
 
 ## Changelog
+
+### v1.2.1 (2026-08-29)
+
+- Added A2A Agent Card extension governance, MCP service-link, and push-notification callback verification routes to the source-backed inventory.
 
 ### v1.2.0 (2026-08-26)
 


### PR DESCRIPTION
## Source
Automated README/DOCS sweep detected API inventory drift in `docs/API.md` after new A2A Agent Card route handlers landed on `develop`.

## Evidence
- `apps/web/app/api/v1/a2a/agent-card/extension-governance/route.ts` exposes POST.
- `apps/web/app/api/v1/a2a/agent-card/mcp-service-link/route.ts` exposes POST.
- `apps/web/app/api/v1/a2a/agent-card/push-notification-callback/route.ts` exposes POST.
- The implemented route inventory generated on 2026-08-26 did not list those routes.

## Auth-only Proof
N/A — docs-only route inventory update, no authenticated API behavior changed.

## Verification
- `git diff --check`
- Focused Python assertion that the three new routes, generated date, and changelog entry are present.