### PR TITLE
fix(web): surface billing API failures

### DIFF
--- a/apps/web/__tests__/components/billing-ui-errors.test.tsx
+++ b/apps/web/__tests__/components/billing-ui-errors.test.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PricingPage from '@/app/(public)/pricing/page';
+import { ManageSubscriptionButton } from '@/components/dashboard/ManageSubscriptionButton';
+
+const { push, toast, manageSubscription, beginCheckout, viewPricing } = vi.hoisted(
+  () => ({
+    push: vi.fn(),
+    toast: vi.fn(),
+    manageSubscription: vi.fn(),
+    beginCheckout: vi.fn(),
+    viewPricing: vi.fn(),
+  })
+);
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast }),
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  analytics: {
+    beginCheckout,
+    manageSubscription,
+    viewPricing,
+  },
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: (_target, tag: string) => {
+        return ({ children, ...props }: React.HTMLAttributes<HTMLElement>) => {
+          delete (props as Record<string, unknown>).initial;
+          delete (props as Record<string, unknown>).animate;
+          delete (props as Record<string, unknown>).transition;
+          delete (props as Record<string, unknown>).whileInView;
+          delete (props as Record<string, unknown>).viewport;
+          return React.createElement(tag, props, children);
+        };
+      },
+    }
+  ),
+}));
+
+describe('billing UI errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.stubEnv('NEXT_PUBLIC_ENABLE_BILLING', 'true');
+  });
+
+  it('shows portal API error code and server message when manage subscription fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        json: async () => ({
+          success: false,
+          error: {
+            code: 'PORTAL_ERROR',
+            message: 'Failed to retrieve billing portal.',
+          },
+        }),
+      })
+    );
+
+    render(<ManageSubscriptionButton />);
+    fireEvent.click(screen.getByRole('button', { name: /manage subscription/i }));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'destructive',
+          description: 'PORTAL_ERROR: Failed to retrieve billing portal.',
+        })
+      );
+    });
+    expect(
+      (screen.getByRole('button', {
+        name: /manage subscription/i,
+      }) as HTMLButtonElement).disabled
+    ).toBe(false);
+  });
+
+  it('shows a generic toast and releases loading when manage subscription fetch rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+
+    render(<ManageSubscriptionButton />);
+    fireEvent.click(screen.getByRole('button', { name: /manage subscription/i }));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'destructive',
+          description: expect.stringMatching(/try again/i),
+        })
+      );
+    });
+    expect(
+      (screen.getByRole('button', {
+        name: /manage subscription/i,
+      }) as HTMLButtonElement).disabled
+    ).toBe(false);
+  });
+
+  it('replaces checkout alert with a toast containing server error code and message', async () => {
+    const alert = vi.fn();
+    vi.stubGlobal('alert', alert);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        status: 500,
+        json: async () => ({
+          success: false,
+          error: {
+            code: 'VARIANT_NOT_CONFIGURED',
+            message: 'Variant for team (annual) is not configured.',
+          },
+        }),
+      })
+    );
+
+    render(<PricingPage />);
+    fireEvent.click(screen.getByRole('button', { name: /^annual/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^subscribe/i }));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'destructive',
+          description:
+            'VARIANT_NOT_CONFIGURED: Variant for team (annual) is not configured.',
+        })
+      );
+    });
+    expect(alert).not.toHaveBeenCalled();
+    expect(
+      (screen.getByRole('button', { name: /^subscribe/i }) as HTMLButtonElement)
+        .disabled
+    ).toBe(false);
+  });
+
+  it('shows a generic toast instead of silently swallowing checkout fetch rejects', async () => {
+    const alert = vi.fn();
+    vi.stubGlobal('alert', alert);
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+
+    render(<PricingPage />);
+    fireEvent.click(screen.getByRole('button', { name: /^subscribe/i }));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'destructive',
+          description: expect.stringMatching(/try again/i),
+        })
+      );
+    });
+    expect(alert).not.toHaveBeenCalled();
+    expect(
+      (screen.getByRole('button', { name: /^subscribe/i }) as HTMLButtonElement)
+        .disabled
+    ).toBe(false);
+  });
+});

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -17,6 +17,29 @@ import {
 import { PricingCard } from '@/components/pricing';
 import { Button } from '@/components/ui/button';
 import { analytics } from '@/lib/analytics';
+import { useToast } from '@/hooks/use-toast';
+
+type BillingErrorResponse = {
+  error?: {
+    code?: unknown;
+    message?: unknown;
+  };
+};
+
+function getBillingErrorDescription(
+  data: BillingErrorResponse | null,
+  fallback: string
+) {
+  const code = typeof data?.error?.code === 'string' ? data.error.code : null;
+  const message =
+    typeof data?.error?.message === 'string' ? data.error.message : null;
+
+  if (code && message) {
+    return `${code}: ${message}`;
+  }
+
+  return message ?? fallback;
+}
 
 function getPlans(billingEnabled: boolean) {
   return [
@@ -100,10 +123,14 @@ const GOVERNANCE_PILLARS = [
 
 export default function PricingPage() {
   const router = useRouter();
+  const { toast } = useToast();
   const billingEnabled = process.env.NEXT_PUBLIC_ENABLE_BILLING === 'true';
   const plans = getPlans(billingEnabled);
   const [billingPeriod, setBillingPeriod] = useState<'monthly' | 'annual'>(
     'monthly'
+  );
+  const [checkoutLoadingPlan, setCheckoutLoadingPlan] = useState<string | null>(
+    null
   );
 
   useEffect(() => {
@@ -133,6 +160,7 @@ export default function PricingPage() {
       billingPeriod,
       'pricing_plan_grid'
     );
+    setCheckoutLoadingPlan(planName);
 
     try {
       const res = await fetch('/api/v1/billing/checkout', {
@@ -143,17 +171,53 @@ export default function PricingPage() {
           billingPeriod,
         }),
       });
-      const data = await res.json();
+      let data: BillingErrorResponse & {
+        success?: boolean;
+        data?: { url?: string };
+      };
+      try {
+        data = await res.json();
+      } catch (error) {
+        console.error('Failed to parse checkout response:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Checkout unavailable',
+          description: 'Unable to read billing response. Please try again.',
+        });
+        return;
+      }
 
       if (data.success && data.data?.url) {
         window.location.assign(data.data.url);
       } else if (res.status === 401) {
+        toast({
+          variant: 'destructive',
+          title: 'Checkout unavailable',
+          description: getBillingErrorDescription(
+            data,
+            'Unable to create checkout. Please try again.'
+          ),
+        });
         router.push('/auth/login?redirect=/pricing');
       } else {
-        alert(data.error?.message || 'Failed to create checkout. Please try again.');
+        toast({
+          variant: 'destructive',
+          title: 'Checkout unavailable',
+          description: getBillingErrorDescription(
+            data,
+            'Unable to create checkout. Please try again.'
+          ),
+        });
       }
-    } catch {
-      console.error('Failed to create checkout session');
+    } catch (error) {
+      console.error('Failed to create checkout session', error);
+      toast({
+        variant: 'destructive',
+        title: 'Checkout unavailable',
+        description: 'Unable to create checkout. Please try again.',
+      });
+    } finally {
+      setCheckoutLoadingPlan(null);
     }
   };
 
@@ -189,6 +253,7 @@ export default function PricingPage() {
               size="lg"
               className="w-full gap-2 sm:w-auto"
               onClick={() => handleSubscribe('Team')}
+              disabled={checkoutLoadingPlan === 'Team'}
             >
               Start with Team
               <ArrowRight className="h-4 w-4" />
@@ -272,6 +337,7 @@ export default function PricingPage() {
                 ctaVariant={plan.ctaVariant}
                 popular={plan.popular}
                 onSubscribe={() => handleSubscribe(plan.name)}
+                disabled={checkoutLoadingPlan === plan.name}
                 delay={index * 0.1}
               />
             );

--- a/apps/web/components/dashboard/ManageSubscriptionButton.tsx
+++ b/apps/web/components/dashboard/ManageSubscriptionButton.tsx
@@ -5,9 +5,33 @@ import { Button } from '@/components/ui/button';
 import { CreditCard, Loader2 } from 'lucide-react';
 import { API_BASE_PATH } from '@agentgram/shared';
 import { analytics } from '@/lib/analytics';
+import { useToast } from '@/hooks/use-toast';
+
+type BillingErrorResponse = {
+  error?: {
+    code?: unknown;
+    message?: unknown;
+  };
+};
+
+function getBillingErrorDescription(
+  data: BillingErrorResponse | null,
+  fallback: string
+) {
+  const code = typeof data?.error?.code === 'string' ? data.error.code : null;
+  const message =
+    typeof data?.error?.message === 'string' ? data.error.message : null;
+
+  if (code && message) {
+    return `${code}: ${message}`;
+  }
+
+  return message ?? fallback;
+}
 
 export function ManageSubscriptionButton() {
   const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
 
   const handleManageSubscription = async () => {
     analytics.manageSubscription();
@@ -21,15 +45,42 @@ export function ManageSubscriptionButton() {
         body: JSON.stringify({}),
       });
 
-      const data = await response.json();
+      let data: BillingErrorResponse & {
+        success?: boolean;
+        data?: { url?: string };
+      };
+      try {
+        data = await response.json();
+      } catch (error) {
+        console.error('Failed to parse billing portal response:', error);
+        toast({
+          variant: 'destructive',
+          title: 'Billing portal unavailable',
+          description: 'Unable to read billing response. Please try again.',
+        });
+        return;
+      }
 
       if (data.success && data.data?.url) {
         window.location.href = data.data.url;
       } else {
         console.error('Failed to get portal URL', data);
+        toast({
+          variant: 'destructive',
+          title: 'Billing portal unavailable',
+          description: getBillingErrorDescription(
+            data,
+            'Unable to open billing portal. Please try again.'
+          ),
+        });
       }
     } catch (error) {
       console.error('Error managing subscription:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Billing portal unavailable',
+        description: 'Unable to open billing portal. Please try again.',
+      });
     } finally {
       setLoading(false);
     }

--- a/apps/web/components/pricing/PricingCard.tsx
+++ b/apps/web/components/pricing/PricingCard.tsx
@@ -19,6 +19,7 @@ interface PricingCardProps {
   ctaVariant?: 'default' | 'outline';
   popular?: boolean;
   onSubscribe?: () => void;
+  disabled?: boolean;
   delay?: number;
 }
 
@@ -32,6 +33,7 @@ export function PricingCard({
   ctaVariant = 'outline',
   popular = false,
   onSubscribe,
+  disabled = false,
   delay = 0,
 }: PricingCardProps) {
   return (
@@ -73,6 +75,7 @@ export function PricingCard({
           variant={ctaVariant}
           className="w-full gap-2"
           onClick={onSubscribe}
+          disabled={disabled}
         >
           {cta}
           <ArrowRight className="w-4 h-4" />


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane — backlog bug item bb730d3333.
Ref: https://github.com/agentgram/agentgram

## Change
Manage Subscription and pricing checkout now surface billing API failures through the existing toast system, including server error.code plus server error.message when present.
Checkout alert() was removed, fetch/non-JSON failures show generic destructive toasts, and checkout/manage loading states are released in finally.

## Evidence
- test: pnpm --filter web exec vitest run __tests__/components/billing-ui-errors.test.tsx → 4 tests passed.
- lint: pnpm --filter web exec eslint components/dashboard/ManageSubscriptionButton.tsx components/pricing/PricingCard.tsx 'app/(public)/pricing/page.tsx' __tests__/components/billing-ui-errors.test.tsx → passed.
- type-check: pnpm --filter web type-check → pre-existing failure: next.config.ts(18,5) TS2353 useTypeScriptCli is not in ExperimentalConfig.
- diff: git log origin/develop..HEAD --oneline | wc -l → 1.

## Auth-only Proof
N/A