### PR TITLE
security(a2a): attest Agent Card provider/docs domains

### DIFF
--- a/apps/web/__tests__/api/a2a-agent-card-canonical-signature.test.ts
+++ b/apps/web/__tests__/api/a2a-agent-card-canonical-signature.test.ts
@@ -4,6 +4,7 @@ const mockVerifyA2aAgentCardSignature = vi.fn();
 const mockAttestA2aAgentCardTransportBindingParity = vi.fn();
 const mockAttestA2aAgentCardRetrievalFreshness = vi.fn();
 const mockAttestA2aAgentCardMcpServiceLink = vi.fn();
+const mockAttestA2aAgentCardDomainControl = vi.fn();
 const mockAttestA2aExtendedAgentCardAuthorizationDowngrade = vi.fn();
 const mockAttestA2aSecurityRequirementSatisfiability = vi.fn();
 const mockBuildA2aAgentCardCanonicalSignatureEvidence = vi.fn();
@@ -17,6 +18,7 @@ vi.mock('@agentgram/auth', () => ({
   attestA2aAgentCardRetrievalFreshness:
     mockAttestA2aAgentCardRetrievalFreshness,
   attestA2aAgentCardMcpServiceLink: mockAttestA2aAgentCardMcpServiceLink,
+  attestA2aAgentCardDomainControl: mockAttestA2aAgentCardDomainControl,
   attestA2aExtendedAgentCardAuthorizationDowngrade:
     mockAttestA2aExtendedAgentCardAuthorizationDowngrade,
   attestA2aSecurityRequirementSatisfiability:
@@ -420,6 +422,110 @@ describe('A2A Agent Card canonical signature route', () => {
     expect(response.status).toBe(409);
     expect(json.error.code).toBe('MCP_SERVICE_LINK_REVIEW_REQUIRED');
     expect(json.error.details.serviceLink.verdict.status).toBe('review-required');
+  });
+
+  it('exports provider/documentation domain-control evidence for external discovery', async () => {
+    const domainControl = {
+      kind: 'agentgram.a2a.agent-card.provider-documentation-domain-control-attestation',
+      generatedAt: '2026-08-23T00:00:00.000Z',
+      signedAgentCardPayloadDigest: 'a'.repeat(64),
+      agentCardUrl: 'https://weather.example/.well-known/agent-card.json',
+      agentCardOrigin: 'https://weather.example',
+      canonicalOrigins: ['https://weather.example'],
+      probeCount: 2,
+      verifiedCount: 2,
+      redirectedCount: 0,
+      mismatchedCount: 0,
+      missingCount: 0,
+      probes: [],
+      verdict: { status: 'verified', reasons: [] },
+      signature: {
+        status: 'verified',
+        signingAlgorithm: 'ed25519',
+        publicKey: 'b'.repeat(64),
+        payloadDigest: 'd'.repeat(64),
+      },
+    };
+    mockAttestA2aAgentCardDomainControl.mockResolvedValueOnce({
+      ok: true,
+      domainControl,
+      signature: { ok: true },
+    });
+    const { POST } = await import(
+      '@/app/api/v1/a2a/agent-card/domain-control/route'
+    );
+    const originObservations = [
+      {
+        target: 'provider-url',
+        requestedUrl: 'https://weather.example/provider',
+        finalUrl: 'https://weather.example/provider',
+        tlsVerified: true,
+        domainControlVerified: true,
+      },
+    ];
+
+    const response = await POST(
+      makeRequest({
+        agentCardUrl: 'https://weather.example/.well-known/agent-card.json',
+        publicKey: 'b'.repeat(64),
+        jws: 'protected.payload.signature',
+        agentCard: { name: 'weather-agent' },
+        originObservations,
+      })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockAttestA2aAgentCardDomainControl).toHaveBeenCalledWith({
+      agentCardUrl: 'https://weather.example/.well-known/agent-card.json',
+      publicKey: 'b'.repeat(64),
+      signature: undefined,
+      jws: 'protected.payload.signature',
+      agentCard: { name: 'weather-agent' },
+      originObservations,
+    });
+    expect(json.data.reportType).toBe('a2a-agent-card-domain-control');
+    expect(json.data.domainControl).toEqual(domainControl);
+  });
+
+  it('fails closed when provider/documentation origins mismatch external discovery policy', async () => {
+    const domainControl = {
+      kind: 'agentgram.a2a.agent-card.provider-documentation-domain-control-attestation',
+      verdict: {
+        status: 'external-discovery-mismatch',
+        reasons: [
+          'provider-url canonical origin https://vendor.example does not match Agent Card origin https://weather.example',
+        ],
+      },
+    };
+    mockAttestA2aAgentCardDomainControl.mockResolvedValueOnce({
+      ok: false,
+      code: 'EXTERNAL_DISCOVERY_MISMATCH',
+      message:
+        'A2A Agent Card provider/documentation origins failed redirect, TLS, domain-control, or signed-card origin checks',
+      domainControl,
+      signature: { ok: true },
+    });
+    const { POST } = await import(
+      '@/app/api/v1/a2a/agent-card/domain-control/route'
+    );
+
+    const response = await POST(
+      makeRequest({
+        agentCardUrl: 'https://weather.example/.well-known/agent-card.json',
+        publicKey: 'b'.repeat(64),
+        signature: 'c'.repeat(128),
+        agentCard: { name: 'weather-agent' },
+        originObservations: [],
+      })
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(json.error.code).toBe('EXTERNAL_DISCOVERY_MISMATCH');
+    expect(json.error.details.domainControl.verdict.status).toBe(
+      'external-discovery-mismatch'
+    );
   });
 
   it('fails closed when signed retrieval freshness evidence is stale', async () => {

--- a/apps/web/__tests__/api/a2a-agent-card-domain-control.test.ts
+++ b/apps/web/__tests__/api/a2a-agent-card-domain-control.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import {
+  attestA2aAgentCardDomainControl,
+  generateAgentKeypair,
+  signA2aAgentCard,
+} from '@agentgram/auth';
+
+const agentCard = {
+  name: 'weather-agent',
+  url: 'https://weather.example/a2a/jsonrpc',
+  preferredTransport: 'JSONRPC',
+  provider: {
+    organization: 'Weather Example',
+    url: 'https://weather.example/provider',
+  },
+  documentationUrl: 'https://weather.example/docs/a2a',
+  skills: [{ id: 'forecast', name: 'Forecast weather' }],
+};
+
+describe('A2A Agent Card provider/documentation domain-control attestation', () => {
+  it('binds provider and documentation canonical origins to the signed Agent Card digest', async () => {
+    const keypair = await generateAgentKeypair();
+    const signature = await signA2aAgentCard(keypair.secretKey, agentCard);
+
+    const verdict = await attestA2aAgentCardDomainControl({
+      agentCardUrl: 'https://weather.example/.well-known/agent-card.json',
+      agentCard,
+      publicKey: keypair.publicKey,
+      signature,
+      originObservations: [
+        {
+          target: 'provider-url',
+          requestedUrl: 'https://weather.example/provider',
+          finalUrl: 'https://weather.example/provider',
+          tlsVerified: true,
+          domainControlVerified: true,
+        },
+        {
+          target: 'documentation-url',
+          requestedUrl: 'https://weather.example/docs/a2a',
+          finalUrl: 'https://weather.example/docs/a2a',
+          tlsVerified: true,
+          domainControlVerified: true,
+        },
+      ],
+      now: new Date('2026-08-23T00:00:00.000Z'),
+    });
+
+    expect(verdict.ok).toBe(true);
+    if (!verdict.ok) {
+      throw new Error(verdict.message);
+    }
+    expect(verdict.domainControl).toMatchObject({
+      kind: 'agentgram.a2a.agent-card.provider-documentation-domain-control-attestation',
+      generatedAt: '2026-08-23T00:00:00.000Z',
+      agentCardUrl: 'https://weather.example/.well-known/agent-card.json',
+      agentCardOrigin: 'https://weather.example',
+      canonicalOrigins: ['https://weather.example'],
+      probeCount: 2,
+      verifiedCount: 2,
+      redirectedCount: 0,
+      mismatchedCount: 0,
+      missingCount: 0,
+      verdict: { status: 'verified', reasons: [] },
+      signature: {
+        status: 'verified',
+        signingAlgorithm: 'ed25519',
+        publicKey: keypair.publicKey,
+      },
+    });
+    expect(verdict.domainControl.signedAgentCardPayloadDigest).toMatch(
+      /^[0-9a-f]{64}$/
+    );
+    expect(verdict.domainControl.signature.payloadDigest).toMatch(
+      /^[0-9a-f]{64}$/
+    );
+    expect(verdict.domainControl.probes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          target: 'provider-url',
+          canonicalOrigin: 'https://weather.example',
+          externalDiscoveryMismatch: false,
+          status: 'verified',
+        }),
+        expect.objectContaining({
+          target: 'documentation-url',
+          canonicalOrigin: 'https://weather.example',
+          externalDiscoveryMismatch: false,
+          status: 'verified',
+        }),
+      ])
+    );
+  });
+
+  it('fails closed when provider/doc origins redirect away from the signed Card origin', async () => {
+    const keypair = await generateAgentKeypair();
+    const signature = await signA2aAgentCard(keypair.secretKey, agentCard);
+
+    const verdict = await attestA2aAgentCardDomainControl({
+      agentCardUrl: 'https://weather.example/.well-known/agent-card.json',
+      agentCard,
+      publicKey: keypair.publicKey,
+      signature,
+      originObservations: [
+        {
+          target: 'provider-url',
+          requestedUrl: 'https://weather.example/provider',
+          finalUrl: 'https://provider-cdn.example/provider',
+          tlsVerified: true,
+          domainControlVerified: true,
+        },
+        {
+          target: 'documentation-url',
+          requestedUrl: 'https://weather.example/docs/a2a',
+          finalUrl: 'https://docs.vendor.example/a2a',
+          tlsVerified: false,
+          domainControlVerified: false,
+        },
+      ],
+      now: new Date('2026-08-23T00:00:00.000Z'),
+    });
+
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) {
+      throw new Error(
+        'expected provider/documentation origin mismatch to fail'
+      );
+    }
+    expect(verdict.code).toBe('EXTERNAL_DISCOVERY_MISMATCH');
+    expect(verdict.domainControl?.verdict.status).toBe(
+      'external-discovery-mismatch'
+    );
+    expect(verdict.domainControl?.mismatchedCount).toBe(2);
+    expect(verdict.domainControl?.probes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          target: 'provider-url',
+          canonicalOrigin: 'https://provider-cdn.example',
+          externalDiscoveryMismatch: true,
+          status: 'mismatched',
+        }),
+        expect.objectContaining({
+          target: 'documentation-url',
+          canonicalOrigin: 'https://docs.vendor.example',
+          tlsVerified: false,
+          domainControlVerified: false,
+          externalDiscoveryMismatch: true,
+          status: 'mismatched',
+        }),
+      ])
+    );
+    expect(verdict.domainControl?.verdict.reasons).toEqual(
+      expect.arrayContaining([
+        'provider-url canonical origin https://provider-cdn.example does not match Agent Card origin https://weather.example',
+        'documentation-url TLS chain was not verified',
+        'documentation-url domain-control proof was not verified',
+      ])
+    );
+  });
+
+  it('rejects non-HTTPS provider or documentation targets before omitting them from the digest', async () => {
+    const keypair = await generateAgentKeypair();
+    const insecureProviderCard = {
+      ...agentCard,
+      provider: {
+        organization: 'Weather Example',
+        url: 'http://weather.example/provider',
+      },
+    };
+    const signature = await signA2aAgentCard(
+      keypair.secretKey,
+      insecureProviderCard
+    );
+
+    const verdict = await attestA2aAgentCardDomainControl({
+      agentCardUrl: 'https://weather.example/.well-known/agent-card.json',
+      agentCard: insecureProviderCard,
+      publicKey: keypair.publicKey,
+      signature,
+      originObservations: [
+        {
+          target: 'documentation-url',
+          requestedUrl: 'https://weather.example/docs/a2a',
+          finalUrl: 'https://weather.example/docs/a2a',
+          tlsVerified: true,
+          domainControlVerified: true,
+        },
+      ],
+    });
+
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) {
+      throw new Error('expected non-HTTPS provider URL to fail');
+    }
+    expect(verdict.code).toBe('DOMAIN_CONTROL_METADATA_INVALID');
+    expect(verdict.message).toBe(
+      'A2A provider.url must be HTTPS for domain-control attestation'
+    );
+  });
+});

--- a/apps/web/__tests__/api/auth-coverage.test.ts
+++ b/apps/web/__tests__/api/auth-coverage.test.ts
@@ -23,6 +23,7 @@ const PUBLIC_API_ROUTE_EXPORTS = new Set([
   'a2a/agent-card/canonical-signature/route.ts#GET',
   'a2a/agent-card/canonical-signature/route.ts#POST',
   'a2a/agent-card/authorization-downgrade-cache-clearance/route.ts#POST',
+  'a2a/agent-card/domain-control/route.ts#POST',
   'a2a/agent-card/extension-governance/route.ts#POST',
   'a2a/agent-card/mcp-service-link/route.ts#POST',
   'a2a/agent-card/push-notification-callback/route.ts#POST',

--- a/apps/web/app/api/v1/a2a/agent-card/domain-control/route.ts
+++ b/apps/web/app/api/v1/a2a/agent-card/domain-control/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from 'next/server';
+import {
+  attestA2aAgentCardDomainControl,
+  withRateLimit,
+} from '@agentgram/auth';
+import {
+  AX_RATE_LIMITS,
+  ErrorResponses,
+  createErrorResponse,
+  createSuccessResponse,
+  jsonResponse,
+} from '@agentgram/shared';
+
+interface AgentCardDomainControlRequestBody {
+  agentCardUrl?: unknown;
+  agentCard?: unknown;
+  publicKey?: unknown;
+  signature?: unknown;
+  jws?: unknown;
+  originObservations?: unknown;
+}
+
+/**
+ * POST /api/v1/a2a/agent-card/domain-control
+ *
+ * Verify a signed A2A Agent Card and attest provider.url/documentationUrl
+ * redirect, TLS, and domain-control observations. Canonical provider and docs
+ * origins are bound to the signed Card digest; external-discovery origin drift
+ * fails closed with a mismatch verdict.
+ * Auth: public (rate-limited) — stateless verification of caller-supplied
+ * signed card and origin observations, no account or developer state is read.
+ */
+const postHandler = async function POST(req: NextRequest) {
+  try {
+    const body = (await req
+      .json()
+      .catch(() => ({}))) as AgentCardDomainControlRequestBody;
+    const verdict = await attestA2aAgentCardDomainControl({
+      agentCardUrl: body.agentCardUrl,
+      agentCard: body.agentCard,
+      publicKey: body.publicKey,
+      signature: body.signature,
+      jws: body.jws,
+      originObservations: body.originObservations,
+    });
+
+    if (!verdict.ok) {
+      return jsonResponse(
+        createErrorResponse(verdict.code, verdict.message, {
+          domainControl: verdict.domainControl,
+        }),
+        verdict.code === 'EXTERNAL_DISCOVERY_MISMATCH' ? 409 : 401
+      );
+    }
+
+    return jsonResponse(
+      createSuccessResponse({
+        reportType: 'a2a-agent-card-domain-control',
+        domainControl: verdict.domainControl,
+      }),
+      200
+    );
+  } catch (error) {
+    console.error('A2A Agent Card domain-control attestation error:', error);
+    return jsonResponse(
+      ErrorResponses.internalError(
+        'Failed to attest A2A Agent Card provider/documentation domain control'
+      ),
+      500
+    );
+  }
+};
+
+export const POST = withRateLimit(
+  {
+    maxRequests: AX_RATE_LIMITS.SCAN.limit,
+    windowMs: AX_RATE_LIMITS.SCAN.windowMs,
+  },
+  postHandler
+);

--- a/packages/auth/src/ed25519.ts
+++ b/packages/auth/src/ed25519.ts
@@ -274,6 +274,79 @@ export type A2aAgentCardMcpServiceLinkVerdict =
       signature: A2aAgentCardSignatureVerdict;
     };
 
+export type A2aAgentCardDomainControlTargetKind =
+  | 'provider-url'
+  | 'documentation-url';
+
+export type A2aAgentCardDomainControlStatus =
+  | 'verified'
+  | 'redirected'
+  | 'mismatched'
+  | 'missing';
+
+export interface A2aAgentCardDomainControlObservation {
+  target: A2aAgentCardDomainControlTargetKind;
+  requestedUrl: string;
+  finalUrl: string;
+  tlsVerified: boolean;
+  domainControlVerified: boolean;
+}
+
+export interface A2aAgentCardDomainControlProbe {
+  target: A2aAgentCardDomainControlTargetKind;
+  declaredUrl: string;
+  declaredOrigin: string;
+  observedFinalUrl: string | null;
+  canonicalOrigin: string | null;
+  tlsVerified: boolean;
+  domainControlVerified: boolean;
+  externalDiscoveryMismatch: boolean;
+  status: A2aAgentCardDomainControlStatus;
+  reasons: string[];
+}
+
+export interface A2aAgentCardDomainControlReport {
+  kind: 'agentgram.a2a.agent-card.provider-documentation-domain-control-attestation';
+  generatedAt: string;
+  signedAgentCardPayloadDigest: string;
+  agentCardUrl: string;
+  agentCardOrigin: string;
+  canonicalOrigins: string[];
+  probeCount: number;
+  verifiedCount: number;
+  redirectedCount: number;
+  mismatchedCount: number;
+  missingCount: number;
+  probes: A2aAgentCardDomainControlProbe[];
+  verdict: {
+    status: 'verified' | 'external-discovery-mismatch';
+    reasons: string[];
+  };
+  signature: {
+    status: 'verified';
+    signingAlgorithm: 'ed25519';
+    publicKey: string;
+    payloadDigest: string;
+  };
+}
+
+export type A2aAgentCardDomainControlVerdict =
+  | {
+      ok: true;
+      domainControl: A2aAgentCardDomainControlReport;
+      signature: Extract<A2aAgentCardSignatureVerdict, { ok: true }>;
+    }
+  | {
+      ok: false;
+      code:
+        | 'SIGNATURE_INVALID'
+        | 'DOMAIN_CONTROL_METADATA_INVALID'
+        | 'EXTERNAL_DISCOVERY_MISMATCH';
+      message: string;
+      domainControl?: A2aAgentCardDomainControlReport;
+      signature: A2aAgentCardSignatureVerdict;
+    };
+
 export type A2aExtensionGovernancePromotionTier =
   | 'core'
   | 'promoted'
@@ -599,6 +672,21 @@ interface NormalizedA2aMcpEndpointObservation {
   requestedAuthority: string;
   finalUrl: string;
   finalAuthority: string;
+}
+
+interface NormalizedA2aDomainControlTarget {
+  target: A2aAgentCardDomainControlTargetKind;
+  declaredUrl: string;
+  declaredOrigin: string;
+}
+
+interface NormalizedA2aDomainControlObservation {
+  target: A2aAgentCardDomainControlTargetKind;
+  requestedUrl: string;
+  finalUrl: string;
+  canonicalOrigin: string;
+  tlsVerified: boolean;
+  domainControlVerified: boolean;
 }
 
 interface NormalizedA2aExtensionDeclaration {
@@ -1158,6 +1246,76 @@ function normalizeMcpEndpointObservations(
     });
   }
   return observations;
+}
+
+function collectA2aDomainControlTargets(
+  agentCard: Record<string, unknown>
+): NormalizedA2aDomainControlTarget[] {
+  const targets: NormalizedA2aDomainControlTarget[] = [];
+  const provider = isRecord(agentCard.provider) ? agentCard.provider : null;
+  const providerUrl = provider === null ? null : parseHttpsUrl(provider.url);
+  const documentationUrl = parseHttpsUrl(agentCard.documentationUrl);
+
+  if (providerUrl !== null) {
+    targets.push({
+      target: 'provider-url',
+      declaredUrl: providerUrl,
+      declaredOrigin: new URL(providerUrl).origin,
+    });
+  }
+  if (documentationUrl !== null) {
+    targets.push({
+      target: 'documentation-url',
+      declaredUrl: documentationUrl,
+      declaredOrigin: new URL(documentationUrl).origin,
+    });
+  }
+
+  return targets;
+}
+
+function normalizeA2aDomainControlObservations(
+  value: unknown
+): NormalizedA2aDomainControlObservation[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((observation) => {
+    if (!isRecord(observation)) {
+      return [];
+    }
+    const target = observation.target;
+    if (target !== 'provider-url' && target !== 'documentation-url') {
+      return [];
+    }
+    const requestedUrl = parseHttpsUrl(observation.requestedUrl);
+    const finalUrl =
+      parseHttpsUrl(observation.finalUrl) ?? parseHttpsUrl(observation.location);
+    if (requestedUrl === null || finalUrl === null) {
+      return [];
+    }
+    return [
+      {
+        target,
+        requestedUrl,
+        finalUrl,
+        canonicalOrigin: new URL(finalUrl).origin,
+        tlsVerified: observation.tlsVerified === true,
+        domainControlVerified: observation.domainControlVerified === true,
+      },
+    ];
+  });
+}
+
+function findA2aDomainControlObservation(
+  target: NormalizedA2aDomainControlTarget,
+  observations: NormalizedA2aDomainControlObservation[]
+): NormalizedA2aDomainControlObservation | undefined {
+  return observations.find(
+    (observation) =>
+      observation.target === target.target &&
+      observation.requestedUrl === target.declaredUrl
+  );
 }
 
 function readExtensionUri(value: Record<string, unknown>): string | null {
@@ -2460,6 +2618,188 @@ export async function attestA2aAgentCardMcpServiceLink(input: {
   }
 
   return { ok: true, serviceLink, signature };
+}
+
+/**
+ * Verify a signed A2A Agent Card and attest that provider.url and
+ * documentationUrl resolve under the external-discovery policy: HTTPS only,
+ * TLS observed as valid, domain-control proof observed, and no silent origin
+ * drift away from the signed Agent Card origin. Canonical origins and mismatch
+ * verdicts are bound to the signed Card digest for discovery clients.
+ */
+export async function attestA2aAgentCardDomainControl(input: {
+  agentCardUrl?: unknown;
+  agentCard?: unknown;
+  publicKey?: unknown;
+  signature?: unknown;
+  jws?: unknown;
+  originObservations?: unknown;
+  now?: Date;
+}): Promise<A2aAgentCardDomainControlVerdict> {
+  const signature = await verifyA2aAgentCardSignature(input);
+  if (!signature.ok) {
+    return {
+      ok: false,
+      code: 'SIGNATURE_INVALID',
+      message:
+        'A2A Agent Card provider/documentation domain-control attestation requires a valid signed Agent Card',
+      signature,
+    };
+  }
+
+  if (!isRecord(input.agentCard)) {
+    return {
+      ok: false,
+      code: 'DOMAIN_CONTROL_METADATA_INVALID',
+      message:
+        'A2A provider/documentation domain-control attestation requires an Agent Card object',
+      signature,
+    };
+  }
+
+  const agentCardUrl = parseHttpsUrl(input.agentCardUrl) ?? parseHttpsUrl(input.agentCard.url);
+  if (agentCardUrl === null) {
+    return {
+      ok: false,
+      code: 'DOMAIN_CONTROL_METADATA_INVALID',
+      message:
+        'A2A provider/documentation domain-control attestation requires an HTTPS agentCardUrl or Agent Card url',
+      signature,
+    };
+  }
+
+  const provider = isRecord(input.agentCard.provider) ? input.agentCard.provider : null;
+  if (provider?.url !== undefined && parseHttpsUrl(provider.url) === null) {
+    return {
+      ok: false,
+      code: 'DOMAIN_CONTROL_METADATA_INVALID',
+      message: 'A2A provider.url must be HTTPS for domain-control attestation',
+      signature,
+    };
+  }
+  if (
+    input.agentCard.documentationUrl !== undefined &&
+    parseHttpsUrl(input.agentCard.documentationUrl) === null
+  ) {
+    return {
+      ok: false,
+      code: 'DOMAIN_CONTROL_METADATA_INVALID',
+      message:
+        'A2A documentationUrl must be HTTPS for domain-control attestation',
+      signature,
+    };
+  }
+
+  const targets = collectA2aDomainControlTargets(input.agentCard);
+  if (targets.length === 0) {
+    return {
+      ok: false,
+      code: 'DOMAIN_CONTROL_METADATA_INVALID',
+      message:
+        'A2A provider/documentation domain-control attestation requires provider.url or documentationUrl HTTPS targets',
+      signature,
+    };
+  }
+
+  const agentCardOrigin = new URL(agentCardUrl).origin;
+  const observations = normalizeA2aDomainControlObservations(input.originObservations);
+  const probes = targets.map((target) => {
+    const observation = findA2aDomainControlObservation(target, observations);
+    const canonicalOrigin = observation?.canonicalOrigin ?? null;
+    const reasons: string[] = [];
+    if (observation === undefined) {
+      reasons.push(`${target.target} requires redirect/TLS/domain-control observation`);
+    }
+    if (observation !== undefined && !observation.tlsVerified) {
+      reasons.push(`${target.target} TLS chain was not verified`);
+    }
+    if (observation !== undefined && !observation.domainControlVerified) {
+      reasons.push(`${target.target} domain-control proof was not verified`);
+    }
+    if (canonicalOrigin !== null && canonicalOrigin !== target.declaredOrigin) {
+      reasons.push(
+        `${target.target} redirected from ${target.declaredOrigin} to ${canonicalOrigin}`
+      );
+    }
+    const externalDiscoveryMismatch =
+      canonicalOrigin !== null && canonicalOrigin !== agentCardOrigin;
+    if (externalDiscoveryMismatch) {
+      reasons.push(
+        `${target.target} canonical origin ${canonicalOrigin} does not match Agent Card origin ${agentCardOrigin}`
+      );
+    }
+    const status: A2aAgentCardDomainControlStatus =
+      observation === undefined
+        ? 'missing'
+        : !observation.tlsVerified || !observation.domainControlVerified || externalDiscoveryMismatch
+          ? 'mismatched'
+          : canonicalOrigin !== target.declaredOrigin
+            ? 'redirected'
+            : 'verified';
+    return {
+      target: target.target,
+      declaredUrl: target.declaredUrl,
+      declaredOrigin: target.declaredOrigin,
+      observedFinalUrl: observation?.finalUrl ?? null,
+      canonicalOrigin,
+      tlsVerified: observation?.tlsVerified ?? false,
+      domainControlVerified: observation?.domainControlVerified ?? false,
+      externalDiscoveryMismatch,
+      status,
+      reasons,
+    } satisfies A2aAgentCardDomainControlProbe;
+  });
+  const reasons = probes.flatMap((probe) => probe.reasons);
+  const canonicalOrigins = [
+    ...new Set(probes.flatMap((probe) => probe.canonicalOrigin ?? [])),
+  ].sort();
+  const verdictStatus: A2aAgentCardDomainControlReport['verdict']['status'] =
+    reasons.length === 0 ? 'verified' : 'external-discovery-mismatch';
+  const payload = {
+    kind: 'agentgram.a2a.agent-card.provider-documentation-domain-control-attestation-payload',
+    signedAgentCardPayloadDigest: signature.payloadDigest,
+    agentCardOrigin,
+    canonicalOrigins,
+    probes,
+    verdictStatus,
+  };
+  const domainControl: A2aAgentCardDomainControlReport = {
+    kind: 'agentgram.a2a.agent-card.provider-documentation-domain-control-attestation',
+    generatedAt: (input.now ?? new Date()).toISOString(),
+    signedAgentCardPayloadDigest: signature.payloadDigest,
+    agentCardUrl,
+    agentCardOrigin,
+    canonicalOrigins,
+    probeCount: probes.length,
+    verifiedCount: probes.filter((probe) => probe.status === 'verified').length,
+    redirectedCount: probes.filter((probe) => probe.status === 'redirected').length,
+    mismatchedCount: probes.filter((probe) => probe.status === 'mismatched').length,
+    missingCount: probes.filter((probe) => probe.status === 'missing').length,
+    probes,
+    verdict: {
+      status: verdictStatus,
+      reasons,
+    },
+    signature: {
+      status: 'verified',
+      signingAlgorithm: 'ed25519',
+      publicKey: String(input.publicKey).toLowerCase(),
+      payloadDigest: await sha256Hex(canonicalJson(payload)),
+    },
+  };
+
+  if (verdictStatus === 'external-discovery-mismatch') {
+    return {
+      ok: false,
+      code: 'EXTERNAL_DISCOVERY_MISMATCH',
+      message:
+        'A2A Agent Card provider/documentation origins failed redirect, TLS, domain-control, or signed-card origin checks',
+      domainControl,
+      signature,
+    };
+  }
+
+  return { ok: true, domainControl, signature };
 }
 
 /**

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -23,6 +23,7 @@ export {
   SIGNATURE_FRESHNESS_WINDOW_MS,
   attestA2aExtendedAgentCardAuthorizationDowngrade,
   attestA2aAgentCardExtensionGovernance,
+  attestA2aAgentCardDomainControl,
   attestA2aAgentCardMcpServiceLink,
   attestA2aAgentCardRetrievalFreshness,
   attestA2aAgentCardTransportBindingParity,
@@ -44,6 +45,12 @@ export {
 } from './ed25519';
 export type {
   A2aAgentCardCanonicalSignatureEvidence,
+  A2aAgentCardDomainControlObservation,
+  A2aAgentCardDomainControlProbe,
+  A2aAgentCardDomainControlReport,
+  A2aAgentCardDomainControlStatus,
+  A2aAgentCardDomainControlTargetKind,
+  A2aAgentCardDomainControlVerdict,
   A2aAgentCardJwsProtectedHeader,
   A2aAgentCardRetrievalFreshnessReport,
   A2aAgentCardRetrievalFreshnessStatus,


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog security item d6b7492647.
Ref: https://github.com/agentgram/agentgram

## Change
Adds a public A2A Agent Card domain-control verifier for provider.url and documentationUrl that binds canonical origins, redirect/TLS/domain-control observations, and external-discovery mismatch verdicts to the signed Card digest. Exports auth package types/function and covers the new public route in auth coverage.

## Evidence
- test: pnpm --filter web exec vitest run __tests__/api/a2a-agent-card-domain-control.test.ts __tests__/api/a2a-agent-card-canonical-signature.test.ts __tests__/api/auth-coverage.test.ts → 3 files passed / 20 tests passed.
- type-check: pnpm --filter @agentgram/auth type-check → passed.
- lint: pnpm --filter @agentgram/auth lint → passed.
- diff: git diff --check → passed.
- note: pnpm --filter web type-check is currently blocked by pre-existing next.config.ts(18,5) TS2353 useTypeScriptCli ExperimentalConfig drift.

## Auth-only Proof
N/A