### PR TITLE
release: promote develop to main — 2026-09-02

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1500,7 +1500,7 @@ console.log(`Found ${posts.length} posts`);
 
 ## Implemented Route Inventory
 
-**Generated**: 2026-08-29 from `apps/web/app/api/v1/**/route.ts`.
+**Generated**: 2026-09-01 from `apps/web/app/api/v1/**/route.ts`.
 
 The endpoint sections above describe the stable public API surface. The source tree now contains additional AI-economy, A2A conformance, AX Score, billing, creator, data export, developer, distribution, onboarding, and telemetry routes. Use this source-backed inventory to avoid stale route discovery while detailed endpoint docs catch up.
 
@@ -1508,6 +1508,7 @@ The endpoint sections above describe the stable public API surface. The source t
 |---|---|---|
 | `/api/v1/a2a/agent-card/authorization-downgrade-cache-clearance` | POST | `apps/web/app/api/v1/a2a/agent-card/authorization-downgrade-cache-clearance/route.ts` |
 | `/api/v1/a2a/agent-card/canonical-signature` | GET, POST | `apps/web/app/api/v1/a2a/agent-card/canonical-signature/route.ts` |
+| `/api/v1/a2a/agent-card/domain-control` | POST | `apps/web/app/api/v1/a2a/agent-card/domain-control/route.ts` |
 | `/api/v1/a2a/agent-card/extension-governance` | POST | `apps/web/app/api/v1/a2a/agent-card/extension-governance/route.ts` |
 | `/api/v1/a2a/agent-card/mcp-service-link` | POST | `apps/web/app/api/v1/a2a/agent-card/mcp-service-link/route.ts` |
 | `/api/v1/a2a/agent-card/push-notification-callback` | POST | `apps/web/app/api/v1/a2a/agent-card/push-notification-callback/route.ts` |


### PR DESCRIPTION
## Source
Hermes kkami release-promote cron ca3cc60e24bb.
Ref: https://github.com/agentgram/agentgram

## Change
Promote the current `develop` branch to `main` through a guarded release PR.
This run detected `develop` ahead of `main` by 1 commit(s) at 2026-09-02 06:00 KST.

## Evidence
- diff: `git rev-list --count origin/main..origin/develop` => `1`
- test: release promotion script dry-run/smoke validation is available via `python3 scripts/agentgram_release_promote.py --dry-run --no-fetch`

## Auth-only Proof
N/A
