### PR TITLE
infra(web): expose Lemon Squeezy key expiry in health

### DIFF
--- a/apps/web/__tests__/api/health.test.ts
+++ b/apps/web/__tests__/api/health.test.ts
@@ -1,6 +1,39 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const encode = (value: unknown) =>
+    Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode(payload)}.signature`;
+}
 
 describe('GET /api/v1/health', () => {
+  const ORIGINAL_BILLING_ENABLED = process.env.NEXT_PUBLIC_ENABLE_BILLING;
+  const ORIGINAL_API_KEY = process.env.LEMONSQUEEZY_API_KEY;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-02T00:00:00.000Z'));
+    delete process.env.NEXT_PUBLIC_ENABLE_BILLING;
+    delete process.env.LEMONSQUEEZY_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (ORIGINAL_BILLING_ENABLED === undefined) {
+      delete process.env.NEXT_PUBLIC_ENABLE_BILLING;
+    } else {
+      process.env.NEXT_PUBLIC_ENABLE_BILLING = ORIGINAL_BILLING_ENABLED;
+    }
+
+    if (ORIGINAL_API_KEY === undefined) {
+      delete process.env.LEMONSQUEEZY_API_KEY;
+    } else {
+      process.env.LEMONSQUEEZY_API_KEY = ORIGINAL_API_KEY;
+    }
+  });
+
   it('returns the standardized public liveness contract', async () => {
     const { GET } = await import('../../app/api/v1/health/route');
 
@@ -12,14 +45,19 @@ describe('GET /api/v1/health', () => {
     expect(json.data.status).toBe('ok');
   });
 
-  it('exposes only status and timestamp in data (no version field)', async () => {
+  it('exposes status, timestamp, and billing telemetry in data (no version field)', async () => {
     const { GET } = await import('../../app/api/v1/health/route');
 
     const response = await GET();
     const json = await response.json();
 
-    expect(Object.keys(json.data).sort()).toEqual(['status', 'timestamp']);
+    expect(Object.keys(json.data).sort()).toEqual(['billing', 'status', 'timestamp']);
     expect(json.data).not.toHaveProperty('version');
+    expect(json.data.billing).toEqual({
+      enabled: false,
+      apiKeyExpiresAt: null,
+      apiKeyDaysLeft: null,
+    });
   });
 
   it('returns a timestamp parseable as a valid ISO date', async () => {
@@ -31,5 +69,22 @@ describe('GET /api/v1/health', () => {
     const parsed = new Date(json.data.timestamp);
     expect(Number.isNaN(parsed.getTime())).toBe(false);
     expect(parsed.toISOString()).toBe(json.data.timestamp);
+  });
+
+  it('includes billing enabled state and Lemon Squeezy API key expiry telemetry', async () => {
+    process.env.NEXT_PUBLIC_ENABLE_BILLING = 'true';
+    process.env.LEMONSQUEEZY_API_KEY = makeJwt({
+      exp: Date.parse('2026-09-04T00:00:00.000Z') / 1000,
+    });
+    const { GET } = await import('../../app/api/v1/health/route');
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(json.data.billing).toEqual({
+      enabled: true,
+      apiKeyExpiresAt: '2026-09-04T00:00:00.000Z',
+      apiKeyDaysLeft: 2,
+    });
   });
 });

--- a/apps/web/__tests__/lib/billing/lemonsqueezy.test.ts
+++ b/apps/web/__tests__/lib/billing/lemonsqueezy.test.ts
@@ -13,6 +13,13 @@ function clearVariantEnv() {
   for (const key of TEAM_ENV) delete process.env[key];
 }
 
+function makeJwt(payload: Record<string, unknown>): string {
+  const encode = (value: unknown) =>
+    Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode(payload)}.signature`;
+}
+
 describe('lemonsqueezy variant mapping', () => {
   beforeEach(() => {
     vi.resetModules();
@@ -84,6 +91,70 @@ describe('lemonsqueezy variant mapping', () => {
   it('exposes Free / Team / Enterprise as the only plan tiers', async () => {
     const { PLANS } = await import('@/lib/billing/lemonsqueezy');
     expect(Object.keys(PLANS).sort()).toEqual(['enterprise', 'free', 'team']);
+  });
+});
+
+describe('Lemon Squeezy API key expiry telemetry', () => {
+  const ORIGINAL_KEY = process.env.LEMONSQUEEZY_API_KEY;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-02T00:00:00.000Z'));
+    delete process.env.LEMONSQUEEZY_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (ORIGINAL_KEY === undefined) {
+      delete process.env.LEMONSQUEEZY_API_KEY;
+    } else {
+      process.env.LEMONSQUEEZY_API_KEY = ORIGINAL_KEY;
+    }
+  });
+
+  it('decodes a valid JWT exp without returning the key material', async () => {
+    process.env.LEMONSQUEEZY_API_KEY = makeJwt({
+      exp: Date.parse('2026-09-04T00:00:00.000Z') / 1000,
+    });
+    const { getApiKeyExpiry } = await import('@/lib/billing/lemonsqueezy');
+
+    expect(getApiKeyExpiry()).toEqual({
+      expiresAt: '2026-09-04T00:00:00.000Z',
+      daysLeft: 2,
+    });
+  });
+
+  it('returns a negative daysLeft for an expired JWT', async () => {
+    process.env.LEMONSQUEEZY_API_KEY = makeJwt({
+      exp: Date.parse('2026-08-31T00:00:00.000Z') / 1000,
+    });
+    const { getApiKeyExpiry } = await import('@/lib/billing/lemonsqueezy');
+
+    expect(getApiKeyExpiry()).toEqual({
+      expiresAt: '2026-08-31T00:00:00.000Z',
+      daysLeft: -2,
+    });
+  });
+
+  it('returns null telemetry when the API key env is missing', async () => {
+    const { getApiKeyExpiry } = await import('@/lib/billing/lemonsqueezy');
+
+    expect(getApiKeyExpiry()).toEqual({ expiresAt: null, daysLeft: null });
+  });
+
+  it('returns null telemetry for a non-JWT API key string', async () => {
+    process.env.LEMONSQUEEZY_API_KEY = 'not-a-jwt';
+    const { getApiKeyExpiry } = await import('@/lib/billing/lemonsqueezy');
+
+    expect(getApiKeyExpiry()).toEqual({ expiresAt: null, daysLeft: null });
+  });
+
+  it('returns null telemetry for a JWT payload with no exp', async () => {
+    process.env.LEMONSQUEEZY_API_KEY = makeJwt({ sub: 'api-key' });
+    const { getApiKeyExpiry } = await import('@/lib/billing/lemonsqueezy');
+
+    expect(getApiKeyExpiry()).toEqual({ expiresAt: null, daysLeft: null });
   });
 });
 

--- a/apps/web/app/api/v1/health/route.ts
+++ b/apps/web/app/api/v1/health/route.ts
@@ -1,10 +1,18 @@
 import { jsonResponse, createSuccessResponse } from '@agentgram/shared';
+import { getApiKeyExpiry, isBillingEnabled } from '@/lib/billing/lemonsqueezy';
 
 export async function GET() {
+  const { expiresAt: apiKeyExpiresAt, daysLeft: apiKeyDaysLeft } = getApiKeyExpiry();
+
   return jsonResponse(
     createSuccessResponse({
       status: 'ok',
       timestamp: new Date().toISOString(),
+      billing: {
+        enabled: isBillingEnabled(),
+        apiKeyExpiresAt,
+        apiKeyDaysLeft,
+      },
     }),
     200
   );

--- a/apps/web/lib/billing/lemonsqueezy.ts
+++ b/apps/web/lib/billing/lemonsqueezy.ts
@@ -5,12 +5,32 @@ import {
 
 let _configured = false;
 
+const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+
+type ApiKeyExpiry = {
+  expiresAt: string | null;
+  daysLeft: number | null;
+};
+
 function firstNonEmptyEnv(...keys: string[]): string | undefined {
   for (const key of keys) {
     const value = process.env[key]?.trim();
     if (value) return value;
   }
   return undefined;
+}
+
+function nullExpiry(): ApiKeyExpiry {
+  return { expiresAt: null, daysLeft: null };
+}
+
+function decodeBase64UrlJson(value: string): unknown {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    '='
+  );
+  return JSON.parse(Buffer.from(padded, 'base64').toString('utf8'));
 }
 
 export function configureLemonSqueezy(): void {
@@ -33,6 +53,35 @@ export function getStoreId(): string {
 
 export function isBillingEnabled(): boolean {
   return process.env.NEXT_PUBLIC_ENABLE_BILLING === 'true';
+}
+
+export function getApiKeyExpiry(): ApiKeyExpiry {
+  const apiKey = process.env.LEMONSQUEEZY_API_KEY?.trim();
+  if (!apiKey) return nullExpiry();
+
+  const segments = apiKey.split('.');
+  if (segments.length < 2 || !segments[1]) return nullExpiry();
+
+  try {
+    const payload = decodeBase64UrlJson(segments[1]);
+    if (
+      typeof payload !== 'object' ||
+      payload === null ||
+      !('exp' in payload) ||
+      typeof payload.exp !== 'number' ||
+      !Number.isFinite(payload.exp)
+    ) {
+      return nullExpiry();
+    }
+
+    const expiresMs = payload.exp * 1000;
+    return {
+      expiresAt: new Date(expiresMs).toISOString(),
+      daysLeft: Math.floor((expiresMs - Date.now()) / MILLIS_PER_DAY),
+    };
+  } catch {
+    return nullExpiry();
+  }
 }
 
 /**


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog infra item 668d36c94a.
Ref: https://github.com/agentgram/agentgram

## Change
Added Lemon Squeezy API key expiry telemetry via getApiKeyExpiry() and exposed billing.enabled/apiKeyExpiresAt/apiKeyDaysLeft on /api/v1/health without returning key material.
Updated health and billing unit tests for valid JWT, expired JWT, missing env, non-JWT, and no-exp cases.

## Evidence
test: pnpm --filter web exec vitest run __tests__/lib/billing/lemonsqueezy.test.ts __tests__/api/health.test.ts __tests__/api/auth-coverage.test.ts — 3 files passed, 19 tests passed.
lint: pnpm --filter web exec eslint lib/billing/lemonsqueezy.ts app/api/v1/health/route.ts __tests__/lib/billing/lemonsqueezy.test.ts __tests__/api/health.test.ts — exit 0.
type-check: pnpm --filter web type-check — blocked by existing next.config.ts(18,5) ExperimentalConfig useTypeScriptCli type error on develop, unrelated to this diff.
diff: 4 scoped files changed.

## Auth-only Proof
N/A
